### PR TITLE
Fixed two discrepancies in the CLI options

### DIFF
--- a/dependency-check-cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/dependency-check-cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -160,7 +160,6 @@ public class App {
         final String suppressionFile = cli.getSuppressionFile();
         final boolean nexusDisabled = cli.isNexusDisabled();
         final String nexusUrl = cli.getNexusUrl();
-        final boolean nexusUsesProxy = cli.isNexusUsesProxy();
         final String databaseDriverName = cli.getDatabaseDriverName();
         final String databaseDriverPath = cli.getDatabaseDriverPath();
         final String connectionString = cli.getConnectionString();
@@ -182,6 +181,10 @@ public class App {
                 Logger.getLogger(App.class.getName()).log(Level.FINE, null, ex);
             }
         }
+        // We have to wait until we've merged the properties before attempting to set whether we use
+        // the proxy for Nexus since it could be disabled in the properties, but not explicitly stated
+        // on the command line
+        final boolean nexusUsesProxy = cli.isNexusUsesProxy();
         if (dataDirectory != null) {
             Settings.setString(Settings.KEYS.DATA_DIRECTORY, dataDirectory);
         } else if (System.getProperty("basedir") != null) {

--- a/dependency-check-cli/src/main/java/org/owasp/dependencycheck/cli/CliParser.java
+++ b/dependency-check-cli/src/main/java/org/owasp/dependencycheck/cli/CliParser.java
@@ -19,6 +19,7 @@ package org.owasp.dependencycheck.cli;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -29,6 +30,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 import org.owasp.dependencycheck.reporting.ReportGenerator.Format;
+import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
 
 /**
@@ -366,8 +368,14 @@ public final class CliParser {
      * @return true if the Nexus Analyzer should use the configured proxy to connect to Nexus; otherwise false
      */
     public boolean isNexusUsesProxy() {
+        // If they didn't specify whether Nexus needs to use the proxy, we should
+        // still honor the property if it's set.
         if (line == null || !line.hasOption(ArgumentName.NEXUS_USES_PROXY)) {
-            return true;
+            try {
+                return Settings.getBoolean(Settings.KEYS.ANALYZER_NEXUS_PROXY);
+            } catch (InvalidSettingException ise) {
+                return true;
+            }
         } else {
             return Boolean.parseBoolean(line.getOptionValue(ArgumentName.NEXUS_USES_PROXY));
         }
@@ -704,7 +712,7 @@ public final class CliParser {
         /**
          * The short CLI argument name for setting the location of an additional properties file.
          */
-        public static final String PROP_SHORT = "p";
+        public static final String PROP_SHORT = "P";
         /**
          * The CLI argument name for setting the location of an additional properties file.
          */


### PR DESCRIPTION
1) Proxy port and Properties files were both using -p. Now the
properties file uses -P.
2) Nexus Proxy was defaulting to true, even if the properties said
false, so moved the check for its setting to happen after the properties
were merged and had it default to checking the properties file and
setting it to true if the properties didn't say.
