### PR TITLE
Switched default Nexus to SSL to fix 301 issues

### DIFF
--- a/dependency-check-core/src/main/resources/dependencycheck.properties
+++ b/dependency-check-core/src/main/resources/dependencycheck.properties
@@ -50,7 +50,7 @@ analyzer.assembly.enabled=true
 
 # the URL for searching Nexus for SHA-1 hashes and whether it's enabled
 analyzer.nexus.enabled=true
-analyzer.nexus.url=http://repository.sonatype.org/service/local/
+analyzer.nexus.url=https://repository.sonatype.org/service/local/
 # If set to true, the proxy will still ONLY be used if the proxy properties (proxy.url, proxy.port)
 # are configured
 analyzer.nexus.proxy=true

--- a/dependency-check-core/src/test/resources/dependencycheck.properties
+++ b/dependency-check-core/src/test/resources/dependencycheck.properties
@@ -49,7 +49,7 @@ cve.url-1.2.base=http://nvd.nist.gov/download/nvdcve-%d.xml
 
 # the URL for searching Nexus for SHA-1 hashes and whether it's enabled
 analyzer.nexus.enabled=true
-analyzer.nexus.url=http://repository.sonatype.org/service/local/
+analyzer.nexus.url=https://repository.sonatype.org/service/local/
 # If set to true, the proxy will still ONLY be used if the proxy properties (proxy.url, proxy.port)
 # are configured
 analyzer.nexus.proxy=true


### PR DESCRIPTION
The default Sonatype URL now returns a 301 for http requests. This was causing the Nexus analyzer to fail during initialization.
