### PR TITLE
Added PMD rule to find Loggers that weren't fields and corrected existin...

### DIFF
--- a/dependency-check-core/dc-rules/dcrules.xml
+++ b/dependency-check-core/dc-rules/dcrules.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ruleset name="DependencyCheck Rules"
+  xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
+    http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+  
+  <rule name="LoggerChaining"
+    message="Logger should be a field, don't chain it"
+    class="net.sourceforge.pmd.lang.rule.XPathRule"
+    language="java">
+    <description><![CDATA[
+Loggers should be created as fields within the class for general
+use, rather than chaining the call to getLogger() followed by
+the work on the Logger.
+    ]]></description>
+    <properties>
+      <property name="xpath">
+        <value><![CDATA[
+//PrimaryPrefix[Name/@Image = 'Logger.getLogger' and count(following-sibling::PrimarySuffix) > 2]
+        ]]></value>
+      </property>
+    </properties>
+    <example><![CDATA[
+Logger.getLogger(Foo.class).log(Level.FINEST, "Don't do this");
+    ]]></example>
+  </rule>
+</ruleset>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -357,7 +357,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-pmd-plugin</artifactId>
-                            <version>3.0.1</version>
+                            <version>3.1</version>
                             <configuration>
                                 <targetJdk>1.6</targetJdk>
                                 <linkXref>true</linkXref>
@@ -365,6 +365,12 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                                 <excludes>
                                     <exclude>**/generated/*.java</exclude>
                                 </excludes>
+                                <rulesets>
+                                  <ruleset>dc-rules/dcrules.xml</ruleset>
+                                  <ruleset>/rulesets/java/basic.xml</ruleset>
+                                  <ruleset>/rulesets/java/imports.xml</ruleset>
+                                  <ruleset>/rulesets/java/unusedcode.xml</ruleset>
+                                </rulesets>
                             </configuration>
                         </plugin>
                         <plugin>

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -66,7 +66,10 @@ public class Engine {
      * A Map of analyzers grouped by Analysis phase.
      */
     private final Set<FileTypeAnalyzer> fileTypeAnalyzers;
-
+    /**
+     * The Logger for use throughout the class.
+     */
+    private static final Logger LOGGER = Logger.getLogger(Engine.class.getName());
     /**
      * Creates a new Engine.
      *
@@ -83,7 +86,7 @@ public class Engine {
         try {
             autoUpdate = Settings.getBoolean(Settings.KEYS.AUTO_UPDATE);
         } catch (InvalidSettingException ex) {
-            Logger.getLogger(Engine.class.getName()).log(Level.FINE, "Invalid setting for auto-update; using true.");
+            LOGGER.log(Level.FINE, "Invalid setting for auto-update; using true.");
         }
         if (autoUpdate) {
             doUpdates();
@@ -175,7 +178,7 @@ public class Engine {
                 scan(files);
             } else {
                 final String msg = String.format("Invalid file path provided to scan '%s'", path);
-                Logger.getLogger(Engine.class.getName()).log(Level.SEVERE, msg);
+                LOGGER.log(Level.SEVERE, msg);
             }
         } else {
             final File file = new File(path);
@@ -269,7 +272,7 @@ public class Engine {
     protected void scanFile(File file) {
         if (!file.isFile()) {
             final String msg = String.format("Path passed to scanFile(File) is not a file: %s. Skipping the file.", file.toString());
-            Logger.getLogger(Engine.class.getName()).log(Level.FINE, msg);
+            LOGGER.log(Level.FINE, msg);
             return;
         }
         final String fileName = file.getName();
@@ -282,7 +285,7 @@ public class Engine {
         } else {
             final String msg = String.format("No file extension found on file '%s'. The file was not analyzed.",
                     file.toString());
-            Logger.getLogger(Engine.class.getName()).log(Level.FINEST, msg);
+            LOGGER.log(Level.FINEST, msg);
         }
     }
 
@@ -295,13 +298,13 @@ public class Engine {
             ensureDataExists();
         } catch (NoDataException ex) {
             final String msg = String.format("%s%n%nUnable to continue dependency-check analysis.", ex.getMessage());
-            Logger.getLogger(Engine.class.getName()).log(Level.SEVERE, msg);
-            Logger.getLogger(Engine.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.SEVERE, msg);
+            LOGGER.log(Level.FINE, null, ex);
             return;
         } catch (DatabaseException ex) {
             final String msg = String.format("%s%n%nUnable to continue dependency-check analysis.", ex.getMessage());
-            Logger.getLogger(Engine.class.getName()).log(Level.SEVERE, msg);
-            Logger.getLogger(Engine.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.SEVERE, msg);
+            LOGGER.log(Level.FINE, null, ex);
             return;
 
         }
@@ -310,8 +313,8 @@ public class Engine {
                 + "----------------------------------------------------%n"
                 + "BEGIN ANALYSIS%n"
                 + "----------------------------------------------------");
-        Logger.getLogger(Engine.class.getName()).log(Level.FINE, logHeader);
-        Logger.getLogger(Engine.class.getName()).log(Level.INFO, "Analysis Starting");
+        LOGGER.log(Level.FINE, logHeader);
+        LOGGER.log(Level.INFO, "Analysis Starting");
 
         // analysis phases
         for (AnalysisPhase phase : AnalysisPhase.values()) {
@@ -325,7 +328,7 @@ public class Engine {
                  * This is okay for adds/deletes because it happens per analyzer.
                  */
                 final String msg = String.format("Begin Analyzer '%s'", a.getName());
-                Logger.getLogger(Engine.class.getName()).log(Level.FINE, msg);
+                LOGGER.log(Level.FINE, msg);
                 final Set<Dependency> dependencySet = new HashSet<Dependency>();
                 dependencySet.addAll(dependencies);
                 for (Dependency d : dependencySet) {
@@ -336,18 +339,18 @@ public class Engine {
                     }
                     if (shouldAnalyze) {
                         final String msgFile = String.format("Begin Analysis of '%s'", d.getActualFilePath());
-                        Logger.getLogger(Engine.class.getName()).log(Level.FINE, msgFile);
+                        LOGGER.log(Level.FINE, msgFile);
                         try {
                             a.analyze(d, this);
                         } catch (AnalysisException ex) {
                             final String exMsg = String.format("An error occured while analyzing '%s'.", d.getActualFilePath());
-                            Logger.getLogger(Engine.class.getName()).log(Level.WARNING, exMsg);
-                            Logger.getLogger(Engine.class.getName()).log(Level.FINE, "", ex);
+                            LOGGER.log(Level.WARNING, exMsg);
+                            LOGGER.log(Level.FINE, "", ex);
                         } catch (Throwable ex) {
                             final String axMsg = String.format("An unexpected error occurred during analysis of '%s'", d.getActualFilePath());
                             //final AnalysisException ax = new AnalysisException(axMsg, ex);
-                            Logger.getLogger(Engine.class.getName()).log(Level.WARNING, axMsg);
-                            Logger.getLogger(Engine.class.getName()).log(Level.FINE, "", ex);
+                            LOGGER.log(Level.WARNING, axMsg);
+                            LOGGER.log(Level.FINE, "", ex);
                         }
                     }
                 }
@@ -365,8 +368,8 @@ public class Engine {
                 + "----------------------------------------------------%n"
                 + "END ANALYSIS%n"
                 + "----------------------------------------------------");
-        Logger.getLogger(Engine.class.getName()).log(Level.FINE, logFooter);
-        Logger.getLogger(Engine.class.getName()).log(Level.INFO, "Analysis Complete");
+        LOGGER.log(Level.FINE, logFooter);
+        LOGGER.log(Level.INFO, "Analysis Complete");
     }
 
     /**
@@ -377,16 +380,16 @@ public class Engine {
     private void initializeAnalyzer(Analyzer analyzer) {
         try {
             final String msg = String.format("Initializing %s", analyzer.getName());
-            Logger.getLogger(Engine.class.getName()).log(Level.FINE, msg);
+            LOGGER.log(Level.FINE, msg);
             analyzer.initialize();
         } catch (Throwable ex) {
             final String msg = String.format("Exception occurred initializing %s.", analyzer.getName());
-            Logger.getLogger(Engine.class.getName()).log(Level.SEVERE, msg);
-            Logger.getLogger(Engine.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.SEVERE, msg);
+            LOGGER.log(Level.FINE, null, ex);
             try {
                 analyzer.close();
             } catch (Throwable ex1) {
-                Logger.getLogger(Engine.class.getName()).log(Level.FINEST, null, ex1);
+                LOGGER.log(Level.FINEST, null, ex1);
             }
         }
     }
@@ -398,11 +401,11 @@ public class Engine {
      */
     private void closeAnalyzer(Analyzer analyzer) {
         final String msg = String.format("Closing Analyzer '%s'", analyzer.getName());
-        Logger.getLogger(Engine.class.getName()).log(Level.FINE, msg);
+        LOGGER.log(Level.FINE, msg);
         try {
             analyzer.close();
         } catch (Throwable ex) {
-            Logger.getLogger(Engine.class.getName()).log(Level.FINEST, null, ex);
+            LOGGER.log(Level.FINEST, null, ex);
         }
     }
 
@@ -417,9 +420,9 @@ public class Engine {
             try {
                 source.update();
             } catch (UpdateException ex) {
-                Logger.getLogger(Engine.class.getName()).log(Level.WARNING,
+                LOGGER.log(Level.WARNING,
                         "Unable to update Cached Web DataSource, using local data instead. Results may not include recent vulnerabilities.");
-                Logger.getLogger(Engine.class.getName()).log(Level.FINE,
+                LOGGER.log(Level.FINE,
                         String.format("Unable to update details for %s", source.getClass().getName()), ex);
             }
         }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgent.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgent.java
@@ -64,7 +64,10 @@ public class DependencyCheckScanAgent {
      * System specific new line character.
      */
     private static final String NEW_LINE = System.getProperty("line.separator", "\n").intern();
-
+    /**
+     * Logger for use throughout the class.
+     */
+    private static final Logger LOGGER = Logger.getLogger(DependencyCheckScanAgent.class.getName());
     /**
      * The application name for the report.
      */
@@ -767,7 +770,7 @@ public class DependencyCheckScanAgent {
             cve.open();
             prop = cve.getDatabaseProperties();
         } catch (DatabaseException ex) {
-            Logger.getLogger(DependencyCheckScanAgent.class.getName()).log(Level.FINE, "Unable to retrieve DB Properties", ex);
+            LOGGER.log(Level.FINE, "Unable to retrieve DB Properties", ex);
         } finally {
             if (cve != null) {
                 cve.close();
@@ -777,13 +780,13 @@ public class DependencyCheckScanAgent {
         try {
             r.generateReports(outDirectory.getCanonicalPath(), this.reportFormat.name());
         } catch (IOException ex) {
-            Logger.getLogger(DependencyCheckScanAgent.class.getName()).log(Level.SEVERE,
+            LOGGER.log(Level.SEVERE,
                     "Unexpected exception occurred during analysis; please see the verbose error log for more details.");
-            Logger.getLogger(DependencyCheckScanAgent.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.FINE, null, ex);
         } catch (Throwable ex) {
-            Logger.getLogger(DependencyCheckScanAgent.class.getName()).log(Level.SEVERE,
+            LOGGER.log(Level.SEVERE,
                     "Unexpected exception occurred during analysis; please see the verbose error log for more details.");
-            Logger.getLogger(DependencyCheckScanAgent.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.FINE, null, ex);
         }
     }
 
@@ -881,9 +884,9 @@ public class DependencyCheckScanAgent {
                 checkForFailure(engine.getDependencies());
             }
         } catch (DatabaseException ex) {
-            Logger.getLogger(DependencyCheckScanAgent.class.getName()).log(Level.SEVERE,
+            LOGGER.log(Level.SEVERE,
                     "Unable to connect to the dependency-check database; analysis has stopped");
-            Logger.getLogger(DependencyCheckScanAgent.class.getName()).log(Level.FINE, "", ex);
+            LOGGER.log(Level.FINE, "", ex);
         } finally {
             Settings.cleanup();
             if (engine != null) {
@@ -961,7 +964,7 @@ public class DependencyCheckScanAgent {
             final String msg = String.format("%n%n"
                     + "One or more dependencies were identified with known vulnerabilities:%n%n%s"
                     + "%n%nSee the dependency-check report for more details.%n%n", summary.toString());
-            Logger.getLogger(DependencyCheckScanAgent.class.getName()).log(Level.WARNING, msg);
+            LOGGER.log(Level.WARNING, msg);
         }
     }
 

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractFileTypeAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractFileTypeAnalyzer.java
@@ -194,7 +194,7 @@ public abstract class AbstractFileTypeAnalyzer extends AbstractAnalyzer implemen
         if (ext == null) {
             final String msg = String.format("The '%s' analyzer is misconfigured and does not have any file extensions;"
                     + " it will be disabled", getName());
-            Logger.getLogger(AbstractFileTypeAnalyzer.class.getName()).log(Level.SEVERE, msg);
+            LOGGER.log(Level.SEVERE, msg);
             return false;
         } else {
             final boolean match = ext.contains(extension);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
@@ -40,7 +40,12 @@ import org.owasp.dependencycheck.utils.Settings;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
-
+    
+    /**
+     * The Logger for use throughout the class
+     */
+    private static final Logger LOGGER = Logger.getLogger(AbstractSuppressionAnalyzer.class.getName());
+    
     //<editor-fold defaultstate="collapsed" desc="All standard implementation details of Analyzer">
     /**
      * Returns a list of file EXTENSIONS supported by this analyzer.
@@ -117,29 +122,29 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
                 final SuppressionParser parser = new SuppressionParser();
                 try {
                     rules = parser.parseSuppressionRules(file);
-                    Logger.getLogger(AbstractSuppressionAnalyzer.class.getName()).log(Level.FINE, rules.size() + " suppression rules were loaded.");
+                    LOGGER.log(Level.FINE, rules.size() + " suppression rules were loaded.");
                 } catch (SuppressionParseException ex) {
                     final String msg = String.format("Unable to parse suppression xml file '%s'", file.getPath());
-                    Logger.getLogger(AbstractSuppressionAnalyzer.class.getName()).log(Level.WARNING, msg);
-                    Logger.getLogger(AbstractSuppressionAnalyzer.class.getName()).log(Level.WARNING, ex.getMessage());
-                    Logger.getLogger(AbstractSuppressionAnalyzer.class.getName()).log(Level.FINE, "", ex);
+                    LOGGER.log(Level.WARNING, msg);
+                    LOGGER.log(Level.WARNING, ex.getMessage());
+                    LOGGER.log(Level.FINE, "", ex);
                     throw ex;
                 }
             }
         } catch (DownloadFailedException ex) {
-            Logger.getLogger(AbstractSuppressionAnalyzer.class.getName()).log(Level.WARNING,
+            LOGGER.log(Level.WARNING,
                     "Unable to fetch the configured suppression file");
-            Logger.getLogger(AbstractSuppressionAnalyzer.class.getName()).log(Level.FINE, "", ex);
+            LOGGER.log(Level.FINE, "", ex);
             throw new SuppressionParseException("Unable to fetch the configured suppression file", ex);
         } catch (MalformedURLException ex) {
-            Logger.getLogger(AbstractSuppressionAnalyzer.class.getName()).log(Level.WARNING,
+            LOGGER.log(Level.WARNING,
                     "Configured suppression file has an invalid URL");
-            Logger.getLogger(AbstractSuppressionAnalyzer.class.getName()).log(Level.FINE, "", ex);
+            LOGGER.log(Level.FINE, "", ex);
             throw new SuppressionParseException("Configured suppression file has an invalid URL", ex);
         } catch (IOException ex) {
-            Logger.getLogger(AbstractSuppressionAnalyzer.class.getName()).log(Level.WARNING,
+            LOGGER.log(Level.WARNING,
                     "Unable to create temp file for suppressions");
-            Logger.getLogger(AbstractSuppressionAnalyzer.class.getName()).log(Level.FINE, "", ex);
+            LOGGER.log(Level.FINE, "", ex);
             throw new SuppressionParseException("Unable to create temp file for suppressions", ex);
         } finally {
             if (deleteTempFile && file != null) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
@@ -351,13 +351,11 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
                             }
                             bos.flush();
                         } catch (FileNotFoundException ex) {
-                            Logger.getLogger(ArchiveAnalyzer.class
-                                    .getName()).log(Level.FINE, null, ex);
+                            LOGGER.log(Level.FINE, null, ex);
                             final String msg = String.format("Unable to find file '%s'.", file.getName());
                             throw new AnalysisException(msg, ex);
                         } catch (IOException ex) {
-                            Logger.getLogger(ArchiveAnalyzer.class
-                                    .getName()).log(Level.FINE, null, ex);
+                            LOGGER.log(Level.FINE, null, ex);
                             final String msg = String.format("IO Exception while parsing file '%s'.", file.getName());
                             throw new AnalysisException(msg, ex);
                         } finally {
@@ -365,8 +363,7 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
                                 try {
                                     bos.close();
                                 } catch (IOException ex) {
-                                    Logger.getLogger(ArchiveAnalyzer.class
-                                            .getName()).log(Level.FINEST, null, ex);
+                                    LOGGER.log(Level.FINEST, null, ex);
                                 }
                             }
                         }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
@@ -73,7 +73,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * Logger
      */
-    private static final Logger LOG = Logger.getLogger(AssemblyAnalyzer.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(AssemblyAnalyzer.class.getName());
 
     /**
      * Builds the beginnings of a List for ProcessBuilder
@@ -106,7 +106,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
     public void analyzeFileType(Dependency dependency, Engine engine)
             throws AnalysisException {
         if (grokAssemblyExe == null) {
-            LOG.warning("GrokAssembly didn't get deployed");
+            LOGGER.warning("GrokAssembly didn't get deployed");
             return;
         }
 
@@ -120,7 +120,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
             rdr = new BufferedReader(new InputStreamReader(proc.getErrorStream(), "UTF-8"));
             String line = null;
             while (rdr.ready() && (line = rdr.readLine()) != null) {
-                LOG.log(Level.WARNING, "Error from GrokAssembly: {0}", line);
+                LOGGER.log(Level.WARNING, "Error from GrokAssembly: {0}", line);
             }
             int rc = 0;
             final Document doc = builder.parse(proc.getInputStream());
@@ -156,10 +156,10 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
                 return;
             }
             if (rc == 3) {
-                LOG.log(Level.INFO, "{0} is not a valid assembly", dependency.getActualFilePath());
+                LOGGER.log(Level.INFO, "{0} is not a valid assembly", dependency.getActualFilePath());
                 return;
             } else if (rc != 0) {
-                LOG.log(Level.WARNING, "Return code {0} from GrokAssembly", rc);
+                LOGGER.log(Level.WARNING, "Return code {0} from GrokAssembly", rc);
             }
 
         } catch (IOException ioe) {
@@ -174,7 +174,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
                 try {
                     rdr.close();
                 } catch (IOException ex) {
-                    Logger.getLogger(AssemblyAnalyzer.class.getName()).log(Level.FINEST, "ignore", ex);
+                    LOGGER.log(Level.FINEST, "ignore", ex);
                 }
             }
         }
@@ -201,23 +201,23 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
             grokAssemblyExe = tempFile;
             // Set the temp file to get deleted when we're done
             grokAssemblyExe.deleteOnExit();
-            LOG.log(Level.FINE, "Extracted GrokAssembly.exe to {0}", grokAssemblyExe.getPath());
+            LOGGER.log(Level.FINE, "Extracted GrokAssembly.exe to {0}", grokAssemblyExe.getPath());
         } catch (IOException ioe) {
-            LOG.log(Level.WARNING, "Could not extract GrokAssembly.exe: {0}", ioe.getMessage());
+            LOGGER.log(Level.WARNING, "Could not extract GrokAssembly.exe: {0}", ioe.getMessage());
             throw new AnalysisException("Could not extract GrokAssembly.exe", ioe);
         } finally {
             if (fos != null) {
                 try {
                     fos.close();
                 } catch (Throwable e) {
-                    LOG.fine("Error closing output stream");
+                    LOGGER.fine("Error closing output stream");
                 }
             }
             if (is != null) {
                 try {
                     is.close();
                 } catch (Throwable e) {
-                    LOG.fine("Error closing input stream");
+                    LOGGER.fine("Error closing input stream");
                 }
             }
         }
@@ -238,22 +238,22 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
             final XPath xpath = XPathFactory.newInstance().newXPath();
             final String error = xpath.evaluate("/assembly/error", doc);
             if (p.waitFor() != 1 || error == null || "".equals(error)) {
-                LOG.warning("An error occured with the .NET AssemblyAnalyzer, please see the log for more details.");
-                LOG.fine("GrokAssembly.exe is not working properly");
+                LOGGER.warning("An error occured with the .NET AssemblyAnalyzer, please see the log for more details.");
+                LOGGER.fine("GrokAssembly.exe is not working properly");
                 grokAssemblyExe = null;
                 throw new AnalysisException("Could not execute .NET AssemblyAnalyzer");
             }
         } catch (Throwable e) {
-            LOG.warning("An error occured with the .NET AssemblyAnalyzer; "
+            LOGGER.warning("An error occured with the .NET AssemblyAnalyzer; "
                     + "this can be ignored unless you are scanning .NET dlls. Please see the log for more details.");
-            LOG.log(Level.FINE, "Could not execute GrokAssembly {0}", e.getMessage());
+            LOGGER.log(Level.FINE, "Could not execute GrokAssembly {0}", e.getMessage());
             throw new AnalysisException("An error occured with the .NET AssemblyAnalyzer", e);
         } finally {
             if (rdr != null) {
                 try {
                     rdr.close();
                 } catch (IOException ex) {
-                    Logger.getLogger(AssemblyAnalyzer.class.getName()).log(Level.FINEST, "ignore", ex);
+                    LOGGER.log(Level.FINEST, "ignore", ex);
                 }
             }
         }
@@ -269,7 +269,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
                 grokAssemblyExe.deleteOnExit();
             }
         } catch (SecurityException se) {
-            LOG.fine("Can't delete temporary GrokAssembly.exe");
+            LOGGER.fine("Can't delete temporary GrokAssembly.exe");
         }
     }
 

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -57,7 +57,10 @@ import org.owasp.dependencycheck.utils.DependencyVersionUtil;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class CPEAnalyzer implements Analyzer {
-
+    /**
+     * The Logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(CPEAnalyzer.class.getName());
     /**
      * The maximum number of query results to return.
      */
@@ -125,15 +128,15 @@ public class CPEAnalyzer implements Analyzer {
      * by another process.
      */
     public void open() throws IOException, DatabaseException {
-        Logger.getLogger(CPEAnalyzer.class.getName()).log(Level.FINE, "Opening the CVE Database");
+        LOGGER.log(Level.FINE, "Opening the CVE Database");
         cve = new CveDB();
         cve.open();
-        Logger.getLogger(CPEAnalyzer.class.getName()).log(Level.FINE, "Creating the Lucene CPE Index");
+        LOGGER.log(Level.FINE, "Creating the Lucene CPE Index");
         cpe = CpeMemoryIndex.getInstance();
         try {
             cpe.open(cve);
         } catch (IndexException ex) {
-            Logger.getLogger(CPEAnalyzer.class.getName()).log(Level.FINE, "IndexException", ex);
+            LOGGER.log(Level.FINE, "IndexException", ex);
             throw new DatabaseException(ex);
         }
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzer.java
@@ -45,7 +45,11 @@ import org.owasp.dependencycheck.utils.LogUtils;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class DependencyBundlingAnalyzer extends AbstractAnalyzer implements Analyzer {
-
+    /**
+     * The Logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(DependencyBundlingAnalyzer.class.getName());
+    
     //<editor-fold defaultstate="collapsed" desc="Constants and Member Variables">
     /**
      * A pattern for obtaining the first part of a filename.
@@ -270,7 +274,7 @@ public class DependencyBundlingAnalyzer extends AbstractAnalyzer implements Anal
         }
         if (LogUtils.isVerboseLoggingEnabled()) {
             final String msg = String.format("IdentifiersMatch=%s (%s, %s)", matches, dependency1.getFileName(), dependency2.getFileName());
-            Logger.getLogger(DependencyBundlingAnalyzer.class.getName()).log(Level.FINE, msg);
+            LOGGER.log(Level.FINE, msg);
         }
         return matches;
     }
@@ -347,7 +351,7 @@ public class DependencyBundlingAnalyzer extends AbstractAnalyzer implements Anal
         }
         if (LogUtils.isVerboseLoggingEnabled()) {
             final String msg = String.format("IsCore=%s (%s, %s)", returnVal, left.getFileName(), right.getFileName());
-            Logger.getLogger(DependencyBundlingAnalyzer.class.getName()).log(Level.FINE, msg);
+            LOGGER.log(Level.FINE, msg);
         }
         return returnVal;
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
@@ -41,7 +41,11 @@ import org.owasp.dependencycheck.dependency.VulnerableSoftware;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class FalsePositiveAnalyzer extends AbstractAnalyzer {
-
+    
+    /**
+     * The Logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(FalsePositiveAnalyzer.class.getName());
     //<editor-fold defaultstate="collapsed" desc="All standard implmentation details of Analyzer">
     /**
      * The name of the analyzer.
@@ -132,8 +136,7 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
                         final String nextVersion = nextCpe.getVersion();
                         if (currentVersion == null && nextVersion == null) {
                             //how did we get here?
-                            Logger.getLogger(FalsePositiveAnalyzer.class
-                                    .getName()).log(Level.FINE, "currentVersion and nextVersion are both null?");
+                            LOGGER.log(Level.FINE, "currentVersion and nextVersion are both null?");
                         } else if (currentVersion == null && nextVersion != null) {
                             dependency.getIdentifiers().remove(currentId);
                         } else if (nextVersion == null && currentVersion != null) {
@@ -217,7 +220,7 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
         try {
             cpe.parseName(value);
         } catch (UnsupportedEncodingException ex) {
-            Logger.getLogger(FalsePositiveAnalyzer.class.getName()).log(Level.FINEST, null, ex);
+            LOGGER.log(Level.FINEST, null, ex);
             return null;
         }
         return cpe;
@@ -337,8 +340,7 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
                             newCpe4,
                             String.format("http://web.nvd.nist.gov/view/vuln/search?cpe=%s", URLEncoder.encode(newCpe4, "UTF-8")));
                 } catch (UnsupportedEncodingException ex) {
-                    Logger.getLogger(FalsePositiveAnalyzer.class
-                            .getName()).log(Level.FINE, null, ex);
+                    LOGGER.log(Level.FINE, null, ex);
                 }
             }
         }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -496,11 +496,8 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
                 model = readPom(source);
             } catch (SecurityException ex) {
                 final String msg = String.format("Unable to parse pom '%s' in jar '%s'; invalid signature", path, jar.getName());
-                Logger
-                        .getLogger(JarAnalyzer.class
-                                .getName()).log(Level.WARNING, msg);
-                Logger.getLogger(JarAnalyzer.class
-                        .getName()).log(Level.FINE, null, ex);
+                LOGGER.log(Level.WARNING, msg);
+                LOGGER.log(Level.FINE, null, ex);
                 throw new AnalysisException(ex);
             } catch (IOException ex) {
                 final String msg = String.format("Unable to parse pom '%s' in jar '%s' (IO Exception)", path, jar.getName());
@@ -693,8 +690,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
                         && !dependency.getFileName().toLowerCase().endsWith("-javadoc.jar")
                         && !dependency.getFileName().toLowerCase().endsWith("-src.jar")
                         && !dependency.getFileName().toLowerCase().endsWith("-doc.jar")) {
-                    Logger.getLogger(JarAnalyzer.class
-                            .getName()).log(Level.INFO,
+                    LOGGER.log(Level.INFO,
                                     String.format("Jar file '%s' does not contain a manifest.",
                                             dependency.getFileName()));
                 }
@@ -1050,11 +1046,8 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
             }
         } catch (IOException ex) {
             final String msg = String.format("Unable to open jar file '%s'.", dependency.getFileName());
-            Logger
-                    .getLogger(JarAnalyzer.class
-                            .getName()).log(Level.WARNING, msg);
-            Logger.getLogger(JarAnalyzer.class
-                    .getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.WARNING, msg);
+            LOGGER.log(Level.FINE, null, ex);
         } finally {
             if (jar != null) {
                 try {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/cpe/CpeMemoryIndex.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/cpe/CpeMemoryIndex.java
@@ -54,7 +54,10 @@ import org.owasp.dependencycheck.utils.Pair;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public final class CpeMemoryIndex {
-
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(CpeMemoryIndex.class.getName());
     /**
      * singleton instance.
      */
@@ -197,7 +200,7 @@ public final class CpeMemoryIndex {
             try {
                 indexReader.close();
             } catch (IOException ex) {
-                Logger.getLogger(CpeMemoryIndex.class.getName()).log(Level.FINEST, null, ex);
+                LOGGER.log(Level.FINEST, null, ex);
             }
             indexReader = null;
         }
@@ -229,7 +232,7 @@ public final class CpeMemoryIndex {
                     saveEntry(pair.getLeft(), pair.getRight(), indexWriter);
                 }
             } catch (DatabaseException ex) {
-                Logger.getLogger(CpeMemoryIndex.class.getName()).log(Level.FINE, null, ex);
+                LOGGER.log(Level.FINE, null, ex);
                 throw new IndexException("Error reading CPE data", ex);
             }
         } catch (CorruptIndexException ex) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/cwe/CweDB.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/cwe/CweDB.java
@@ -29,7 +29,10 @@ import java.util.logging.Logger;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public final class CweDB {
-
+    /**
+     * The Logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(CweDB.class.getName());
     /**
      * Empty private constructor as this is a utility class.
      */
@@ -54,17 +57,17 @@ public final class CweDB {
             oin = new ObjectInputStream(input);
             return (HashMap<String, String>) oin.readObject();
         } catch (ClassNotFoundException ex) {
-            Logger.getLogger(CweDB.class.getName()).log(Level.WARNING, "Unable to load CWE data. This should not be an issue.");
-            Logger.getLogger(CweDB.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.WARNING, "Unable to load CWE data. This should not be an issue.");
+            LOGGER.log(Level.FINE, null, ex);
         } catch (IOException ex) {
-            Logger.getLogger(CweDB.class.getName()).log(Level.WARNING, "Unable to load CWE data due to an IO Error. This should not be an issue.");
-            Logger.getLogger(CweDB.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.WARNING, "Unable to load CWE data due to an IO Error. This should not be an issue.");
+            LOGGER.log(Level.FINE, null, ex);
         } finally {
             if (oin != null) {
                 try {
                     oin.close();
                 } catch (IOException ex) {
-                    Logger.getLogger(CweDB.class.getName()).log(Level.FINEST, null, ex);
+                    LOGGER.log(Level.FINEST, null, ex);
                 }
             }
         }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/UrlTokenizingFilter.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/UrlTokenizingFilter.java
@@ -36,7 +36,10 @@ import org.owasp.dependencycheck.utils.UrlStringUtils;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public final class UrlTokenizingFilter extends AbstractTokenizingFilter {
-
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(UrlTokenizingFilter.class.getName());
     /**
      * Constructs a new VersionTokenizingFilter.
      *
@@ -67,7 +70,7 @@ public final class UrlTokenizingFilter extends AbstractTokenizingFilter {
                             final List<String> data = UrlStringUtils.extractImportantUrlData(part);
                             tokens.addAll(data);
                         } catch (MalformedURLException ex) {
-                            Logger.getLogger(UrlTokenizingFilter.class.getName()).log(Level.FINE, "error parsing " + part, ex);
+                            LOGGER.log(Level.FINE, "error parsing " + part, ex);
                             tokens.add(part);
                         }
                     } else {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -46,7 +46,10 @@ import org.owasp.dependencycheck.utils.Pair;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class CveDB {
-
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(CveDB.class.getName());
     /**
      * Database connection
      */
@@ -95,12 +98,12 @@ public class CveDB {
                 conn.close();
             } catch (SQLException ex) {
                 final String msg = "There was an error attempting to close the CveDB, see the log for more details.";
-                Logger.getLogger(DBUtils.class.getName()).log(Level.SEVERE, msg);
-                Logger.getLogger(DBUtils.class.getName()).log(Level.FINE, null, ex);
+                LOGGER.log(Level.SEVERE, msg);
+                LOGGER.log(Level.FINE, null, ex);
             } catch (Throwable ex) {
                 final String msg = "There was an exception attempting to close the CveDB, see the log for more details.";
-                Logger.getLogger(DBUtils.class.getName()).log(Level.SEVERE, msg);
-                Logger.getLogger(DBUtils.class.getName()).log(Level.FINE, null, ex);
+                LOGGER.log(Level.SEVERE, msg);
+                LOGGER.log(Level.FINE, null, ex);
             }
             conn = null;
         }
@@ -135,7 +138,7 @@ public class CveDB {
     @Override
     @SuppressWarnings("FinalizeDeclaration")
     protected void finalize() throws Throwable {
-        Logger.getLogger(DBUtils.class.getName()).log(Level.FINE, "Entering finalize");
+        LOGGER.log(Level.FINE, "Entering finalize");
         close();
         super.finalize();
     }
@@ -284,8 +287,8 @@ public class CveDB {
             }
         } catch (SQLException ex) {
             final String msg = "An unexpected SQL Exception occurred; please see the verbose log for more details.";
-            Logger.getLogger(CveDB.class.getName()).log(Level.SEVERE, msg);
-            Logger.getLogger(CveDB.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.SEVERE, msg);
+            LOGGER.log(Level.FINE, null, ex);
         } finally {
             DBUtils.closeResultSet(rs);
             DBUtils.closeStatement(ps);
@@ -336,8 +339,8 @@ public class CveDB {
             }
         } catch (SQLException ex) {
             final String msg = "An unexpected SQL Exception occurred; please see the verbose log for more details.";
-            Logger.getLogger(CveDB.class.getName()).log(Level.SEVERE, msg);
-            Logger.getLogger(CveDB.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.SEVERE, msg);
+            LOGGER.log(Level.FINE, null, ex);
         } finally {
             DBUtils.closeStatement(ps);
             DBUtils.closeResultSet(rs);
@@ -358,8 +361,8 @@ public class CveDB {
                 updateProperty = getConnection().prepareStatement(UPDATE_PROPERTY);
                 insertProperty = getConnection().prepareStatement(INSERT_PROPERTY);
             } catch (SQLException ex) {
-                Logger.getLogger(CveDB.class.getName()).log(Level.WARNING, "Unable to save properties to the database");
-                Logger.getLogger(CveDB.class.getName()).log(Level.FINE, "Unable to save properties to the database", ex);
+                LOGGER.log(Level.WARNING, "Unable to save properties to the database");
+                LOGGER.log(Level.FINE, "Unable to save properties to the database", ex);
                 return;
             }
             for (Entry<Object, Object> entry : props.entrySet()) {
@@ -374,8 +377,8 @@ public class CveDB {
                     }
                 } catch (SQLException ex) {
                     final String msg = String.format("Unable to save property '%s' with a value of '%s' to the database", key, value);
-                    Logger.getLogger(CveDB.class.getName()).log(Level.WARNING, msg);
-                    Logger.getLogger(CveDB.class.getName()).log(Level.FINE, null, ex);
+                    LOGGER.log(Level.WARNING, msg);
+                    LOGGER.log(Level.FINE, null, ex);
                 }
             }
         } finally {
@@ -397,8 +400,8 @@ public class CveDB {
             try {
                 updateProperty = getConnection().prepareStatement(UPDATE_PROPERTY);
             } catch (SQLException ex) {
-                Logger.getLogger(CveDB.class.getName()).log(Level.WARNING, "Unable to save properties to the database");
-                Logger.getLogger(CveDB.class.getName()).log(Level.FINE, "Unable to save properties to the database", ex);
+                LOGGER.log(Level.WARNING, "Unable to save properties to the database");
+                LOGGER.log(Level.FINE, "Unable to save properties to the database", ex);
                 return;
             }
             try {
@@ -408,8 +411,8 @@ public class CveDB {
                     try {
                         insertProperty = getConnection().prepareStatement(INSERT_PROPERTY);
                     } catch (SQLException ex) {
-                        Logger.getLogger(CveDB.class.getName()).log(Level.WARNING, "Unable to save properties to the database");
-                        Logger.getLogger(CveDB.class.getName()).log(Level.FINE, "Unable to save properties to the database", ex);
+                        LOGGER.log(Level.WARNING, "Unable to save properties to the database");
+                        LOGGER.log(Level.FINE, "Unable to save properties to the database", ex);
                         return;
                     }
                     insertProperty.setString(1, key);
@@ -418,8 +421,8 @@ public class CveDB {
                 }
             } catch (SQLException ex) {
                 final String msg = String.format("Unable to save property '%s' with a value of '%s' to the database", key, value);
-                Logger.getLogger(CveDB.class.getName()).log(Level.WARNING, msg);
-                Logger.getLogger(CveDB.class.getName()).log(Level.FINE, null, ex);
+                LOGGER.log(Level.WARNING, msg);
+                LOGGER.log(Level.FINE, null, ex);
             }
         } finally {
             DBUtils.closeStatement(updateProperty);
@@ -440,7 +443,7 @@ public class CveDB {
         try {
             cpe.parseName(cpeStr);
         } catch (UnsupportedEncodingException ex) {
-            Logger.getLogger(CveDB.class.getName()).log(Level.FINEST, null, ex);
+            LOGGER.log(Level.FINEST, null, ex);
         }
         final DependencyVersion detectedVersion = parseDependencyVersion(cpe);
         final List<Vulnerability> vulnerabilities = new ArrayList<Vulnerability>();
@@ -678,7 +681,7 @@ public class CveDB {
 
         } catch (SQLException ex) {
             final String msg = String.format("Error updating '%s'", vuln.getName());
-            Logger.getLogger(CveDB.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.FINE, null, ex);
             throw new DatabaseException(msg, ex);
         } finally {
             DBUtils.closeStatement(selectVulnerabilityId);
@@ -707,8 +710,8 @@ public class CveDB {
             }
         } catch (SQLException ex) {
             final String msg = "An unexpected SQL Exception occurred; please see the verbose log for more details.";
-            Logger.getLogger(CveDB.class.getName()).log(Level.SEVERE, msg);
-            Logger.getLogger(CveDB.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.SEVERE, msg);
+            LOGGER.log(Level.FINE, null, ex);
         } finally {
             DBUtils.closeStatement(ps);
         }
@@ -763,7 +766,7 @@ public class CveDB {
             cpe.parseName(cpeStr);
         } catch (UnsupportedEncodingException ex) {
             //never going to happen.
-            Logger.getLogger(CveDB.class.getName()).log(Level.FINEST, null, ex);
+            LOGGER.log(Level.FINEST, null, ex);
         }
         return parseDependencyVersion(cpe);
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DatabaseProperties.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DatabaseProperties.java
@@ -17,7 +17,6 @@
  */
 package org.owasp.dependencycheck.data.nvdcve;
 
-import com.hazelcast.logging.Logger;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -26,6 +25,8 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.TreeMap;
 import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.owasp.dependencycheck.data.update.NvdCveInfo;
 import org.owasp.dependencycheck.data.update.exception.UpdateException;
 
@@ -35,7 +36,11 @@ import org.owasp.dependencycheck.data.update.exception.UpdateException;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class DatabaseProperties {
-
+    
+    /**
+     * The Logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(DatabaseProperties.class.getName());
     /**
      * Modified key word, used as a key to store information about the modified file (i.e. the containing the last 8
      * days of updates)..
@@ -151,7 +156,7 @@ public class DatabaseProperties {
                         final String formatted = format.format(date);
                         map.put(key, formatted);
                     } catch (Throwable ex) { //deliberatly being broad in this catch clause
-                        Logger.getLogger(DatabaseProperties.class.getName()).log(Level.FINE, "Unable to parse timestamp from DB", ex);
+                        LOGGER.log(Level.FINE, "Unable to parse timestamp from DB", ex);
                         map.put(key, entry.getValue());
                     }
                 } else {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DriverLoader.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DriverLoader.java
@@ -36,7 +36,11 @@ import java.util.logging.Logger;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public final class DriverLoader {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(DriverLoader.class.getName());
     /**
      * Private constructor for a utility class.
      */
@@ -83,7 +87,7 @@ public final class DriverLoader {
                     } catch (MalformedURLException ex) {
                         final String msg = String.format("Unable to load database driver '%s'; invalid path provided '%s'",
                                 className, f.getAbsoluteFile());
-                        Logger.getLogger(DriverLoader.class.getName()).log(Level.FINE, msg, ex);
+                        LOGGER.log(Level.FINE, msg, ex);
                         throw new DriverLoadException(msg, ex);
                     }
                 }
@@ -93,7 +97,7 @@ public final class DriverLoader {
                 } catch (MalformedURLException ex) {
                     final String msg = String.format("Unable to load database driver '%s'; invalid path provided '%s'",
                             className, file.getAbsoluteFile());
-                    Logger.getLogger(DriverLoader.class.getName()).log(Level.FINE, msg, ex);
+                    LOGGER.log(Level.FINE, msg, ex);
                     throw new DriverLoadException(msg, ex);
                 }
             }
@@ -127,19 +131,19 @@ public final class DriverLoader {
             return shim;
         } catch (ClassNotFoundException ex) {
             final String msg = String.format("Unable to load database driver '%s'", className);
-            Logger.getLogger(DriverLoader.class.getName()).log(Level.FINE, msg, ex);
+            LOGGER.log(Level.FINE, msg, ex);
             throw new DriverLoadException(msg, ex);
         } catch (InstantiationException ex) {
             final String msg = String.format("Unable to load database driver '%s'", className);
-            Logger.getLogger(DriverLoader.class.getName()).log(Level.FINE, msg, ex);
+            LOGGER.log(Level.FINE, msg, ex);
             throw new DriverLoadException(msg, ex);
         } catch (IllegalAccessException ex) {
             final String msg = String.format("Unable to load database driver '%s'", className);
-            Logger.getLogger(DriverLoader.class.getName()).log(Level.FINE, msg, ex);
+            LOGGER.log(Level.FINE, msg, ex);
             throw new DriverLoadException(msg, ex);
         } catch (SQLException ex) {
             final String msg = String.format("Unable to load database driver '%s'", className);
-            Logger.getLogger(DriverLoader.class.getName()).log(Level.FINE, msg, ex);
+            LOGGER.log(Level.FINE, msg, ex);
             throw new DriverLoadException(msg, ex);
         }
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DriverShim.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DriverShim.java
@@ -38,7 +38,11 @@ import java.util.logging.Logger;
  * @see java.sql.Driver
  */
 class DriverShim implements Driver {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(DriverShim.class.getName());
     /**
      * The database driver being wrapped.
      */
@@ -123,11 +127,11 @@ class DriverShim implements Driver {
             try {
                 return (Logger) m.invoke(m);
             } catch (IllegalAccessException ex) {
-                Logger.getLogger(DriverShim.class.getName()).log(Level.FINER, null, ex);
+                LOGGER.log(Level.FINER, null, ex);
             } catch (IllegalArgumentException ex) {
-                Logger.getLogger(DriverShim.class.getName()).log(Level.FINER, null, ex);
+                LOGGER.log(Level.FINER, null, ex);
             } catch (InvocationTargetException ex) {
-                Logger.getLogger(DriverShim.class.getName()).log(Level.FINER, null, ex);
+                LOGGER.log(Level.FINER, null, ex);
             }
         }
         throw new SQLFeatureNotSupportedException();

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
@@ -29,7 +29,11 @@ import org.owasp.dependencycheck.utils.DownloadFailedException;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class NvdCveUpdater implements CachedWebDataSource {
-
+    
+    /**
+     * The logger
+     */
+    private static final Logger LOGGER = Logger.getLogger(NvdCveUpdater.class.getName());
     /**
      * <p>
      * Downloads the latest NVD CVE XML file from the web and imports it into the current CVE Database.</p>
@@ -44,13 +48,13 @@ public class NvdCveUpdater implements CachedWebDataSource {
                 task.update();
             }
         } catch (MalformedURLException ex) {
-            Logger.getLogger(NvdCveUpdater.class.getName()).log(Level.WARNING,
+            LOGGER.log(Level.WARNING,
                     "NVD CVE properties files contain an invalid URL, unable to update the data to use the most current data.");
-            Logger.getLogger(NvdCveUpdater.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.FINE, null, ex);
         } catch (DownloadFailedException ex) {
-            Logger.getLogger(NvdCveUpdater.class.getName()).log(Level.WARNING,
+            LOGGER.log(Level.WARNING,
                     "Unable to download the NVD CVE data, unable to update the data to use the most current data.");
-            Logger.getLogger(NvdCveUpdater.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.FINE, null, ex);
         }
     }
 }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/StandardUpdate.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/StandardUpdate.java
@@ -46,7 +46,7 @@ import org.owasp.dependencycheck.utils.Settings;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class StandardUpdate {
-
+    private static final Logger LOGGER = Logger.getLogger(StandardUpdate.class.getName());
     /**
      * The max thread pool size to use when downloading files.
      */
@@ -104,7 +104,7 @@ public class StandardUpdate {
                 return;
             }
             if (maxUpdates > 3) {
-                Logger.getLogger(StandardUpdate.class.getName()).log(Level.INFO,
+                LOGGER.log(Level.INFO,
                         "NVD CVE requires several updates; this could take a couple of minutes.");
             }
             if (maxUpdates > 0) {
@@ -134,19 +134,19 @@ public class StandardUpdate {
                     downloadExecutors.shutdownNow();
                     processExecutor.shutdownNow();
 
-                    Logger.getLogger(StandardUpdate.class.getName()).log(Level.FINE, "Thread was interrupted during download", ex);
+                    LOGGER.log(Level.FINE, "Thread was interrupted during download", ex);
                     throw new UpdateException("The download was interrupted", ex);
                 } catch (ExecutionException ex) {
                     downloadExecutors.shutdownNow();
                     processExecutor.shutdownNow();
 
-                    Logger.getLogger(StandardUpdate.class.getName()).log(Level.FINE, "Thread was interrupted during download execution", ex);
+                    LOGGER.log(Level.FINE, "Thread was interrupted during download execution", ex);
                     throw new UpdateException("The execution of the download was interrupted", ex);
                 }
                 if (task == null) {
                     downloadExecutors.shutdownNow();
                     processExecutor.shutdownNow();
-                    Logger.getLogger(StandardUpdate.class.getName()).log(Level.FINE, "Thread was interrupted during download");
+                    LOGGER.log(Level.FINE, "Thread was interrupted during download");
                     throw new UpdateException("The download was interrupted; unable to complete the update");
                 } else {
                     processFutures.add(task);
@@ -161,11 +161,11 @@ public class StandardUpdate {
                     }
                 } catch (InterruptedException ex) {
                     processExecutor.shutdownNow();
-                    Logger.getLogger(StandardUpdate.class.getName()).log(Level.FINE, "Thread was interrupted during processing", ex);
+                    LOGGER.log(Level.FINE, "Thread was interrupted during processing", ex);
                     throw new UpdateException(ex);
                 } catch (ExecutionException ex) {
                     processExecutor.shutdownNow();
-                    Logger.getLogger(StandardUpdate.class.getName()).log(Level.FINE, "Execution Exception during process", ex);
+                    LOGGER.log(Level.FINE, "Execution Exception during process", ex);
                     throw new UpdateException(ex);
                 } finally {
                     processExecutor.shutdown();
@@ -197,10 +197,10 @@ public class StandardUpdate {
             updates = retrieveCurrentTimestampsFromWeb();
         } catch (InvalidDataException ex) {
             final String msg = "Unable to retrieve valid timestamp from nvd cve downloads page";
-            Logger.getLogger(StandardUpdate.class.getName()).log(Level.FINE, msg, ex);
+            LOGGER.log(Level.FINE, msg, ex);
             throw new DownloadFailedException(msg, ex);
         } catch (InvalidSettingException ex) {
-            Logger.getLogger(StandardUpdate.class.getName()).log(Level.FINE, "Invalid setting found when retrieving timestamps", ex);
+            LOGGER.log(Level.FINE, "Invalid setting found when retrieving timestamps", ex);
             throw new DownloadFailedException("Invalid settings", ex);
         }
 
@@ -233,9 +233,7 @@ public class StandardUpdate {
                             } catch (NumberFormatException ex) {
                                 final String msg = String.format("Error parsing '%s' '%s' from nvdcve.lastupdated",
                                         DatabaseProperties.LAST_UPDATED_BASE, entry.getId());
-                                Logger
-                                        .getLogger(StandardUpdate.class
-                                                .getName()).log(Level.FINE, msg, ex);
+                                LOGGER.log(Level.FINE, msg, ex);
                             }
                             if (currentTimestamp == entry.getTimestamp()) {
                                 entry.setNeedsUpdate(false);
@@ -245,8 +243,8 @@ public class StandardUpdate {
                 }
             } catch (NumberFormatException ex) {
                 final String msg = "An invalid schema version or timestamp exists in the data.properties file.";
-                Logger.getLogger(StandardUpdate.class.getName()).log(Level.WARNING, msg);
-                Logger.getLogger(StandardUpdate.class.getName()).log(Level.FINE, "", ex);
+                LOGGER.log(Level.WARNING, msg);
+                LOGGER.log(Level.FINE, "", ex);
             }
         }
         return updates;
@@ -290,7 +288,7 @@ public class StandardUpdate {
             try {
                 cveDB.close();
             } catch (Throwable ignore) {
-                Logger.getLogger(StandardUpdate.class.getName()).log(Level.FINEST, "Error closing the cveDB", ignore);
+                LOGGER.log(Level.FINEST, "Error closing the cveDB", ignore);
             }
         }
     }
@@ -309,7 +307,7 @@ public class StandardUpdate {
             cveDB.open();
         } catch (DatabaseException ex) {
             closeDataStores();
-            Logger.getLogger(StandardUpdate.class.getName()).log(Level.FINE, "Database Exception opening databases", ex);
+            LOGGER.log(Level.FINE, "Database Exception opening databases", ex);
             throw new UpdateException("Error updating the CPE/CVE data, please see the log file for more details.");
         }
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/task/CallableDownloadTask.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/task/CallableDownloadTask.java
@@ -37,7 +37,11 @@ import org.owasp.dependencycheck.utils.Settings;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class CallableDownloadTask implements Callable<Future<ProcessTask>> {
-
+    
+    /**
+     * The Logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(CallableDownloadTask.class.getName());
     /**
      * Simple constructor for the callable download task.
      *
@@ -172,27 +176,27 @@ public class CallableDownloadTask implements Callable<Future<ProcessTask>> {
             final URL url1 = new URL(nvdCveInfo.getUrl());
             final URL url2 = new URL(nvdCveInfo.getOldSchemaVersionUrl());
             String msg = String.format("Download Started for NVD CVE - %s", nvdCveInfo.getId());
-            Logger.getLogger(CallableDownloadTask.class.getName()).log(Level.INFO, msg);
+            LOGGER.log(Level.INFO, msg);
             try {
                 Downloader.fetchFile(url1, first);
                 Downloader.fetchFile(url2, second);
             } catch (DownloadFailedException ex) {
                 msg = String.format("Download Failed for NVD CVE - %s%nSome CVEs may not be reported.", nvdCveInfo.getId());
-                Logger.getLogger(CallableDownloadTask.class.getName()).log(Level.WARNING, msg);
-                Logger.getLogger(CallableDownloadTask.class.getName()).log(Level.FINE, null, ex);
+                LOGGER.log(Level.WARNING, msg);
+                LOGGER.log(Level.FINE, null, ex);
                 return null;
             }
 
             msg = String.format("Download Complete for NVD CVE - %s", nvdCveInfo.getId());
-            Logger.getLogger(CallableDownloadTask.class.getName()).log(Level.INFO, msg);
+            LOGGER.log(Level.INFO, msg);
 
             final ProcessTask task = new ProcessTask(cveDB, this, settings);
             return this.processorService.submit(task);
 
         } catch (Throwable ex) {
             final String msg = String.format("An exception occurred downloading NVD CVE - %s%nSome CVEs may not be reported.", nvdCveInfo.getId());
-            Logger.getLogger(CallableDownloadTask.class.getName()).log(Level.WARNING, msg);
-            Logger.getLogger(CallableDownloadTask.class.getName()).log(Level.FINE, "Download Task Failed", ex);
+            LOGGER.log(Level.WARNING, msg);
+            LOGGER.log(Level.FINE, "Download Task Failed", ex);
         } finally {
             Settings.cleanup();
         }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/task/ProcessTask.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/task/ProcessTask.java
@@ -46,7 +46,11 @@ import org.xml.sax.SAXException;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class ProcessTask implements Callable<ProcessTask> {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(ProcessTask.class.getName());
     /**
      * A field to store any update exceptions that occur during the "call".
      */
@@ -154,7 +158,7 @@ public class ProcessTask implements Callable<ProcessTask> {
      */
     private void processFiles() throws UpdateException {
         String msg = String.format("Processing Started for NVD CVE - %s", filePair.getNvdCveInfo().getId());
-        Logger.getLogger(StandardUpdate.class.getName()).log(Level.INFO, msg);
+        LOGGER.log(Level.INFO, msg);
         try {
             importXML(filePair.getFirst(), filePair.getSecond());
             cveDB.commit();
@@ -177,6 +181,6 @@ public class ProcessTask implements Callable<ProcessTask> {
             filePair.cleanup();
         }
         msg = String.format("Processing Complete for NVD CVE - %s", filePair.getNvdCveInfo().getId());
-        Logger.getLogger(StandardUpdate.class.getName()).log(Level.INFO, msg);
+        LOGGER.log(Level.INFO, msg);
     }
 }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/xml/NvdCve20Handler.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/xml/NvdCve20Handler.java
@@ -39,7 +39,11 @@ import org.xml.sax.helpers.DefaultHandler;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class NvdCve20Handler extends DefaultHandler {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(NvdCve20Handler.class.getName());
     /**
      * the current supported schema version.
      */
@@ -168,8 +172,8 @@ public class NvdCve20Handler extends DefaultHandler {
                 final float score = Float.parseFloat(nodeText.toString());
                 vulnerability.setCvssScore(score);
             } catch (NumberFormatException ex) {
-                Logger.getLogger(NvdCve20Handler.class.getName()).log(Level.SEVERE, "Error parsing CVSS Score.");
-                Logger.getLogger(NvdCve20Handler.class.getName()).log(Level.FINE, null, ex);
+                LOGGER.log(Level.SEVERE, "Error parsing CVSS Score.");
+                LOGGER.log(Level.FINE, null, ex);
             }
             nodeText = null;
         } else if (current.isCVSSAccessVectorNode()) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -36,7 +36,11 @@ import org.owasp.dependencycheck.utils.FileUtils;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class Dependency implements Comparable<Dependency> {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(Dependency.class.getName());
     /**
      * The actual file path of the dependency on disk.
      */
@@ -480,12 +484,12 @@ public class Dependency implements Comparable<Dependency> {
             sha1 = Checksum.getSHA1Checksum(file);
         } catch (IOException ex) {
             final String msg = String.format("Unable to read '%s' to determine hashes.", file.getName());
-            Logger.getLogger(Dependency.class.getName()).log(Level.WARNING, msg);
-            Logger.getLogger(Dependency.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.WARNING, msg);
+            LOGGER.log(Level.FINE, null, ex);
         } catch (NoSuchAlgorithmException ex) {
             final String msg = "Unable to use MD5 of SHA1 checksums.";
-            Logger.getLogger(Dependency.class.getName()).log(Level.WARNING, msg);
-            Logger.getLogger(Dependency.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.WARNING, msg);
+            LOGGER.log(Level.FINE, null, ex);
         }
         this.setMd5sum(md5);
         this.setSha1sum(sha1);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/EvidenceCollection.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/EvidenceCollection.java
@@ -37,7 +37,11 @@ import org.owasp.dependencycheck.utils.UrlStringUtils;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class EvidenceCollection implements Iterable<Evidence> {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(EvidenceCollection.class.getName());
     /**
      * Used to iterate over highest confidence evidence contained in the collection.
      */
@@ -360,7 +364,7 @@ public class EvidenceCollection implements Iterable<Evidence> {
                     final List<String> data = UrlStringUtils.extractImportantUrlData(part);
                     sb.append(' ').append(StringUtils.join(data, ' '));
                 } catch (MalformedURLException ex) {
-                    Logger.getLogger(EvidenceCollection.class.getName()).log(Level.FINE, "error parsing " + part, ex);
+                    LOGGER.log(Level.FINE, "error parsing " + part, ex);
                     sb.append(' ').append(part);
                 }
             } else {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/VulnerableSoftware.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/VulnerableSoftware.java
@@ -30,7 +30,11 @@ import org.owasp.dependencycheck.data.cpe.IndexEntry;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class VulnerableSoftware extends IndexEntry implements Serializable, Comparable<VulnerableSoftware> {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(VulnerableSoftware.class.getName());
     /**
      * The serial version UID.
      */
@@ -46,8 +50,8 @@ public class VulnerableSoftware extends IndexEntry implements Serializable, Comp
             parseName(cpe);
         } catch (UnsupportedEncodingException ex) {
             final String msg = String.format("Character encoding is unsupported for CPE '%s'.", cpe);
-            Logger.getLogger(VulnerableSoftware.class.getName()).log(Level.WARNING, msg);
-            Logger.getLogger(VulnerableSoftware.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.WARNING, msg);
+            LOGGER.log(Level.FINE, null, ex);
             setName(cpe);
         }
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/reporting/EscapeTool.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/reporting/EscapeTool.java
@@ -28,7 +28,11 @@ import org.apache.commons.lang.StringEscapeUtils;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class EscapeTool {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(EscapeTool.class.getName());
     /**
      * URL Encodes the provided text.
      *
@@ -39,8 +43,8 @@ public class EscapeTool {
         try {
             return URLEncoder.encode(text, "UTF-8");
         } catch (UnsupportedEncodingException ex) {
-            Logger.getLogger(EscapeTool.class.getName()).log(Level.WARNING, "UTF-8 is not supported?");
-            Logger.getLogger(EscapeTool.class.getName()).log(Level.INFO, null, ex);
+            LOGGER.log(Level.WARNING, "UTF-8 is not supported?");
+            LOGGER.log(Level.INFO, null, ex);
         }
         return "";
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
@@ -49,7 +49,11 @@ import org.owasp.dependencycheck.utils.Settings;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class ReportGenerator {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(ReportGenerator.class.getName());
     /**
      * An enumeration of the report formats.
      */
@@ -208,8 +212,8 @@ public class ReportGenerator {
                 input = new FileInputStream(f);
             } catch (FileNotFoundException ex) {
                 final String msg = "Unable to generate the report, the report template file could not be found.";
-                Logger.getLogger(ReportGenerator.class.getName()).log(Level.SEVERE, msg);
-                Logger.getLogger(ReportGenerator.class.getName()).log(Level.FINE, null, ex);
+                LOGGER.log(Level.SEVERE, msg);
+                LOGGER.log(Level.FINE, null, ex);
             }
         } else {
             templatePath = "templates/" + templateName + ".vsl";
@@ -244,20 +248,20 @@ public class ReportGenerator {
                 try {
                     writer.close();
                 } catch (IOException ex) {
-                    Logger.getLogger(ReportGenerator.class.getName()).log(Level.FINEST, null, ex);
+                    LOGGER.log(Level.FINEST, null, ex);
                 }
             }
             if (outputStream != null) {
                 try {
                     outputStream.close();
                 } catch (IOException ex) {
-                    Logger.getLogger(ReportGenerator.class.getName()).log(Level.FINEST, null, ex);
+                    LOGGER.log(Level.FINEST, null, ex);
                 }
             }
             try {
                 reader.close();
             } catch (IOException ex) {
-                Logger.getLogger(ReportGenerator.class.getName()).log(Level.FINEST, null, ex);
+                LOGGER.log(Level.FINEST, null, ex);
             }
         }
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/reporting/VelocityLoggerRedirect.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/reporting/VelocityLoggerRedirect.java
@@ -36,7 +36,11 @@ import org.apache.velocity.runtime.log.LogChute;
  * @author Steve Springett <steve.springett@owasp.org>
  */
 public class VelocityLoggerRedirect implements LogChute {
-
+    
+    /**
+     * The Logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(VelocityLoggerRedirect.class.getName());
     /**
      * This will be invoked once by the LogManager.
      *
@@ -54,7 +58,7 @@ public class VelocityLoggerRedirect implements LogChute {
      * @param message the message to be logged
      */
     public void log(int level, String message) {
-        Logger.getLogger(Velocity.class.getName()).log(getLevel(level), message);
+        LOGGER.log(getLevel(level), message);
     }
 
     /**
@@ -66,7 +70,7 @@ public class VelocityLoggerRedirect implements LogChute {
      * @param t a throwable to log
      */
     public void log(int level, String message, Throwable t) {
-        Logger.getLogger(Velocity.class.getName()).log(getLevel(level), message, t);
+        LOGGER.log(getLevel(level), message, t);
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/suppression/SuppressionErrorHandler.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/suppression/SuppressionErrorHandler.java
@@ -29,7 +29,11 @@ import org.xml.sax.SAXParseException;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class SuppressionErrorHandler implements ErrorHandler {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(SuppressionErrorHandler.class.getName());
     /**
      * Builds a prettier exception message.
      *
@@ -65,7 +69,7 @@ public class SuppressionErrorHandler implements ErrorHandler {
      */
     @Override
     public void warning(SAXParseException ex) throws SAXException {
-        Logger.getLogger(SuppressionErrorHandler.class.getName()).log(Level.FINE, null, ex);
+        LOGGER.log(Level.FINE, null, ex);
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/suppression/SuppressionParser.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/suppression/SuppressionParser.java
@@ -40,7 +40,11 @@ import org.xml.sax.XMLReader;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class SuppressionParser {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(SuppressionParser.class.getName());
     /**
      * JAXP Schema Language. Source: http://docs.oracle.com/javase/tutorial/jaxp/sax/validation.html
      */
@@ -85,16 +89,16 @@ public class SuppressionParser {
 
             return handler.getSuppressionRules();
         } catch (ParserConfigurationException ex) {
-            Logger.getLogger(SuppressionParser.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.FINE, null, ex);
             throw new SuppressionParseException(ex);
         } catch (SAXException ex) {
-            Logger.getLogger(SuppressionParser.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.FINE, null, ex);
             throw new SuppressionParseException(ex);
         } catch (FileNotFoundException ex) {
-            Logger.getLogger(SuppressionParser.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.FINE, null, ex);
             throw new SuppressionParseException(ex);
         } catch (IOException ex) {
-            Logger.getLogger(SuppressionParser.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.FINE, null, ex);
             throw new SuppressionParseException(ex);
         }
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/Checksum.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/Checksum.java
@@ -20,7 +20,11 @@ import java.util.logging.Logger;
  *
  */
 public final class Checksum {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(Checksum.class.getName());
     /**
      * Private constructor for a utility class.
      */
@@ -57,7 +61,7 @@ public final class Checksum {
                 try {
                     fis.close();
                 } catch (IOException ex) {
-                    Logger.getLogger(Checksum.class.getName()).log(Level.FINEST, "Error closing file '" + file.getName() + "'.", ex);
+                    LOGGER.log(Level.FINEST, "Error closing file '" + file.getName() + "'.", ex);
                 }
             }
         }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/DBUtils.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/DBUtils.java
@@ -31,7 +31,11 @@ import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public final class DBUtils {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(DBUtils.class.getName());
     /**
      * Private constructor for a utility class.
      */
@@ -70,8 +74,7 @@ public final class DBUtils {
             try {
                 statement.close();
             } catch (SQLException ex) {
-                Logger.getLogger(CveDB.class
-                        .getName()).log(Level.FINEST, statement.toString(), ex);
+                LOGGER.log(Level.FINEST, statement.toString(), ex);
             }
         }
     }
@@ -86,8 +89,7 @@ public final class DBUtils {
             try {
                 rs.close();
             } catch (SQLException ex) {
-                Logger.getLogger(CveDB.class
-                        .getName()).log(Level.FINEST, rs.toString(), ex);
+                LOGGER.log(Level.FINEST, rs.toString(), ex);
             }
         }
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
@@ -36,7 +36,11 @@ import java.util.zip.InflaterInputStream;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public final class Downloader {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(Downloader.class.getName());
     /**
      * Private constructor for utility class.
      */
@@ -124,7 +128,7 @@ public final class Downloader {
                     try {
                         writer.close();
                     } catch (Throwable ex) {
-                        Logger.getLogger(Downloader.class.getName()).log(Level.FINEST,
+                        LOGGER.log(Level.FINEST,
                                 "Error closing the writer in Downloader.", ex);
                     }
                 }
@@ -132,7 +136,7 @@ public final class Downloader {
                     try {
                         reader.close();
                     } catch (Throwable ex) {
-                        Logger.getLogger(Downloader.class.getName()).log(Level.FINEST,
+                        LOGGER.log(Level.FINEST,
                                 "Error closing the reader in Downloader.", ex);
                     }
                 }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
@@ -39,7 +39,11 @@ import org.owasp.dependencycheck.Engine;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public final class FileUtils {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(FileUtils.class.getName());
     /**
      * Bit bucket for non-Windows systems
      */
@@ -87,7 +91,7 @@ public final class FileUtils {
         if (!org.apache.commons.io.FileUtils.deleteQuietly(file)) {
             success = false;
             final String msg = String.format("Failed to delete file: %s; attempting to delete on exit.", file.getPath());
-            Logger.getLogger(FileUtils.class.getName()).log(Level.FINE, msg);
+            LOGGER.log(Level.FINE, msg);
             file.deleteOnExit();
         }
         return success;
@@ -188,7 +192,7 @@ public final class FileUtils {
         try {
             fis = new FileInputStream(archive);
         } catch (FileNotFoundException ex) {
-            Logger.getLogger(FileUtils.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.FINE, null, ex);
             throw new ExtractionException("Archive file was not found.", ex);
         }
         zis = new ZipInputStream(new BufferedInputStream(fis));
@@ -217,11 +221,11 @@ public final class FileUtils {
                             }
                             bos.flush();
                         } catch (FileNotFoundException ex) {
-                            Logger.getLogger(FileUtils.class.getName()).log(Level.FINE, null, ex);
+                            LOGGER.log(Level.FINE, null, ex);
                             final String msg = String.format("Unable to find file '%s'.", file.getName());
                             throw new ExtractionException(msg, ex);
                         } catch (IOException ex) {
-                            Logger.getLogger(FileUtils.class.getName()).log(Level.FINE, null, ex);
+                            LOGGER.log(Level.FINE, null, ex);
                             final String msg = String.format("IO Exception while parsing file '%s'.", file.getName());
                             throw new ExtractionException(msg, ex);
                         } finally {
@@ -229,7 +233,7 @@ public final class FileUtils {
                                 try {
                                     bos.close();
                                 } catch (IOException ex) {
-                                    Logger.getLogger(FileUtils.class.getName()).log(Level.FINEST, null, ex);
+                                    LOGGER.log(Level.FINEST, null, ex);
                                 }
                             }
                         }
@@ -238,13 +242,13 @@ public final class FileUtils {
             }
         } catch (IOException ex) {
             final String msg = String.format("Exception reading archive '%s'.", archive.getName());
-            Logger.getLogger(FileUtils.class.getName()).log(Level.FINE, msg, ex);
+            LOGGER.log(Level.FINE, msg, ex);
             throw new ExtractionException(msg, ex);
         } finally {
             try {
                 zis.close();
             } catch (IOException ex) {
-                Logger.getLogger(FileUtils.class.getName()).log(Level.FINEST, null, ex);
+                LOGGER.log(Level.FINEST, null, ex);
             }
         }
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/LogUtils.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/LogUtils.java
@@ -31,7 +31,11 @@ import java.util.logging.SimpleFormatter;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public final class LogUtils {
-
+    
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(LogUtils.class.getName());
     /**
      * Private constructor for a utility class.
      */
@@ -59,15 +63,15 @@ public final class LogUtils {
                 logger.setLevel(Level.FINE);
             }
         } catch (IOException ex) {
-            Logger.getLogger(LogUtils.class.getName()).log(Level.FINE, "IO Error preparing the logger", ex);
+            LOGGER.log(Level.FINE, "IO Error preparing the logger", ex);
         } catch (SecurityException ex) {
-            Logger.getLogger(LogUtils.class.getName()).log(Level.FINE, "Error preparing the logger", ex);
+            LOGGER.log(Level.FINE, "Error preparing the logger", ex);
         } finally {
             if (in != null) {
                 try {
                     in.close();
                 } catch (Throwable ex) {
-                    Logger.getLogger(LogUtils.class.getName()).log(Level.FINEST, "Error closing resource stream", ex);
+                    LOGGER.log(Level.FINEST, "Error closing resource stream", ex);
                 }
             }
         }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -225,14 +225,14 @@ public final class Settings {
             in = this.getClass().getClassLoader().getResourceAsStream(PROPERTIES_FILE);
             props.load(in);
         } catch (IOException ex) {
-            Logger.getLogger(Settings.class.getName()).log(Level.SEVERE, "Unable to load default settings.");
-            Logger.getLogger(Settings.class.getName()).log(Level.FINE, null, ex);
+            LOGGER.log(Level.SEVERE, "Unable to load default settings.");
+            LOGGER.log(Level.FINE, null, ex);
         } finally {
             if (in != null) {
                 try {
                     in.close();
                 } catch (IOException ex) {
-                    Logger.getLogger(Settings.class.getName()).log(Level.FINEST, null, ex);
+                    LOGGER.log(Level.FINEST, null, ex);
                 }
             }
         }
@@ -413,16 +413,16 @@ public final class Settings {
      */
     public static File getDataFile(String key) {
         final String file = getString(key);
-        Logger.getLogger(Settings.class.getName()).log(Level.FINE, String.format("Settings.getDataFile() - file: '%s'", file));
+        LOGGER.log(Level.FINE, String.format("Settings.getDataFile() - file: '%s'", file));
         if (file == null) {
             return null;
         }
         if (file.startsWith("[JAR]")) {
-            Logger.getLogger(Settings.class.getName()).log(Level.FINE, "Settings.getDataFile() - transforming filename");
+            LOGGER.log(Level.FINE, "Settings.getDataFile() - transforming filename");
             final File jarPath = getJarPath();
-            Logger.getLogger(Settings.class.getName()).log(Level.FINE, String.format("Settings.getDataFile() - jar file: '%s'", jarPath.toString()));
+            LOGGER.log(Level.FINE, String.format("Settings.getDataFile() - jar file: '%s'", jarPath.toString()));
             final File retVal = new File(jarPath, file.substring(6));
-            Logger.getLogger(Settings.class.getName()).log(Level.FINE, String.format("Settings.getDataFile() - returning: '%s'", retVal.toString()));
+            LOGGER.log(Level.FINE, String.format("Settings.getDataFile() - returning: '%s'", retVal.toString()));
             return retVal;
         }
         return new File(file);
@@ -439,7 +439,7 @@ public final class Settings {
         try {
             decodedPath = URLDecoder.decode(jarPath, "UTF-8");
         } catch (UnsupportedEncodingException ex) {
-            Logger.getLogger(Settings.class.getName()).log(Level.FINEST, null, ex);
+            LOGGER.log(Level.FINEST, null, ex);
         }
 
         final File path = new File(decodedPath);
@@ -529,7 +529,7 @@ public final class Settings {
             value = Integer.parseInt(Settings.getString(key));
         } catch (NumberFormatException ex) {
             final String msg = String.format("Could not convert property '%s' to an int.", key);
-            Logger.getLogger(Settings.class.getName()).log(Level.FINEST, msg, ex);
+            LOGGER.log(Level.FINEST, msg, ex);
             value = defaultValue;
         }
         return value;


### PR DESCRIPTION
Created a PMD rule to identify when we're doing things like:

```
Logger.getLogger(Foo.class).log(Level.FINE, "Don't chain");
```

so that we'd make a field out of the logger. Fixed all the existing instances.

I upgraded the version of PMD being used for the reports and added some additional configuration for it:
1. Added the reference to the ruleset I wrote for finding the logger.
2. Added explicit references to the rulesets which are documented to be the defaults with the Maven PMD plugin.
