### PR TITLE
Enable loading of suppression file from classpath resource

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
@@ -17,16 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.*;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Pattern;
 import org.owasp.dependencycheck.suppression.SuppressionParseException;
 import org.owasp.dependencycheck.suppression.SuppressionParser;
 import org.owasp.dependencycheck.suppression.SuppressionRule;
@@ -34,6 +24,17 @@ import org.owasp.dependencycheck.utils.DownloadFailedException;
 import org.owasp.dependencycheck.utils.Downloader;
 import org.owasp.dependencycheck.utils.FileUtils;
 import org.owasp.dependencycheck.utils.Settings;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 /**
  * Abstract base suppression analyzer that contains methods for parsing the suppression xml file.
@@ -48,6 +49,7 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
     private static final Logger LOGGER = Logger.getLogger(AbstractSuppressionAnalyzer.class.getName());
 
     //<editor-fold defaultstate="collapsed" desc="All standard implementation details of Analyzer">
+
     /**
      * Returns a list of file EXTENSIONS supported by this analyzer.
      *
@@ -58,6 +60,7 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
     }
 
     //</editor-fold>
+
     /**
      * The initialize method loads the suppression XML file.
      *
@@ -68,6 +71,7 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
         super.initialize();
         loadSuppressionData();
     }
+
     /**
      * The list of suppression rules
      */
@@ -124,9 +128,7 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
                         try {
                             org.apache.commons.io.FileUtils.copyInputStreamToFile(suppressionsFromClasspath, file);
                         } catch (IOException ex) {
-                            LOGGER.log(Level.WARNING, "Unable to locate suppressions file in classpath");
-                            LOGGER.log(Level.FINE, "", ex);
-                            throw new SuppressionParseException("Unable to locate suppressions file in classpath", ex);
+                            throwSuppressionParseException("Unable to locate suppressions file in classpath", ex);
                         }
                     }
                 }
@@ -146,24 +148,21 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
                 }
             }
         } catch (DownloadFailedException ex) {
-            LOGGER.log(Level.WARNING,
-                    "Unable to fetch the configured suppression file");
-            LOGGER.log(Level.FINE, "", ex);
-            throw new SuppressionParseException("Unable to fetch the configured suppression file", ex);
+            throwSuppressionParseException("Unable to fetch the configured suppression file", ex);
         } catch (MalformedURLException ex) {
-            LOGGER.log(Level.WARNING,
-                    "Configured suppression file has an invalid URL");
-            LOGGER.log(Level.FINE, "", ex);
-            throw new SuppressionParseException("Configured suppression file has an invalid URL", ex);
+            throwSuppressionParseException("Configured suppression file has an invalid URL", ex);
         } catch (IOException ex) {
-            LOGGER.log(Level.WARNING,
-                    "Unable to create temp file for suppressions");
-            LOGGER.log(Level.FINE, "", ex);
-            throw new SuppressionParseException("Unable to create temp file for suppressions", ex);
+            throwSuppressionParseException("Unable to create temp file for suppressions", ex);
         } finally {
             if (deleteTempFile && file != null) {
                 FileUtils.delete(file);
             }
         }
+    }
+
+    private void throwSuppressionParseException(String message, Exception exception) throws SuppressionParseException {
+        LOGGER.log(Level.WARNING, message);
+        LOGGER.log(Level.FINE, "", exception);
+        throw new SuppressionParseException(message, exception);
     }
 }


### PR DESCRIPTION
DependencyCheck supported only suppression files loaded via URL or a file path. Similar analysis plugins (e.g. FindBugs, CheckStyle) are also able to locate filter/suppression files in the classpath. This makes it possible to put these files into a separate Maven artifact and reuse them easily among modules or projects.

I have added this feature to the AbstractSuppressionAnalyzer in a non-invasive way by attempting to load suppressions via classpath only if the previous attempts fail. I built it similar to the URL download way via a temporary file. It allows to keep the API and responsibility or the SuppressionParser as it is. All the validation if the suppressions can be loaded at all remains in the AbstractSuppressionAnalyzer.
