### PR TITLE
Add option to whitelist CVE:s

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -18,17 +18,6 @@
  */
 package org.owasp.dependencycheck;
 
-import java.util.EnumMap;
-import java.io.File;
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.owasp.dependencycheck.analyzer.AnalysisException;
 import org.owasp.dependencycheck.analyzer.AnalysisPhase;
 import org.owasp.dependencycheck.analyzer.Analyzer;
@@ -42,9 +31,17 @@ import org.owasp.dependencycheck.data.cpe.IndexException;
 import org.owasp.dependencycheck.data.nvdcve.CveDB;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.Vulnerability;
 import org.owasp.dependencycheck.utils.FileUtils;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Scans files, directories, etc. for Dependencies. Analyzers are loaded and
@@ -56,393 +53,414 @@ import org.owasp.dependencycheck.utils.Settings;
  */
 public class Engine {
 
-    /**
-     * The list of dependencies.
-     */
-    private final List<Dependency> dependencies = new ArrayList<Dependency>();
-    /**
-     * A Map of analyzers grouped by Analysis phase.
-     */
-    private final EnumMap<AnalysisPhase, List<Analyzer>> analyzers =
-            new EnumMap<AnalysisPhase, List<Analyzer>>(AnalysisPhase.class);
-    /**
-     * A set of extensions supported by the analyzers.
-     */
-    private final Set<String> extensions = new HashSet<String>();
+	/**
+	 * The list of dependencies.
+	 */
+	private final List<Dependency> dependencies = new ArrayList<Dependency>();
+	/**
+	 * A Map of analyzers grouped by Analysis phase.
+	 */
+	private final EnumMap<AnalysisPhase, List<Analyzer>> analyzers =
+			new EnumMap<AnalysisPhase, List<Analyzer>>(AnalysisPhase.class);
+	/**
+	 * A set of extensions supported by the analyzers.
+	 */
+	private final Set<String> extensions = new HashSet<String>();
+	private final Collection<String> whiteListedDependencies;
 
-    /**
-     * Creates a new Engine.
-     */
-    public Engine() {
-        boolean autoUpdate = true;
-        try {
-            autoUpdate = Settings.getBoolean(Settings.KEYS.AUTO_UPDATE);
-        } catch (InvalidSettingException ex) {
-            Logger.getLogger(Engine.class.getName()).log(Level.FINE, "Invalid setting for auto-update; using true.");
-        }
-        if (autoUpdate) {
-            doUpdates();
-        }
-        loadAnalyzers();
-    }
+	public Engine() {
+		this(null);
+	}
 
-    /**
-     * Creates a new Engine.
-     *
-     * @param autoUpdate indicates whether or not data should be updated from
-     * the Internet
-     * @deprecated This function should no longer be used; the autoupdate flag
-     * should be set using:
-     * <code>Settings.setBoolean(Settings.KEYS.AUTO_UPDATE, value);</code>
-     */
-    @Deprecated
-    public Engine(boolean autoUpdate) {
-        if (autoUpdate) {
-            doUpdates();
-        }
-        loadAnalyzers();
-    }
+	/**
+	 * Creates a new Engine.
+	 */
+	public Engine(String whiteListedDependencies) {
+		boolean autoUpdate = true;
+		if (whiteListedDependencies != null) {
+			StringTokenizer tok = new StringTokenizer(whiteListedDependencies, " ,");
+			this.whiteListedDependencies = new HashSet<String>();
+			while (tok.hasMoreElements()) {
+				String whiteListed = tok.nextToken();
+				this.whiteListedDependencies.add(whiteListed);
+				Logger.getLogger(Engine.class.getName()).log(Level.INFO, "Whitelisting " + whiteListed + ". This CVE will not generate any warnings.");
+			}
+		} else {
+			this.whiteListedDependencies = Collections.emptySet();
+		}
+		try {
+			autoUpdate = Settings.getBoolean(Settings.KEYS.AUTO_UPDATE);
+		} catch (InvalidSettingException ex) {
+			Logger.getLogger(Engine.class.getName()).log(Level.FINE, "Invalid setting for auto-update; using true.");
+		}
+		if (autoUpdate) {
+			doUpdates();
+		}
+		loadAnalyzers();
+	}
 
-    /**
-     * Loads the analyzers specified in the configuration file (or system
-     * properties).
-     */
-    private void loadAnalyzers() {
+	/**
+	 * Creates a new Engine.
+	 *
+	 * @param autoUpdate indicates whether or not data should be updated from
+	 *                   the Internet
+	 * @deprecated This function should no longer be used; the autoupdate flag
+	 *             should be set using:
+	 *             <code>Settings.setBoolean(Settings.KEYS.AUTO_UPDATE, value);</code>
+	 */
+	@Deprecated
+	public Engine(boolean autoUpdate) {
+		this.whiteListedDependencies = Collections.emptySet();
+		if (autoUpdate) {
+			doUpdates();
+		}
+		loadAnalyzers();
+	}
 
-        for (AnalysisPhase phase : AnalysisPhase.values()) {
-            analyzers.put(phase, new ArrayList<Analyzer>());
-        }
+	/**
+	 * Loads the analyzers specified in the configuration file (or system
+	 * properties).
+	 */
+	private void loadAnalyzers() {
 
-        final AnalyzerService service = AnalyzerService.getInstance();
-        final Iterator<Analyzer> iterator = service.getAnalyzers();
-        while (iterator.hasNext()) {
-            final Analyzer a = iterator.next();
-            analyzers.get(a.getAnalysisPhase()).add(a);
-            if (a.getSupportedExtensions() != null) {
-                extensions.addAll(a.getSupportedExtensions());
-            }
-        }
-    }
+		for (AnalysisPhase phase : AnalysisPhase.values()) {
+			analyzers.put(phase, new ArrayList<Analyzer>());
+		}
 
-    /**
-     * Get the List of the analyzers for a specific phase of analysis.
-     *
-     * @param phase the phase to get the configured analyzers.
-     * @return the analyzers loaded
-     */
-    public List<Analyzer> getAnalyzers(AnalysisPhase phase) {
-        return analyzers.get(phase);
-    }
+		final AnalyzerService service = AnalyzerService.getInstance();
+		final Iterator<Analyzer> iterator = service.getAnalyzers();
+		while (iterator.hasNext()) {
+			final Analyzer a = iterator.next();
+			analyzers.get(a.getAnalysisPhase()).add(a);
+			if (a.getSupportedExtensions() != null) {
+				extensions.addAll(a.getSupportedExtensions());
+			}
+		}
+	}
 
-    /**
-     * Get the dependencies identified.
-     *
-     * @return the dependencies identified
-     */
-    public List<Dependency> getDependencies() {
-        return dependencies;
-    }
+	/**
+	 * Get the List of the analyzers for a specific phase of analysis.
+	 *
+	 * @param phase the phase to get the configured analyzers.
+	 * @return the analyzers loaded
+	 */
+	public List<Analyzer> getAnalyzers(AnalysisPhase phase) {
+		return analyzers.get(phase);
+	}
 
-    /**
-     * Scans an array of files or directories. If a directory is specified, it
-     * will be scanned recursively. Any dependencies identified are added to the
-     * dependency collection.
-     *
-     * @since v0.3.2.5
-     *
-     * @param paths an array of paths to files or directories to be analyzed.
-     */
-    public void scan(String[] paths) {
-        for (String path : paths) {
-            final File file = new File(path);
-            scan(file);
-        }
-    }
+	/**
+	 * Get the dependencies identified.
+	 *
+	 * @return the dependencies identified
+	 */
+	public List<Dependency> getDependencies() {
+		return dependencies;
+	}
 
-    /**
-     * Scans a given file or directory. If a directory is specified, it will be
-     * scanned recursively. Any dependencies identified are added to the
-     * dependency collection.
-     *
-     * @param path the path to a file or directory to be analyzed.
-     */
-    public void scan(String path) {
-        final File file = new File(path);
-        scan(file);
-    }
+	/**
+	 * Scans an array of files or directories. If a directory is specified, it
+	 * will be scanned recursively. Any dependencies identified are added to the
+	 * dependency collection.
+	 *
+	 * @param paths an array of paths to files or directories to be analyzed.
+	 * @since v0.3.2.5
+	 */
+	public void scan(String[] paths) {
+		for (String path : paths) {
+			final File file = new File(path);
+			scan(file);
+		}
+	}
 
-    /**
-     * Scans an array of files or directories. If a directory is specified, it
-     * will be scanned recursively. Any dependencies identified are added to the
-     * dependency collection.
-     *
-     * @since v0.3.2.5
-     *
-     * @param files an array of paths to files or directories to be analyzed.
-     */
-    public void scan(File[] files) {
-        for (File file : files) {
-            scan(file);
-        }
-    }
+	/**
+	 * Scans a given file or directory. If a directory is specified, it will be
+	 * scanned recursively. Any dependencies identified are added to the
+	 * dependency collection.
+	 *
+	 * @param path the path to a file or directory to be analyzed.
+	 */
+	public void scan(String path) {
+		final File file = new File(path);
+		scan(file);
+	}
 
-    /**
-     * Scans a list of files or directories. If a directory is specified, it
-     * will be scanned recursively. Any dependencies identified are added to the
-     * dependency collection.
-     *
-     * @since v0.3.2.5
-     *
-     * @param files a set of paths to files or directories to be analyzed.
-     */
-    public void scan(Set<File> files) {
-        for (File file : files) {
-            scan(file);
-        }
-    }
+	/**
+	 * Scans an array of files or directories. If a directory is specified, it
+	 * will be scanned recursively. Any dependencies identified are added to the
+	 * dependency collection.
+	 *
+	 * @param files an array of paths to files or directories to be analyzed.
+	 * @since v0.3.2.5
+	 */
+	public void scan(File[] files) {
+		for (File file : files) {
+			scan(file);
+		}
+	}
 
-    /**
-     * Scans a list of files or directories. If a directory is specified, it
-     * will be scanned recursively. Any dependencies identified are added to the
-     * dependency collection.
-     *
-     * @since v0.3.2.5
-     *
-     * @param files a set of paths to files or directories to be analyzed.
-     */
-    public void scan(List<File> files) {
-        for (File file : files) {
-            scan(file);
-        }
-    }
+	/**
+	 * Scans a list of files or directories. If a directory is specified, it
+	 * will be scanned recursively. Any dependencies identified are added to the
+	 * dependency collection.
+	 *
+	 * @param files a set of paths to files or directories to be analyzed.
+	 * @since v0.3.2.5
+	 */
+	public void scan(Set<File> files) {
+		for (File file : files) {
+			scan(file);
+		}
+	}
 
-    /**
-     * Scans a given file or directory. If a directory is specified, it will be
-     * scanned recursively. Any dependencies identified are added to the
-     * dependency collection.
-     *
-     * @since v0.3.2.4
-     *
-     * @param file the path to a file or directory to be analyzed.
-     */
-    public void scan(File file) {
-        if (file.exists()) {
-            if (file.isDirectory()) {
-                scanDirectory(file);
-            } else {
-                scanFile(file);
-            }
-        }
-    }
+	/**
+	 * Scans a list of files or directories. If a directory is specified, it
+	 * will be scanned recursively. Any dependencies identified are added to the
+	 * dependency collection.
+	 *
+	 * @param files a set of paths to files or directories to be analyzed.
+	 * @since v0.3.2.5
+	 */
+	public void scan(List<File> files) {
+		for (File file : files) {
+			scan(file);
+		}
+	}
 
-    /**
-     * Recursively scans files and directories. Any dependencies identified are
-     * added to the dependency collection.
-     *
-     * @param dir the directory to scan.
-     */
-    protected void scanDirectory(File dir) {
-        final File[] files = dir.listFiles();
-        if (files != null) {
-            for (File f : files) {
-                if (f.isDirectory()) {
-                    scanDirectory(f);
-                } else {
-                    scanFile(f);
-                }
-            }
-        }
-    }
+	/**
+	 * Scans a given file or directory. If a directory is specified, it will be
+	 * scanned recursively. Any dependencies identified are added to the
+	 * dependency collection.
+	 *
+	 * @param file the path to a file or directory to be analyzed.
+	 * @since v0.3.2.4
+	 */
+	public void scan(File file) {
+		if (file.exists()) {
+			if (file.isDirectory()) {
+				scanDirectory(file);
+			} else {
+				scanFile(file);
+			}
+		}
+	}
 
-    /**
-     * Scans a specified file. If a dependency is identified it is added to the
-     * dependency collection.
-     *
-     * @param file The file to scan.
-     */
-    protected void scanFile(File file) {
-        if (!file.isFile()) {
-            final String msg = String.format("Path passed to scanFile(File) is not a file: %s. Skipping the file.", file.toString());
-            Logger.getLogger(Engine.class.getName()).log(Level.FINE, msg);
-            return;
-        }
-        final String fileName = file.getName();
-        final String extension = FileUtils.getFileExtension(fileName);
-        if (extension != null) {
-            if (extensions.contains(extension)) {
-                final Dependency dependency = new Dependency(file);
-                dependencies.add(dependency);
-            }
-        } else {
-            final String msg = String.format("No file extension found on file '%s'. The file was not analyzed.",
-                    file.toString());
-            Logger.getLogger(Engine.class.getName()).log(Level.FINEST, msg);
-        }
-    }
+	/**
+	 * Recursively scans files and directories. Any dependencies identified are
+	 * added to the dependency collection.
+	 *
+	 * @param dir the directory to scan.
+	 */
+	protected void scanDirectory(File dir) {
+		final File[] files = dir.listFiles();
+		if (files != null) {
+			for (File f : files) {
+				if (f.isDirectory()) {
+					scanDirectory(f);
+				} else {
+					scanFile(f);
+				}
+			}
+		}
+	}
 
-    /**
-     * Runs the analyzers against all of the dependencies.
-     */
-    public void analyzeDependencies() {
-        //need to ensure that data exists
-        try {
-            ensureDataExists();
-        } catch (NoDataException ex) {
-            final String msg = String.format("%n%n%s%n%nUnable to continue dependency-check analysis.", ex.getMessage());
-            Logger.getLogger(Engine.class.getName()).log(Level.SEVERE, msg);
-            Logger.getLogger(Engine.class.getName()).log(Level.FINE, null, ex);
-            return;
-        }
+	/**
+	 * Scans a specified file. If a dependency is identified it is added to the
+	 * dependency collection.
+	 *
+	 * @param file The file to scan.
+	 */
+	protected void scanFile(File file) {
+		if (!file.isFile()) {
+			final String msg = String.format("Path passed to scanFile(File) is not a file: %s. Skipping the file.", file.toString());
+			Logger.getLogger(Engine.class.getName()).log(Level.FINE, msg);
+			return;
+		}
+		final String fileName = file.getName();
+		final String extension = FileUtils.getFileExtension(fileName);
+		if (extension != null) {
+			if (extensions.contains(extension)) {
+				final Dependency dependency = new Dependency(file);
+				dependencies.add(dependency);
+			}
+		} else {
+			final String msg = String.format("No file extension found on file '%s'. The file was not analyzed.",
+					file.toString());
+			Logger.getLogger(Engine.class.getName()).log(Level.FINEST, msg);
+		}
+	}
 
-        //phase one initialize
-        for (AnalysisPhase phase : AnalysisPhase.values()) {
-            final List<Analyzer> analyzerList = analyzers.get(phase);
-            for (Analyzer a : analyzerList) {
-                try {
-                    final String msg = String.format("Initializing %s", a.getName());
-                    Logger.getLogger(Engine.class.getName()).log(Level.FINE, msg);
-                    a.initialize();
-                } catch (Exception ex) {
-                    final String msg = String.format("Exception occurred initializing %s.", a.getName());
-                    Logger.getLogger(Engine.class.getName()).log(Level.SEVERE, msg);
-                    Logger.getLogger(Engine.class.getName()).log(Level.INFO, null, ex);
-                    try {
-                        a.close();
-                    } catch (Exception ex1) {
-                        Logger.getLogger(Engine.class.getName()).log(Level.FINEST, null, ex1);
-                    }
-                }
-            }
-        }
+	/**
+	 * Runs the analyzers against all of the dependencies.
+	 */
+	public void analyzeDependencies() {
+		//need to ensure that data exists
+		try {
+			ensureDataExists();
+		} catch (NoDataException ex) {
+			final String msg = String.format("%n%n%s%n%nUnable to continue dependency-check analysis.", ex.getMessage());
+			Logger.getLogger(Engine.class.getName()).log(Level.SEVERE, msg);
+			Logger.getLogger(Engine.class.getName()).log(Level.FINE, null, ex);
+			return;
+		}
 
-        // analysis phases
-        for (AnalysisPhase phase : AnalysisPhase.values()) {
-            final List<Analyzer> analyzerList = analyzers.get(phase);
+		//phase one initialize
+		for (AnalysisPhase phase : AnalysisPhase.values()) {
+			final List<Analyzer> analyzerList = analyzers.get(phase);
+			for (Analyzer a : analyzerList) {
+				try {
+					final String msg = String.format("Initializing %s", a.getName());
+					Logger.getLogger(Engine.class.getName()).log(Level.FINE, msg);
+					a.initialize();
+				} catch (Exception ex) {
+					final String msg = String.format("Exception occurred initializing %s.", a.getName());
+					Logger.getLogger(Engine.class.getName()).log(Level.SEVERE, msg);
+					Logger.getLogger(Engine.class.getName()).log(Level.INFO, null, ex);
+					try {
+						a.close();
+					} catch (Exception ex1) {
+						Logger.getLogger(Engine.class.getName()).log(Level.FINEST, null, ex1);
+					}
+				}
+			}
+		}
 
-            for (Analyzer a : analyzerList) {
-                /* need to create a copy of the collection because some of the
-                 * analyzers may modify it. This prevents ConcurrentModificationExceptions.
+		// analysis phases
+		for (AnalysisPhase phase : AnalysisPhase.values()) {
+			final List<Analyzer> analyzerList = analyzers.get(phase);
+
+			for (Analyzer a : analyzerList) {
+			    /* need to create a copy of the collection because some of the
+			     * analyzers may modify it. This prevents ConcurrentModificationExceptions.
                  * This is okay for adds/deletes because it happens per analyzer.
                  */
-                final String msg = String.format("Begin Analyzer '%s'", a.getName());
-                Logger.getLogger(Engine.class.getName()).log(Level.FINE, msg);
-                final Set<Dependency> dependencySet = new HashSet<Dependency>();
-                dependencySet.addAll(dependencies);
-                for (Dependency d : dependencySet) {
-                    final String msgFile = String.format("Begin Analysis of '%s'", d.getActualFilePath());
-                    Logger.getLogger(Engine.class.getName()).log(Level.FINE, msgFile);
-                    if (a.supportsExtension(d.getFileExtension())) {
-                        try {
-                            a.analyze(d, this);
-                        } catch (AnalysisException ex) {
-                            d.addAnalysisException(ex);
-                        }
-                    }
-                }
-            }
-        }
+				final String msg = String.format("Begin Analyzer '%s'", a.getName());
+				Logger.getLogger(Engine.class.getName()).log(Level.FINE, msg);
+				final Set<Dependency> dependencySet = new HashSet<Dependency>();
+				dependencySet.addAll(dependencies);
+				for (Dependency d : dependencySet) {
+					final String msgFile = String.format("Begin Analysis of '%s'", d.getActualFilePath());
+					Logger.getLogger(Engine.class.getName()).log(Level.FINE, msgFile);
+					if (a.supportsExtension(d.getFileExtension())) {
+						try {
+							a.analyze(d, this);
+							for (Iterator<Dependency> iterator = dependencySet.iterator(); iterator.hasNext(); ) {
+								Dependency next = iterator.next();
+								for (java.util.Iterator<Vulnerability> dependencyIterator = next.getVulnerabilities().iterator(); dependencyIterator.hasNext(); ) {
+									Vulnerability vulnerability = dependencyIterator.next();
+									if (whiteListedDependencies.contains(vulnerability.getName())) {
+										Logger.getLogger(Engine.class.getName()).log(Level.INFO, "Ignoring whitelisted vulnerability " + vulnerability.getName());
+										dependencyIterator.remove();
+									}
+								}
+							}
+						} catch (AnalysisException ex) {
+							d.addAnalysisException(ex);
+						}
+					}
+				}
+			}
+		}
+		//close/cleanup
+		for (AnalysisPhase phase : AnalysisPhase.values()) {
+			final List<Analyzer> analyzerList = analyzers.get(phase);
+			for (Analyzer a : analyzerList) {
+				final String msg = String.format("Closing Analyzer '%s'", a.getName());
+				Logger.getLogger(Engine.class.getName()).log(Level.FINE, msg);
+				try {
+					a.close();
+				} catch (Exception ex) {
+					Logger.getLogger(Engine.class.getName()).log(Level.FINEST, null, ex);
+				}
+			}
+		}
+	}
 
-        //close/cleanup
-        for (AnalysisPhase phase : AnalysisPhase.values()) {
-            final List<Analyzer> analyzerList = analyzers.get(phase);
-            for (Analyzer a : analyzerList) {
-                final String msg = String.format("Closing Analyzer '%s'", a.getName());
-                Logger.getLogger(Engine.class.getName()).log(Level.FINE, msg);
-                try {
-                    a.close();
-                } catch (Exception ex) {
-                    Logger.getLogger(Engine.class.getName()).log(Level.FINEST, null, ex);
-                }
-            }
-        }
-    }
+	/**
+	 * Cycles through the cached web data sources and calls update on all of
+	 * them.
+	 */
+	private void doUpdates() {
+		final UpdateService service = UpdateService.getInstance();
+		final Iterator<CachedWebDataSource> iterator = service.getDataSources();
+		while (iterator.hasNext()) {
+			final CachedWebDataSource source = iterator.next();
+			try {
+				source.update();
+			} catch (UpdateException ex) {
+				Logger.getLogger(Engine.class.getName()).log(Level.WARNING,
+						"Unable to update Cached Web DataSource, using local data instead. Results may not include recent vulnerabilities.");
+				Logger.getLogger(Engine.class.getName()).log(Level.FINE,
+						String.format("Unable to update details for %s", source.getClass().getName()), ex);
+			}
+		}
+	}
 
-    /**
-     * Cycles through the cached web data sources and calls update on all of
-     * them.
-     */
-    private void doUpdates() {
-        final UpdateService service = UpdateService.getInstance();
-        final Iterator<CachedWebDataSource> iterator = service.getDataSources();
-        while (iterator.hasNext()) {
-            final CachedWebDataSource source = iterator.next();
-            try {
-                source.update();
-            } catch (UpdateException ex) {
-                Logger.getLogger(Engine.class.getName()).log(Level.WARNING,
-                        "Unable to update Cached Web DataSource, using local data instead. Results may not include recent vulnerabilities.");
-                Logger.getLogger(Engine.class.getName()).log(Level.FINE,
-                        String.format("Unable to update details for %s", source.getClass().getName()), ex);
-            }
-        }
-    }
+	/**
+	 * Returns a full list of all of the analyzers. This is useful for reporting
+	 * which analyzers where used.
+	 *
+	 * @return a list of Analyzers
+	 */
+	public List<Analyzer> getAnalyzers() {
+		final List<Analyzer> ret = new ArrayList<Analyzer>();
+		for (AnalysisPhase phase : AnalysisPhase.values()) {
+			final List<Analyzer> analyzerList = analyzers.get(phase);
+			ret.addAll(analyzerList);
+		}
+		return ret;
+	}
 
-    /**
-     * Returns a full list of all of the analyzers. This is useful for reporting
-     * which analyzers where used.
-     *
-     * @return a list of Analyzers
-     */
-    public List<Analyzer> getAnalyzers() {
-        final List<Analyzer> ret = new ArrayList<Analyzer>();
-        for (AnalysisPhase phase : AnalysisPhase.values()) {
-            final List<Analyzer> analyzerList = analyzers.get(phase);
-            ret.addAll(analyzerList);
-        }
-        return ret;
-    }
+	/**
+	 * Checks all analyzers to see if an extension is supported.
+	 *
+	 * @param ext a file extension
+	 * @return true or false depending on whether or not the file extension is
+	 *         supported
+	 */
+	public boolean supportsExtension(String ext) {
+		if (ext == null) {
+			return false;
+		}
+		for (AnalysisPhase phase : AnalysisPhase.values()) {
+			final List<Analyzer> analyzerList = analyzers.get(phase);
+			for (Analyzer a : analyzerList) {
+				if (a.getSupportedExtensions() != null && a.supportsExtension(ext)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
 
-    /**
-     * Checks all analyzers to see if an extension is supported.
-     *
-     * @param ext a file extension
-     * @return true or false depending on whether or not the file extension is
-     * supported
-     */
-    public boolean supportsExtension(String ext) {
-        if (ext == null) {
-            return false;
-        }
-        for (AnalysisPhase phase : AnalysisPhase.values()) {
-            final List<Analyzer> analyzerList = analyzers.get(phase);
-            for (Analyzer a : analyzerList) {
-                if (a.getSupportedExtensions() != null && a.supportsExtension(ext)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
+	/**
+	 * Checks the CPE Index to ensure documents exists. If none exist a
+	 * NoDataException is thrown.
+	 *
+	 * @throws NoDataException thrown if no data exists in the CPE Index
+	 */
+	private void ensureDataExists() throws NoDataException {
+		CpeMemoryIndex cpe = CpeMemoryIndex.getInstance();
+		CveDB cve = new CveDB();
 
-    /**
-     * Checks the CPE Index to ensure documents exists. If none exist a
-     * NoDataException is thrown.
-     *
-     * @throws NoDataException thrown if no data exists in the CPE Index
-     */
-    private void ensureDataExists() throws NoDataException {
-        CpeMemoryIndex cpe = CpeMemoryIndex.getInstance();
-        CveDB cve = new CveDB();
-
-        try {
-            cve.open();
-            cpe.open(cve);
-        } catch (IndexException ex) {
-            throw new NoDataException(ex);
-        } catch (IOException ex) {
-            throw new NoDataException(ex);
-        } catch (SQLException ex) {
-            throw new NoDataException(ex);
-        } catch (DatabaseException ex) {
-            throw new NoDataException(ex);
-        } catch (ClassNotFoundException ex) {
-            throw new NoDataException(ex);
-        } finally {
-            cve.close();
-        }
-        if (cpe.numDocs() <= 0) {
-            cpe.close();
-            throw new NoDataException();
-        }
-    }
+		try {
+			cve.open();
+			cpe.open(cve);
+		} catch (IndexException ex) {
+			throw new NoDataException(ex);
+		} catch (IOException ex) {
+			throw new NoDataException(ex);
+		} catch (SQLException ex) {
+			throw new NoDataException(ex);
+		} catch (DatabaseException ex) {
+			throw new NoDataException(ex);
+		} catch (ClassNotFoundException ex) {
+			throw new NoDataException(ex);
+		} finally {
+			cve.close();
+		}
+		if (cpe.numDocs() <= 0) {
+			cpe.close();
+			throw new NoDataException();
+		}
+	}
 }

--- a/dependency-check-maven/src/site/markdown/configuration.md
+++ b/dependency-check-maven/src/site/markdown/configuration.md
@@ -14,3 +14,4 @@ proxyUrl            | The Proxy URL.                     |
 proxyPort           | The Proxy Port.                    |
 proxyUsername       | Defines the proxy user name.       |
 proxyPassword       | Defines the proxy password.        |
+whiteListedDependencies | Defines optional white-listed vulnerabilities which should be ignored. Configurable via the 'org.owasp.dependencycheck.whitelisted' (comma-separated string, eg. 'CVE-2008-6504,CVE-2006-0550') |


### PR DESCRIPTION
This PR adds a  comma-separated parameter with the name org.owasp.dependencycheck.whitelisted which contains the name(s) of optional whitelisted CVE:s.

This is useful if we want to suppress warnings for certain CVE:s, for example if they have a bad version specification. ('All versions', for example)
