### PR TITLE
Updated plugins.

### DIFF
--- a/dependency-check-gradle/pom.xml
+++ b/dependency-check-gradle/pom.xml
@@ -58,7 +58,7 @@ Copyright (c) 2015 Wei Ma. All Rights Reserved.
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>
                         <artifactId>doxia-module-markdown</artifactId>
-                        <version>1.4</version>
+                        <version>1.6</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/dependency-check-jenkins/pom.xml
+++ b/dependency-check-jenkins/pom.xml
@@ -62,7 +62,7 @@
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>
                         <artifactId>doxia-module-markdown</artifactId>
-                        <version>1.4</version>
+                        <version>1.6</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -129,19 +129,19 @@ Copyright (c) 2012 - Jeremy Long
         <apache.lucene.version>4.7.2</apache.lucene.version>
         <slf4j.version>1.7.12</slf4j.version>
         <logback.version>1.1.3</logback.version>
-        <reporting.checkstyle-plugin.version>2.11</reporting.checkstyle-plugin.version>
+        <reporting.checkstyle-plugin.version>2.16</reporting.checkstyle-plugin.version>
         <reporting.cobertura-plugin.version>2.6</reporting.cobertura-plugin.version>
-        <reporting.findbugs-plugin.version>2.5.3</reporting.findbugs-plugin.version>
-        <reporting.javadoc-plugin.version>2.9.1</reporting.javadoc-plugin.version>
-        <reporting.jxr-plugin.version>2.4</reporting.jxr-plugin.version>
+        <reporting.findbugs-plugin.version>3.0.1</reporting.findbugs-plugin.version>
+        <reporting.javadoc-plugin.version>2.10.3</reporting.javadoc-plugin.version>
+        <reporting.jxr-plugin.version>2.5</reporting.jxr-plugin.version>
         <!-- todo(code review): only used in maven module? Not needed elsewhere -->
-        <reporting.maven-plugin-plugin.version>3.2</reporting.maven-plugin-plugin.version>
-        <reporting.pmd-plugin.version>3.0.1</reporting.pmd-plugin.version>
+        <reporting.maven-plugin-plugin.version>3.4</reporting.maven-plugin-plugin.version>
+        <reporting.pmd-plugin.version>3.5</reporting.pmd-plugin.version>
         <!-- TODO(code review) project-info-reports-plugin was/is not used in utils. Expected/intended? -->
-        <reporting.project-info-reports-plugin.version>2.7</reporting.project-info-reports-plugin.version>
-        <reporting.surefire-report-plugin.version>2.16</reporting.surefire-report-plugin.version>
+        <reporting.project-info-reports-plugin.version>2.8</reporting.project-info-reports-plugin.version>
+        <reporting.surefire-report-plugin.version>2.18.1</reporting.surefire-report-plugin.version>
         <reporting.taglist-plugin.version>2.4</reporting.taglist-plugin.version>
-        <reporting.versions-plugin.version>2.1</reporting.versions-plugin.version>
+        <reporting.versions-plugin.version>2.2</reporting.versions-plugin.version>
     </properties>
     <distributionManagement>
         <site>
@@ -189,7 +189,7 @@ Copyright (c) 2012 - Jeremy Long
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.3.1</version>
+                    <version>1.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -234,11 +234,7 @@ Copyright (c) 2012 - Jeremy Long
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <!-- Before upgrading this to a newer version, verify the pages produced by `mvn site` still works.
-                    In particular, pay attention to all pages under "File type analyzers" as well as those under "General".
-                    Previously when testing with maven-site-plugin 3.4, these links have stopped working for some reason.
-                    -->
-                    <version>3.3</version>
+                    <version>3.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -334,7 +330,7 @@ Copyright (c) 2012 - Jeremy Long
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>
                         <artifactId>doxia-module-markdown</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                     </dependency>
                 </dependencies>
                 <configuration>


### PR DESCRIPTION
- I was able to update the site plugin to version 3.4
  - I double checked that the markdown pages still worked (by upgrading `doxia-module-markdown` to 1.6), and that the _file type analyzer_ pages work.
- I noticed that some plugins were not the latest version, so updated those.
- I noticed that some plugins versions were mismatched (surefire-report); so updated that.
