### PR TITLE
Upgrade maven-plugin-annotations to latest version

### DIFF
--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -324,7 +324,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.3</version>
+            <version>3.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
In the neverending story of upgrading dependencies, it looks like there was a new release of maven-plugin-annotations.
