### PR TITLE
Runtime and Provided dependencies should be excluded from analysis - Add Zippable Extension configurable

### DIFF
--- a/dependency-check-ant/src/main/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTask.java
+++ b/dependency-check-ant/src/main/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTask.java
@@ -20,6 +20,8 @@ package org.owasp.dependencycheck.taskdefs;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -32,6 +34,8 @@ import org.apache.tools.ant.types.ResourceCollection;
 import org.apache.tools.ant.types.resources.FileProvider;
 import org.apache.tools.ant.types.resources.Resources;
 import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.Analyzer;
+import org.owasp.dependencycheck.analyzer.ArchiveAnalyzer;
 import org.owasp.dependencycheck.data.nvdcve.CveDB;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseProperties;
@@ -616,6 +620,30 @@ public class DependencyCheckTask extends Task {
         this.databasePassword = databasePassword;
     }
 
+    /**
+     * File extensions to add to analysis next to jar, zip, ....
+     */
+    private String extraExtensions;
+
+    /**
+     * Get the value of extraExtensions.
+     *
+     * @return the value of extraExtensions
+     */
+    public String getExtraExtensions() {
+        return extraExtensions;
+    }
+
+    /**
+     * Set the value of extraExtensions.
+     *
+     * @param extraExtensions new value of extraExtensions
+     */
+    public void setExtraExtensions(String extraExtensions) {
+        this.extraExtensions = extraExtensions;
+    }
+
+
     @Override
     public void execute() throws BuildException {
         final InputStream in = DependencyCheckTask.class.getClassLoader().getResourceAsStream(LOG_PROPERTIES_FILE);
@@ -626,6 +654,12 @@ public class DependencyCheckTask extends Task {
         populateSettings();
 
         final Engine engine = new Engine();
+
+        if (extraExtensions != null && ! extraExtensions.isEmpty())
+            for (Analyzer analyzer : engine.getAnalyzers())
+                if (analyzer instanceof ArchiveAnalyzer)
+                    ((ArchiveAnalyzer)analyzer).addSupportedExtensions(new HashSet<String>(Arrays.asList(extraExtensions.split("\\s*,\\s*"))));
+
         for (Resource resource : path) {
             final FileProvider provider = resource.as(FileProvider.class);
             if (provider != null) {

--- a/dependency-check-ant/src/site/markdown/configuration.md
+++ b/dependency-check-ant/src/site/markdown/configuration.md
@@ -42,5 +42,6 @@ databaseDriverPath    | The path to the database driver JAR file; only used if t
 connectionString      | The connection string used to connect to the database. | Optional
 databaseUser          | The username used when connecting to the database. | Optional
 databasePassword      | The password used when connecting to the database. | Optional
+extraExtensions       | List of extra extensions to be scanned, comma separated. | Optional
 
 

--- a/dependency-check-cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/dependency-check-cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -21,10 +21,14 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.cli.ParseException;
+import org.owasp.dependencycheck.analyzer.Analyzer;
+import org.owasp.dependencycheck.analyzer.ArchiveAnalyzer;
 import org.owasp.dependencycheck.cli.CliParser;
 import org.owasp.dependencycheck.data.nvdcve.CveDB;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
@@ -83,7 +87,7 @@ public class App {
             cli.printVersionInfo();
         } else if (cli.isRunScan()) {
             updateSettings(cli);
-            runScan(cli.getReportDirectory(), cli.getReportFormat(), cli.getApplicationName(), cli.getScanFiles());
+            runScan(cli.getReportDirectory(), cli.getReportFormat(), cli.getApplicationName(), cli.getScanFiles(), cli.getExtraExtensions());
         } else {
             cli.printHelp();
         }
@@ -97,8 +101,13 @@ public class App {
      * @param applicationName the application name for the report
      * @param files the files/directories to scan
      */
-    private void runScan(String reportDirectory, String outputFormat, String applicationName, String[] files) {
+    private void runScan(String reportDirectory, String outputFormat, String applicationName, String[] files, String extraExtensions) {
         final Engine scanner = new Engine();
+
+        if (extraExtensions != null && ! extraExtensions.isEmpty())
+            for (Analyzer analyzer : scanner.getAnalyzers())
+                if (analyzer instanceof ArchiveAnalyzer)
+                    ((ArchiveAnalyzer)analyzer).addSupportedExtensions(new HashSet<String>(Arrays.asList(extraExtensions.split("\\s*,\\s*"))));
 
         for (String file : files) {
             scanner.scan(file);
@@ -155,6 +164,7 @@ public class App {
         final String connectionString = cli.getConnectionString();
         final String databaseUser = cli.getDatabaseUser();
         final String databasePassword = cli.getDatabasePassword();
+        final String extraExtensions = cli.getExtraExtensions();
 
         if (propertiesFile != null) {
             try {
@@ -219,6 +229,9 @@ public class App {
         }
         if (databasePassword != null && !databasePassword.isEmpty()) {
             Settings.setString(Settings.KEYS.DB_PASSWORD, databasePassword);
+        }
+        if (extraExtensions!= null && !extraExtensions.isEmpty()) {
+            Settings.setString(Settings.KEYS.EXTRA_EXTENSIONS, extraExtensions);
         }
     }
 }

--- a/dependency-check-cli/src/main/java/org/owasp/dependencycheck/cli/CliParser.java
+++ b/dependency-check-cli/src/main/java/org/owasp/dependencycheck/cli/CliParser.java
@@ -204,6 +204,10 @@ public final class CliParser {
                 .withDescription("The url to the Nexus Server.")
                 .create();
 
+        final Option extraExtensions = OptionBuilder.withArgName("extraExtensions").hasArg().withLongOpt(ArgumentName.EXTRA_EXTENSIONS)
+                .withDescription("List of extra extensions to be scanned")
+                .create();
+
         //This is an option group because it can be specified more then once.
         final OptionGroup og = new OptionGroup();
         og.addOption(path);
@@ -220,7 +224,8 @@ public final class CliParser {
                 .addOption(verboseLog)
                 .addOption(suppressionFile)
                 .addOption(disableNexusAnalyzer)
-                .addOption(nexusUrl);
+                .addOption(nexusUrl)
+                .addOption(extraExtensions);
     }
 
     /**
@@ -549,6 +554,15 @@ public final class CliParser {
     }
 
     /**
+     * Returns the extra Extensions if specified; otherwise null is returned.
+     *
+     * @return the extra Extensions; otherwise null is returned
+     */
+    public String getExtraExtensions() {
+        return line.getOptionValue(ArgumentName.EXTRA_EXTENSIONS);
+    }
+
+    /**
      * A collection of static final strings that represent the possible command line arguments.
      */
     public static class ArgumentName {
@@ -701,5 +715,9 @@ public final class CliParser {
          * The CLI argument name for setting the path to the database driver; in case it is not on the class path.
          */
         public static final String DB_DRIVER_PATH = "dbDriverPath";
+        /**
+         * The CLI argument name for setting extra extensions.
+         */
+        public static final String EXTRA_EXTENSIONS = "extraExtension";
     }
 }

--- a/dependency-check-cli/src/site/markdown/arguments.md
+++ b/dependency-check-cli/src/site/markdown/arguments.md
@@ -28,3 +28,4 @@ Short  | Argument Name         | Parameter   | Description | Requirement
        | \-\-dbUser            | \<user\>    | The username used to connect to the database. | Optional
        | \-\-disableNexus      |             | Disable the Nexus Analyzer. | Optional
        | \-\-nexus             | \<url\>     | The url to the Nexus Server. | Optional
+       | \-\-extraExtensions   | \<strings\> | List of extensions to be scanned, comma separated. | Optional

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
@@ -96,6 +96,14 @@ public class ArchiveAnalyzer extends AbstractAnalyzer implements Analyzer {
     }
 
     /**
+     * Add a list of file EXTENSIONS to be supported by this analyzer.
+     *
+     */
+    public void addSupportedExtensions(Set<String> extraExtensions) {
+        EXTENSIONS.addAll(extraExtensions);
+    }
+
+    /**
      * Returns a list of file EXTENSIONS supported by this analyzer.
      *
      * @return a list of file EXTENSIONS supported by this analyzer.

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -149,6 +149,10 @@ public final class Settings {
          * The path to mono, if available.
          */
         public static final String ANALYZER_ASSEMBLY_MONO_PATH = "analyzer.assembly.mono.path";
+        /**
+         * The extra extensions, if available.
+         */
+        public static final String EXTRA_EXTENSIONS = "extra.extensions";
     }
     /**
      * The properties file location.

--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/DependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/DependencyCheckMojo.java
@@ -23,10 +23,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.text.DateFormat;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.maven.artifact.Artifact;
@@ -45,6 +42,8 @@ import org.apache.maven.reporting.MavenMultiPageReport;
 import org.apache.maven.reporting.MavenReport;
 import org.apache.maven.reporting.MavenReportException;
 import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.Analyzer;
+import org.owasp.dependencycheck.analyzer.ArchiveAnalyzer;
 import org.owasp.dependencycheck.data.nvdcve.CveDB;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseProperties;
@@ -229,7 +228,11 @@ public class DependencyCheckMojo extends AbstractMojo implements MavenMultiPageR
     @Parameter(property = "databasePassword", defaultValue = "", required = false)
     private String databasePassword;
     // </editor-fold>
-
+    /**
+     * File extensions to add to analysis next to jar, zip, ....
+     */
+    @Parameter(property = "extraExtensions", required = false)
+    private String[] extraExtensions;
     /**
      * Executes the Dependency-Check on the dependent libraries.
      *
@@ -242,6 +245,13 @@ public class DependencyCheckMojo extends AbstractMojo implements MavenMultiPageR
 
         populateSettings();
         final Engine engine = new Engine();
+
+        if (extraExtensions != null) {
+            for (Analyzer analyzer : engine.getAnalyzers())
+              if (analyzer instanceof ArchiveAnalyzer)
+                  ((ArchiveAnalyzer)analyzer).addSupportedExtensions(new HashSet<String>(Arrays.asList(extraExtensions)));
+        }
+
         final Set<Artifact> artifacts = project.getArtifacts();
         for (Artifact a : artifacts) {
             if (!Artifact.SCOPE_TEST.equals(a.getScope()) && !Artifact.SCOPE_PROVIDED.equals(a.getScope()) && !Artifact.SCOPE_RUNTIME.equals(a.getScope())) {

--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/DependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/DependencyCheckMojo.java
@@ -248,7 +248,7 @@ public class DependencyCheckMojo extends AbstractMojo implements MavenMultiPageR
         final Engine engine = new Engine();
         final Set<Artifact> artifacts = project.getArtifacts();
         for (Artifact a : artifacts) {
-            if (!TEST_SCOPE.equals(a.getScope())) {
+            if (!Artifact.SCOPE_TEST.equals(a.getScope()) && !Artifact.SCOPE_PROVIDED.equals(a.getScope()) && !Artifact.SCOPE_RUNTIME.equals(a.getScope())) {
                 engine.scan(a.getFile().getAbsolutePath());
             }
         }

--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/DependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/DependencyCheckMojo.java
@@ -77,10 +77,6 @@ public class DependencyCheckMojo extends AbstractMojo implements MavenMultiPageR
      */
     private static final String LOG_PROPERTIES_FILE = "log.properties";
     /**
-     * The name of the test scope.
-     */
-    public static final String TEST_SCOPE = "test";
-    /**
      * System specific new line character.
      */
     private static final String NEW_LINE = System.getProperty("line.separator", "\n").intern();

--- a/dependency-check-maven/src/site/markdown/configuration.md
+++ b/dependency-check-maven/src/site/markdown/configuration.md
@@ -22,3 +22,4 @@ databaseDriverPath    | The path to the database driver JAR file; only used if t
 connectionString      | The connection string used to connect to the database. |
 databaseUser          | The username used when connecting to the database. |
 databasePassword      | The password used when connecting to the database. |
+extraExtensions      | List of extra extensions to be scanned. |


### PR DESCRIPTION
No need to scan Runtime and Provided dependencies, as they won't be bundled 
