### PR TITLE
Upgrade jmockit to latest version

### DIFF
--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -354,7 +354,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
-            <version>1.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -294,7 +294,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
-            <version>1.15</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -294,7 +294,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
-            <version>1.14</version>
+            <version>1.15</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -370,17 +370,29 @@ Copyright (c) 2012 - Jeremy Long
             </plugin>
         </plugins>
     </reporting>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>1.3</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -382,6 +382,11 @@ Copyright (c) 2012 - Jeremy Long
                 <artifactId>hamcrest-core</artifactId>
                 <version>1.3</version>
             </dependency>
+            <dependency>
+                <groupId>org.jmockit</groupId>
+                <artifactId>jmockit</artifactId>
+                <version>1.15</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>


### PR DESCRIPTION
`mvn clean install` is still passing.
