### PR TITLE
Replaced deprecated constructors which contained parameter Version

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/cpe/CpeMemoryIndex.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/cpe/CpeMemoryIndex.java
@@ -125,7 +125,7 @@ public final class CpeMemoryIndex {
                 }
                 indexSearcher = new IndexSearcher(indexReader);
                 searchingAnalyzer = createSearchingAnalyzer();
-                queryParser = new QueryParser(LuceneUtils.CURRENT_VERSION, Fields.DOCUMENT_KEY, searchingAnalyzer);
+                queryParser = new QueryParser(Fields.DOCUMENT_KEY, searchingAnalyzer);
                 openState = true;
             }
         }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/AlphaNumericTokenizer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/AlphaNumericTokenizer.java
@@ -19,7 +19,6 @@ package org.owasp.dependencycheck.data.lucene;
 
 import java.io.Reader;
 import org.apache.lucene.analysis.util.CharTokenizer;
-import org.apache.lucene.util.Version;
 
 /**
  * Tokenizes the input breaking it into tokens when non-alpha/numeric characters are found.
@@ -31,11 +30,10 @@ public class AlphaNumericTokenizer extends CharTokenizer {
     /**
      * Constructs a new AlphaNumericTokenizer.
      *
-     * @param matchVersion the lucene version
      * @param in the Reader
      */
-    public AlphaNumericTokenizer(Version matchVersion, Reader in) {
-        super(matchVersion, in);
+    public AlphaNumericTokenizer(Reader in) {
+        super(in);
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/FieldAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/FieldAnalyzer.java
@@ -59,7 +59,7 @@ public class FieldAnalyzer extends Analyzer {
      */
     @Override
     protected TokenStreamComponents createComponents(String fieldName, Reader reader) {
-        final Tokenizer source = new AlphaNumericTokenizer(version, reader);
+        final Tokenizer source = new AlphaNumericTokenizer(reader);
 
         TokenStream stream = source;
 
@@ -72,7 +72,7 @@ public class FieldAnalyzer extends Analyzer {
                 | WordDelimiterFilter.SPLIT_ON_NUMERICS
                 | WordDelimiterFilter.STEM_ENGLISH_POSSESSIVE, null);
 
-        stream = new LowerCaseFilter(version, stream);
+        stream = new LowerCaseFilter(stream);
         stream = new StopFilter(version, stream, StopAnalyzer.ENGLISH_STOP_WORDS_SET);
 
         return new TokenStreamComponents(source, stream);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/SearchFieldAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/SearchFieldAnalyzer.java
@@ -62,7 +62,7 @@ public class SearchFieldAnalyzer extends Analyzer {
      */
     @Override
     protected TokenStreamComponents createComponents(String fieldName, Reader reader) {
-        final Tokenizer source = new AlphaNumericTokenizer(version, reader);
+        final Tokenizer source = new AlphaNumericTokenizer(reader);
 
         TokenStream stream = source;
 
@@ -74,7 +74,7 @@ public class SearchFieldAnalyzer extends Analyzer {
                 | WordDelimiterFilter.SPLIT_ON_NUMERICS
                 | WordDelimiterFilter.STEM_ENGLISH_POSSESSIVE, null);
 
-        stream = new LowerCaseFilter(version, stream);
+        stream = new LowerCaseFilter(stream);
         stream = new UrlTokenizingFilter(stream);
         concatenatingFilter = new TokenPairConcatenatingFilter(stream);
         stream = concatenatingFilter;

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/SearchVersionAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/SearchVersionAnalyzer.java
@@ -41,17 +41,10 @@ public class SearchVersionAnalyzer extends Analyzer {
     // http://www.codewrecks.com/blog/index.php/2012/08/25/index-your-blog-using-tags-and-lucene-net/
 
     /**
-     * The Lucene Version used.
-     */
-    private final Version version;
-
-    /**
      * Creates a new SearchVersionAnalyzer.
      *
-     * @param version the Lucene version
      */
-    public SearchVersionAnalyzer(Version version) {
-        this.version = version;
+    public SearchVersionAnalyzer() {
     }
 
     /**
@@ -63,9 +56,9 @@ public class SearchVersionAnalyzer extends Analyzer {
      */
     @Override
     protected TokenStreamComponents createComponents(String fieldName, Reader reader) {
-        final Tokenizer source = new WhitespaceTokenizer(version, reader);
+        final Tokenizer source = new WhitespaceTokenizer(reader);
         TokenStream stream = source;
-        stream = new LowerCaseFilter(version, stream);
+        stream = new LowerCaseFilter(stream);
         stream = new VersionTokenizingFilter(stream);
         return new TokenStreamComponents(source, stream);
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/VersionAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/VersionAnalyzer.java
@@ -23,7 +23,6 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer;
-import org.apache.lucene.util.Version;
 
 /**
  * VersionAnalyzer is a Lucene Analyzer used to analyze version information.
@@ -41,18 +40,10 @@ public class VersionAnalyzer extends Analyzer {
     // http://www.codewrecks.com/blog/index.php/2012/08/25/index-your-blog-using-tags-and-lucene-net/
 
     /**
-     * The Lucene Version used.
-     */
-    private final Version version;
-
-    /**
      * Creates a new VersionAnalyzer.
      *
-     * @param version the Lucene version
      */
-    public VersionAnalyzer(Version version) {
-        this.version = version;
-    }
+    public VersionAnalyzer() {}
 
     /**
      * Creates the TokenStreamComponents
@@ -63,9 +54,9 @@ public class VersionAnalyzer extends Analyzer {
      */
     @Override
     protected TokenStreamComponents createComponents(String fieldName, Reader reader) {
-        final Tokenizer source = new WhitespaceTokenizer(version, reader);
+        final Tokenizer source = new WhitespaceTokenizer(reader);
         TokenStream stream = source;
-        stream = new LowerCaseFilter(version, stream);
+        stream = new LowerCaseFilter(stream);
         return new TokenStreamComponents(source, stream);
     }
 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/lucene/FieldAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/lucene/FieldAnalyzerTest.java
@@ -89,7 +89,7 @@ public class FieldAnalyzerTest {
         map.put(field1, searchAnalyzerProduct);
         map.put(field2, searchAnalyzerVendor);
         PerFieldAnalyzerWrapper wrapper = new PerFieldAnalyzerWrapper(new StandardAnalyzer(LuceneUtils.CURRENT_VERSION), map);
-        QueryParser parser = new QueryParser(LuceneUtils.CURRENT_VERSION, field1, wrapper);
+        QueryParser parser = new QueryParser(field1, wrapper);
 
         Query q = parser.parse(querystr);
         //System.out.println(q.toString());

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/lucene/TokenPairConcatenatingFilterTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/lucene/TokenPairConcatenatingFilterTest.java
@@ -61,7 +61,7 @@ public class TokenPairConcatenatingFilterTest extends BaseTokenStreamTestCase {
      * test some examples
      */
     public void testExamples() throws IOException {
-        Tokenizer wsTokenizer = new WhitespaceTokenizer(LuceneUtils.CURRENT_VERSION, new StringReader("one two three"));
+        Tokenizer wsTokenizer = new WhitespaceTokenizer(new StringReader("one two three"));
         TokenStream filter = new TokenPairConcatenatingFilter(wsTokenizer);
         assertTokenStreamContents(filter,
                 new String[]{"one", "onetwo", "two", "twothree", "three"});
@@ -75,7 +75,7 @@ public class TokenPairConcatenatingFilterTest extends BaseTokenStreamTestCase {
     @Test
     public void testClear() throws IOException {
 
-        TokenStream ts = new WhitespaceTokenizer(LuceneUtils.CURRENT_VERSION, new StringReader("one two three"));
+        TokenStream ts = new WhitespaceTokenizer(new StringReader("one two three"));
         TokenPairConcatenatingFilter filter = new TokenPairConcatenatingFilter(ts);
         assertTokenStreamContents(filter, new String[]{"one", "onetwo", "two", "twothree", "three"});
 


### PR DESCRIPTION
Cleaning up most of the constructors now marked deprecated after I upgraded the Apache Lucene version. 
When looking into the code, these ended up toggling behaviour if Lucene version was later than 3.1. 

Some deprecated Lucene-related constructors remain, but these were less straight-forward as they assigned the version number to fields for presumably later usage. The constructors are deprecated though, but I'll look a bit closer into what they are actually used for.

While working on this I found VersionAnalyzer, SearchVersionAnalyzer and VersionTokenizingFilter which seem to have been deprecated for some time, and are currently unused classes in DependencyCheck. Would it be ok to remove these or should they be kept around (for instance if deprecated classes are only removed with major version changes)? The latter case only occured to me after I had removed unused parameter from the constructors, but I can revert that part if you want. :)
