### PR TITLE
Change confidence on filename version when it's just a simple integer

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzer.java
@@ -108,8 +108,16 @@ public class FileNameAnalyzer extends AbstractAnalyzer implements Analyzer {
         //add version evidence
         final DependencyVersion version = DependencyVersionUtil.parseVersion(fileName);
         if (version != null) {
-            dependency.getVersionEvidence().addEvidence("file", "name",
-                    version.toString(), Confidence.HIGHEST);
+            // If the version number is just a number like 2 or 23, reduce the confidence
+            // a shade. This should hopefully correct for cases like log4j.jar or
+            // struts2-core.jar
+            if (version.getVersionParts() == null || version.getVersionParts().size() < 2) {
+                dependency.getVersionEvidence().addEvidence("file", "name",
+                        version.toString(), Confidence.MEDIUM);
+            } else {
+                dependency.getVersionEvidence().addEvidence("file", "name",
+                        version.toString(), Confidence.HIGHEST);
+            }
             dependency.getVersionEvidence().addEvidence("file", "name",
                     fileName, Confidence.MEDIUM);
         }


### PR DESCRIPTION
The `FileNameAnalyzer` sets its confidence to `HIGHEST` for the version number, but there are times when this has negative consequences. If a filename includes the product name, but no version information, but the product name itself has digits, those digits become the version number. For instance, a jar called `struts2-core.jar` will have a matched CPE of `cpe:/a:apache:struts:2.0.0` even if there are other analyzers which can also determine a version number. `log4j.jar` also produces problematic results.

This patch reduces the confidence to `MEDIUM` on filename version numbers matched where the version number matched is just a single integer. I had originally considered changing the `DependencyVersionUtil` to either have multiple methods for when it needs to drop down to the `RX_SINGLE_VERSION`, but decided against it as this would un-necessarily couple the `DependencyVersionUtil` to the concept of confidence.
