### PR TITLE
Clean up more deprecated code

### DIFF
--- a/dependency-check-ant/src/test/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTaskTest.java
+++ b/dependency-check-ant/src/test/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTaskTest.java
@@ -31,8 +31,9 @@ import org.owasp.dependencycheck.utils.Settings;
  */
 public class DependencyCheckTaskTest extends BuildFileTest {
     //TODO: The use of deprecated class BuildFileTestcan possibly
-    //be replaced with BuildFileRule. However, it doesn't seem to be included
-    //in the ant-testutil jar.
+    //be replaced with BuildFileRule. However, it currently isn't included in the ant-testutil jar.
+    //This should be fixed in ant-testutil 1.9.5, so we can check back once that has been released.
+    //Reference: http://mail-archives.apache.org/mod_mbox/ant-user/201406.mbox/%3C000001cf87ba$8949b690$9bdd23b0$@de%3E
 
     @Before
     @Override

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/cpe/CpeMemoryIndex.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/cpe/CpeMemoryIndex.java
@@ -153,7 +153,7 @@ public final class CpeMemoryIndex {
     private Analyzer createIndexingAnalyzer() {
         final Map fieldAnalyzers = new HashMap();
         fieldAnalyzers.put(Fields.DOCUMENT_KEY, new KeywordAnalyzer());
-        return new PerFieldAnalyzerWrapper(new FieldAnalyzer(LuceneUtils.CURRENT_VERSION), fieldAnalyzers);
+        return new PerFieldAnalyzerWrapper(new FieldAnalyzer(), fieldAnalyzers);
     }
 
     /**
@@ -165,12 +165,12 @@ public final class CpeMemoryIndex {
     private Analyzer createSearchingAnalyzer() {
         final Map<String, Analyzer> fieldAnalyzers = new HashMap<String, Analyzer>();
         fieldAnalyzers.put(Fields.DOCUMENT_KEY, new KeywordAnalyzer());
-        productSearchFieldAnalyzer = new SearchFieldAnalyzer(LuceneUtils.CURRENT_VERSION);
-        vendorSearchFieldAnalyzer = new SearchFieldAnalyzer(LuceneUtils.CURRENT_VERSION);
+        productSearchFieldAnalyzer = new SearchFieldAnalyzer();
+        vendorSearchFieldAnalyzer = new SearchFieldAnalyzer();
         fieldAnalyzers.put(Fields.PRODUCT, productSearchFieldAnalyzer);
         fieldAnalyzers.put(Fields.VENDOR, vendorSearchFieldAnalyzer);
 
-        return new PerFieldAnalyzerWrapper(new FieldAnalyzer(LuceneUtils.CURRENT_VERSION), fieldAnalyzers);
+        return new PerFieldAnalyzerWrapper(new FieldAnalyzer(), fieldAnalyzers);
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/FieldAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/FieldAnalyzer.java
@@ -25,7 +25,6 @@ import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.core.StopAnalyzer;
 import org.apache.lucene.analysis.core.StopFilter;
 import org.apache.lucene.analysis.miscellaneous.WordDelimiterFilter;
-import org.apache.lucene.util.Version;
 
 /**
  * <p>
@@ -37,18 +36,10 @@ import org.apache.lucene.util.Version;
 public class FieldAnalyzer extends Analyzer {
 
     /**
-     * The Lucene Version used.
-     */
-    private final Version version;
-
-    /**
      * Creates a new FieldAnalyzer.
      *
-     * @param version the Lucene version
      */
-    public FieldAnalyzer(Version version) {
-        this.version = version;
-    }
+    public FieldAnalyzer() { }
 
     /**
      * Creates the TokenStreamComponents
@@ -73,7 +64,7 @@ public class FieldAnalyzer extends Analyzer {
                 | WordDelimiterFilter.STEM_ENGLISH_POSSESSIVE, null);
 
         stream = new LowerCaseFilter(stream);
-        stream = new StopFilter(version, stream, StopAnalyzer.ENGLISH_STOP_WORDS_SET);
+        stream = new StopFilter(stream, StopAnalyzer.ENGLISH_STOP_WORDS_SET);
 
         return new TokenStreamComponents(source, stream);
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/LuceneUtils.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/LuceneUtils.java
@@ -46,7 +46,7 @@ public final class LuceneUtils {
      * @param text the data to be escaped
      */
     @SuppressWarnings("fallthrough")
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings(
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
             value = "SF_SWITCH_NO_DEFAULT",
             justification = "The switch below does have a default.")
     public static void appendEscapedLuceneQuery(StringBuilder buf,

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/LuceneUtils.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/LuceneUtils.java
@@ -17,6 +17,7 @@
  */
 package org.owasp.dependencycheck.data.lucene;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.lucene.util.Version;
 
 /**
@@ -46,7 +47,7 @@ public final class LuceneUtils {
      * @param text the data to be escaped
      */
     @SuppressWarnings("fallthrough")
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    @SuppressFBWarnings(
             value = "SF_SWITCH_NO_DEFAULT",
             justification = "The switch below does have a default.")
     public static void appendEscapedLuceneQuery(StringBuilder buf,

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/SearchFieldAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/lucene/SearchFieldAnalyzer.java
@@ -25,7 +25,6 @@ import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.core.StopAnalyzer;
 import org.apache.lucene.analysis.core.StopFilter;
 import org.apache.lucene.analysis.miscellaneous.WordDelimiterFilter;
-import org.apache.lucene.util.Version;
 
 /**
  * A Lucene field analyzer used to analyzer queries against the CPE data.
@@ -35,10 +34,6 @@ import org.apache.lucene.util.Version;
 public class SearchFieldAnalyzer extends Analyzer {
 
     /**
-     * The Lucene Version used.
-     */
-    private final Version version;
-    /**
      * A local reference to the TokenPairConcatenatingFilter so that we can clear any left over state if this analyzer
      * is re-used.
      */
@@ -47,11 +42,8 @@ public class SearchFieldAnalyzer extends Analyzer {
     /**
      * Constructs a new SearchFieldAnalyzer.
      *
-     * @param version the Lucene version
      */
-    public SearchFieldAnalyzer(Version version) {
-        this.version = version;
-    }
+    public SearchFieldAnalyzer() {  }
 
     /**
      * Creates a the TokenStreamComponents used to analyze the stream.
@@ -78,7 +70,7 @@ public class SearchFieldAnalyzer extends Analyzer {
         stream = new UrlTokenizingFilter(stream);
         concatenatingFilter = new TokenPairConcatenatingFilter(stream);
         stream = concatenatingFilter;
-        stream = new StopFilter(version, stream, StopAnalyzer.ENGLISH_STOP_WORDS_SET);
+        stream = new StopFilter(stream, StopAnalyzer.ENGLISH_STOP_WORDS_SET);
 
         return new TokenStreamComponents(source, stream);
     }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/lucene/FieldAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/lucene/FieldAnalyzerTest.java
@@ -88,7 +88,7 @@ public class FieldAnalyzerTest {
         HashMap<String, Analyzer> map = new HashMap<String, Analyzer>();
         map.put(field1, searchAnalyzerProduct);
         map.put(field2, searchAnalyzerVendor);
-        PerFieldAnalyzerWrapper wrapper = new PerFieldAnalyzerWrapper(new StandardAnalyzer(LuceneUtils.CURRENT_VERSION), map);
+        PerFieldAnalyzerWrapper wrapper = new PerFieldAnalyzerWrapper(new StandardAnalyzer(), map);
         QueryParser parser = new QueryParser(field1, wrapper);
 
         Query q = parser.parse(querystr);

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/lucene/FieldAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/lucene/FieldAnalyzerTest.java
@@ -69,7 +69,7 @@ public class FieldAnalyzerTest {
     @Test
     public void testAnalyzers() throws Exception {
 
-        Analyzer analyzer = new FieldAnalyzer(LuceneUtils.CURRENT_VERSION);
+        Analyzer analyzer = new FieldAnalyzer();
         Directory index = new RAMDirectory();
 
         String field1 = "product";
@@ -83,8 +83,8 @@ public class FieldAnalyzerTest {
         //Analyzer searchingAnalyzer = new SearchFieldAnalyzer(LuceneUtils.CURRENT_VERSION);
         String querystr = "product:\"(Spring Framework Core)\" vendor:(SpringSource)";
 
-        SearchFieldAnalyzer searchAnalyzerProduct = new SearchFieldAnalyzer(LuceneUtils.CURRENT_VERSION);
-        SearchFieldAnalyzer searchAnalyzerVendor = new SearchFieldAnalyzer(LuceneUtils.CURRENT_VERSION);
+        SearchFieldAnalyzer searchAnalyzerProduct = new SearchFieldAnalyzer();
+        SearchFieldAnalyzer searchAnalyzerVendor = new SearchFieldAnalyzer();
         HashMap<String, Analyzer> map = new HashMap<String, Analyzer>();
         map.put(field1, searchAnalyzerProduct);
         map.put(field2, searchAnalyzerVendor);


### PR DESCRIPTION
Fixes more code which became deprecated when upgrading the libraries.
Mainly solved by removing Version from Apache Lucene constructors. LuceneUtils.CURRENT_VERSION is still used in two places, but it looks like Lucene is overall moving away from specifying version when creating objects. I see the Version enum has a comment on removing the older specific version numbers once they hit 5.0, so those will be going away at least. 

See commit log for more details
