### PR TITLE
Upgrade plugins to latest version

### DIFF
--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -37,6 +37,9 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
         </site>
     </distributionManagement>
     <!-- end copy -->
+    <prerequisites>
+        <maven>3.0</maven>
+    </prerequisites>
     <build>
         <resources>
             <resource>
@@ -193,7 +196,7 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.1</version>
+                <version>2.3</version>
                 <configuration>
                     <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -268,7 +268,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
                 <configuration>
                     <systemProperties>
                         <property>

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -220,17 +220,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                        </manifest>
-                    </archive>
-                    <excludes>
-                        <exclude>**/checkstyle*</exclude>
-                    </excludes>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -37,9 +37,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
         </site>
     </distributionManagement>
     <!-- end copy -->
-    <prerequisites>
-        <maven>3.0</maven>
-    </prerequisites>
     <build>
         <resources>
             <resource>

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -68,7 +68,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.6</version>
                 <configuration>
                     <escapeWindowsPaths>false</escapeWindowsPaths>
                 </configuration>

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -282,12 +282,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <showDeprecation>false</showDeprecation>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -224,7 +224,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
                 <configuration>
                     <instrumentation>
                         <ignoreTrivial>true</ignoreTrivial>

--- a/dependency-check-cli/pom.xml
+++ b/dependency-check-cli/pom.xml
@@ -71,7 +71,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
                 <configuration>
                     <instrumentation>
                         <ignoreTrivial>true</ignoreTrivial>

--- a/dependency-check-cli/pom.xml
+++ b/dependency-check-cli/pom.xml
@@ -114,7 +114,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
                 <configuration>
                     <systemProperties>
                         <property>

--- a/dependency-check-cli/pom.xml
+++ b/dependency-check-cli/pom.xml
@@ -60,17 +60,12 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifest>
                             <mainClass>org.owasp.dependencycheck.App</mainClass>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
                     </archive>
-                    <excludes>
-                        <exclude>**/checkstyle*</exclude>
-                    </excludes>
                 </configuration>
             </plugin>
             <plugin>

--- a/dependency-check-cli/pom.xml
+++ b/dependency-check-cli/pom.xml
@@ -133,12 +133,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <showDeprecation>false</showDeprecation>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/dependency-check-cli/pom.xml
+++ b/dependency-check-cli/pom.xml
@@ -274,7 +274,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>appassembler-maven-plugin</artifactId>
-                <version>1.8.1</version>
                 <configuration>
                     <programs>
                         <program>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -397,12 +397,8 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
-                    <showDeprecation>false</showDeprecation>
                     <compilerArgument>-Xlint:unchecked</compilerArgument>
-                    <source>1.6</source>
-                    <target>1.6</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -192,7 +192,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
                 <configuration>
                     <systemProperties>
                         <property>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -93,7 +93,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
                 <executions>
                     <execution>
                         <phase>generate-resources</phase>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -110,7 +110,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
                 <executions>
                     <execution>
                         <id>jar</id>
@@ -127,16 +126,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                        </manifest>
-                    </archive>
-                    <excludes>
-                        <exclude>**/checkstyle*</exclude>
-                    </excludes>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -201,31 +201,14 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.16</version>
                 <configuration>
                     <systemProperties>
                         <property>
                             <name>data.directory</name>
                             <value>${project.build.directory}/data</value>
                         </property>
-                        <property>
-                            <name>temp.directory</name>
-                            <value>${project.build.directory}/temp</value>
-                        </property>
-
                     </systemProperties>
-                    <includes>
-                        <include>**/*IntegrationTest.java</include>
-                    </includes>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -573,6 +573,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.18.1</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -580,7 +581,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.16</version>
+                        <version>2.18.1</version>
                         <configuration>
                             <systemProperties>
                                 <property>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -573,7 +573,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.16</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -129,7 +129,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
                 <configuration>
                     <instrumentation>
                         <ignoreTrivial>true</ignoreTrivial>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -280,12 +280,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <showDeprecation>false</showDeprecation>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -89,7 +89,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
                 <configuration>
                     <systemProperties>
                         <property>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -66,7 +66,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     <goalPrefix>dependency-check</goalPrefix>
@@ -106,7 +105,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                 <inherited>true</inherited>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.2</version>
                 <executions>
                     <execution>
                         <id>enforce-maven-3</id>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -40,9 +40,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         </site>
     </distributionManagement>
     <!-- end copy -->
-    <prerequisites>
-        <maven>3.0</maven>
-    </prerequisites>
     <build>
         <resources>
             <resource>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -45,7 +45,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
                 <configuration>
                     <instrumentation>
                         <ignoreTrivial>true</ignoreTrivial>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -78,7 +78,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
                 <configuration>
                     <systemProperties>
                         <property>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -118,12 +118,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <showDeprecation>false</showDeprecation>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -93,26 +93,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.16</version>
-                <configuration>
-                    <systemProperties>
-                        <property>
-                            <name>temp.directory</name>
-                            <value>${project.build.directory}/temp</value>
-                        </property>
-                    </systemProperties>
-                    <includes>
-                        <include>**/*IntegrationTest.java</include>
-                    </includes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,11 @@ Copyright (c) 2012 - Jeremy Long
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>2.9</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>2.8.2</version>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,30 @@ Copyright (c) 2012 - Jeremy Long
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.18.1</version>
+                    <configuration>
+                        <systemProperties>
+                            <property>
+                                <name>temp.directory</name>
+                                <value>${project.build.directory}/temp</value>
+                            </property>
+                        </systemProperties>
+                        <includes>
+                            <include>**/*IntegrationTest.java</include>
+                        </includes>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.5</version>
                     <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@ Copyright (c) 2012 - Jeremy Long
                     <version>1.9</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>cobertura-maven-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>2.5.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,9 @@ Copyright (c) 2012 - Jeremy Long
         </site>
     </distributionManagement>
     <!-- end copy -->
+    <prerequisites>
+        <maven>2.2.1</maven>
+    </prerequisites>
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,11 @@ Copyright (c) 2012 - Jeremy Long
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>2.7</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.18.1</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@ Copyright (c) 2012 - Jeremy Long
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.2</version>
                     <configuration>
                         <showDeprecation>false</showDeprecation>
                         <source>1.6</source>

--- a/pom.xml
+++ b/pom.xml
@@ -140,11 +140,6 @@ Copyright (c) 2012 - Jeremy Long
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.2</version>
-                    <configuration>
-                        <showDeprecation>false</showDeprecation>
-                        <source>1.6</source>
-                        <target>1.6</target>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -160,25 +155,6 @@ Copyright (c) 2012 - Jeremy Long
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>2.18.1</version>
-                    <configuration>
-                        <systemProperties>
-                            <property>
-                                <name>temp.directory</name>
-                                <value>${project.build.directory}/temp</value>
-                            </property>
-                        </systemProperties>
-                        <includes>
-                            <include>**/*IntegrationTest.java</include>
-                        </includes>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>integration-test</goal>
-                                <goal>verify</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -189,16 +165,6 @@ Copyright (c) 2012 - Jeremy Long
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.5</version>
-                    <configuration>
-                        <archive>
-                            <manifest>
-                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                            </manifest>
-                        </archive>
-                        <excludes>
-                            <exclude>**/checkstyle*</exclude>
-                        </excludes>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -225,6 +191,48 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <showDeprecation>false</showDeprecation>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <property>
+                            <name>temp.directory</name>
+                            <value>${project.build.directory}/temp</value>
+                        </property>
+                    </systemProperties>
+                    <includes>
+                        <include>**/*IntegrationTest.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                    <excludes>
+                        <exclude>**/checkstyle*</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,11 @@ Copyright (c) 2012 - Jeremy Long
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.5</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
                     <version>2.5.2</version>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,11 @@ Copyright (c) 2012 - Jeremy Long
                         <target>1.6</target>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.7</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -156,7 +161,6 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.7</version>
                 <executions>
                     <execution>
                         <id>site-filtering-hack</id>

--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,6 @@ Copyright (c) 2012 - Jeremy Long
             <!--<plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.4</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,16 @@ Copyright (c) 2012 - Jeremy Long
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>appassembler-maven-plugin</artifactId>
+                    <version>1.9</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>2.5.3</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
                     <version>2.6.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@ Copyright (c) 2012 - Jeremy Long
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.4.2</version>
+                    <version>2.5.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,20 @@ Copyright (c) 2012 - Jeremy Long
         <maven>2.2.1</maven>
     </prerequisites>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.1</version>
+                    <configuration>
+                        <showDeprecation>false</showDeprecation>
+                        <source>1.6</source>
+                        <target>1.6</target>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -138,11 +152,6 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,11 @@ Copyright (c) 2012 - Jeremy Long
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.6.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.2</version>
                     <configuration>
@@ -140,6 +145,11 @@ Copyright (c) 2012 - Jeremy Long
                         <source>1.6</source>
                         <target>1.6</target>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -167,6 +177,11 @@ Copyright (c) 2012 - Jeremy Long
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.5</version>
                     <configuration>
@@ -179,6 +194,11 @@ Copyright (c) 2012 - Jeremy Long
                             <exclude>**/checkstyle*</exclude>
                         </excludes>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.4.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -196,7 +216,6 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.4.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@ Copyright (c) 2012 - Jeremy Long
     </distributionManagement>
     <!-- end copy -->
     <prerequisites>
-        <maven>2.2.1</maven>
+        <maven>3.0</maven>
     </prerequisites>
     <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,11 @@ Copyright (c) 2012 - Jeremy Long
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>1.3.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>2.8.2</version>
                 </plugin>
@@ -180,6 +185,11 @@ Copyright (c) 2012 - Jeremy Long
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.5</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-plugin-plugin</artifactId>
+                    <version>3.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,21 @@ Copyright (c) 2012 - Jeremy Long
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.5</version>
+                    <configuration>
+                        <archive>
+                            <manifest>
+                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            </manifest>
+                        </archive>
+                        <excludes>
+                            <exclude>**/checkstyle*</exclude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>2.7</version>
                 </plugin>


### PR DESCRIPTION
This is still work in progress, though should be ready to start talking about.

Upgrades plugins used to latest version available, see commit messages for details. At the same time I've taken the opportunity to move the plugin names and version numbers into pluginManagement placed in the parent pom. This makes it possible to update the version numbers in a single place.

Some questions/comments:
1. I had some surprises with moving plugins into pluginManagement. Even after doing so, -core would still report that the plugins used the older version. It turned out that these were in fact also declared inside a profile where it was set to use the older version number. I don't know much about this case, but I tried experimenting and it seemed like the profile did _not_ pick up entries from the parent pom's pluginManagement. For the mean time, I've upgraded these version numbers manually, but if possible I would like to define them in a single place.
2. As you might see from the diff, I have tried to move common configurations out to the parent pom to avoid duplication/repetition. 
3. Unfortunately, I have not been able to verify that all plugins still perform as expected after the version upgrade. This is for the most part simply because I am not familiar with all of them, and some are quite hard to verify (at least without -Ddryrun) such as maven-release-plugin. 
4. This is also why I've left maven-site/github-site-plugins alone. I'm not really familiar with the setup nor how to verify this. I skimmed the blogpost linked to, and I will look closer into understanding it in the future. I have looked some at it though, and hope it will be possible to at least put part of the common configuration in a single place. 
5. Required maven version. 
5 A) I've currently required 2.2.1 in the parent pom (and effectively all submodules not overriding this). Then I discovered that the -ant module requires maven 3.0 in order to use the latest version of the maven-shade-plugin, so I changed that module. I am somewhat torn on specifying the highest required version number in the parent pom versus only where it is strictly needed. Any preferences on this.
5 B) I also noticed that although the -maven module requires maven 3.0, it only requires 2.2.1 at least based on plugin usage. I am not sure whether there was a reason for specifying this, so I have left it alone. 
6. Is the maven-gpg-plugin still used? I assume it has been commented out so that regular developers won't need to sign every local build they do, but it may be used for release builds. If it is still used, I'd like to declare the version number under pluginManagement so that we can keep it up to date, while keeping the actual usage out-commented. If it isn't used, I can remove it.
