### PR TITLE
More dependency management

### DIFF
--- a/dependency-check-cli/pom.xml
+++ b/dependency-check-cli/pom.xml
@@ -310,7 +310,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
         </dependency>
         <dependency>
             <groupId>org.owasp</groupId>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -391,7 +391,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -279,33 +279,27 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-settings</artifactId>
-            <version>3.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-site-plugin</artifactId>
-            <version>3.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.reporting</groupId>
             <artifactId>maven-reporting-api</artifactId>
-            <version>3.0</version>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>
@@ -315,7 +309,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
-            <version>3.3.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -223,7 +223,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -385,17 +385,17 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-core</artifactId>
-                <version>3.2.5</version>
+                <version>3.3.3</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
-                <version>3.2.5</version>
+                <version>3.3.3</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-settings</artifactId>
-                <version>3.2.5</version>
+                <version>3.3.3</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -362,6 +362,11 @@ Copyright (c) 2012 - Jeremy Long
                 <version>1.2</version>
             </dependency>
             <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.4</version>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>

--- a/pom.xml
+++ b/pom.xml
@@ -383,6 +383,41 @@ Copyright (c) 2012 - Jeremy Long
                 <version>1.9.5</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>3.2.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-plugin-api</artifactId>
+                <version>3.2.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-settings</artifactId>
+                <version>3.2.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.plugin-testing</groupId>
+                <artifactId>maven-plugin-testing-harness</artifactId>
+                <version>3.3.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.plugin-tools</groupId>
+                <artifactId>maven-plugin-annotations</artifactId>
+                <version>3.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.reporting</groupId>
+                <artifactId>maven-reporting-api</artifactId>
+                <version>3.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
                 <version>1.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,11 @@ Copyright (c) 2012 - Jeremy Long
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>commons-cli</groupId>
+                <artifactId>commons-cli</artifactId>
+                <version>1.2</version>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>

--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,9 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
+                <!-- Before upgrading to 1.3, note that this introduces several
+                deprecation warnings. Most notable OptionBuilder has been
+                marked as deprecated. Should probably be sorted out. -->
                 <version>1.2</version>
             </dependency>
             <dependency>
@@ -383,6 +386,8 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>org.jmockit</groupId>
                 <artifactId>jmockit</artifactId>
+                <!-- Upgrading to 1.17 introduces build failures when building
+                with OpenJDK. -->
                 <version>1.16</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
Moves more version numbers from the various modules (-cli, -maven, -utils) into the parent pom. That way, if multiple modules use the same dependency, they will have the same version. Also makes it easier to maintain by keeping the version numbers in a single place.

Upgarded maven-core, -plugin-api and -settings to latest version.

Added comments for dependencies where newer versions are available, but upgrading will introduce problems or warnings.

Verified `mvn clean install` still runs successfully.
