### PR TITLE
Upgrades

### DIFF
--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -423,12 +423,10 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-testutil</artifactId>
-            <version>1.9.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dependency-check-ant/src/test/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTaskTest.java
+++ b/dependency-check-ant/src/test/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTaskTest.java
@@ -18,34 +18,41 @@
 package org.owasp.dependencycheck.taskdefs;
 
 import java.io.File;
-import org.apache.tools.ant.BuildFileTest;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.BuildFileRule;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.owasp.dependencycheck.data.nvdcve.BaseDBTestCase;
 import org.owasp.dependencycheck.utils.Settings;
+
+import static org.junit.Assert.assertTrue;
+
 
 /**
  *
  * @author Jeremy Long
  */
-public class DependencyCheckTaskTest extends BuildFileTest {
-    //TODO: The use of deprecated class BuildFileTestcan possibly
-    //be replaced with BuildFileRule. However, it currently isn't included in the ant-testutil jar.
-    //This should be fixed in ant-testutil 1.9.5, so we can check back once that has been released.
-    //Reference: http://mail-archives.apache.org/mod_mbox/ant-user/201406.mbox/%3C000001cf87ba$8949b690$9bdd23b0$@de%3E
+public class DependencyCheckTaskTest {
+
+    @Rule
+    public BuildFileRule buildFile = new BuildFileRule();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Before
-    @Override
     public void setUp() throws Exception {
         Settings.initialize();
         BaseDBTestCase.ensureDBExists();
         final String buildFile = this.getClass().getClassLoader().getResource("build.xml").getPath();
-        configureProject(buildFile);
+        this.buildFile.configureProject(buildFile);
     }
 
     @After
-    @Override
     public void tearDown() {
         //no cleanup...
         //executeTarget("cleanup");
@@ -63,7 +70,7 @@ public class DependencyCheckTaskTest extends BuildFileTest {
                 throw new Exception("Unable to delete 'target/DependencyCheck-Report.html' prior to test.");
             }
         }
-        executeTarget("test.fileset");
+        buildFile.executeTarget("test.fileset");
 
         assertTrue("DependencyCheck report was not generated", report.exists());
 
@@ -82,7 +89,7 @@ public class DependencyCheckTaskTest extends BuildFileTest {
                 throw new Exception("Unable to delete 'target/DependencyCheck-Report.xml' prior to test.");
             }
         }
-        executeTarget("test.filelist");
+        buildFile.executeTarget("test.filelist");
 
         assertTrue("DependencyCheck report was not generated", report.exists());
     }
@@ -100,7 +107,7 @@ public class DependencyCheckTaskTest extends BuildFileTest {
                 throw new Exception("Unable to delete 'target/DependencyCheck-Vulnerability.html' prior to test.");
             }
         }
-        executeTarget("test.dirset");
+        buildFile.executeTarget("test.dirset");
         assertTrue("DependencyCheck report was not generated", report.exists());
     }
 
@@ -109,7 +116,7 @@ public class DependencyCheckTaskTest extends BuildFileTest {
      */
     @Test
     public void testGetFailBuildOnCVSS() {
-        expectBuildException("failCVSS", "asdfasdfscore");
-        System.out.println(this.getOutput());
+        expectedException.expect(BuildException.class);
+        buildFile.executeTarget("failCVSS");
     }
 }

--- a/dependency-check-ant/src/test/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTaskTest.java
+++ b/dependency-check-ant/src/test/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTaskTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertTrue;
 public class DependencyCheckTaskTest {
 
     @Rule
-    public BuildFileRule buildFile = new BuildFileRule();
+    public BuildFileRule buildFileRule = new BuildFileRule();
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -49,7 +49,7 @@ public class DependencyCheckTaskTest {
         Settings.initialize();
         BaseDBTestCase.ensureDBExists();
         final String buildFile = this.getClass().getClassLoader().getResource("build.xml").getPath();
-        this.buildFile.configureProject(buildFile);
+        buildFileRule.configureProject(buildFile);
     }
 
     @After
@@ -70,7 +70,7 @@ public class DependencyCheckTaskTest {
                 throw new Exception("Unable to delete 'target/DependencyCheck-Report.html' prior to test.");
             }
         }
-        buildFile.executeTarget("test.fileset");
+        buildFileRule.executeTarget("test.fileset");
 
         assertTrue("DependencyCheck report was not generated", report.exists());
 
@@ -89,7 +89,7 @@ public class DependencyCheckTaskTest {
                 throw new Exception("Unable to delete 'target/DependencyCheck-Report.xml' prior to test.");
             }
         }
-        buildFile.executeTarget("test.filelist");
+        buildFileRule.executeTarget("test.filelist");
 
         assertTrue("DependencyCheck report was not generated", report.exists());
     }
@@ -107,7 +107,7 @@ public class DependencyCheckTaskTest {
                 throw new Exception("Unable to delete 'target/DependencyCheck-Vulnerability.html' prior to test.");
             }
         }
-        buildFile.executeTarget("test.dirset");
+        buildFileRule.executeTarget("test.dirset");
         assertTrue("DependencyCheck report was not generated", report.exists());
     }
 
@@ -117,6 +117,6 @@ public class DependencyCheckTaskTest {
     @Test
     public void testGetFailBuildOnCVSS() {
         expectedException.expect(BuildException.class);
-        buildFile.executeTarget("failCVSS");
+        buildFileRule.executeTarget("failCVSS");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -360,6 +360,16 @@ Copyright (c) 2012 - Jeremy Long
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant</artifactId>
+                <version>1.9.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant-testutil</artifactId>
+                <version>1.9.5</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
                 <version>1.3</version>


### PR DESCRIPTION
Upgrading dependencies to Ant 1.9.5 which was recently released.

Moved the version number to dependencyManagement in the root pom to keep track of it in one place.
This allowed me to finally replace the deprecated inheritance in DependencyCheckTaskTest (see deleted TODO for details). Should be equivalent now, only using the new rule. Only thing lacking is that the last test is no longer printing the result of getOutput, but since that didn't assert anything, I don't know whether it needs a replacement.
