### PR TITLE
Added test for suppression file via classpath feature

### DIFF
--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzerTest.java
@@ -18,9 +18,7 @@
 package org.owasp.dependencycheck.analyzer;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
@@ -43,9 +41,6 @@ import static org.junit.Assert.assertNull;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class AbstractSuppressionAnalyzerTest extends BaseTest {
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     private AbstractSuppressionAnalyzer instance;
 
@@ -87,10 +82,9 @@ public class AbstractSuppressionAnalyzerTest extends BaseTest {
         assertEquals(expCount, result.size());
     }
 
-    @Test
+    @Test(expected = SuppressionParseException.class)
     public void testFailureToLocateSuppressionFileInClasspath() throws Exception {
         Settings.setString(Settings.KEYS.SUPPRESSION_FILE, "doesnotexist.xml");
-        exception.expect(SuppressionParseException.class);
         instance.initialize();
     }
 

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzerTest.java
@@ -17,31 +17,84 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.suppression.SuppressionParseException;
+import org.owasp.dependencycheck.suppression.SuppressionRule;
+import org.owasp.dependencycheck.utils.Settings;
+
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import org.junit.Before;
-import org.junit.Test;
-import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.Engine;
-import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
-import org.owasp.dependencycheck.dependency.Dependency;
-import org.owasp.dependencycheck.suppression.SuppressionRule;
-import org.owasp.dependencycheck.utils.Settings;
 
 /**
- *
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class AbstractSuppressionAnalyzerTest extends BaseTest {
 
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private AbstractSuppressionAnalyzer instance;
+
     @Before
-    public void setUp() throws Exception {
+    public void createObjectUnderTest() throws Exception {
+        instance = new AbstractSuppressionAnalyzerImpl();
+    }
+
+    /**
+     * Test of getSupportedExtensions method, of class AbstractSuppressionAnalyzer.
+     */
+    @Test
+    public void testGetSupportedExtensions() {
+        Set<String> result = instance.getSupportedExtensions();
+        assertNull(result);
+    }
+
+    /**
+     * Test of getRules method, of class AbstractSuppressionAnalyzer for suppression file declared as URL.
+     */
+    @Test
+    public void testGetRulesFromSuppressionFileFromURL() throws Exception {
+        setSupressionFileFromURL();
+        instance.initialize();
+        int expCount = 5;
+        List<SuppressionRule> result = instance.getRules();
+        assertEquals(expCount, result.size());
+    }
+
+    /**
+     * Test of getRules method, of class AbstractSuppressionAnalyzer for suppression file declared as URL.
+     */
+    @Test
+    public void testGetRulesFromSuppressionFileInClasspath() throws Exception {
+        Settings.setString(Settings.KEYS.SUPPRESSION_FILE, "suppressions.xml");
+        instance.initialize();
+        int expCount = 5;
+        List<SuppressionRule> result = instance.getRules();
+        assertEquals(expCount, result.size());
+    }
+
+    @Test
+    public void testFailureToLocateSuppressionFileInClasspath() throws Exception {
+        Settings.setString(Settings.KEYS.SUPPRESSION_FILE, "doesnotexist.xml");
+        exception.expect(SuppressionParseException.class);
+        instance.initialize();
+    }
+
+    private void setSupressionFileFromURL() throws Exception {
         try {
             final String uri = this.getClass().getClassLoader().getResource("suppressions.xml").toURI().toURL().toString();
             Settings.setString(Settings.KEYS.SUPPRESSION_FILE, uri);
@@ -50,37 +103,6 @@ public class AbstractSuppressionAnalyzerTest extends BaseTest {
         } catch (MalformedURLException ex) {
             Logger.getLogger(AbstractSuppressionAnalyzerTest.class.getName()).log(Level.SEVERE, null, ex);
         }
-    }
-
-    /**
-     * Test of getSupportedExtensions method, of class AbstractSuppressionAnalyzer.
-     */
-    @Test
-    public void testGetSupportedExtensions() {
-        AbstractSuppressionAnalyzer instance = new AbstractSuppressionAnalyzerImpl();
-        Set<String> result = instance.getSupportedExtensions();
-        assertNull(result);
-    }
-
-    /**
-     * Test of initialize method, of class AbstractSuppressionAnalyzer.
-     */
-    @Test
-    public void testInitialize() throws Exception {
-        AbstractSuppressionAnalyzer instance = new AbstractSuppressionAnalyzerImpl();
-        instance.initialize();
-    }
-
-    /**
-     * Test of getRules method, of class AbstractSuppressionAnalyzer.
-     */
-    @Test
-    public void testGetRules() throws Exception {
-        AbstractSuppressionAnalyzer instance = new AbstractSuppressionAnalyzerImpl();
-        instance.initialize();
-        int expCount = 5;
-        List<SuppressionRule> result = instance.getRules();
-        assertEquals(expCount, result.size());
     }
 
     public class AbstractSuppressionAnalyzerImpl extends AbstractSuppressionAnalyzer {

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzerTest.java
@@ -83,7 +83,7 @@ public class AbstractSuppressionAnalyzerTest extends BaseTest {
     }
 
     @Test(expected = SuppressionParseException.class)
-    public void testFailureToLocateSuppressionFileInClasspath() throws Exception {
+    public void testFailureToLocateSuppressionFileAnywhere() throws Exception {
         Settings.setString(Settings.KEYS.SUPPRESSION_FILE, "doesnotexist.xml");
         instance.initialize();
     }


### PR DESCRIPTION
(+) added test case for loading suppression file via classpath
(+) added test case for failing to locate suppression file entirely
(+) initialize object under test as field in @Before instead of using local variables
(-) redundant test for initialization
(-) setting up suppression via URL in @Before for all test methods, even those where it is not needed
