### PR TITLE
Eliminated duplicate key in dependencycheck.properties file

### DIFF
--- a/dependency-check-core/src/test/resources/dependencycheck.properties
+++ b/dependency-check-core/src/test/resources/dependencycheck.properties
@@ -40,7 +40,8 @@ data.driver_name=org.h2.Driver
 data.driver_path=
 
 # the path to the cpe xml file
-cpe.url=http://static.nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.2.xml.gz
+#cpe.url=http://static.nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.2.xml.gz
+cpe.url=http://static.nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz
 # the path to the cpe meta data file.
 cpe.meta.url=http://static.nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.2.meta
 
@@ -61,8 +62,6 @@ cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml.gz
 #cve.url-2.0.base=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml
 
 cpe.validfordays=30
-cpe.url=http://static.nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz
-
 
 # the URL for searching Nexus for SHA-1 hashes and whether it's enabled
 analyzer.nexus.enabled=true


### PR DESCRIPTION
Commented out first instance of cpe.url, and moved 2nd instance up. Assumption: the 2nd value was being used.
