### PR TITLE
fixes https://github.com/jeremylong/DependencyCheck/issues/84

### DIFF
--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -276,6 +276,11 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <version>3.0</version>
         </dependency>
         <dependency>
+        	<groupId>org.apache.maven</groupId>
+        	<artifactId>maven-settings</artifactId>
+        	<version>3.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>3.0</version>


### PR DESCRIPTION
Fix for the issue.
Not tested as it's not easily buildable:
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project dependency-check-core: Could not resolve dependencies for project org.owasp:dependency-check-core:jar:1.1.3-SNAPSHOT: The following artifacts could not be resolved: org.apache.lucene:lucene-test-framework:jar:4.3.1, org.glassfish.main.admingui:war:war:4.0, org.dojotoolkit:dojo-war:war:1.3.0: Failure to find org.apache.lucene:lucene-test-framework:jar:4.3.1 in http://nexus.evry.com/nexus/content/groups/public/ was cached in the local repository, resolution will not be reattempted until the update interval of nexus has elapsed or updates are forced -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :dependency-check-core
et2448@ubuntu:~/projects/ext/github.com/DependencyCheck$ 
