### PR TITLE
NexusAnalyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ nb-configuration.xml
 /target/
 #maven-shade-plugin generated pom
 dependency-reduced-pom.xml
+# vim files
+*.swp

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
@@ -1,0 +1,182 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Dependency-check-core is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Dependency-check-core is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * dependency-check-core. If not, see http://www.gnu.org/licenses/.
+ *
+ * Copyright (c) 2012 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.analyzer;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.data.nexus.MavenArtifact;
+import org.owasp.dependencycheck.data.nexus.NexusSearch;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.Evidence;
+import org.owasp.dependencycheck.utils.Settings;
+
+/**
+ * Analyzer which will attempt to locate a dependency on a Nexus service
+ * by SHA-1 digest of the dependency.
+ *
+ * There are two settings which govern this behavior:
+ *
+ * <ul>
+ *   <li>{@link org.owasp.dependencycheck.utils.Settings.KEYS#ANALYZER_NEXUS_ENABLED}
+ * determines whether this analyzer is even enabled. This can be overridden by
+ * setting the system property.</li>
+ *   <li>{@link org.owasp.dependencycheck.utils.Settings.KEYS#ANALYZER_NEXUS_URL}
+ * the URL to a Nexus service to search by SHA-1. There is an expected <code>%s</code>
+ * in this where the SHA-1 will get entered.</li>
+ * </ul>
+ *
+ * @author colezlaw
+ */
+public class NexusAnalyzer extends AbstractAnalyzer {
+    /**
+     * The logger
+     */
+    private static final Logger LOGGER = Logger.getLogger(NexusAnalyzer.class.getName());
+
+    /**
+     * The name of the analyzer
+     */
+    private static final String ANALYZER_NAME = "Nexus Analyzer";
+
+    /**
+     * The phase in which the analyzer runs
+     */
+    private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.INFORMATION_COLLECTION;
+
+    /**
+     * The types of files on which this will work.
+     */
+    private static final Set<String> SUPPORTED_EXTENSIONS = newHashSet("jar");
+
+    /**
+     * Whether this is actually enabled. Will get set during initialization
+     */
+    private boolean enabled = false;
+
+    /**
+     * The Nexus Search to be set up for this analyzer.
+     */
+    private NexusSearch searcher;
+
+    /**
+     * Initializes the analyzer once before any analysis is performed.
+     *
+     * @throws Exception if there's an error during initialization.
+     */
+    public void initialize() throws Exception {
+        enabled = Settings.getBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED);
+
+        final String searchUrl = Settings.getString(Settings.KEYS.ANALYZER_NEXUS_URL);
+
+        if (enabled) {
+            try {
+                searcher = new NexusSearch(new URL(searchUrl));
+            } catch (MalformedURLException mue) {
+                // I know that initialize can throw an exception, but we'll
+                // just disable the analyzer if the URL isn't valid
+                LOGGER.warning(String.format("Property %s not a valid URL. Nexus searching disabled",
+                            searchUrl));
+            }
+        }
+    }
+
+    /**
+     * Returns the analyzer's name.
+     *
+     * @return the name of the analyzer
+     */
+    public String getName() {
+        return ANALYZER_NAME;
+    }
+
+    /**
+     * Returns the analysis phase under which the analyzer runs.
+     *
+     * @return the phase under which this analyzer runs
+     */
+    public AnalysisPhase getAnalysisPhase() {
+        return ANALYSIS_PHASE;
+    }
+
+    /**
+     * Returns the extensions for which this Analyzer runs.
+     *
+     * @return the extensions for which this Analyzer runs
+     */
+    public Set<String> getSupportedExtensions() {
+        return SUPPORTED_EXTENSIONS;
+    }
+
+    /**
+     * Determines whether the incoming extension is supported.
+     *
+     * @param extension the extension to check for support
+     * @return whether the extension is supported
+     */
+    public boolean supportsExtension(String extension) {
+        return SUPPORTED_EXTENSIONS.contains(extension);
+    }
+
+    /**
+     * Performs the analysis.
+     *
+     * @param dependency the dependency to analyze
+     * @param engine the engine
+     * @throws AnalysisException when there's an exception during analysis
+     */
+    public void analyze(Dependency dependency, Engine engine) throws AnalysisException {
+        // Make a quick exit if this analyzer is disabled
+        if (!enabled) {
+            return;
+        }
+
+        try {
+            final MavenArtifact ma = searcher.searchSha1(dependency.getSha1sum());
+            if (ma.getGroupId() != null && !"".equals(ma.getGroupId())) {
+                dependency.getVendorEvidence().addEvidence("nexus", "groupid", ma.getGroupId(),
+                        Evidence.Confidence.HIGH);
+            }
+            if (ma.getArtifactId() != null && !"".equals(ma.getArtifactId())) {
+                dependency.getProductEvidence().addEvidence("nexus", "artifactid", ma.getArtifactId(),
+                        Evidence.Confidence.HIGH);
+            }
+            if (ma.getVersion() != null && !"".equals(ma.getVersion())) {
+                dependency.getVersionEvidence().addEvidence("nexus", "version", ma.getVersion(),
+                        Evidence.Confidence.HIGH);
+            }
+            if (ma.getArtifactUrl() != null && !"".equals(ma.getArtifactUrl())) {
+                dependency.addIdentifier("maven", ma.toString(), ma.getArtifactUrl());
+            }
+        } catch (IllegalArgumentException iae) {
+            dependency.addAnalysisException(new AnalysisException("Invalid SHA-1"));
+        } catch (FileNotFoundException fnfe) {
+            dependency.addAnalysisException(new AnalysisException("Artifact not found on repository"));
+        } catch (IOException ioe) {
+            dependency.addAnalysisException(new AnalysisException("Could not connect to repository", ioe));
+        }
+    }
+}
+
+// vim: cc=120:sw=4:ts=4:sts=4

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nexus/MavenArtifact.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nexus/MavenArtifact.java
@@ -1,0 +1,154 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Dependency-check-core is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Dependency-check-core is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * dependency-check-core. If not, see http://www.gnu.org/licenses/.
+ *
+ * Copyright (c) 2012 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.nexus;
+
+/**
+ * Simple bean representing a Maven Artifact.
+ *
+ * @author colezlaw
+ */
+public class MavenArtifact {
+    /**
+     * The groupId
+     */
+    private String groupId;
+
+    /**
+     * The artifactId
+     */
+    private String artifactId;
+
+    /**
+     * The version
+     */
+    private String version;
+
+    /**
+     * The artifact url. This may change depending on which Nexus
+     * server the search took place.
+     */
+    private String artifactUrl;
+
+
+    /**
+     * Creates an empty MavenArtifact.
+     */
+    public MavenArtifact() {
+    }
+
+    /**
+     * Creates a MavenArtifact with the given attributes.
+     *
+     * @param groupId the groupId
+     * @param artifactId the artifactId
+     * @param version the version
+     */
+    public MavenArtifact(String groupId, String artifactId, String version) {
+        setGroupId(groupId);
+        setArtifactId(artifactId);
+        setVersion(version);
+    }
+
+    /**
+     * Creates a MavenArtifact with the given attributes.
+     *
+     * @param groupId the groupId
+     * @param artifactId the artifactId
+     * @param version the version
+     * @param url the artifactLink url
+     */
+    public MavenArtifact(String groupId, String artifactId, String version, String url) {
+        setGroupId(groupId);
+        setArtifactId(artifactId);
+        setVersion(version);
+        setArtifactUrl(url);
+    }
+
+    /**
+     * Returns the Artifact coordinates as a String.
+     *
+     * @return the String representation of the artifact coordinates
+     */
+    @Override
+    public String toString() {
+        return String.format("%s:%s:%s", groupId, artifactId, version);
+    }
+
+    /**
+     * Sets the groupId.
+     *
+     * @param groupId the groupId
+     */
+    public void setGroupId(String groupId) { this.groupId = groupId; }
+
+    /**
+     * Gets the groupId.
+     *
+     * @return the groupId
+     */
+    public String getGroupId() { return groupId; }
+
+    /**
+     * Sets the artifactId.
+     *
+     * @param artifactId the artifactId
+     */
+    public void setArtifactId(String artifactId) { this.artifactId = artifactId; }
+
+    /**
+     * Gets the artifactId.
+     *
+     * @return the artifactId
+     */
+    public String getArtifactId() { return artifactId; }
+
+    /**
+     * Sets the version.
+     *
+     * @param version the version
+     */
+    public void setVersion(String version) { this.version = version; }
+
+    /**
+     * Gets the version.
+     *
+     * @return the version
+     */
+    public String getVersion() { return version; }
+
+    /**
+     * Sets the artifactUrl.
+     *
+     * @param artifactUrl the artifactUrl
+     */
+    public void setArtifactUrl(String artifactUrl) {
+        this.artifactUrl = artifactUrl;
+    }
+
+    /**
+     * Gets the artifactUrl.
+     *
+     * @return the artifactUrl
+     */
+    public String getArtifactUrl() {
+        return artifactUrl;
+    }
+}
+
+// vim: cc=120:sw=4:ts=4:sts=4

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusSearch.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusSearch.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Dependency-check-core is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Dependency-check-core is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * dependency-check-core. If not, see http://www.gnu.org/licenses/.
+ *
+ * Copyright (c) 2012 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.nexus;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.logging.Logger;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+import org.w3c.dom.Document;
+
+/**
+ * Class of methods to search Nexus repositories.
+ *
+ * @author colezlaw
+ */
+public class NexusSearch {
+    /**
+     * The root URL for the Nexus repository service
+     */
+    private final URL rootURL;
+
+    /**
+     * Used for logging.
+     */
+    private static final Logger LOGGER = Logger.getLogger(NexusSearch.class.getName());
+
+    /**
+     * Creates a NexusSearch for the given repository URL.
+     *
+     * @param rootURL the root URL of the repository on which searches should execute.
+     *        full URL's are calculated relative to this URL, so it should end with a /
+     */
+    public NexusSearch(URL rootURL) {
+        this.rootURL = rootURL;
+    }
+
+    /**
+     * Searches the configured Nexus repository for the given sha1
+     * hash. If the artifact is found, a <code>MavenArtifact</code> is populated
+     * with the coordinate information.
+     *
+     * @param sha1 The SHA-1 hash string for which to search
+     * @return the populated Maven coordinates
+     * @throws IOException if it's unable to connect to the specified repositor or
+     *         if the specified artifact is not found.
+     */
+    public MavenArtifact searchSha1(String sha1) throws IOException {
+        if (null == sha1 || !sha1.matches("^[0-9A-Fa-f]{40}$")) {
+            throw new IllegalArgumentException("Invalid SHA1 format");
+        }
+
+        final URL url = new URL(rootURL, String.format("identify/sha1/%s", sha1.toLowerCase()));
+
+        LOGGER.fine(String.format("Searching Nexus url %s", url.toString()));
+
+        final URLConnection conn = url.openConnection();
+        conn.setDoOutput(true);
+
+        // JSON would be more elegant, but there's not currently a dependency
+        // on JSON, so don't want to add one just for this
+        conn.addRequestProperty("Accept", "application/xml");
+        conn.connect();
+
+        try {
+            final DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            final Document doc = builder.parse(conn.getInputStream());
+            final XPath xpath = XPathFactory.newInstance().newXPath();
+            final String groupId = xpath.evaluate("/org.sonatype.nexus.rest.model.NexusArtifact/groupId", doc);
+            final String artifactId = xpath.evaluate("/org.sonatype.nexus.rest.model.NexusArtifact/artifactId", doc);
+            final String version = xpath.evaluate("/org.sonatype.nexus.rest.model.NexusArtifact/version", doc);
+            final String link = xpath.evaluate("/org.sonatype.nexus.rest.model.NexusArtifact/artifactLink", doc);
+            return new MavenArtifact(groupId, artifactId, version, link);
+        } catch (FileNotFoundException fnfe) {
+            // This is what we get when the SHA1 they sent doesn't exist in Nexus. This
+            // is useful upstream for recovery, so we just re-throw it
+            throw fnfe;
+        } catch (Exception e) {
+            // Anything else is jacked-up XML stuff that we really can't recover from well
+            throw new IOException(e.getMessage(), e);
+        }
+    }
+}
+
+// vim: cc=120:sw=4:ts=4:sts=4

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nexus/package-info.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nexus/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * <html>
+ * <head>
+ * <title>org.owasp.dependencycheck.data.nexus</title>
+ * </head>
+ * <body>
+ * <p>Contains classes related to searching a Nexus repository.</p>
+ * <p>These are used to abstract Nexus searching away from
+ * OWASP Dependency Check so they can be reused elsewhere.</p>
+ * </body>
+ * </html>
+ */

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -147,6 +147,14 @@ public final class Settings {
          * The key for a list of suppression files.
          */
         public static final String SUPPRESSION_FILE = "suppression.file";
+        /**
+         * The properties key for whether the Nexus analyzer is enabled.
+         */
+        public static final String ANALYZER_NEXUS_ENABLED = "analyzer.nexus.enabled";
+        /**
+         * The properties key for the Nexus search URL.
+         */
+        public static final String ANALYZER_NEXUS_URL = "analyzer.nexus.url";
     }
     /**
      * The properties file location.

--- a/dependency-check-core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
+++ b/dependency-check-core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
@@ -8,3 +8,4 @@ org.owasp.dependencycheck.analyzer.CpeSuppressionAnalyzer
 org.owasp.dependencycheck.analyzer.DependencyBundlingAnalyzer
 org.owasp.dependencycheck.analyzer.NvdCveAnalyzer
 org.owasp.dependencycheck.analyzer.VulnerabilitySuppressionAnalyzer
+org.owasp.dependencycheck.analyzer.NexusAnalyzer

--- a/dependency-check-core/src/main/resources/dependencycheck.properties
+++ b/dependency-check-core/src/main/resources/dependencycheck.properties
@@ -46,3 +46,8 @@ cve.url-2.0.modified=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-modifie
 cve.startyear=2002
 cve.url-2.0.base=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml
 cve.url-1.2.base=http://nvd.nist.gov/download/nvdcve-%d.xml
+
+# the URL for searching Nexus for SHA-1 hashes and whether it's enabled
+analyzer.nexus.enabled=true
+analyzer.nexus.url=http://repository.sonatype.org/service/local/
+

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/nexus/NexusSearchTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/nexus/NexusSearchTest.java
@@ -1,0 +1,56 @@
+package org.owasp.dependencycheck.data.nexus;
+
+import java.io.FileNotFoundException;
+import java.net.URL;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import org.owasp.dependencycheck.utils.Settings;
+
+public class NexusSearchTest {
+    private static final Logger LOGGER = Logger.getLogger(NexusSearchTest.class.getName());
+    private NexusSearch searcher;
+
+    @Before
+    public void setUp() throws Exception {
+        String nexusUrl = Settings.getString(Settings.KEYS.ANALYZER_NEXUS_URL);
+        LOGGER.fine(nexusUrl);
+        searcher = new NexusSearch(new URL(nexusUrl));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullSha1() throws Exception {
+        searcher.searchSha1(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMalformedSha1() throws Exception {
+        searcher.searchSha1("invalid");
+    }
+
+    // This test does generate network traffic and communicates with a host
+    // you may not be able to reach. Remove the @Ignore annotation if you want to
+    // test it anyway
+    @Ignore @Test
+    public void testValidSha1() throws Exception {
+        MavenArtifact ma = searcher.searchSha1("9977a8d04e75609cf01badc4eb6a9c7198c4c5ea");
+        assertEquals("Incorrect group", "org.apache.maven.plugins", ma.getGroupId());
+        assertEquals("Incorrect artifact", "maven-compiler-plugin", ma.getArtifactId());
+        assertEquals("Incorrect version", "3.1", ma.getVersion());
+        assertNotNull("URL Should not be null", ma.getArtifactUrl());
+    }
+
+    // This test does generate network traffic and communicates with a host
+    // you may not be able to reach. Remove the @Ignore annotation if you want to
+    // test it anyway
+    @Ignore @Test(expected = FileNotFoundException.class)
+    public void testMissingSha1() throws Exception {
+        searcher.searchSha1("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    }
+}
+
+// vim: cc=120:sw=4:ts=4:sts=4

--- a/dependency-check-core/src/test/resources/dependencycheck.properties
+++ b/dependency-check-core/src/test/resources/dependencycheck.properties
@@ -46,3 +46,7 @@ cve.url-2.0.modified=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-modifie
 cve.startyear=2013
 cve.url-2.0.base=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml
 cve.url-1.2.base=http://nvd.nist.gov/download/nvdcve-%d.xml
+
+# the URL for searching Nexus for SHA-1 hashes and whether it's enabled
+analyzer.nexus.enabled=false
+analyzer.nexus.url=http://repository.sonatype.org/service/local/


### PR DESCRIPTION
This adds a new Analyzer which will search Maven Central for the SHA-1 of the dependency. If it is found, the groupId, artifactId, and version are added as Vendor, Product, and Version evidence, respectively. Furthermore, it adds a new Identifier with the Maven coordinates for the jar identified.

You can disable this analyzer by setting `analyzer.nexus.enabled` to `false`. It is set to `false` in `src/main/resources` in order to keep the results of existing tests consistent. The Nexus repository can be changed using the property `analyzer.nexus.url`. By default, it's set to Maven central, but can be changed, for example, if you have an internal Nexus repository which mirrors central.
