### PR TITLE
Fixed suppression analyzer to load from input stream fixing failure

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
@@ -100,9 +100,8 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
     private void loadSuppressionData() throws SuppressionParseException {
         final SuppressionParser parser = new SuppressionParser();
         File file = null;
-        file = new File(this.getClass().getClassLoader().getResource("dependencycheck-base-suppression.xml").getPath());
         try {
-            rules = parser.parseSuppressionRules(file);
+            rules = parser.parseSuppressionRules(this.getClass().getClassLoader().getResourceAsStream("dependencycheck-base-suppression.xml"));
         } catch (SuppressionParseException ex) {
             LOGGER.log(Level.FINE, "Unable to parse the base suppression data file", ex);
         }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/suppression/SuppressionParser.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/suppression/SuppressionParser.java
@@ -27,9 +27,11 @@ import java.io.Reader;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
@@ -67,9 +69,24 @@ public class SuppressionParser {
      */
     public List<SuppressionRule> parseSuppressionRules(File file) throws SuppressionParseException {
         try {
+            return parseSuppressionRules(new FileInputStream(file));
+        } catch (IOException ex) {
+            LOGGER.log(Level.FINE, null, ex);
+            throw new SuppressionParseException(ex);
+        }
+    }
+
+    /**
+     * Parses the given xml stream and returns a list of the suppression rules contained.
+     * 
+     * @param inputStream an InputStream containing suppression rues
+     * @return a list of suppression rules
+     * @throws SuppressionParseException if the xml cannot be parsed
+     */
+    public List<SuppressionRule> parseSuppressionRules(InputStream inputStream) throws SuppressionParseException {
+        try {
             final InputStream schemaStream = this.getClass().getClassLoader().getResourceAsStream("schema/suppression.xsd");
             final SuppressionHandler handler = new SuppressionHandler();
-
             final SAXParserFactory factory = SAXParserFactory.newInstance();
             factory.setNamespaceAware(true);
             factory.setValidating(true);
@@ -80,7 +97,6 @@ public class SuppressionParser {
             xmlReader.setErrorHandler(new SuppressionErrorHandler());
             xmlReader.setContentHandler(handler);
 
-            final InputStream inputStream = new FileInputStream(file);
             final Reader reader = new InputStreamReader(inputStream, "UTF-8");
             final InputSource in = new InputSource(reader);
             //in.setEncoding("UTF-8");


### PR DESCRIPTION
This fixes the broken Suppression Analyzer by doing the following:
- Allowing suppression files to be loaded from an `InputStream` in addition to a `File`
- Opening the base suppression list as an `InputStream` and passing that to get parsed
