### PR TITLE
Removes the test for default Maven repository directory.

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -295,15 +295,11 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
         }
         File externalPom = null;
         if (pomEntries.isEmpty()) {
-            if (dependency.getActualFilePath().matches(".*\\.m2.repository\\b.*")) {
-                String pomPath = dependency.getActualFilePath();
-                pomPath = pomPath.substring(0, pomPath.lastIndexOf('.')) + ".pom";
-                externalPom = new File(pomPath);
-                if (externalPom.isFile()) {
-                    pomEntries.add(pomPath);
-                } else {
-                    return false;
-                }
+            String pomPath = dependency.getActualFilePath();
+            pomPath = pomPath.substring(0, pomPath.lastIndexOf('.')) + ".pom";
+            externalPom = new File(pomPath);
+            if (externalPom.isFile()) {
+                pomEntries.add(pomPath);
             } else {
                 return false;
             }


### PR DESCRIPTION
Error: If the M3_REPO directory is not set to a path that contains _/m2/repository/_ the DependencyCheck doesn't read <library>.pom file. Some dependencies like "spring-core-3.2.0.RELEASE.jar" are not found due to this error.

Fix: Remove the test for default Maven repository directory. The existing check for the existence of <library>.pom file is sufficient.
