### PR TITLE
Inclusion of evidence from the project-pom, configration to exclude internal groupIds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Eclipse project files
 .classpath
 .project
+.settings
+maven-eclipse.xml
+.externalToolBuilders
 # Netbeans configuration
 nb-configuration.xml
 /target/

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
@@ -24,13 +24,13 @@ import java.net.URL;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.data.nexus.NexusSearch;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
-import org.owasp.dependencycheck.dependency.Identifier;
 import org.owasp.dependencycheck.utils.Settings;
 
 /**
@@ -152,29 +152,7 @@ public class NexusAnalyzer extends AbstractFileTypeAnalyzer {
     public void analyzeFileType(Dependency dependency, Engine engine) throws AnalysisException {
         try {
             final MavenArtifact ma = searcher.searchSha1(dependency.getSha1sum());
-            if (ma.getGroupId() != null && !"".equals(ma.getGroupId())) {
-                dependency.getVendorEvidence().addEvidence("nexus", "groupid", ma.getGroupId(), Confidence.HIGH);
-            }
-            if (ma.getArtifactId() != null && !"".equals(ma.getArtifactId())) {
-                dependency.getProductEvidence().addEvidence("nexus", "artifactid", ma.getArtifactId(), Confidence.HIGH);
-            }
-            if (ma.getVersion() != null && !"".equals(ma.getVersion())) {
-                dependency.getVersionEvidence().addEvidence("nexus", "version", ma.getVersion(), Confidence.HIGH);
-            }
-            if (ma.getArtifactUrl() != null && !"".equals(ma.getArtifactUrl())) {
-                boolean found = false;
-                for (Identifier i : dependency.getIdentifiers()) {
-                    if ("maven".equals(i.getType()) && i.getValue().equals(ma.toString())) {
-                        found = true;
-                        i.setConfidence(Confidence.HIGHEST);
-                        i.setUrl(ma.getArtifactUrl());
-                        break;
-                    }
-                }
-                if (!found) {
-                    dependency.addIdentifier("maven", ma.toString(), ma.getArtifactUrl(), Confidence.HIGHEST);
-                }
-            }
+            dependency.addAsEvidence("nexus", ma, Confidence.HIGH);
         } catch (IllegalArgumentException iae) {
             //dependency.addAnalysisException(new AnalysisException("Invalid SHA-1"));
             LOGGER.info(String.format("invalid sha-1 hash on %s", dependency.getFileName()));

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -26,6 +26,8 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.utils.Checksum;
 import org.owasp.dependencycheck.utils.FileUtils;
 
@@ -317,6 +319,38 @@ public class Dependency implements Serializable, Comparable<Dependency> {
     }
 
     /**
+     * Adds the maven artifact as evidence.
+     * @param source The source of the evidence.
+     * @param mavenArtifact The maven artifact.
+     * @param confidence The confidence level of this evidence.
+     */
+    public void addAsEvidence(String source, MavenArtifact mavenArtifact, Confidence confidence) {
+        if (mavenArtifact.getGroupId() != null && !"".equals(mavenArtifact.getGroupId())) {
+            this.getVendorEvidence().addEvidence(source, "groupid", mavenArtifact.getGroupId(), confidence);
+        }
+        if (mavenArtifact.getArtifactId() != null && !"".equals(mavenArtifact.getArtifactId())) {
+            this.getProductEvidence().addEvidence(source, "artifactid", mavenArtifact.getArtifactId(), confidence);
+        }
+        if (mavenArtifact.getVersion() != null && !"".equals(mavenArtifact.getVersion())) {
+            this.getVersionEvidence().addEvidence(source, "version", mavenArtifact.getVersion(), confidence);
+        }
+        if (mavenArtifact.getArtifactUrl() != null && !"".equals(mavenArtifact.getArtifactUrl())) {
+            boolean found = false;
+            for (Identifier i : this.getIdentifiers()) {
+                if ("maven".equals(i.getType()) && i.getValue().equals(mavenArtifact.toString())) {
+                    found = true;
+                    i.setConfidence(Confidence.HIGHEST);
+                    i.setUrl(mavenArtifact.getArtifactUrl());
+                    break;
+                }
+            }
+            if (!found) {
+                this.addIdentifier("maven", mavenArtifact.toString(), mavenArtifact.getArtifactUrl(), Confidence.HIGHEST);
+            }
+        }
+    }
+
+    /**
      * Adds an entry to the list of detected Identifiers for the dependency file.
      *
      * @param identifier the identifier to add
@@ -324,6 +358,7 @@ public class Dependency implements Serializable, Comparable<Dependency> {
     public void addIdentifier(Identifier identifier) {
         this.identifiers.add(identifier);
     }
+
     /**
      * A set of identifiers that have been suppressed.
      */
@@ -441,6 +476,7 @@ public class Dependency implements Serializable, Comparable<Dependency> {
     public EvidenceCollection getVersionEvidence() {
         return this.versionEvidence;
     }
+
     /**
      * The description of the JAR file.
      */
@@ -463,6 +499,7 @@ public class Dependency implements Serializable, Comparable<Dependency> {
     public void setDescription(String description) {
         this.description = description;
     }
+
     /**
      * The license that this dependency uses.
      */
@@ -485,6 +522,7 @@ public class Dependency implements Serializable, Comparable<Dependency> {
     public void setLicense(String license) {
         this.license = license;
     }
+
     /**
      * A list of vulnerabilities for this dependency.
      */
@@ -540,6 +578,7 @@ public class Dependency implements Serializable, Comparable<Dependency> {
     public void addVulnerability(Vulnerability vulnerability) {
         this.vulnerabilities.add(vulnerability);
     }
+
     /**
      * A collection of related dependencies.
      */

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
@@ -17,16 +17,20 @@
  */
 package org.owasp.dependencycheck.dependency;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.util.List;
 import java.util.Set;
+
 import org.junit.After;
 import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 
 /**
  *
@@ -152,7 +156,7 @@ public class DependencyTest {
     public void testGetMd5sum() {
         File file = new File(this.getClass().getClassLoader().getResource("struts2-core-2.1.2.jar").getPath());
         Dependency instance = new Dependency(file);
-//        assertEquals("89CE9E36AA9A9E03F1450936D2F4F8DD0F961F8B", result.getSha1sum());
+        //        assertEquals("89CE9E36AA9A9E03F1450936D2F4F8DD0F961F8B", result.getSha1sum());
         String expResult = "C30B57142E1CCBC1EFD5CD15F307358F";
         String result = instance.getMd5sum();
         assertEquals(expResult, result);
@@ -293,5 +297,35 @@ public class DependencyTest {
         EvidenceCollection expResult = null;
         EvidenceCollection result = instance.getVersionEvidence();
         assertTrue(true); //this is just a getter setter pair.
+    }
+
+    /**
+     * Test of addAsEvidence method, of class Dependency.
+     */
+    @Test
+    public void testAddAsEvidence() {
+        Dependency instance = new Dependency();
+        MavenArtifact mavenArtifact = new MavenArtifact("group", "artifact", "version", "url");
+        instance.addAsEvidence("pom", mavenArtifact, Confidence.HIGH);
+        assertTrue(instance.getEvidence().contains(Confidence.HIGH));
+        assertFalse(instance.getEvidence().getEvidence("pom", "groupid").isEmpty());
+        assertFalse(instance.getEvidence().getEvidence("pom", "artifactid").isEmpty());
+        assertFalse(instance.getEvidence().getEvidence("pom", "version").isEmpty());
+        assertFalse(instance.getIdentifiers().isEmpty());
+    }
+
+    /**
+     * Test of addAsEvidence method, of class Dependency.
+     */
+    @Test
+    public void testAddAsEvidenceWithEmptyArtefact() {
+        Dependency instance = new Dependency();
+        MavenArtifact mavenArtifact = new MavenArtifact(null, null, null, null);
+        instance.addAsEvidence("pom", mavenArtifact, Confidence.HIGH);
+        assertFalse(instance.getEvidence().contains(Confidence.HIGH));
+        assertTrue(instance.getEvidence().getEvidence("pom", "groupid").isEmpty());
+        assertTrue(instance.getEvidence().getEvidence("pom", "artifactid").isEmpty());
+        assertTrue(instance.getEvidence().getEvidence("pom", "version").isEmpty());
+        assertTrue(instance.getIdentifiers().isEmpty());
     }
 }

--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/DependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/DependencyCheckMojo.java
@@ -245,7 +245,11 @@ public class DependencyCheckMojo extends ReportAggregationMojo {
     private boolean skipProvidedScope = false;
     /**
      * Skip Analysis of Dependencies that have a groupId that starts with this string.
-     * Multiple excludes are allowed by repeating the element. 
+     * <pre>
+     * &lt;excludeInternalGroupIds&gt;
+     *  &lt;groupId&gt;some.group.id&lt;/groupId&gt;
+     * &lt;/excludeInternalGroupIds&gt;
+     * </pre> 
      */
     @SuppressWarnings("CanBeFinal")
     @Parameter(property = "excludeInternalGroupIds", required = false)

--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/DependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/DependencyCheckMojo.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -243,6 +244,13 @@ public class DependencyCheckMojo extends ReportAggregationMojo {
     @Parameter(property = "skipProvidedScope", defaultValue = "false", required = false)
     private boolean skipProvidedScope = false;
     /**
+     * Skip Analysis of Dependencies that have a groupId that starts with this string.
+     * Multiple excludes are allowed by repeating the element. 
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "excludeInternalGroupIds", required = false)
+    private String[] excludeInternalGroupIds = new String[0];
+    /**
      * The data directory, hold DC SQL DB.
      */
     @Parameter(property = "dataDirectory", defaultValue = "", required = false)
@@ -361,6 +369,12 @@ public class DependencyCheckMojo extends ReportAggregationMojo {
         }
         if (skipRuntimeScope && !Artifact.SCOPE_RUNTIME.equals(a.getScope())) {
             return true;
+        }
+        for (String groupId : excludeInternalGroupIds) {
+            if (!StringUtils.isEmpty(groupId) && (a.getGroupId().startsWith(groupId))) {
+                LOGGER.log(Level.INFO, "Excluding " + a.getGroupId() + ":" + a.getArtifactId());
+                return true;
+            }
         }
         return false;
     }

--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/DependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/DependencyCheckMojo.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -46,6 +47,7 @@ import org.apache.maven.settings.Proxy;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.DependencyBundlingAnalyzer;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Identifier;
@@ -58,9 +60,7 @@ import org.owasp.dependencycheck.utils.Settings;
  *
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
-@Mojo(name = "check", defaultPhase = LifecyclePhase.COMPILE, threadSafe = true,
-        requiresDependencyResolution = ResolutionScope.RUNTIME_PLUS_SYSTEM,
-        requiresOnline = true)
+@Mojo(name = "check", defaultPhase = LifecyclePhase.COMPILE, threadSafe = true, requiresDependencyResolution = ResolutionScope.RUNTIME_PLUS_SYSTEM, requiresOnline = true)
 public class DependencyCheckMojo extends ReportAggregationMojo {
 
     //<editor-fold defaultstate="collapsed" desc="Private fields">
@@ -292,6 +292,7 @@ public class DependencyCheckMojo extends ReportAggregationMojo {
     @Parameter(property = "externalReport")
     @Deprecated
     private String externalReport = null;
+
     // </editor-fold>
     /**
      * Constructs a new dependency-check-mojo.
@@ -326,8 +327,7 @@ public class DependencyCheckMojo extends ReportAggregationMojo {
             if (excludeFromScan(a)) {
                 continue;
             }
-
-            localEngine.scan(a.getFile().getAbsolutePath());
+            localEngine.scan(a.getFile().getAbsoluteFile(), new MavenArtifact(a.getGroupId(), a.getArtifactId(), a.getVersion()));
         }
         localEngine.analyzeDependencies();
 
@@ -396,8 +396,7 @@ public class DependencyCheckMojo extends ReportAggregationMojo {
         }
 
         if (proxyUrl != null && !proxyUrl.isEmpty()) {
-            LOGGER.warning("Deprecated configuration detected, proxyUrl will be ignored; use the maven settings "
-                    + "to configure the proxy instead");
+            LOGGER.warning("Deprecated configuration detected, proxyUrl will be ignored; use the maven settings " + "to configure the proxy instead");
         }
         final Proxy proxy = getMavenProxy();
         if (proxy != null) {
@@ -510,6 +509,7 @@ public class DependencyCheckMojo extends ReportAggregationMojo {
         }
         return null;
     }
+
     //</editor-fold>
 
     /**
@@ -530,8 +530,7 @@ public class DependencyCheckMojo extends ReportAggregationMojo {
                 checkForFailure(engine.getDependencies());
             }
         } catch (DatabaseException ex) {
-            LOGGER.log(Level.SEVERE,
-                    "Unable to connect to the dependency-check database; analysis has stopped");
+            LOGGER.log(Level.SEVERE, "Unable to connect to the dependency-check database; analysis has stopped");
             LOGGER.log(Level.FINE, "", ex);
         }
     }
@@ -580,16 +579,15 @@ public class DependencyCheckMojo extends ReportAggregationMojo {
                 engine = initializeEngine();
                 engine.getDependencies().addAll(deps);
             } catch (DatabaseException ex) {
-                final String msg = String.format("An unrecoverable exception with the dependency-check initialization occured while scanning %s",
-                        getProject().getName());
+                final String msg = String.format("An unrecoverable exception with the dependency-check initialization occured while scanning %s", getProject()
+                        .getName());
                 throw new MavenReportException(msg, ex);
             }
         } else {
             try {
                 engine = executeDependencyCheck();
             } catch (DatabaseException ex) {
-                final String msg = String.format("An unrecoverable exception with the dependency-check scan occured while scanning %s",
-                        getProject().getName());
+                final String msg = String.format("An unrecoverable exception with the dependency-check scan occured while scanning %s", getProject().getName());
                 throw new MavenReportException(msg, ex);
             }
         }
@@ -612,8 +610,7 @@ public class DependencyCheckMojo extends ReportAggregationMojo {
             try {
                 engine = executeDependencyCheck(project);
             } catch (DatabaseException ex) {
-                final String msg = String.format("An unrecoverable exception with the dependency-check scan occured while scanning %s",
-                        project.getName());
+                final String msg = String.format("An unrecoverable exception with the dependency-check scan occured while scanning %s", project.getName());
                 throw new MavenReportException(msg, ex);
             }
         }
@@ -646,8 +643,7 @@ public class DependencyCheckMojo extends ReportAggregationMojo {
      * @return the output name
      */
     public String getOutputName() {
-        if ("HTML".equalsIgnoreCase(this.format)
-                || "ALL".equalsIgnoreCase(this.format)) {
+        if ("HTML".equalsIgnoreCase(this.format) || "ALL".equalsIgnoreCase(this.format)) {
             return "dependency-check-report";
         } else if ("XML".equalsIgnoreCase(this.format)) {
             return "dependency-check-report.xml#";
@@ -685,8 +681,7 @@ public class DependencyCheckMojo extends ReportAggregationMojo {
      * @return the description
      */
     public String getDescription(Locale locale) {
-        return "A report providing details on any published "
-                + "vulnerabilities within project dependencies. This report is a best effort but may contain "
+        return "A report providing details on any published " + "vulnerabilities within project dependencies. This report is a best effort but may contain "
                 + "false positives and false negatives.";
     }
 
@@ -740,6 +735,7 @@ public class DependencyCheckMojo extends ReportAggregationMojo {
     protected boolean canGenerateAggregateReport() {
         return isAggregate() && isLastProject();
     }
+
     // </editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Methods to fail build or show summary">
@@ -807,12 +803,12 @@ public class DependencyCheckMojo extends ReportAggregationMojo {
             }
         }
         if (summary.length() > 0) {
-            final String msg = String.format("%n%n"
-                    + "One or more dependencies were identified with known vulnerabilities:%n%n%s"
+            final String msg = String.format("%n%n" + "One or more dependencies were identified with known vulnerabilities:%n%n%s"
                     + "%n%nSee the dependency-check report for more details.%n%n", summary.toString());
             LOGGER.log(Level.WARNING, msg);
         }
     }
+
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Methods to read/write the serialized data file">


### PR DESCRIPTION
Hi Jeremy,

First of all: thank you for Dependency Check!

I've made two new features of which I hope you'll consider to include in the project. Both are for the maven plugin.
- I noticed that only the (jar) files of the maven dependencies are are used but not the group, artifact and version fields which are present as well. This is mostly the same data retrieved when querying nexus. Using this data instead of nexus speeds up the analysis process considerably. So I added an additional scan method in the Engine that also takes a MavenArtifact and evaluates it like the nexus evidence. I moved the evaluation code from the NexusAnalyzer to Dependency to share it between Engine and NexusAnalyzer.
- The (internal) project I am working on uses a lot of poorly named artifacts which trigger false positives because of name clashes. Since they all start with a common groupId I've added the feature to exclude those from analysis using the excludeInternalGroupIds configuration parameter, like this:

``` xml
    <excludeInternalGroupIds>
        <groupId>some.internal.group.id</groupId>
    </excludeInternalGroupIds>
```

I apologize for the code reformatting in my commits. I found out when it was too late :-)

Best regards,

Erik Hooijmeijer
