### PR TITLE
Upgraded some more dependencies

### DIFF
--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -456,12 +456,12 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.9.3</version>
+            <version>1.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-testutil</artifactId>
-            <version>1.9.3</version>
+            <version>1.9.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dependency-check-ant/src/test/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTaskTest.java
+++ b/dependency-check-ant/src/test/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTaskTest.java
@@ -30,6 +30,9 @@ import org.owasp.dependencycheck.utils.Settings;
  * @author Jeremy Long <jeremy.long@owasp.org>
  */
 public class DependencyCheckTaskTest extends BuildFileTest {
+    //TODO: The use of deprecated class BuildFileTestcan possibly
+    //be replaced with BuildFileRule. However, it doesn't seem to be included
+    //in the ant-testutil jar.
 
     @Before
     @Override

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -728,6 +728,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         </profile>
     </profiles>
     <properties>
-        <apache.lucene.version>4.5.1</apache.lucene.version>
+        <apache.lucene.version>4.6.1</apache.lucene.version>
     </properties>
 </project>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -728,6 +728,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         </profile>
     </profiles>
     <properties>
-        <apache.lucene.version>4.7.1</apache.lucene.version>
+        <apache.lucene.version>4.10.3</apache.lucene.version>
     </properties>
 </project>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -439,7 +439,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.8.1</version>
+            <version>1.9</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -422,13 +422,13 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
-            <version>1.12</version>
+            <version>1.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
-            <version>2.0.1</version>
+            <version>3.0.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -449,7 +449,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.5</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -728,6 +728,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         </profile>
     </profiles>
     <properties>
-        <apache.lucene.version>4.6.1</apache.lucene.version>
+        <apache.lucene.version>4.7.1</apache.lucene.version>
     </properties>
 </project>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -416,7 +416,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-test-framework</artifactId>
-            <version>4.3.1</version>
+            <version>${apache.lucene.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -454,17 +454,17 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>4.5.1</version>
+            <version>${apache.lucene.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analyzers-common</artifactId>
-            <version>4.5.1</version>
+            <version>${apache.lucene.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queryparser</artifactId>
-            <version>4.5.1</version>
+            <version>${apache.lucene.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
@@ -732,4 +732,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             </dependencies>
         </profile>
     </profiles>
+    <properties>
+        <apache.lucene.version>4.5.1</apache.lucene.version>
+    </properties>
 </project>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -474,7 +474,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.3.172</version>
+            <version>1.3.176</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -432,11 +432,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>1.9</version>

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/AlphaNumericTokenizer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/AlphaNumericTokenizer.java
@@ -39,17 +39,6 @@ public class AlphaNumericTokenizer extends CharTokenizer {
     }
 
     /**
-     * Constructs a new AlphaNumericTokenizer.
-     *
-     * @param matchVersion the lucene version
-     * @param factory the AttributeFactory
-     * @param in the Reader
-     */
-    public AlphaNumericTokenizer(Version matchVersion, AttributeFactory factory, Reader in) {
-        super(matchVersion, factory, in);
-    }
-
-    /**
      * Determines if the char passed in is part of a token.
      *
      * @param c the char being analyzed

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/LuceneUtils.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/LuceneUtils.java
@@ -31,7 +31,7 @@ public final class LuceneUtils {
      * The current version of Lucene being used. Declaring this one place so an upgrade doesn't require hunting through
      * the code base.
      */
-    public static final Version CURRENT_VERSION = Version.LUCENE_45;
+    public static final Version CURRENT_VERSION = Version.LATEST;
 
     /**
      * Private constructor as this is a utility class.

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/lucene/UrlTokenizingFilterTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/lucene/UrlTokenizingFilterTest.java
@@ -20,16 +20,10 @@ package org.owasp.dependencycheck.data.lucene;
 import java.io.IOException;
 import java.io.Reader;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.Analyzer.TokenStreamComponents;
 import org.apache.lucene.analysis.BaseTokenStreamTestCase;
-import static org.apache.lucene.analysis.BaseTokenStreamTestCase.checkOneTerm;
 import org.apache.lucene.analysis.MockTokenizer;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 
 /**
  *
@@ -48,24 +42,6 @@ public class UrlTokenizingFilterTest extends BaseTokenStreamTestCase {
                 return new TokenStreamComponents(source, new UrlTokenizingFilter(source));
             }
         };
-    }
-
-    @BeforeClass
-    public static void setUpClass() {
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        super.tearDown();
     }
 
     /**
@@ -102,6 +78,6 @@ public class UrlTokenizingFilterTest extends BaseTokenStreamTestCase {
                 return new TokenStreamComponents(tokenizer, new UrlTokenizingFilter(tokenizer));
             }
         };
-        checkOneTermReuse(a, "", "");
+        checkOneTerm(a, "", "");
     }
 }

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -304,27 +304,27 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.0</version>
+            <version>3.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-settings</artifactId>
-            <version>3.0</version>
+            <version>3.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.0</version>
+            <version>3.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-site-plugin</artifactId>
-            <version>3.0</version>
+            <version>3.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.0</version>
+            <version>3.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -335,13 +335,13 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
-            <version>1.12</version>
+            <version>1.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
-            <version>2.1</version>
+            <version>3.3.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Continuing on, I've upgraded most of the dependencies to use the latest version. See commit log for details.

Some comments:
- I left the majority in -core alone, since it looked like most of them were included to verify those versions are indeeded marked as vulnerable.
- `mvn clean install` still runs sucessfully, though since I don't have mono installed, the .NET related tests have been ignored (Cool, haven't seen Assume used in practice before). Someone might want to doublecheck those are still working.
- When upgrading h2 to the 1.4.x-series I saw some failing tests because they couldn't connect to the database. From their homepage it looks like this is still in beta (http://www.h2database.com/html/changelog.html) so I went with the latest 1.3.x instead. I didn't look more into it, but should probably do so if a stable release of the 1.4.x-series show up.
- Apache Lucene also has some newer versions, though switching to these caused compilation errors. I might look more into why, but thought I'd deal with the upgrades which didn't require code changes first.
