### PR TITLE
Remove dependency file extension property

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -30,7 +30,6 @@ import org.owasp.dependencycheck.data.update.UpdateService;
 import org.owasp.dependencycheck.data.update.exception.UpdateException;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.exception.NoDataException;
-import org.owasp.dependencycheck.utils.FileUtils;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
@@ -38,12 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.util.ArrayList;
-import java.util.EnumMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Scans files, directories, etc. for Dependencies. Analyzers are loaded and used to process the files found by the scan, if a
@@ -308,22 +302,14 @@ public class Engine implements FileFilter {
      * @return the scanned dependency
      */
     protected Dependency scanFile(File file) {
-        if (!file.isFile()) {
-            LOGGER.debug("Path passed to scanFile(File) is not a file: {}. Skipping the file.", file);
-            return null;
-        }
-        final String fileName = file.getName();
-        String extension = FileUtils.getFileExtension(fileName);
-        if (null == extension) {
-            extension = fileName;
-        }
         Dependency dependency = null;
-        if (accept(file)) {
-            dependency = new Dependency(file);
-            if (extension.equals(fileName)) {
-                dependency.setFileExtension(extension);
+        if (file.isFile()) {
+            if (accept(file)) {
+                dependency = new Dependency(file);
+                dependencies.add(dependency);
             }
-            dependencies.add(dependency);
+        } else {
+            LOGGER.debug("Path passed to scanFile(File) is not a file: {}. Skipping the file.", file);
         }
         return dependency;
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
@@ -106,9 +106,10 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
     private static final Set<String> EXTENSIONS = newHashSet("tar", "gz", "tgz");
 
     /**
-     * The set of file extensions to remove from the engine's collection of dependencies.
+     * Detects files with extensions to remove from the engine's collection of dependencies.
      */
-    private static final Set<String> REMOVE_FROM_ANALYSIS = newHashSet("zip", "tar", "gz", "tgz"); //TODO add nupkg, apk, sar?
+    private static final FileFilter REMOVE_FROM_ANALYSIS =
+            FileFilterBuilder.newInstance().addExtensions("zip", "tar", "gz", "tgz").build(); //TODO add nupkg, apk, sar?
 
     static {
         final String additionalZipExt = Settings.getString(Settings.KEYS.ADDITIONAL_ZIP_EXTENSIONS);
@@ -125,6 +126,11 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
     protected FileFilter getFileFilter() {
         return FILTER;
     }
+
+    /**
+     * Detects files with .zip extension.
+     */
+    private static final FileFilter ZIP_FILTER = FileFilterBuilder.newInstance().addExtensions("zip").build();
 
     /**
      * Returns the name of the analyzer.
@@ -236,8 +242,8 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
                 }
             }
         }
-        if (REMOVE_FROM_ANALYSIS.contains(dependency.getFileExtension())) {
-            if ("zip".equals(dependency.getFileExtension()) && isZipFileActuallyJarFile(dependency)) {
+        if (REMOVE_FROM_ANALYSIS.accept(dependency.getActualFile())) {
+            if (ZIP_FILTER.accept(dependency.getActualFile()) && isZipFileActuallyJarFile(dependency)) {
                 final File tdir = getNextTempDirectory();
                 final String fileName = dependency.getFileName();
 

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
@@ -17,6 +17,7 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
+import java.io.FileFilter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Identifier;
 import org.owasp.dependencycheck.dependency.VulnerableSoftware;
+import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +48,9 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
      * The Logger.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(FalsePositiveAnalyzer.class);
+
+    private static final FileFilter DLL_EXE_FILTER = FileFilterBuilder.newInstance().addExtensions("dll", "exe").build();
+
     //<editor-fold defaultstate="collapsed" desc="All standard implementation details of Analyzer">
     /**
      * The name of the analyzer.
@@ -412,8 +417,7 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
      */
     private void removeDuplicativeEntriesFromJar(Dependency dependency, Engine engine) {
         if (dependency.getFileName().toLowerCase().endsWith("pom.xml")
-                || "dll".equals(dependency.getFileExtension())
-                || "exe".equals(dependency.getFileExtension())) {
+                || DLL_EXE_FILTER.accept(dependency.getActualFile())) {
             String parentPath = dependency.getFilePath().toLowerCase();
             if (parentPath.contains(".jar")) {
                 parentPath = parentPath.substring(0, parentPath.indexOf(".jar") + 4);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -68,11 +68,7 @@ public class Dependency implements Serializable, Comparable<Dependency> {
      * The file name of the dependency.
      */
     private String fileName;
-    /**
-     * The file extension of the dependency.
-     */
-    private String fileExtension;
-    /**
+   /**
      * The md5 hash of the dependency.
      */
     private String md5sum;
@@ -120,7 +116,6 @@ public class Dependency implements Serializable, Comparable<Dependency> {
         this.actualFilePath = file.getAbsolutePath();
         this.filePath = this.actualFilePath;
         this.fileName = file.getName();
-        this.fileExtension = FileUtils.getFileExtension(fileName);
         determineHashes(file);
     }
 
@@ -229,24 +224,6 @@ public class Dependency implements Serializable, Comparable<Dependency> {
      */
     public String getFilePath() {
         return this.filePath;
-    }
-
-    /**
-     * Sets the file extension of the dependency.
-     *
-     * @param fileExtension the file name of the dependency
-     */
-    public void setFileExtension(String fileExtension) {
-        this.fileExtension = fileExtension;
-    }
-
-    /**
-     * Gets the file extension of the dependency.
-     *
-     * @return the file extension of the dependency
-     */
-    public String getFileExtension() {
-        return this.fileExtension;
     }
 
     /**
@@ -735,7 +712,6 @@ public class Dependency implements Serializable, Comparable<Dependency> {
         return ObjectUtils.equals(this.actualFilePath, other.actualFilePath)
                 && ObjectUtils.equals(this.filePath, other.filePath)
                 && ObjectUtils.equals(this.fileName, other.fileName)
-                && ObjectUtils.equals(this.fileExtension, other.fileExtension)
                 && ObjectUtils.equals(this.md5sum, other.md5sum)
                 && ObjectUtils.equals(this.sha1sum, other.sha1sum)
                 && ObjectUtils.equals(this.identifiers, other.identifiers)
@@ -758,7 +734,7 @@ public class Dependency implements Serializable, Comparable<Dependency> {
     @Override
     public int hashCode() {
         int hash = MAGIC_HASH_INIT_VALUE;
-        for (Object field : new Object[]{this.actualFilePath, this.filePath, this.fileName, this.fileExtension, this.md5sum,
+        for (Object field : new Object[]{this.actualFilePath, this.filePath, this.fileName, this.md5sum,
             this.sha1sum, this.identifiers, this.vendorEvidence, this.productEvidence, this.versionEvidence,
             this.description, this.license, this.vulnerabilities, this.relatedDependencies, this.projectReferences,
             this.availableVersions}) {

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/update/BaseUpdaterTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/update/BaseUpdaterTest.java
@@ -18,11 +18,13 @@
 package org.owasp.dependencycheck.data.update;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.data.nvdcve.CveDB;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseProperties;
 import org.owasp.dependencycheck.data.update.exception.UpdateException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  *

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
@@ -128,29 +128,6 @@ public class DependencyTest {
     }
 
     /**
-     * Test of setFileExtension method, of class Dependency.
-     */
-    @Test
-    public void testSetFileExtension() {
-        String fileExtension = "jar";
-        Dependency instance = new Dependency();
-        instance.setFileExtension(fileExtension);
-        assertEquals(fileExtension, instance.getFileExtension());
-    }
-
-    /**
-     * Test of getFileExtension method, of class Dependency.
-     */
-    @Test
-    public void testGetFileExtension() {
-        Dependency instance = new Dependency();
-        String expResult = "jar";
-        instance.setFileExtension(expResult);
-        String result = instance.getFileExtension();
-        assertEquals(expResult, result);
-    }
-
-    /**
      * Test of getMd5sum method, of class Dependency.
      */
     @Test


### PR DESCRIPTION
The Dependency class now has no need of a file extension property, now that FileFilter is used throughout. This pull request performs some housekeeping, removing this property, and removing code that (now) needlessly refers to it.
