### PR TITLE
Fixed logger name in PythonPackageAnalyzer.

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
@@ -57,7 +57,7 @@ public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
      * The logger.
      */
     private static final Logger LOGGER = Logger
-            .getLogger(PythonDistributionAnalyzer.class.getName());
+            .getLogger(PythonPackageAnalyzer.class.getName());
 
     /**
      * Filename extensions for files to be analyzed.


### PR DESCRIPTION
Noticed this in a casual look at the code.
