### PR TITLE
Modified NexusAnalyzer to download POM if required

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
@@ -226,7 +226,7 @@ public class NexusAnalyzer extends AbstractFileTypeAnalyzer {
                     final File baseDir = Settings.getTempDirectory();
                     pomFile = File.createTempFile("pom", ".xml", baseDir);
                     if (!pomFile.delete()) {
-                        final String msg = String.format("Unable to fetch pom.xml for %s from Central; "
+                        final String msg = String.format("Unable to fetch pom.xml for %s from Nexus repository; "
                                 + "this could result in undetected CPE/CVEs.", dependency.getFileName());
                         LOGGER.warning(msg);
                         LOGGER.fine("Unable to delete temp file");
@@ -235,7 +235,7 @@ public class NexusAnalyzer extends AbstractFileTypeAnalyzer {
                     Downloader.fetchFile(new URL(ma.getPomUrl()), pomFile);
                     pomUtil.analyzePOM(dependency, pomFile);
                 } catch (DownloadFailedException ex) {
-                    final String msg = String.format("Unable to download pom.xml for %s from Central; "
+                    final String msg = String.format("Unable to download pom.xml for %s from Nexus repository; "
                             + "this could result in undetected CPE/CVEs.", dependency.getFileName());
                     LOGGER.warning(msg);
                 } finally {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
@@ -17,6 +17,7 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -24,13 +25,18 @@ import java.net.URL;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.io.FileUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.data.nexus.NexusSearch;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.Evidence;
+import org.owasp.dependencycheck.jaxb.pom.PomUtils;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
+import org.owasp.dependencycheck.utils.DownloadFailedException;
+import org.owasp.dependencycheck.utils.Downloader;
 import org.owasp.dependencycheck.utils.Settings;
 
 /**
@@ -83,6 +89,10 @@ public class NexusAnalyzer extends AbstractFileTypeAnalyzer {
      * Field indicating if the analyzer is enabled.
      */
     private final boolean enabled = checkEnabled();
+    /**
+     * Field for doing POM work
+     */
+    private final PomUtils pomUtil = new PomUtils();
 
     /**
      * Determines if this analyzer is enabled
@@ -202,6 +212,38 @@ public class NexusAnalyzer extends AbstractFileTypeAnalyzer {
         try {
             final MavenArtifact ma = searcher.searchSha1(dependency.getSha1sum());
             dependency.addAsEvidence("nexus", ma, Confidence.HIGH);
+            boolean pomAnalyzed = false;
+            LOGGER.fine("POM URL " + ma.getPomUrl());
+            for (Evidence e : dependency.getVendorEvidence()) {
+                if ("pom".equals(e.getSource())) {
+                    pomAnalyzed = true;
+                    break;
+                }
+            }
+            if (!pomAnalyzed && ma.getPomUrl() != null) {
+                File pomFile = null;
+                try {
+                    final File baseDir = Settings.getTempDirectory();
+                    pomFile = File.createTempFile("pom", ".xml", baseDir);
+                    if (!pomFile.delete()) {
+                        final String msg = String.format("Unable to fetch pom.xml for %s from Central; "
+                                + "this could result in undetected CPE/CVEs.", dependency.getFileName());
+                        LOGGER.warning(msg);
+                        LOGGER.fine("Unable to delete temp file");
+                    }
+                    LOGGER.fine(String.format("Downloading %s", ma.getPomUrl()));
+                    Downloader.fetchFile(new URL(ma.getPomUrl()), pomFile);
+                    pomUtil.analyzePOM(dependency, pomFile);
+                } catch (DownloadFailedException ex) {
+                    final String msg = String.format("Unable to download pom.xml for %s from Central; "
+                            + "this could result in undetected CPE/CVEs.", dependency.getFileName());
+                    LOGGER.warning(msg);
+                } finally {
+                    if (pomFile != null && !FileUtils.deleteQuietly(pomFile)) {
+                        pomFile.deleteOnExit();
+                    }
+                }
+            }
         } catch (IllegalArgumentException iae) {
             //dependency.addAnalysisException(new AnalysisException("Invalid SHA-1"));
             LOGGER.info(String.format("invalid sha-1 hash on %s", dependency.getFileName()));

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nexus/MavenArtifact.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nexus/MavenArtifact.java
@@ -17,6 +17,8 @@
  */
 package org.owasp.dependencycheck.data.nexus;
 
+import java.io.File;
+
 /**
  * Simple bean representing a Maven Artifact.
  *

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusSearch.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusSearch.java
@@ -131,7 +131,18 @@ public class NexusSearch {
                         .evaluate(
                                 "/org.sonatype.nexus.rest.model.NexusArtifact/artifactLink",
                                 doc);
-                return new MavenArtifact(groupId, artifactId, version, link);
+                final String pomLink = xpath
+                        .evaluate(
+                                "/org.sonatype.nexus.rest.model.NexusArtifact/pomLink",
+                                doc);
+                MavenArtifact ma = new MavenArtifact(groupId, artifactId, version);
+                if (link != null && !"".equals(link)) {
+                  ma.setArtifactUrl(link);
+                }
+                if (pomLink != null & !"".equals(pomLink)) {
+                  ma.setPomUrl(pomLink);
+                }
+                return ma;
             } catch (Throwable e) {
                 // Anything else is jacked-up XML stuff that we really can't recover
                 // from well

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/jaxb/pom/PomUtils.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/jaxb/pom/PomUtils.java
@@ -31,8 +31,13 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.sax.SAXSource;
+
+import org.owasp.dependencycheck.analyzer.JarAnalyzer;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.dependency.Confidence;
+import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.jaxb.pom.generated.Model;
+import org.owasp.dependencycheck.jaxb.pom.generated.Organization;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLFilter;
@@ -134,4 +139,88 @@ public class PomUtils {
         }
         return model;
     }
+
+  /**
+   * Reads in the pom file and adds elements as evidence to the given dependency.
+   *
+   * @param dependency the dependency being analyzed
+   * @param pomFile the pom file to read
+   * @throws AnalysisException is thrown if there is an exception parsing the pom
+   */
+  public void analyzePOM(Dependency dependency, File pomFile) throws AnalysisException {
+    final Model pom = this.readPom(pomFile);
+
+    String groupid = pom.getGroupId();
+    String parentGroupId = null;
+
+    if (pom.getParent() != null) {
+      parentGroupId = pom.getParent().getGroupId();
+      if ((groupid == null || groupid.isEmpty()) && parentGroupId != null && !parentGroupId.isEmpty()) {
+        groupid = parentGroupId;
+      }
+    }
+    if (groupid != null && !groupid.isEmpty()) {
+      dependency.getVendorEvidence().addEvidence("pom", "groupid", groupid, Confidence.HIGHEST);
+      dependency.getProductEvidence().addEvidence("pom", "groupid", groupid, Confidence.LOW);
+      if (parentGroupId != null && !parentGroupId.isEmpty() && !parentGroupId.equals(groupid)) {
+        dependency.getVendorEvidence().addEvidence("pom", "parent-groupid", parentGroupId, Confidence.MEDIUM);
+        dependency.getProductEvidence().addEvidence("pom", "parent-groupid", parentGroupId, Confidence.LOW);
+      }
+    }
+    String artifactid = pom.getArtifactId();
+    String parentArtifactId = null;
+    if (pom.getParent() != null) {
+      parentArtifactId = pom.getParent().getArtifactId();
+      if ((artifactid == null || artifactid.isEmpty()) && parentArtifactId != null && !parentArtifactId.isEmpty()) {
+        artifactid = parentArtifactId;
+      }
+    }
+    if (artifactid != null && !artifactid.isEmpty()) {
+      if (artifactid.startsWith("org.") || artifactid.startsWith("com.")) {
+        artifactid = artifactid.substring(4);
+      }
+      dependency.getProductEvidence().addEvidence("pom", "artifactid", artifactid, Confidence.HIGHEST);
+      dependency.getVendorEvidence().addEvidence("pom", "artifactid", artifactid, Confidence.LOW);
+      if (parentArtifactId != null && !parentArtifactId.isEmpty() && !parentArtifactId.equals(artifactid)) {
+        dependency.getProductEvidence().addEvidence("pom", "parent-artifactid", parentArtifactId, Confidence.MEDIUM);
+        dependency.getVendorEvidence().addEvidence("pom", "parent-artifactid", parentArtifactId, Confidence.LOW);
+      }
+    }
+    //version
+    String version = pom.getVersion();
+    String parentVersion = null;
+    if (pom.getParent() != null) {
+      parentVersion = pom.getParent().getVersion();
+      if ((version == null || version.isEmpty()) && parentVersion != null && !parentVersion.isEmpty()) {
+        version = parentVersion;
+      }
+    }
+    if (version != null && !version.isEmpty()) {
+      dependency.getVersionEvidence().addEvidence("pom", "version", version, Confidence.HIGHEST);
+      if (parentVersion != null && !parentVersion.isEmpty() && !parentVersion.equals(version)) {
+        dependency.getVersionEvidence().addEvidence("pom", "parent-version", version, Confidence.LOW);
+      }
+    }
+
+    final Organization org = pom.getOrganization();
+    if (org != null) {
+      final String orgName = org.getName();
+      if (orgName != null && !orgName.isEmpty()) {
+        dependency.getVendorEvidence().addEvidence("pom", "organization name", orgName, Confidence.HIGH);
+      }
+    }
+    final String pomName = pom.getName();
+    if (pomName != null && !pomName.isEmpty()) {
+      dependency.getProductEvidence().addEvidence("pom", "name", pomName, Confidence.HIGH);
+      dependency.getVendorEvidence().addEvidence("pom", "name", pomName, Confidence.HIGH);
+    }
+
+    if (pom.getDescription() != null) {
+      final String description = pom.getDescription();
+      if (description != null && !description.isEmpty()) {
+        JarAnalyzer.addDescription(dependency, description, "pom", "description");
+      }
+    }
+    JarAnalyzer.extractLicense(pom, null, dependency);
+  }
 }


### PR DESCRIPTION
NexusAnalyzer previously would just get GAV for a
match, but the POM may be separate from the jar
and contain other valuable information. This
includes refactoring of the analyzePom into
PomUtils.
