### PR TITLE
Implement the nested configuration for proxy and cve related settings

### DIFF
--- a/dependency-check-gradle/README.md
+++ b/dependency-check-gradle/README.md
@@ -18,9 +18,7 @@ Current latest version is `0.0.7`
 
 ### Step 1, Apply dependency check gradle plugin
 
-Please refer to either one of the solution
-
-#### Solution 1，Install from Maven Central (Recommended)
+Install from Maven central repo
 
 ```groovy
 buildscript {
@@ -31,62 +29,13 @@ buildscript {
         classpath 'com.thoughtworks.tools:dependency-check:0.0.7'
     }
 }
-```
 
 apply plugin: 'dependency.check'
-
-#### Solution 2，Install from Gradle Plugin Portal
-
-[dependency check gradle plugin on Gradle Plugin Portal](https://plugins.gradle.org/plugin/dependency.check)
-
-**Build script snippet for new, incubating, plugin mechanism introduced in Gradle 2.1:**
-
-```groovy
-plugins {
-    id "dependency.check" version "0.0.7"
-}
-```
-
-**Build script snippet for use in all Gradle versions:**
-
-```groovy
-buildscript {
-  repositories {
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
-  }
-  dependencies {
-    classpath "gradle.plugin.com.tools.security:dependency-check:0.0.7"
-  }
-}
-
-apply plugin: "dependency-check"
-```
-
-#### Solution 3，Install from Bintray
-
-```groovy
-apply plugin: "dependency-check"
-
-buildscript {
-    repositories {
-        maven {
-            url 'http://dl.bintray.com/wei/maven'
-        }
-        mavenCentral()
-    }
-    dependencies {
-        classpath(
-                'com.tools.security:dependency-check:0.0.7'
-        )
-    }
-}
 ```
 
 ### Step 2, Run gradle task
 
-Once gradle plugin applied, run following gradle task to check the dependencies:
+Once gradle plugin applied, run following gradle task to check dependencies:
 
 ```
 gradle dependencyCheck

--- a/dependency-check-gradle/README.md
+++ b/dependency-check-gradle/README.md
@@ -7,9 +7,12 @@ This is a DependencyCheck gradle plugin designed for project which use Gradle as
 
 Dependency-Check is a utility that attempts to detect publicly disclosed vulnerabilities contained within project dependencies. It does this by determining if there is a Common Platform Enumeration (CPE) identifier for a given dependency. If found, it will generate a report linking to the associated CVE entries.
 
-Current latest version is `0.0.6`
-
 =========
+
+## What's New
+Current latest version is `0.0.7`
+- Implement nested configuration for proxy settings
+- Bug fix: Remove duplicated configuration items
 
 ## Usage
 
@@ -25,7 +28,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.thoughtworks.tools:dependency-check:0.0.6'
+        classpath 'com.thoughtworks.tools:dependency-check:0.0.7'
     }
 }
 ```
@@ -40,7 +43,7 @@ apply plugin: 'dependency.check'
 
 ```groovy
 plugins {
-    id "dependency.check" version "0.0.6"
+    id "dependency.check" version "0.0.7"
 }
 ```
 
@@ -54,7 +57,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.com.tools.security:dependency-check:0.0.6"
+    classpath "gradle.plugin.com.tools.security:dependency-check:0.0.7"
   }
 }
 
@@ -75,7 +78,7 @@ buildscript {
     }
     dependencies {
         classpath(
-                'com.tools.security:dependency-check:0.0.6'
+                'com.tools.security:dependency-check:0.0.7'
         )
     }
 }
@@ -106,14 +109,16 @@ Maybe you have to use proxy to access internet, in this case, you could configur
 
 ```groovy
 dependencyCheck {
-    proxyServer = "127.0.0.1"      // required, the server name or IP address of the proxy
-    proxyPort = 3128               // required, the port number of the proxy
-
-    // optional, the proxy server might require username
-    // proxyUsername = "username"
-
-    // optional, the proxy server might require password
-    // proxyPassword = "password"
+    proxy {
+        server = "127.0.0.1"      // required, the server name or IP address of the proxy
+        port = 3128               // required, the port number of the proxy
+        
+        // optional, the proxy server might require username
+        // username = "username"
+    
+        // optional, the proxy server might require password
+        // password = "password"
+    }
 }
 ```
 
@@ -123,9 +128,6 @@ In addition, if the proxy only allow HTTP `GET` or `POST` methods, you will find
 
 ```groovy
 dependencyCheck {
-    proxyServer = "127.0.0.1"      // required, the server name or IP address of the proxy
-    proxyPort = 3128               // required, the port number of the proxy
-
     quickQueryTimestamp = false    // when set to false, it means use HTTP GET method to query timestamp. (default value is true)
 }
 ```
@@ -142,7 +144,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath "gradle.plugin.com.tools.security:dependency-check:0.0.6"
+    classpath "gradle.plugin.com.tools.security:dependency-check:0.0.7"
   }
 }
 
@@ -159,7 +161,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath "gradle.plugin.com.tools.security:dependency-check:0.0.6"
+    classpath "gradle.plugin.com.tools.security:dependency-check:0.0.7"
   }
 }
 

--- a/dependency-check-gradle/build.gradle
+++ b/dependency-check-gradle/build.gradle
@@ -73,7 +73,7 @@ task integTest(type: Test) {
 }
 
 group = 'com.thoughtworks.tools'
-version = '0.0.6'
+version = '0.0.7'
 
 apply from: 'conf/publish/local.gradle'
 //apply from: 'conf/publish/maven.gradle'

--- a/dependency-check-gradle/src/main/groovy/com/tools/security/extension/CveExtension.groovy
+++ b/dependency-check-gradle/src/main/groovy/com/tools/security/extension/CveExtension.groovy
@@ -18,10 +18,10 @@
 
 package com.tools.security.extension
 
-class DependencyCheckExtension {
-    ProxyExtension proxyExtension
-    CveExtension cveExtension
-
-    String outputDirectory = "./reports"
-    Boolean quickQueryTimestamp;
+class CveExtension {
+    String url20Modified
+    String url12Modified
+    Integer startYear
+    String url20Base
+    String url12Base
 }

--- a/dependency-check-gradle/src/main/groovy/com/tools/security/extension/ProxyExtension.groovy
+++ b/dependency-check-gradle/src/main/groovy/com/tools/security/extension/ProxyExtension.groovy
@@ -18,16 +18,9 @@
 
 package com.tools.security.extension
 
-class DependencyCheckExtension {
-    ProxyExtension proxyExtension;
-
-    String cveUrl20Modified
-    String cveUrl12Modified
-    Integer cveStartYear
-    String cveUrl20Base
-    String cveUrl12Base
-
-    String outputDirectory = "./reports"
-
-    Boolean quickQueryTimestamp;
+class ProxyExtension {
+    String server
+    Integer port
+    String username
+    String password
 }

--- a/dependency-check-gradle/src/main/groovy/com/tools/security/plugin/DependencyCheckGradlePlugin.groovy
+++ b/dependency-check-gradle/src/main/groovy/com/tools/security/plugin/DependencyCheckGradlePlugin.groovy
@@ -18,6 +18,7 @@
 
 package com.tools.security.plugin
 
+import com.tools.security.extension.CveExtension
 import com.tools.security.extension.DependencyCheckExtension
 import com.tools.security.extension.ProxyExtension
 import com.tools.security.tasks.DependencyCheckTask
@@ -28,6 +29,7 @@ class DependencyCheckGradlePlugin implements Plugin<Project> {
     private static final String ROOT_EXTENSION_NAME = 'dependencyCheck'
     private static final String TASK_NAME = 'dependencyCheck'
     private static final String PROXY_EXTENSION_NAME = "proxy"
+    private static final String CVE_EXTENSION_NAME = "cve"
 
     @Override
     void apply(Project project) {
@@ -38,6 +40,7 @@ class DependencyCheckGradlePlugin implements Plugin<Project> {
     def initializeConfigurations(Project project) {
         project.extensions.create(ROOT_EXTENSION_NAME, DependencyCheckExtension)
         project.dependencyCheck.extensions.create(PROXY_EXTENSION_NAME, ProxyExtension)
+        project.dependencyCheck.extensions.create(CVE_EXTENSION_NAME, CveExtension)
     }
 
     def registerTasks(Project project) {

--- a/dependency-check-gradle/src/main/groovy/com/tools/security/plugin/DependencyCheckGradlePlugin.groovy
+++ b/dependency-check-gradle/src/main/groovy/com/tools/security/plugin/DependencyCheckGradlePlugin.groovy
@@ -19,13 +19,15 @@
 package com.tools.security.plugin
 
 import com.tools.security.extension.DependencyCheckExtension
+import com.tools.security.extension.ProxyExtension
 import com.tools.security.tasks.DependencyCheckTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 class DependencyCheckGradlePlugin implements Plugin<Project> {
-    private static final String EXTENSION_NAME = 'dependencyCheck'
+    private static final String ROOT_EXTENSION_NAME = 'dependencyCheck'
     private static final String TASK_NAME = 'dependencyCheck'
+    private static final String PROXY_EXTENSION_NAME = "proxy"
 
     @Override
     void apply(Project project) {
@@ -34,7 +36,8 @@ class DependencyCheckGradlePlugin implements Plugin<Project> {
     }
 
     def initializeConfigurations(Project project) {
-        project.extensions.create(EXTENSION_NAME, DependencyCheckExtension)
+        project.extensions.create(ROOT_EXTENSION_NAME, DependencyCheckExtension)
+        project.dependencyCheck.extensions.create(PROXY_EXTENSION_NAME, ProxyExtension)
     }
 
     def registerTasks(Project project) {

--- a/dependency-check-gradle/src/main/groovy/com/tools/security/tasks/DependencyCheckTask.groovy
+++ b/dependency-check-gradle/src/main/groovy/com/tools/security/tasks/DependencyCheckTask.groovy
@@ -134,11 +134,11 @@ class DependencyCheckTask extends DefaultTask {
     }
 
     def overrideCveUrlSetting() {
-        overrideStringBasedSettingWhenProvided(CVE_MODIFIED_20_URL, config.cveUrl20Modified)
-        overrideStringBasedSettingWhenProvided(CVE_MODIFIED_12_URL, config.cveUrl12Modified)
-        overrideIntegerBasedSettingWhenProvided(CVE_START_YEAR, config.cveStartYear)
-        overrideStringBasedSettingWhenProvided(CVE_SCHEMA_2_0, config.cveUrl20Base)
-        overrideStringBasedSettingWhenProvided(CVE_SCHEMA_1_2, config.cveUrl12Base)
+        overrideStringBasedSettingWhenProvided(CVE_MODIFIED_20_URL, config.cve.url20Modified)
+        overrideStringBasedSettingWhenProvided(CVE_MODIFIED_12_URL, config.cve.url12Modified)
+        overrideIntegerBasedSettingWhenProvided(CVE_START_YEAR, config.cve.startYear)
+        overrideStringBasedSettingWhenProvided(CVE_SCHEMA_2_0, config.cve.url20Base)
+        overrideStringBasedSettingWhenProvided(CVE_SCHEMA_1_2, config.cve.url12Base)
     }
 
     def overrideDownloaderSetting() {

--- a/dependency-check-gradle/src/main/groovy/com/tools/security/tasks/DependencyCheckTask.groovy
+++ b/dependency-check-gradle/src/main/groovy/com/tools/security/tasks/DependencyCheckTask.groovy
@@ -114,10 +114,10 @@ class DependencyCheckTask extends DefaultTask {
         if (isProxySettingExist()) {
             logger.lifecycle("Using proxy ${config.proxy.server}:${config.proxy.port}")
 
-            overrideStringBasedSettingWhenProvided(PROXY_SERVER, config.proxy.server)
-            overrideStringBasedSettingWhenProvided(PROXY_PORT, "${config.proxy.port}")
-            overrideStringBasedSettingWhenProvided(PROXY_USERNAME, config.proxy.username)
-            overrideStringBasedSettingWhenProvided(PROXY_PASSWORD, config.proxy.password)
+            overrideStringSetting(PROXY_SERVER, config.proxy.server)
+            overrideStringSetting(PROXY_PORT, "${config.proxy.port}")
+            overrideStringSetting(PROXY_USERNAME, config.proxy.username)
+            overrideStringSetting(PROXY_PASSWORD, config.proxy.password)
         }
     }
 
@@ -134,32 +134,32 @@ class DependencyCheckTask extends DefaultTask {
     }
 
     def overrideCveUrlSetting() {
-        overrideStringBasedSettingWhenProvided(CVE_MODIFIED_20_URL, config.cve.url20Modified)
-        overrideStringBasedSettingWhenProvided(CVE_MODIFIED_12_URL, config.cve.url12Modified)
-        overrideIntegerBasedSettingWhenProvided(CVE_START_YEAR, config.cve.startYear)
-        overrideStringBasedSettingWhenProvided(CVE_SCHEMA_2_0, config.cve.url20Base)
-        overrideStringBasedSettingWhenProvided(CVE_SCHEMA_1_2, config.cve.url12Base)
+        overrideStringSetting(CVE_MODIFIED_20_URL, config.cve.url20Modified)
+        overrideStringSetting(CVE_MODIFIED_12_URL, config.cve.url12Modified)
+        overrideIntegerSetting(CVE_START_YEAR, config.cve.startYear)
+        overrideStringSetting(CVE_SCHEMA_2_0, config.cve.url20Base)
+        overrideStringSetting(CVE_SCHEMA_1_2, config.cve.url12Base)
     }
 
     def overrideDownloaderSetting() {
-        overrideBooleanBasedSettingWhenProvided(DOWNLOADER_QUICK_QUERY_TIMESTAMP, config.quickQueryTimestamp)
+        overrideBooleanSetting(DOWNLOADER_QUICK_QUERY_TIMESTAMP, config.quickQueryTimestamp)
     }
 
-    private overrideStringBasedSettingWhenProvided(String key, String providedValue) {
+    private overrideStringSetting(String key, String providedValue) {
         if (providedValue != null) {
             logger.lifecycle("Setting [${key}] overrided with value [${providedValue}]")
             setString(key, providedValue)
         }
     }
 
-    private overrideIntegerBasedSettingWhenProvided(String key, Integer providedValue) {
+    private overrideIntegerSetting(String key, Integer providedValue) {
         if (providedValue != null) {
             logger.lifecycle("Setting [${key}] overrided with value [${providedValue}]")
             setString(key, "${providedValue}")
         }
     }
 
-    private overrideBooleanBasedSettingWhenProvided(String key, Boolean providedValue) {
+    private overrideBooleanSetting(String key, Boolean providedValue) {
         if (providedValue != null) {
             logger.lifecycle("Setting [${key}] overrided with value [${providedValue}]")
             setBoolean(key, providedValue)

--- a/dependency-check-gradle/src/main/groovy/com/tools/security/tasks/DependencyCheckTask.groovy
+++ b/dependency-check-gradle/src/main/groovy/com/tools/security/tasks/DependencyCheckTask.groovy
@@ -112,17 +112,17 @@ class DependencyCheckTask extends DefaultTask {
 
     def overrideProxySetting() {
         if (isProxySettingExist()) {
-            logger.lifecycle("Using proxy ${config.proxyServer}:${config.proxyPort}")
+            logger.lifecycle("Using proxy ${config.proxy.server}:${config.proxy.port}")
 
-            overrideStringBasedSettingWhenProvided(PROXY_SERVER, config.proxyServer)
-            overrideStringBasedSettingWhenProvided(PROXY_PORT, "${config.proxyPort}")
-            overrideStringBasedSettingWhenProvided(PROXY_USERNAME, config.proxyUsername)
-            overrideStringBasedSettingWhenProvided(PROXY_PASSWORD, config.proxyPassword)
+            overrideStringBasedSettingWhenProvided(PROXY_SERVER, config.proxy.server)
+            overrideStringBasedSettingWhenProvided(PROXY_PORT, "${config.proxy.port}")
+            overrideStringBasedSettingWhenProvided(PROXY_USERNAME, config.proxy.username)
+            overrideStringBasedSettingWhenProvided(PROXY_PASSWORD, config.proxy.password)
         }
     }
 
     def isProxySettingExist() {
-        config.proxyServer != null && config.proxyPort != null
+        config.proxy.server != null && config.proxy.port != null
     }
 
     def getAllDependencies(project) {

--- a/dependency-check-gradle/src/test/groovy/com/tools/security/plugin/DependencyCheckGradlePluginSpec.groovy
+++ b/dependency-check-gradle/src/test/groovy/com/tools/security/plugin/DependencyCheckGradlePluginSpec.groovy
@@ -52,11 +52,11 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
         project.dependencyCheck.proxy.port == null
         project.dependencyCheck.proxy.username == null
         project.dependencyCheck.proxy.password == null
-        project.dependencyCheck.cveUrl12Modified == null
-        project.dependencyCheck.cveUrl20Modified == null
-        project.dependencyCheck.cveStartYear == null
-        project.dependencyCheck.cveUrl12Base == null
-        project.dependencyCheck.cveUrl20Base == null
+        project.dependencyCheck.cve.url12Modified == null
+        project.dependencyCheck.cve.url20Modified == null
+        project.dependencyCheck.cve.startYear == null
+        project.dependencyCheck.cve.url12Base == null
+        project.dependencyCheck.cve.url20Base == null
         project.dependencyCheck.outputDirectory == './reports'
         project.dependencyCheck.quickQueryTimestamp == null
     }
@@ -70,11 +70,15 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
                 username = 'proxyUsername'
                 password = 'proxyPassword'
             }
-            cveUrl12Modified = 'cveUrl12Modified'
-            cveUrl20Modified = 'cveUrl20Modified'
-            cveStartYear = 2002
-            cveUrl12Base = 'cveUrl12Base'
-            cveUrl20Base = 'cveUrl20Base'
+
+            cve {
+                startYear = 2002
+                url12Base = 'cveUrl12Base'
+                url20Base = 'cveUrl20Base'
+                url12Modified = 'cveUrl12Modified'
+                url20Modified = 'cveUrl20Modified'
+            }
+
             outputDirectory = 'outputDirectory'
             quickQueryTimestamp = false
         }
@@ -84,11 +88,11 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
         project.dependencyCheck.proxy.port == 3128
         project.dependencyCheck.proxy.username == 'proxyUsername'
         project.dependencyCheck.proxy.password == 'proxyPassword'
-        project.dependencyCheck.cveUrl12Modified == 'cveUrl12Modified'
-        project.dependencyCheck.cveUrl20Modified == 'cveUrl20Modified'
-        project.dependencyCheck.cveStartYear == 2002
-        project.dependencyCheck.cveUrl12Base == 'cveUrl12Base'
-        project.dependencyCheck.cveUrl20Base == 'cveUrl20Base'
+        project.dependencyCheck.cve.url12Modified == 'cveUrl12Modified'
+        project.dependencyCheck.cve.url20Modified == 'cveUrl20Modified'
+        project.dependencyCheck.cve.startYear == 2002
+        project.dependencyCheck.cve.url12Base == 'cveUrl12Base'
+        project.dependencyCheck.cve.url20Base == 'cveUrl20Base'
         project.dependencyCheck.outputDirectory == 'outputDirectory'
         project.dependencyCheck.quickQueryTimestamp == false
     }

--- a/dependency-check-gradle/src/test/groovy/com/tools/security/plugin/DependencyCheckGradlePluginSpec.groovy
+++ b/dependency-check-gradle/src/test/groovy/com/tools/security/plugin/DependencyCheckGradlePluginSpec.groovy
@@ -48,10 +48,10 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
         expect:
         task.group == 'Dependency Check'
         task.description == 'Produce dependency security report.'
-        project.dependencyCheck.proxyServer == null
-        project.dependencyCheck.proxyPort == null
-        project.dependencyCheck.proxyUsername == null
-        project.dependencyCheck.proxyPassword == null
+        project.dependencyCheck.proxy.server == null
+        project.dependencyCheck.proxy.port == null
+        project.dependencyCheck.proxy.username == null
+        project.dependencyCheck.proxy.password == null
         project.dependencyCheck.cveUrl12Modified == null
         project.dependencyCheck.cveUrl20Modified == null
         project.dependencyCheck.cveStartYear == null
@@ -64,10 +64,12 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
     def 'tasks use correct values when extension is used'() {
         when:
         project.dependencyCheck {
-            proxyServer = '127.0.0.1'
-            proxyPort = 3128
-            proxyUsername = 'proxyUsername'
-            proxyPassword = 'proxyPassword'
+            proxy {
+                server = '127.0.0.1'
+                port = 3128
+                username = 'proxyUsername'
+                password = 'proxyPassword'
+            }
             cveUrl12Modified = 'cveUrl12Modified'
             cveUrl20Modified = 'cveUrl20Modified'
             cveStartYear = 2002
@@ -78,10 +80,10 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
         }
 
         then:
-        project.dependencyCheck.proxyServer == '127.0.0.1'
-        project.dependencyCheck.proxyPort == 3128
-        project.dependencyCheck.proxyUsername == 'proxyUsername'
-        project.dependencyCheck.proxyPassword == 'proxyPassword'
+        project.dependencyCheck.proxy.server == '127.0.0.1'
+        project.dependencyCheck.proxy.port == 3128
+        project.dependencyCheck.proxy.username == 'proxyUsername'
+        project.dependencyCheck.proxy.password == 'proxyPassword'
         project.dependencyCheck.cveUrl12Modified == 'cveUrl12Modified'
         project.dependencyCheck.cveUrl20Modified == 'cveUrl20Modified'
         project.dependencyCheck.cveStartYear == 2002


### PR DESCRIPTION
Hi Jeremy,

I implemented nested configuration for proxy and cve related settings, now in client side, users could configure dependency check gradle plugin like this:

``` groovy
dependencyCheck {
    proxy {
        server = "127.0.0.1"
        port = 4321
    }
}
```

Thanks.
