### PR TITLE
Place maven-site related plugins under pluginManagement and (attempt to) upgrade them

### DIFF
--- a/dependency-check-jenkins/pom.xml
+++ b/dependency-check-jenkins/pom.xml
@@ -58,7 +58,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.3</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,10 @@ Copyright (c) 2012 - Jeremy Long
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
+                    <!-- Before upgrading this to a newer version, verify the pages produced by `mvn site` still works.
+                    In particular, pay attention to all pages under "File type analyzers" as well as those under "General".
+                    Previously when testing with maven-site-plugin 3.4, these links have stopped working for some reason.
+                    -->
                     <version>3.3</version>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@ Copyright (c) 2012 - Jeremy Long
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,11 @@ Copyright (c) 2012 - Jeremy Long
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.18.1</version>
                 </plugin>
@@ -292,7 +297,6 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.3</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@ Copyright (c) 2012 - Jeremy Long
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>3.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,11 @@ Copyright (c) 2012 - Jeremy Long
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.18.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>com.github.github</groupId>
+                    <artifactId>site-maven-plugin</artifactId>
+                    <version>0.10</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -311,7 +316,6 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>com.github.github</groupId>
                 <artifactId>site-maven-plugin</artifactId>
-                <version>0.9</version>
                 <configuration>
                     <message>Creating site for ${project.artifactId}, ${project.version}</message>
                     <!-- this does the trick to place every module in the correct subfolder -->


### PR DESCRIPTION
(Work in progress)

Partially a follow-up of #182, where maven-site-plugin was not changed.

Looked a bit at it now and tried to upgrade maven-site-plugin and the related one from github to latest version. As I've tried to comment I ran into problems when upgrading maven-site-plugin to 3.4. After running `mvn site` I took a look at the output in target to verify things was still working, and too my surprise several links under "General" and all under "File type analyzers" on the left-side menu had stopped working. I haven't set up/defined things for site before, so I don't know how that works. Though I have a wild theory that site.xml has links to html-files while the content itself lives in markdown files, so maybe the conversion/mapping from markdown to html is somehow broken or works differently in the newer version.

I have not seen any changes/regression after upgrading the version number for the github plugin, though I haven't gone through all submodules thoroughly. 

Let me know if you have any suggestions or find more problems with this. Worst-case scenario I think the version numbers should still be placed in pluginManagement so we got them in one place, and document/comment why they are not running the latest version.
