### PR TITLE
Try to fix accidental disabling of analyzers during large multi-module maven projects

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractFileTypeAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractFileTypeAnalyzer.java
@@ -159,8 +159,6 @@ public abstract class AbstractFileTypeAnalyzer extends AbstractAnalyzer implemen
     public final void initialize() throws Exception {
         if (filesMatched) {
             initializeFileTypeAnalyzer();
-        } else {
-            enabled = false;
         }
     }
 


### PR DESCRIPTION
Hi Jeremy,

after some debugging I found out why for some multi-module maven projects the list of dependencies scanned is zero. It appears that if after at least one module didn't result in any files to analyze for a given analyzer, it is completely disabled (without being re-enabled), so that subsequent modules during the same build will have no files (via supportsExtension) checked.

Please check if the change is the correct way to solve the problem that multi-module maven builds are sometimes resulting in zero dependencies being identified. 

Thanks & best regards,
Christian
@cschneider4711
