### PR TITLE
Modify AbstractFileTypeAnalyzer to use FileFilter instead of just file extensions

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileFilter;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashSet;
@@ -50,7 +51,7 @@ import java.util.Set;
  *
  * @author Jeremy Long
  */
-public class Engine {
+public class Engine implements FileFilter{
 
     /**
      * The list of dependencies.
@@ -317,7 +318,7 @@ public class Engine {
             extension = fileName;
         }
         Dependency dependency = null;
-        if (supportsExtension(extension)) {
+        if (accept(file)) {
             dependency = new Dependency(file);
             if (extension.equals(fileName)) {
                 dependency.setFileExtension(extension);
@@ -379,7 +380,7 @@ public class Engine {
                     boolean shouldAnalyze = true;
                     if (a instanceof FileTypeAnalyzer) {
                         final FileTypeAnalyzer fAnalyzer = (FileTypeAnalyzer) a;
-                        shouldAnalyze = fAnalyzer.supportsExtension(d.getFileExtension());
+                        shouldAnalyze = fAnalyzer.accept(d.getActualFile());
                     }
                     if (shouldAnalyze) {
                         LOGGER.debug("Begin Analysis of '{}'", d.getActualFilePath());
@@ -482,18 +483,18 @@ public class Engine {
     /**
      * Checks all analyzers to see if an extension is supported.
      *
-     * @param ext a file extension
+     * @param file a file extension
      * @return true or false depending on whether or not the file extension is supported
      */
-    public boolean supportsExtension(String ext) {
-        if (ext == null) {
+    public boolean accept(File file) {
+        if (file == null) {
             return false;
         }
         boolean scan = false;
         for (FileTypeAnalyzer a : this.fileTypeAnalyzers) {
             /* note, we can't break early on this loop as the analyzers need to know if
              they have files to work on prior to initialization */
-            scan |= a.supportsExtension(ext);
+            scan |= a.accept(file);
         }
         return scan;
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractFileTypeAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractFileTypeAnalyzer.java
@@ -17,9 +17,15 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.io.File;
+import java.io.FileFilter;
+import java.util.*;
+
+import org.apache.commons.io.IOCase;
+import org.apache.commons.io.filefilter.IOFileFilter;
+import org.apache.commons.io.filefilter.NameFileFilter;
+import org.apache.commons.io.filefilter.OrFileFilter;
+import org.apache.commons.io.filefilter.SuffixFileFilter;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
@@ -36,6 +42,7 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractFileTypeAnalyzer extends AbstractAnalyzer implements FileTypeAnalyzer {
 
     //<editor-fold defaultstate="collapsed" desc="Constructor">
+
     /**
      * Base constructor that all children must call. This checks the configuration to determine if the analyzer is
      * enabled.
@@ -98,21 +105,20 @@ public abstract class AbstractFileTypeAnalyzer extends AbstractAnalyzer implemen
 //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Abstract methods children must implement">
+
     /**
      * <p>
-     * Returns a list of supported file extensions. An example would be an analyzer that inspected java jar files. The
-     * getSupportedExtensions function would return a set with a single element "jar".</p>
+     * Returns the {@link java.io.FileFilter} used to determine which files are to be analyzed.
+     * An example would be an analyzer that inspected Java jar files. Implementors may use
+     * {@link org.owasp.dependencycheck.utils.FileFilterBuilder}.</p>
      *
+     * @return the file filter used to determine which files are to be analyzed
+     * <p/>
      * <p>
-     * <b>Note:</b> when implementing this the extensions returned MUST be lowercase.</p>
-     *
-     * @return The file extensions supported by this analyzer.
-     *
-     * <p>
-     * If the analyzer returns null it will not cause additional files to be analyzed but will be executed against every
-     * file loaded</p>
+     * If the analyzer returns null it will not cause additional files to be analyzed, but will be executed against
+     * every file loaded.</p>
      */
-    protected abstract Set<String> getSupportedExtensions();
+    protected abstract FileFilter getFileFilter();
 
     /**
      * Initializes the file type analyzer.
@@ -126,7 +132,7 @@ public abstract class AbstractFileTypeAnalyzer extends AbstractAnalyzer implemen
      * scanned, and added to the list of dependencies within the engine.
      *
      * @param dependency the dependency to analyze
-     * @param engine the engine scanning
+     * @param engine     the engine scanning
      * @throws AnalysisException thrown if there is an analysis exception
      */
     protected abstract void analyzeFileType(Dependency dependency, Engine engine) throws AnalysisException;
@@ -141,6 +147,7 @@ public abstract class AbstractFileTypeAnalyzer extends AbstractAnalyzer implemen
 
 //</editor-fold>
     //<editor-fold defaultstate="collapsed" desc="Final implementations for the Analyzer interface">
+
     /**
      * Initializes the analyzer.
      *
@@ -175,7 +182,7 @@ public abstract class AbstractFileTypeAnalyzer extends AbstractAnalyzer implemen
      * scanned, and added to the list of dependencies within the engine.
      *
      * @param dependency the dependency to analyze
-     * @param engine the engine scanning
+     * @param engine     the engine scanning
      * @throws AnalysisException thrown if there is an analysis exception
      */
     @Override
@@ -185,38 +192,30 @@ public abstract class AbstractFileTypeAnalyzer extends AbstractAnalyzer implemen
         }
     }
 
-    /**
-     * Returns whether or not this analyzer can process the given extension.
-     *
-     * @param extension the file extension to test for support.
-     * @return whether or not the specified file extension is supported by this analyzer.
-     */
     @Override
-    public final boolean supportsExtension(String extension) {
-        if (!enabled) {
-            return false;
-        }
-        final Set<String> ext = getSupportedExtensions();
-        if (ext == null) {
-            LOGGER.error("The '{}' analyzer is misconfigured and does not have any file extensions;"
-                + " it will be disabled", getName());
-            return false;
-        } else {
-            final boolean match = ext.contains(extension);
-            if (match) {
-                filesMatched = match;
+    public boolean accept(File pathname) {
+        FileFilter filter = getFileFilter();
+        boolean accepted = false;
+        if (null == filter) {
+            LOGGER.error("The '{}' analyzer is misconfigured and does not have a file filter; it will be disabled", getName());
+        } else if (enabled) {
+            accepted = filter.accept(pathname);
+            if (accepted) {
+                filesMatched = true;
             }
-            return match;
         }
+        return accepted;
     }
-//</editor-fold>
+
+    //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Static utility methods">
+
     /**
      * <p>
      * Utility method to help in the creation of the extensions set. This constructs a new Set that can be used in a
      * final static declaration.</p>
-     *
+     * <p/>
      * <p>
      * This implementation was copied from
      * http://stackoverflow.com/questions/2041778/initialize-java-hashset-values-by-construction</p>
@@ -226,9 +225,10 @@ public abstract class AbstractFileTypeAnalyzer extends AbstractAnalyzer implemen
      */
     protected static Set<String> newHashSet(String... strings) {
         final Set<String> set = new HashSet<String>();
-
         Collections.addAll(set, strings);
         return set;
     }
+
+
 //</editor-fold>
 }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractFileTypeAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractFileTypeAnalyzer.java
@@ -17,15 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.util.*;
-
-import org.apache.commons.io.IOCase;
-import org.apache.commons.io.filefilter.IOFileFilter;
-import org.apache.commons.io.filefilter.NameFileFilter;
-import org.apache.commons.io.filefilter.OrFileFilter;
-import org.apache.commons.io.filefilter.SuffixFileFilter;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
@@ -33,6 +24,12 @@ import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * The base FileTypeAnalyzer that all analyzers that have specific file types they analyze should extend.

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
@@ -17,22 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
-
 import ch.qos.cal10n.IMessageConveyor;
 import ch.qos.cal10n.MessageConveyor;
 import org.owasp.dependencycheck.Engine;
@@ -41,11 +25,22 @@ import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
 import org.owasp.dependencycheck.utils.DCResources;
+import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.cal10n.LocLogger;
 import org.slf4j.cal10n.LocLoggerFactory;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * Analyzer for getting company, product, and version information from a .NET assembly.
@@ -66,7 +61,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * The list of supported extensions
      */
-    private static final Set<String> SUPPORTED_EXTENSIONS = newHashSet("dll", "exe");
+    private static final String[] SUPPORTED_EXTENSIONS = {"dll", "exe"};
     /**
      * The temp value for GrokAssembly.exe
      */
@@ -296,14 +291,12 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
         }
     }
 
-    /**
-     * Gets the set of extensions supported by this analyzer.
-     *
-     * @return the list of supported extensions
-     */
+    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addExtensions(
+            SUPPORTED_EXTENSIONS).build();
+
     @Override
-    public Set<String> getSupportedExtensions() {
-        return SUPPORTED_EXTENSIONS;
+    protected FileFilter getFileFilter() {
+        return FILTER;
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AutoconfAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AutoconfAnalyzer.java
@@ -17,22 +17,23 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.commons.io.FileUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.EvidenceCollection;
+import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.owasp.dependencycheck.utils.Settings;
 import org.owasp.dependencycheck.utils.UrlStringUtils;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Used to analyze Autoconf input files named configure.ac or configure.in. Files simply named "configure" are also analyzed,
@@ -71,8 +72,7 @@ public class AutoconfAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * The set of file extensions supported by this analyzer.
      */
-    private static final Set<String> EXTENSIONS = newHashSet("ac", "in",
-            CONFIGURE);
+    private static final String[] EXTENSIONS = {"ac", "in"};
 
     /**
      * Matches AC_INIT variables in the output configure script.
@@ -103,14 +103,12 @@ public class AutoconfAnalyzer extends AbstractFileTypeAnalyzer {
                 | Pattern.CASE_INSENSITIVE);
     }
 
-    /**
-     * Returns a list of file EXTENSIONS supported by this analyzer.
-     *
-     * @return a list of file EXTENSIONS supported by this analyzer.
-     */
+    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addFilenames(CONFIGURE).addExtensions(
+            EXTENSIONS).build();
+
     @Override
-    public Set<String> getSupportedExtensions() {
-        return EXTENSIONS;
+    protected FileFilter getFileFilter() {
+        return FILTER;
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
@@ -17,12 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.net.URL;
-import java.util.List;
-import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
@@ -31,13 +25,17 @@ import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
+import org.owasp.dependencycheck.utils.*;
 import org.owasp.dependencycheck.xml.pom.PomUtils;
-import org.owasp.dependencycheck.utils.DownloadFailedException;
-import org.owasp.dependencycheck.utils.Downloader;
-import org.owasp.dependencycheck.utils.InvalidSettingException;
-import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
 
 /**
  * Analyzer which will attempt to locate a dependency, and the GAV information, by querying Central for the dependency's SHA-1
@@ -65,7 +63,7 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * The types of files on which this will work.
      */
-    private static final Set<String> SUPPORTED_EXTENSIONS = newHashSet("jar");
+    private static final String SUPPORTED_EXTENSIONS = "jar";
 
     /**
      * The analyzer should be disabled if there are errors, so this is a flag to determine if such an error has occurred.
@@ -163,14 +161,11 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
         return ANALYSIS_PHASE;
     }
 
-    /**
-     * Returns the extensions for which this Analyzer runs.
-     *
-     * @return the extensions for which this Analyzer runs
-     */
+    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addExtensions(SUPPORTED_EXTENSIONS).build();
+
     @Override
-    public Set<String> getSupportedExtensions() {
-        return SUPPORTED_EXTENSIONS;
+    protected FileFilter getFileFilter() {
+        return FILTER;
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FileTypeAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FileTypeAnalyzer.java
@@ -17,20 +17,14 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
+import java.io.FileFilter;
+
 /**
  * An Analyzer that scans specific file types.
  *
  * @author Jeremy Long
  */
-public interface FileTypeAnalyzer extends Analyzer {
-
-    /**
-     * Returns whether or not this analyzer can process the given extension.
-     *
-     * @param extension the file extension to test for support.
-     * @return whether or not the specified file extension is supported by this analyzer.
-     */
-    boolean supportsExtension(String extension);
+public interface FileTypeAnalyzer extends Analyzer, FileFilter {
 
     /**
      * Resets the analyzers state.

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -17,14 +17,7 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.Reader;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -47,6 +40,7 @@ import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.EvidenceCollection;
+import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.owasp.dependencycheck.xml.pom.License;
 import org.owasp.dependencycheck.xml.pom.PomUtils;
 import org.owasp.dependencycheck.xml.pom.Model;
@@ -168,16 +162,13 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * The set of file extensions supported by this analyzer.
      */
-    private static final Set<String> EXTENSIONS = newHashSet("jar", "war");
+    private static final String[] EXTENSIONS = {"jar", "war"};
 
-    /**
-     * Returns a list of file EXTENSIONS supported by this analyzer.
-     *
-     * @return a list of file EXTENSIONS supported by this analyzer.
-     */
+    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addExtensions(EXTENSIONS).build();
+
     @Override
-    public Set<String> getSupportedExtensions() {
-        return EXTENSIONS;
+    protected FileFilter getFileFilter() {
+        return FILTER;
     }
 
     /**
@@ -388,7 +379,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
      * @param dependency the dependency being analyzed
      * @return returns the POM object
      * @throws AnalysisException is thrown if there is an exception extracting or parsing the POM
-     * {@link org.owasp.dependencycheck.jaxb.pom.generated.Model} object
+     * {@link org.owasp.dependencycheck.xml.pom.Model} object
      */
     private Model extractPom(String path, JarFile jar, Dependency dependency) throws AnalysisException {
         InputStream input = null;

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JavaScriptAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JavaScriptAnalyzer.java
@@ -17,19 +17,16 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.Set;
-import java.util.regex.Pattern;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.regex.Pattern;
 
 /**
  *
@@ -56,16 +53,13 @@ public class JavaScriptAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * The set of file extensions supported by this analyzer.
      */
-    private static final Set<String> EXTENSIONS = newHashSet("js");
+    private static final String EXTENSIONS = "js";
 
-    /**
-     * Returns a list of file EXTENSIONS supported by this analyzer.
-     *
-     * @return a list of file EXTENSIONS supported by this analyzer.
-     */
+    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addExtensions(EXTENSIONS).build();
+
     @Override
-    public Set<String> getSupportedExtensions() {
-        return EXTENSIONS;
+    protected FileFilter getFileFilter() {
+        return FILTER;
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
@@ -17,12 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
@@ -31,13 +25,17 @@ import org.owasp.dependencycheck.data.nexus.NexusSearch;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
+import org.owasp.dependencycheck.utils.*;
 import org.owasp.dependencycheck.xml.pom.PomUtils;
-import org.owasp.dependencycheck.utils.InvalidSettingException;
-import org.owasp.dependencycheck.utils.DownloadFailedException;
-import org.owasp.dependencycheck.utils.Downloader;
-import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 /**
  * Analyzer which will attempt to locate a dependency on a Nexus service by SHA-1 digest of the dependency.
@@ -78,7 +76,7 @@ public class NexusAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * The types of files on which this will work.
      */
-    private static final Set<String> SUPPORTED_EXTENSIONS = newHashSet("jar");
+    private static final String SUPPORTED_EXTENSIONS = "jar";
 
     /**
      * The Nexus Search to be set up for this analyzer.
@@ -183,14 +181,11 @@ public class NexusAnalyzer extends AbstractFileTypeAnalyzer {
         return ANALYSIS_PHASE;
     }
 
-    /**
-     * Returns the extensions for which this Analyzer runs.
-     *
-     * @return the extensions for which this Analyzer runs
-     */
+    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addExtensions(SUPPORTED_EXTENSIONS).build();
+
     @Override
-    public Set<String> getSupportedExtensions() {
-        return SUPPORTED_EXTENSIONS;
+    protected FileFilter getFileFilter() {
+        return FILTER;
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NuspecAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NuspecAnalyzer.java
@@ -17,10 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.Set;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.nuget.NugetPackage;
@@ -29,9 +25,15 @@ import org.owasp.dependencycheck.data.nuget.NuspecParser;
 import org.owasp.dependencycheck.data.nuget.XPathNuspecParser;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 
 /**
  * Analyzer which will parse a Nuspec file to gather module information.
@@ -58,7 +60,7 @@ public class NuspecAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * The types of files on which this will work.
      */
-    private static final Set<String> SUPPORTED_EXTENSIONS = newHashSet("nuspec");
+    private static final String SUPPORTED_EXTENSIONS = "nuspec";
 
     /**
      * Initializes the analyzer once before any analysis is performed.
@@ -99,14 +101,12 @@ public class NuspecAnalyzer extends AbstractFileTypeAnalyzer {
         return ANALYSIS_PHASE;
     }
 
-    /**
-     * Returns the extensions for which this Analyzer runs.
-     *
-     * @return the extensions for which this Analyzer runs
-     */
+    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addExtensions(
+            SUPPORTED_EXTENSIONS).build();
+
     @Override
-    public Set<String> getSupportedExtensions() {
-        return SUPPORTED_EXTENSIONS;
+    protected FileFilter getFileFilter() {
+        return FILTER;
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
@@ -17,17 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.NameFileFilter;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
@@ -36,10 +25,20 @@ import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.EvidenceCollection;
+import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.owasp.dependencycheck.utils.Settings;
 import org.owasp.dependencycheck.utils.UrlStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Used to analyze a Python package, and collect information that can be used to determine the associated CPE.
@@ -63,8 +62,7 @@ public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * Filename extensions for files to be analyzed.
      */
-    private static final Set<String> EXTENSIONS = Collections
-            .unmodifiableSet(Collections.singleton("py"));
+    private static final String EXTENSIONS = "py";
 
     /**
      * Pattern for matching the module docstring in a source file.
@@ -134,14 +132,11 @@ public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
         return AnalysisPhase.INFORMATION_COLLECTION;
     }
 
-    /**
-     * Returns the set of supported file extensions.
-     *
-     * @return the set of supported file extensions
-     */
+    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addExtensions(EXTENSIONS).build();
+
     @Override
-    protected Set<String> getSupportedExtensions() {
-        return EXTENSIONS;
+    protected FileFilter getFileFilter() {
+        return FILTER;
     }
 
     /**
@@ -209,12 +204,12 @@ public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
      */
     private boolean analyzeFileContents(Dependency dependency, File file)
             throws AnalysisException {
-        String contents = "";
+        String contents;
         try {
             contents = FileUtils.readFileToString(file).trim();
         } catch (IOException e) {
             throw new AnalysisException(
-                    "Problem occured while reading dependency file.", e);
+                    "Problem occurred while reading dependency file.", e);
         }
         boolean found = false;
         if (!contents.isEmpty()) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/ExtractionUtil.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/ExtractionUtil.java
@@ -109,8 +109,7 @@ public final class ExtractionUtil {
                     }
                 } else {
                     final File file = new File(extractTo, entry.getName());
-                    final String ext = getFileExtension(file.getName());
-                    if (engine == null || engine.supportsExtension(ext)) {
+                    if (engine == null || engine.accept(file)) {
                         BufferedOutputStream bos = null;
                         FileOutputStream fos;
                         try {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/FileFilterBuilder.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/FileFilterBuilder.java
@@ -18,6 +18,7 @@
 
 package org.owasp.dependencycheck.utils;
 
+import org.apache.commons.io.IOCase;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.NameFileFilter;
 import org.apache.commons.io.filefilter.OrFileFilter;
@@ -43,7 +44,7 @@ public class FileFilterBuilder {
     private Set<String> filenames = new HashSet<String>();
 
     /**
-     * Add to the set of filenames to accept for analysis. Case sensitivity is assumed.
+     * Add to the set of filenames to accept for analysis. Case-sensitivity is assumed.
      *
      * @param names one or more filenames to accept for analysis
      */
@@ -55,7 +56,7 @@ public class FileFilterBuilder {
     private Set<String> extensions = new HashSet<String>();
 
     /**
-     * Add to the set of file extensions to accept for analysis. Case sensitivity is assumed.
+     * Add to the set of file extensions to accept for analysis. Case-insensitivity is assumed.
      *
      * @param extensions one or more file extensions to accept for analysis
      */
@@ -64,7 +65,7 @@ public class FileFilterBuilder {
     }
 
     /**
-     * Add to the set of file extensions to accept for analysis. Case sensitivity is assumed.
+     * Add to the set of file extensions to accept for analysis. Case-insensitivity is assumed.
      *
      * @param extensions one or more file extensions to accept for analysis
      */
@@ -103,7 +104,7 @@ public class FileFilterBuilder {
             filter.addFileFilter(new NameFileFilter(new ArrayList<String>(filenames)));
         }
         if (!extensions.isEmpty()) {
-            filter.addFileFilter(new SuffixFileFilter(new ArrayList<String>(extensions)));
+            filter.addFileFilter(new SuffixFileFilter(new ArrayList<String>(extensions), IOCase.INSENSITIVE));
         }
         for (IOFileFilter iof : fileFilters) {
             filter.addFileFilter(iof);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/FileFilterBuilder.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/FileFilterBuilder.java
@@ -24,41 +24,53 @@ import org.apache.commons.io.filefilter.NameFileFilter;
 import org.apache.commons.io.filefilter.OrFileFilter;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
 
-import java.io.File;
 import java.io.FileFilter;
 import java.util.*;
 
 /**
- * Utility class for building useful {@link FileFilter} instances for
+ * <p>Utility class for building useful {@link FileFilter} instances for
  * {@link org.owasp.dependencycheck.analyzer.AbstractFileTypeAnalyzer} implementations. The built filter uses
- * {@link OrFileFilter} to logically OR the given filter conditions.
+ * {@link OrFileFilter} to logically OR the given filter conditions. Example usage:</p>
+ *
+ * <pre>
+ *     FileFilter filter = FileFilterBuilder.newInstance().addExtensions("jar", "war").build();
+ * </pre>
  *
  * @author Dale Visser <dvisser@ida.org>
+ * @see <a href="https://en.wikipedia.org/wiki/Builder_pattern">Builder pattern</a>
  */
 public class FileFilterBuilder {
 
-    public static FileFilterBuilder newInstance(){
+    private Set<String> filenames = new HashSet<String>();
+    private Set<String> extensions = new HashSet<String>();
+    private List<IOFileFilter> fileFilters = new ArrayList<IOFileFilter>();
+
+    /**
+     * Create a new instance and return it. This method is for convenience in using the builder pattern within a single
+     * statement.
+     *
+     * @return a new builder instance
+     */
+    public static FileFilterBuilder newInstance() {
         return new FileFilterBuilder();
     }
-
-    private Set<String> filenames = new HashSet<String>();
 
     /**
      * Add to the set of filenames to accept for analysis. Case-sensitivity is assumed.
      *
      * @param names one or more filenames to accept for analysis
+     * @return this builder
      */
     public FileFilterBuilder addFilenames(String... names) {
         filenames.addAll(Arrays.asList(names));
         return this;
     }
 
-    private Set<String> extensions = new HashSet<String>();
-
     /**
      * Add to the set of file extensions to accept for analysis. Case-insensitivity is assumed.
      *
      * @param extensions one or more file extensions to accept for analysis
+     * @return this builder
      */
     public FileFilterBuilder addExtensions(String... extensions) {
         return this.addExtensions(Arrays.asList(extensions));
@@ -68,8 +80,9 @@ public class FileFilterBuilder {
      * Add to the set of file extensions to accept for analysis. Case-insensitivity is assumed.
      *
      * @param extensions one or more file extensions to accept for analysis
+     * @return this builder
      */
-    public FileFilterBuilder addExtensions(Iterable<String> extensions){
+    public FileFilterBuilder addExtensions(Iterable<String> extensions) {
         for (String extension : extensions) {
             // Ultimately, SuffixFileFilter will be used, and the "." needs to be explicit.
             this.extensions.add(extension.startsWith(".") ? extension : "." + extension);
@@ -77,12 +90,11 @@ public class FileFilterBuilder {
         return this;
     }
 
-    private List<IOFileFilter> fileFilters = new ArrayList<IOFileFilter>();
-
     /**
      * Add to a list of {@link IOFileFilter} instances to consult for whether to accept a file for analysis.
      *
      * @param filters one or more file filters to consult for whether to accept for analysis
+     * @return this builder
      */
     public FileFilterBuilder addFileFilters(IOFileFilter... filters) {
         fileFilters.addAll(Arrays.asList(filters));

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/FileFilterBuilder.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/FileFilterBuilder.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2015 Institute for Defense Analyses. All Rights Reserved.
+ */
+
+package org.owasp.dependencycheck.utils;
+
+import org.apache.commons.io.filefilter.IOFileFilter;
+import org.apache.commons.io.filefilter.NameFileFilter;
+import org.apache.commons.io.filefilter.OrFileFilter;
+import org.apache.commons.io.filefilter.SuffixFileFilter;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.*;
+
+/**
+ * Utility class for building useful {@link FileFilter} instances for
+ * {@link org.owasp.dependencycheck.analyzer.AbstractFileTypeAnalyzer} implementations. The built filter uses
+ * {@link OrFileFilter} to logically OR the given filter conditions.
+ *
+ * @author Dale Visser <dvisser@ida.org>
+ */
+public class FileFilterBuilder {
+
+    public static FileFilterBuilder newInstance(){
+        return new FileFilterBuilder();
+    }
+
+    private Set<String> filenames = new HashSet<String>();
+
+    /**
+     * Add to the set of filenames to accept for analysis. Case sensitivity is assumed.
+     *
+     * @param names one or more filenames to accept for analysis
+     */
+    public FileFilterBuilder addFilenames(String... names) {
+        filenames.addAll(Arrays.asList(names));
+        return this;
+    }
+
+    private Set<String> extensions = new HashSet<String>();
+
+    /**
+     * Add to the set of file extensions to accept for analysis. Case sensitivity is assumed.
+     *
+     * @param extensions one or more file extensions to accept for analysis
+     */
+    public FileFilterBuilder addExtensions(String... extensions) {
+        return this.addExtensions(Arrays.asList(extensions));
+    }
+
+    /**
+     * Add to the set of file extensions to accept for analysis. Case sensitivity is assumed.
+     *
+     * @param extensions one or more file extensions to accept for analysis
+     */
+    public FileFilterBuilder addExtensions(Iterable<String> extensions){
+        for (String extension : extensions) {
+            // Ultimately, SuffixFileFilter will be used, and the "." needs to be explicit.
+            this.extensions.add(extension.startsWith(".") ? extension : "." + extension);
+        }
+        return this;
+    }
+
+    private List<IOFileFilter> fileFilters = new ArrayList<IOFileFilter>();
+
+    /**
+     * Add to a list of {@link IOFileFilter} instances to consult for whether to accept a file for analysis.
+     *
+     * @param filters one or more file filters to consult for whether to accept for analysis
+     */
+    public FileFilterBuilder addFileFilters(IOFileFilter... filters) {
+        fileFilters.addAll(Arrays.asList(filters));
+        return this;
+    }
+
+    /**
+     * Builds the filter and returns it.
+     *
+     * @return a filter that is the logical OR of all the conditions provided by the add... methods
+     * @throws IllegalStateException if no add... method has been called with one or more arguments
+     */
+    public FileFilter build() {
+        if (filenames.isEmpty() && extensions.isEmpty() && fileFilters.isEmpty()) {
+            throw new IllegalStateException("May only be invoked after at least one add... method has been invoked.");
+        }
+        OrFileFilter filter = new OrFileFilter();
+        if (!filenames.isEmpty()) {
+            filter.addFileFilter(new NameFileFilter(new ArrayList<String>(filenames)));
+        }
+        if (!extensions.isEmpty()) {
+            filter.addFileFilter(new SuffixFileFilter(new ArrayList<String>(extensions)));
+        }
+        for (IOFileFilter iof : fileFilters) {
+            filter.addFileFilter(iof);
+        }
+        return filter;
+    }
+}

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/xml/pom/PomUtils.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/xml/pom/PomUtils.java
@@ -48,8 +48,7 @@ public final class PomUtils {
      *
      * @param file the pom.xml file
      * @return returns a
-     * @throws AnalysisException is thrown if there is an exception extracting or parsing the POM
-     * {@link org.owasp.dependencycheck.jaxb.pom.generated.Model} object
+     * @throws AnalysisException is thrown if there is an exception extracting or parsing the POM {@link Model} object
      */
     public static Model readPom(File file) throws AnalysisException {
         Model model = null;
@@ -78,8 +77,7 @@ public final class PomUtils {
      * @param path the path to the pom.xml file within the jar file
      * @param jar the jar file to extract the pom from
      * @return returns a
-     * @throws AnalysisException is thrown if there is an exception extracting or parsing the POM
-     * {@link org.owasp.dependencycheck.jaxb.pom.generated.Model} object
+     * @throws AnalysisException is thrown if there is an exception extracting or parsing the POM {@link Model} object
      */
     public static Model readPom(String path, JarFile jar) throws AnalysisException {
         final ZipEntry entry = jar.getEntry(path);

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzerIntegrationTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzerIntegrationTest.java
@@ -20,8 +20,7 @@ package org.owasp.dependencycheck.analyzer;
 import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
@@ -39,7 +38,7 @@ public class ArchiveAnalyzerIntegrationTest extends AbstractDatabaseTestCase {
      * Test of getSupportedExtensions method, of class ArchiveAnalyzer.
      */
     @Test
-    public void testGetSupportedExtensions() {
+    public void testSupportsExtensions() {
         ArchiveAnalyzer instance = new ArchiveAnalyzer();
         Set<String> expResult = new HashSet<String>();
         expResult.add("zip");
@@ -52,8 +51,9 @@ public class ArchiveAnalyzerIntegrationTest extends AbstractDatabaseTestCase {
         expResult.add("tar");
         expResult.add("gz");
         expResult.add("tgz");
-        Set result = instance.getSupportedExtensions();
-        assertEquals(expResult, result);
+        for (String ext : expResult) {
+            assertTrue(ext, instance.accept(new File("test." + ext)));
+        }
     }
 
     /**
@@ -72,28 +72,9 @@ public class ArchiveAnalyzerIntegrationTest extends AbstractDatabaseTestCase {
      */
     @Test
     public void testSupportsExtension() {
-        String extension = "7z"; //not supported
+        String extension = "test.7z"; //not supported
         ArchiveAnalyzer instance = new ArchiveAnalyzer();
-        boolean expResult = false;
-        boolean result = instance.supportsExtension(extension);
-        assertEquals(expResult, result);
-
-        extension = "war"; //supported
-        expResult = true;
-        result = instance.supportsExtension(extension);
-        assertEquals(expResult, result);
-
-        extension = "ear"; //supported
-        result = instance.supportsExtension(extension);
-        assertEquals(expResult, result);
-
-        extension = "zip"; //supported
-        result = instance.supportsExtension(extension);
-        assertEquals(expResult, result);
-
-        extension = "nupkg"; //supported
-        result = instance.supportsExtension(extension);
-        assertEquals(expResult, result);
+        assertFalse(extension, instance.accept(new File(extension)));
     }
 
     /**
@@ -129,7 +110,7 @@ public class ArchiveAnalyzerIntegrationTest extends AbstractDatabaseTestCase {
     public void testAnalyze() throws Exception {
         ArchiveAnalyzer instance = new ArchiveAnalyzer();
         //trick the analyzer into thinking it is active.
-        instance.supportsExtension("ear");
+        instance.accept(new File("test.ear"));
         try {
             instance.initialize();
             File file = BaseTest.getResourceAsFile(this, "daytrader-ear-2.1.7.ear");
@@ -160,7 +141,7 @@ public class ArchiveAnalyzerIntegrationTest extends AbstractDatabaseTestCase {
     public void testAnalyzeTar() throws Exception {
         ArchiveAnalyzer instance = new ArchiveAnalyzer();
         //trick the analyzer into thinking it is active so that it will initialize
-        instance.supportsExtension("tar");
+        instance.accept(new File("test.tar"));
         try {
             instance.initialize();
 
@@ -191,7 +172,7 @@ public class ArchiveAnalyzerIntegrationTest extends AbstractDatabaseTestCase {
     @Test
     public void testAnalyzeTarGz() throws Exception {
         ArchiveAnalyzer instance = new ArchiveAnalyzer();
-        instance.supportsExtension("zip"); //ensure analyzer is "enabled"
+        instance.accept(new File("zip")); //ensure analyzer is "enabled"
         try {
             instance.initialize();
 
@@ -244,7 +225,7 @@ public class ArchiveAnalyzerIntegrationTest extends AbstractDatabaseTestCase {
     @Test
     public void testAnalyzeTgz() throws Exception {
         ArchiveAnalyzer instance = new ArchiveAnalyzer();
-        instance.supportsExtension("zip"); //ensure analyzer is "enabled"
+        instance.accept(new File("zip")); //ensure analyzer is "enabled"
         try {
             instance.initialize();
 

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzerTest.java
@@ -58,7 +58,7 @@ public class AssemblyAnalyzerTest extends BaseTest {
     public void setUp() throws Exception {
         try {
             analyzer = new AssemblyAnalyzer();
-            analyzer.supportsExtension("dll");
+            analyzer.accept(new File("test.dll")); // trick into "thinking it is active"
             analyzer.initialize();
         } catch (Exception e) {
             if (e.getMessage().contains("Could not execute .NET AssemblyAnalyzer")) {
@@ -155,7 +155,7 @@ public class AssemblyAnalyzerTest extends BaseTest {
             System.setProperty(LOG_KEY, "error");
             // Have to make a NEW analyzer because during setUp, it would have gotten the correct one
             AssemblyAnalyzer aanalyzer = new AssemblyAnalyzer();
-            aanalyzer.supportsExtension("dll");
+            aanalyzer.accept(new File("test.dll")); // trick into "thinking it is active"
             aanalyzer.initialize();
             fail("Expected an AnalysisException");
         } catch (AnalysisException ae) {

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/AutoconfAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/AutoconfAnalyzerTest.java
@@ -17,19 +17,17 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Arrays;
-import java.util.HashSet;
-
-import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for AutoconfAnalyzer. The test resources under autoconf/ were
@@ -164,27 +162,15 @@ public class AutoconfAnalyzerTest extends BaseTest {
 	}
 
 	/**
-	 * Test of {@link AutoconfAnalyzer#getSupportedExtensions}.
+	 * Test of {@link AutoconfAnalyzer#accept(File)}.
 	 */
 	@Test
-	public void testGetSupportedExtensions() {
-		final String[] expected = { "ac", "in", "configure" };
-		assertEquals("Supported extensions should just have the following: "
-				+ StringUtils.join(expected, ", "),
-				new HashSet<String>(Arrays.asList(expected)),
-				analyzer.getSupportedExtensions());
-	}
-
-	/**
-	 * Test of {@link AutoconfAnalyzer#supportsExtension}.
-	 */
-	@Test
-	public void testSupportsExtension() {
+	public void testSupportsFileExtension() {
 		assertTrue("Should support \"ac\" extension.",
-				analyzer.supportsExtension("ac"));
+				analyzer.accept(new File("configure.ac")));
 		assertTrue("Should support \"in\" extension.",
-				analyzer.supportsExtension("in"));
+				analyzer.accept(new File("configure.in")));
 		assertTrue("Should support \"configure\" extension.",
-				analyzer.supportsExtension("configure"));
+				analyzer.accept(new File("configure")));
 	}
 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CPEAnalyzerIntegrationTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CPEAnalyzerIntegrationTest.java
@@ -149,7 +149,7 @@ public class CPEAnalyzerIntegrationTest extends AbstractDatabaseTestCase {
 
         HintAnalyzer hintAnalyzer = new HintAnalyzer();
         JarAnalyzer jarAnalyzer = new JarAnalyzer();
-        jarAnalyzer.supportsExtension("jar");
+        jarAnalyzer.accept(new File("test.jar"));//trick analyzer into "thinking it is active"
 
         jarAnalyzer.analyze(struts, null);
         hintAnalyzer.analyze(struts, null);

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/JarAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/JarAnalyzerTest.java
@@ -17,19 +17,19 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.util.HashSet;
-import java.util.Properties;
-import java.util.Set;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
 
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 /**
- *
  * @author Jeremy Long
  */
 public class JarAnalyzerTest extends BaseTest {
@@ -94,13 +94,14 @@ public class JarAnalyzerTest extends BaseTest {
      * Test of getSupportedExtensions method, of class JarAnalyzer.
      */
     @Test
-    public void testGetSupportedExtensions() {
+    public void testAcceptSupportedExtensions() throws Exception {
         JarAnalyzer instance = new JarAnalyzer();
-        Set<String> expResult = new HashSet<String>();
-        expResult.add("jar");
-        expResult.add("war");
-        Set result = instance.getSupportedExtensions();
-        assertEquals(expResult, result);
+        instance.initialize();
+        instance.setEnabled(true);
+        String[] files = {"test.jar", "test.war"};
+        for (String name : files) {
+            assertTrue(name, instance.accept(new File(name)));
+        }
     }
 
     /**
@@ -111,18 +112,6 @@ public class JarAnalyzerTest extends BaseTest {
         JarAnalyzer instance = new JarAnalyzer();
         String expResult = "Jar Analyzer";
         String result = instance.getName();
-        assertEquals(expResult, result);
-    }
-
-    /**
-     * Test of supportsExtension method, of class JarAnalyzer.
-     */
-    @Test
-    public void testSupportsExtension() {
-        String extension = "jar";
-        JarAnalyzer instance = new JarAnalyzer();
-        boolean expResult = true;
-        boolean result = instance.supportsExtension(extension);
         assertEquals(expResult, result);
     }
 

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/JavaScriptAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/JavaScriptAnalyzerTest.java
@@ -17,14 +17,15 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.util.HashSet;
-import java.util.Set;
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.dependency.Dependency;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -36,12 +37,12 @@ public class JavaScriptAnalyzerTest extends BaseTest {
      * Test of getSupportedExtensions method, of class JavaScriptAnalyzer.
      */
     @Test
-    public void testGetSupportedExtensions() {
+    public void testAcceptSupportedExtensions() throws Exception {
         JavaScriptAnalyzer instance = new JavaScriptAnalyzer();
-        Set<String> expResult = new HashSet<String>();
-        expResult.add("js");
-        Set result = instance.getSupportedExtensions();
-        assertEquals(expResult, result);
+        instance.initialize();
+        instance.setEnabled(true);
+        String name = "test.js";
+        assertTrue(name, instance.accept(new File(name)));
     }
 
     /**
@@ -53,18 +54,6 @@ public class JavaScriptAnalyzerTest extends BaseTest {
         JavaScriptAnalyzer instance = new JavaScriptAnalyzer();
         String expResult = "JavaScript Analyzer";
         String result = instance.getName();
-        assertEquals(expResult, result);
-    }
-
-    /**
-     * Test of supportsExtension method, of class JavaScriptAnalyzer.
-     */
-    @Test
-    public void testSupportsExtension() {
-        String extension = "js";
-        JavaScriptAnalyzer instance = new JavaScriptAnalyzer();
-        boolean expResult = true;
-        boolean result = instance.supportsExtension(extension);
         assertEquals(expResult, result);
     }
 

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/NuspecAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/NuspecAnalyzerTest.java
@@ -24,6 +24,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
 
+import java.io.File;
+
 public class NuspecAnalyzerTest extends BaseTest {
 
     private NuspecAnalyzer instance;
@@ -31,6 +33,7 @@ public class NuspecAnalyzerTest extends BaseTest {
     @Before
     public void setUp() throws Exception {
         instance = new NuspecAnalyzer();
+        instance.initialize();
         instance.setEnabled(true);
     }
 
@@ -40,15 +43,9 @@ public class NuspecAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testGetSupportedExtensions() {
-        assertTrue(instance.getSupportedExtensions().contains("nuspec"));
-        assertFalse(instance.getSupportedExtensions().contains("nupkg"));
-    }
-
-    @Test
-    public void testSupportsExtension() {
-        assertTrue(instance.supportsExtension("nuspec"));
-        assertFalse(instance.supportsExtension("nupkg"));
+    public void testSupportsFileExtensions() {
+        assertTrue(instance.accept(new File("test.nuspec")));
+        assertFalse(instance.accept(new File("test.nupkg")));
     }
 
     @Test

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzerTest.java
@@ -17,13 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Arrays;
-import java.util.HashSet;
-
-import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +24,11 @@ import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for PythonDistributionAnalyzer.
@@ -77,32 +75,20 @@ public class PythonDistributionAnalyzerTest extends BaseTest {
     }
 
     /**
-     * Test of getSupportedExtensions method, of class PythonDistributionAnalyzer.
-     */
-    @Test
-    public void testGetSupportedExtensions() {
-        final String[] expected = {"whl", "egg", "zip", "METADATA", "PKG-INFO"};
-        assertEquals("Supported extensions should just have the following: "
-                + StringUtils.join(expected, ", "),
-                new HashSet<String>(Arrays.asList(expected)),
-                analyzer.getSupportedExtensions());
-    }
-
-    /**
      * Test of supportsExtension method, of class PythonDistributionAnalyzer.
      */
     @Test
-    public void testSupportsExtension() {
+    public void testSupportsFiles() {
         assertTrue("Should support \"whl\" extension.",
-                analyzer.supportsExtension("whl"));
+                analyzer.accept(new File("test.whl")));
         assertTrue("Should support \"egg\" extension.",
-                analyzer.supportsExtension("egg"));
+                analyzer.accept(new File("test.egg")));
         assertTrue("Should support \"zip\" extension.",
-                analyzer.supportsExtension("zip"));
+                analyzer.accept(new File("test.zip")));
         assertTrue("Should support \"METADATA\" extension.",
-                analyzer.supportsExtension("METADATA"));
+                analyzer.accept(new File("METADATA")));
         assertTrue("Should support \"PKG-INFO\" extension.",
-                analyzer.supportsExtension("PKG-INFO"));
+                analyzer.accept(new File("PKG-INFO")));
     }
 
     /**
@@ -119,7 +105,7 @@ public class PythonDistributionAnalyzerTest extends BaseTest {
     /**
      * Test of inspect method, of class PythonDistributionAnalyzer.
      *
-     * @throws Exception is thrown when an exception occurs.
+     * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
     public void testAnalyzeSitePackage() throws AnalysisException {

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzerTest.java
@@ -17,21 +17,18 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Arrays;
-import java.util.HashSet;
-
-import org.apache.commons.lang.StringUtils;
 import org.junit.After;
-import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for PythonPackageAnalyzer.
@@ -78,24 +75,12 @@ public class PythonPackageAnalyzerTest extends BaseTest {
     }
 
     /**
-     * Test of getSupportedExtensions method, of class PythonPackageAnalyzer.
-     */
-    @Test
-    public void testGetSupportedExtensions() {
-        final String[] expected = {"py"};
-        assertEquals("Supported extensions should just have the following: "
-                + StringUtils.join(expected, ", "),
-                new HashSet<String>(Arrays.asList(expected)),
-                analyzer.getSupportedExtensions());
-    }
-
-    /**
      * Test of supportsExtension method, of class PythonPackageAnalyzer.
      */
     @Test
-    public void testSupportsExtension() {
+    public void testSupportsFileExtension() {
         assertTrue("Should support \"py\" extension.",
-                analyzer.supportsExtension("py"));
+                analyzer.accept(new File("test.py")));
     }
 
     @Test


### PR DESCRIPTION
There are a few motivations for making this change:
1. Some analyzers are already needing to consider special build/package files that always have a certain name. It would reduce noise and processing time to need only consider those files, rather than also other files sharing the same extension.
2. A hack considering the entire filename as the extension has been used up to now for files with no extension on their filenames, e.g., `MANIFEST`.
3. This change paves the way for the possibility of accepting files on the basis of other conditions, such as magic numbers at the beginning of the file. (Specifically, I am currently working on an analyzer that would benefit nicely from this.)
#270 and #274 almost certainly will have merge conflicts with this pull request. If this is merged first, I will update those, and vice versa.
