### PR TITLE
Upgrade to junit 4.12

### DIFF
--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -339,13 +339,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-            <type>jar</type>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
             <version>2.1</version>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -279,11 +279,5 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
             <artifactId>commons-io</artifactId>
             <version>2.4</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -256,9 +256,8 @@ Copyright (c) 2012 - Jeremy Long
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
-            <type>jar</type>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
- Upgrade to junit 4.12 which was released recently.
- The submodules will inherit this dependy from the parent pom, so removed it from two of the submodules. This way, we'll have the definition in one place and only need to update the version number once.
- Dropped type because "jar" is the default.
