### PR TITLE
Pom cleanup

### DIFF
--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -267,20 +267,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>${reporting.project-info-reports-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>summary</report>
-                            <report>license</report>
-                            <report>help</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${reporting.javadoc-plugin.version}</version>
                 <configuration>

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -385,11 +385,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
                     </rulesets>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${reporting.findbugs-plugin.version}</version>
-            </plugin>
         </plugins>
     </reporting>
     <dependencies>

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -266,19 +266,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-                <version>${reporting.versions-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>dependency-updates-report</report>
-                            <report>plugin-updates-report</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${reporting.checkstyle-plugin.version}</version>

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -193,7 +193,7 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
+                <version>2.4.1</version>
                 <configuration>
                     <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -330,30 +330,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>taglist-maven-plugin</artifactId>
-                <version>${reporting.taglist-plugin.version}</version>
-                <configuration>
-                    <tagListOptions>
-                        <tagClasses>
-                            <tagClass>
-                                <displayName>Todo Work</displayName>
-                                <tags>
-                                    <tag>
-                                        <matchString>todo</matchString>
-                                        <matchType>ignoreCase</matchType>
-                                    </tag>
-                                    <tag>
-                                        <matchString>FIXME</matchString>
-                                        <matchType>exact</matchType>
-                                    </tag>
-                                </tags>
-                            </tagClass>
-                        </tagClasses>
-                    </tagListOptions>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${reporting.checkstyle-plugin.version}</version>

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -311,18 +311,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>${reporting.surefire-report-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>report-only</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${reporting.checkstyle-plugin.version}</version>
                 <configuration>

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -192,14 +192,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.3</version>
                 <configuration>

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -318,11 +318,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jxr-plugin</artifactId>
-                <version>${reporting.jxr-plugin.version}</version>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
                 <version>${reporting.cobertura-plugin.version}</version>

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -266,23 +266,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${reporting.javadoc-plugin.version}</version>
-                <configuration>
-                    <failOnError>false</failOnError>
-                    <bottom>Copyright© 2012-15 Jeremy Long. All Rights Reserved.</bottom>
-                </configuration>
-                <reportSets>
-                    <reportSet>
-                        <id>default</id>
-                        <reports>
-                            <report>javadoc</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
                 <version>${reporting.versions-plugin.version}</version>

--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -318,11 +318,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>${reporting.cobertura-plugin.version}</version>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <version>${reporting.surefire-report-plugin.version}</version>

--- a/dependency-check-cli/pom.xml
+++ b/dependency-check-cli/pom.xml
@@ -175,19 +175,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-                <version>${reporting.versions-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>dependency-updates-report</report>
-                            <report>plugin-updates-report</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${reporting.checkstyle-plugin.version}</version>

--- a/dependency-check-cli/pom.xml
+++ b/dependency-check-cli/pom.xml
@@ -175,23 +175,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${reporting.javadoc-plugin.version}</version>
-                <configuration>
-                    <failOnError>false</failOnError>
-                    <bottom>Copyright� 2012-15 Jeremy Long. All Rights Reserved.</bottom>
-                </configuration>
-                <reportSets>
-                    <reportSet>
-                        <id>default</id>
-                        <reports>
-                            <report>javadoc</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
                 <version>${reporting.versions-plugin.version}</version>

--- a/dependency-check-cli/pom.xml
+++ b/dependency-check-cli/pom.xml
@@ -221,30 +221,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>taglist-maven-plugin</artifactId>
-                <version>${reporting.taglist-plugin.version}</version>
-                <configuration>
-                    <tagListOptions>
-                        <tagClasses>
-                            <tagClass>
-                                <displayName>Todo Work</displayName>
-                                <tags>
-                                    <tag>
-                                        <matchString>todo</matchString>
-                                        <matchType>ignoreCase</matchType>
-                                    </tag>
-                                    <tag>
-                                        <matchString>FIXME</matchString>
-                                        <matchType>exact</matchType>
-                                    </tag>
-                                </tags>
-                            </tagClass>
-                        </tagClasses>
-                    </tagListOptions>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${reporting.checkstyle-plugin.version}</version>

--- a/dependency-check-cli/pom.xml
+++ b/dependency-check-cli/pom.xml
@@ -276,11 +276,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                     </rulesets>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${reporting.findbugs-plugin.version}</version>
-            </plugin>
         </plugins>
     </reporting>
     <dependencies>

--- a/dependency-check-cli/pom.xml
+++ b/dependency-check-cli/pom.xml
@@ -180,20 +180,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>${reporting.project-info-reports-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>summary</report>
-                            <report>license</report>
-                            <report>help</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${reporting.javadoc-plugin.version}</version>
                 <configuration>
@@ -221,11 +207,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                         </reports>
                     </reportSet>
                 </reportSets>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jxr-plugin</artifactId>
-                <version>${reporting.jxr-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/dependency-check-cli/pom.xml
+++ b/dependency-check-cli/pom.xml
@@ -209,11 +209,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>${reporting.cobertura-plugin.version}</version>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <version>${reporting.surefire-report-plugin.version}</version>

--- a/dependency-check-cli/pom.xml
+++ b/dependency-check-cli/pom.xml
@@ -206,18 +206,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>${reporting.surefire-report-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>report-only</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${reporting.checkstyle-plugin.version}</version>
                 <configuration>

--- a/dependency-check-cli/pom.xml
+++ b/dependency-check-cli/pom.xml
@@ -125,10 +125,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>appassembler-maven-plugin</artifactId>
                 <configuration>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -111,13 +111,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>jar</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                    <execution>
                         <id>test-jar</id>
                         <phase>package</phase>
                         <goals>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -278,30 +278,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>taglist-maven-plugin</artifactId>
-                <version>${reporting.taglist-plugin.version}</version>
-                <configuration>
-                    <tagListOptions>
-                        <tagClasses>
-                            <tagClass>
-                                <displayName>Todo Work</displayName>
-                                <tags>
-                                    <tag>
-                                        <matchString>todo</matchString>
-                                        <matchType>ignoreCase</matchType>
-                                    </tag>
-                                    <tag>
-                                        <matchString>FIXME</matchString>
-                                        <matchType>exact</matchType>
-                                    </tag>
-                                </tags>
-                            </tagClass>
-                        </tagClasses>
-                    </tagListOptions>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${reporting.checkstyle-plugin.version}</version>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -222,23 +222,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${reporting.javadoc-plugin.version}</version>
-                <configuration>
-                    <failOnError>false</failOnError>
-                    <bottom>Copyright© 2012-15 Jeremy Long. All Rights Reserved.</bottom>
-                </configuration>
-                <reportSets>
-                    <reportSet>
-                        <id>default</id>
-                        <reports>
-                            <report>javadoc</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
                 <version>${reporting.versions-plugin.version}</version>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -333,11 +333,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                     </rulesets>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${reporting.findbugs-plugin.version}</version>
-            </plugin>
         </plugins>
     </reporting>
     <dependencies>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -259,11 +259,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>${reporting.cobertura-plugin.version}</version>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <version>${reporting.surefire-report-plugin.version}</version>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -230,20 +230,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>${reporting.project-info-reports-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>summary</report>
-                            <report>license</report>
-                            <report>help</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${reporting.javadoc-plugin.version}</version>
                 <configuration>
@@ -271,11 +257,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                         </reports>
                     </reportSet>
                 </reportSets>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jxr-plugin</artifactId>
-                <version>${reporting.jxr-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -222,19 +222,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-                <version>${reporting.versions-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>dependency-updates-report</report>
-                            <report>plugin-updates-report</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <reportSets>

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -254,13 +254,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>${reporting.surefire-report-plugin.version}</version>
                 <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>report-only</report>
-                        </reports>
-                    </reportSet>
                     <reportSet>
                         <id>integration-tests</id>
                         <reports>

--- a/dependency-check-gradle/pom.xml
+++ b/dependency-check-gradle/pom.xml
@@ -48,6 +48,10 @@ Copyright (c) 2015 Wei Ma. All Rights Reserved.
             <url>${basedir}/../target/site/${project.version}/dependency-check-gradle</url>
         </site>
     </distributionManagement>
+    <properties>
+        <!-- Skip the surefire report since there are no tests... -->
+        <skipSurefireReport>true</skipSurefireReport>
+    </properties>
     <!-- end copy -->
     <build>
         <plugins>

--- a/dependency-check-gradle/pom.xml
+++ b/dependency-check-gradle/pom.xml
@@ -34,12 +34,6 @@ Copyright (c) 2015 Wei Ma. All Rights Reserved.
     <description>dependency-check-gradle is a Gradle Plugin that uses dependency-check-core to detect publicly disclosed vulnerabilities associated with the project's dependencies. The plugin will generate a report listing the dependency, any identified Common Platform Enumeration (CPE) identifiers, and the associated Common Vulnerability and Exposure (CVE) entries.</description>
     <inceptionYear>2015</inceptionYear>
 
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-        </license>
-    </licenses>
     <!-- begin copy from http://minds.coremedia.com/2012/09/11/problem-solved-deploy-multi-module-maven-project-site-as-github-pages/ -->
     <distributionManagement>
         <site>

--- a/dependency-check-gradle/pom.xml
+++ b/dependency-check-gradle/pom.xml
@@ -67,22 +67,4 @@ Copyright (c) 2015 Wei Ma. All Rights Reserved.
             </plugin>
         </plugins>
     </build>
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>${reporting.project-info-reports-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>summary</report>
-                            <report>license</report>
-                            <report>help</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-        </plugins>
-    </reporting>
 </project>

--- a/dependency-check-gradle/pom.xml
+++ b/dependency-check-gradle/pom.xml
@@ -51,6 +51,8 @@ Copyright (c) 2015 Wei Ma. All Rights Reserved.
     <properties>
         <!-- Skip the surefire report since there are no tests... -->
         <skipSurefireReport>true</skipSurefireReport>
+        <!-- Skip the versions report since there are no dependencies... -->
+        <versions.skip>true</versions.skip>
     </properties>
     <!-- end copy -->
     <build>

--- a/dependency-check-jenkins/pom.xml
+++ b/dependency-check-jenkins/pom.xml
@@ -22,6 +22,8 @@
     <properties>
         <!-- Skip the surefire report since there are no tests... -->
         <skipSurefireReport>true</skipSurefireReport>
+        <!-- Skip the versions report since there are no dependencies... -->
+        <versions.skip>true</versions.skip>
     </properties>
 
     <packaging>pom</packaging>

--- a/dependency-check-jenkins/pom.xml
+++ b/dependency-check-jenkins/pom.xml
@@ -71,22 +71,4 @@
             </plugin>
         </plugins>
     </build>
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>${reporting.project-info-reports-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>summary</report>
-                            <report>license</report>
-                            <report>help</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-        </plugins>
-    </reporting>
 </project>

--- a/dependency-check-jenkins/pom.xml
+++ b/dependency-check-jenkins/pom.xml
@@ -19,6 +19,11 @@
     </distributionManagement>
     <!-- end copy -->
 
+    <properties>
+        <!-- Skip the surefire report since there are no tests... -->
+        <skipSurefireReport>true</skipSurefireReport>
+    </properties>
+
     <packaging>pom</packaging>
     <inceptionYear>2012</inceptionYear>
     <organization>

--- a/dependency-check-jenkins/pom.xml
+++ b/dependency-check-jenkins/pom.xml
@@ -54,12 +54,6 @@
         <system>github</system>
         <url>https://github.com/jenkinsci/dependency-check-jenkins/issues</url>
     </issueManagement>
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-        </license>
-    </licenses>
     <build>
         <plugins>
             <plugin>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -136,23 +136,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${reporting.javadoc-plugin.version}</version>
-                <configuration>
-                    <failOnError>false</failOnError>
-                    <bottom>Copyright� 2012-15 Jeremy Long. All Rights Reserved.</bottom>
-                </configuration>
-                <reportSets>
-                    <reportSet>
-                        <id>default</id>
-                        <reports>
-                            <report>javadoc</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
                 <version>${reporting.versions-plugin.version}</version>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -129,20 +129,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>${reporting.project-info-reports-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>summary</report>
-                            <report>license</report>
-                            <report>help</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>${reporting.maven-plugin-plugin.version}</version>
                 <configuration>
@@ -178,11 +164,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                         </reports>
                     </reportSet>
                 </reportSets>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jxr-plugin</artifactId>
-                <version>${reporting.jxr-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -136,19 +136,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-                <version>${reporting.versions-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>dependency-updates-report</report>
-                            <report>plugin-updates-report</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${reporting.checkstyle-plugin.version}</version>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -163,18 +163,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>${reporting.surefire-report-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>report-only</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${reporting.checkstyle-plugin.version}</version>
                 <configuration>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -166,11 +166,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>${reporting.cobertura-plugin.version}</version>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <version>${reporting.surefire-report-plugin.version}</version>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -178,30 +178,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>taglist-maven-plugin</artifactId>
-                <version>${reporting.taglist-plugin.version}</version>
-                <configuration>
-                    <tagListOptions>
-                        <tagClasses>
-                            <tagClass>
-                                <displayName>Todo Work</displayName>
-                                <tags>
-                                    <tag>
-                                        <matchString>todo</matchString>
-                                        <matchType>ignoreCase</matchType>
-                                    </tag>
-                                    <tag>
-                                        <matchString>FIXME</matchString>
-                                        <matchType>exact</matchType>
-                                    </tag>
-                                </tags>
-                            </tagClass>
-                        </tagClasses>
-                    </tagListOptions>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${reporting.checkstyle-plugin.version}</version>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -40,6 +40,9 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         </site>
     </distributionManagement>
     <!-- end copy -->
+    <properties>
+        <version.maven-plugin-plugin>3.4</version.maven-plugin-plugin>
+    </properties>
     <build>
         <resources>
             <resource>
@@ -63,6 +66,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
+                <version>${version.maven-plugin-plugin}</version>
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     <goalPrefix>dependency-check</goalPrefix>
@@ -126,7 +130,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>${reporting.maven-plugin-plugin.version}</version>
+                <version>${version.maven-plugin-plugin}</version>
                 <configuration>
                     <goalPrefix>dependency-check</goalPrefix>
                 </configuration>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -234,11 +234,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                     </rulesets>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${reporting.findbugs-plugin.version}</version>
-            </plugin>
         </plugins>
     </reporting>
     <dependencies>

--- a/dependency-check-maven/pom.xml
+++ b/dependency-check-maven/pom.xml
@@ -119,10 +119,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
     <reporting>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -38,6 +38,7 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
     <!-- end copy -->
 
     <properties>
+        <findbugs.onlyAnalyze>org.owasp.dependencycheck.utils.*</findbugs.onlyAnalyze>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <build>
@@ -201,14 +202,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
                         <ruleset>/rulesets/java/imports.xml</ruleset>
                         <ruleset>/rulesets/java/unusedcode.xml</ruleset>
                     </rulesets>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${reporting.findbugs-plugin.version}</version>
-                <configuration>
-                    <onlyAnalyze>org.owasp.dependencycheck.utils.*</onlyAnalyze>
                 </configuration>
             </plugin>
         </plugins>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -148,30 +148,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>taglist-maven-plugin</artifactId>
-                <version>${reporting.taglist-plugin.version}</version>
-                <configuration>
-                    <tagListOptions>
-                        <tagClasses>
-                            <tagClass>
-                                <displayName>Todo Work</displayName>
-                                <tags>
-                                    <tag>
-                                        <matchString>todo</matchString>
-                                        <matchType>ignoreCase</matchType>
-                                    </tag>
-                                    <tag>
-                                        <matchString>FIXME</matchString>
-                                        <matchType>exact</matchType>
-                                    </tag>
-                                </tags>
-                            </tagClass>
-                        </tagClasses>
-                    </tagListOptions>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${reporting.checkstyle-plugin.version}</version>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -97,10 +97,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
     <reporting>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -136,11 +136,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jxr-plugin</artifactId>
-                <version>${reporting.jxr-plugin.version}</version>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
                 <version>${reporting.cobertura-plugin.version}</version>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -102,23 +102,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${reporting.javadoc-plugin.version}</version>
-                <configuration>
-                    <failOnError>false</failOnError>
-                    <bottom>Copyright© 2012-15 Jeremy Long. All Rights Reserved.</bottom>
-                </configuration>
-                <reportSets>
-                    <reportSet>
-                        <id>default</id>
-                        <reports>
-                            <report>javadoc</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
                 <version>${reporting.versions-plugin.version}</version>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -102,19 +102,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-                <version>${reporting.versions-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>dependency-updates-report</report>
-                            <report>plugin-updates-report</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${reporting.checkstyle-plugin.version}</version>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -136,11 +136,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>${reporting.cobertura-plugin.version}</version>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <version>${reporting.surefire-report-plugin.version}</version>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -133,18 +133,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>${reporting.surefire-report-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>report-only</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${reporting.checkstyle-plugin.version}</version>
                 <configuration>

--- a/dependency-check-utils/pom.xml
+++ b/dependency-check-utils/pom.xml
@@ -39,7 +39,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
 
     <properties>
         <findbugs.onlyAnalyze>org.owasp.dependencycheck.utils.*</findbugs.onlyAnalyze>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,6 @@ Copyright (c) 2012 - Jeremy Long
         <!-- todo(code review): only used in maven module? Not needed elsewhere -->
         <reporting.maven-plugin-plugin.version>3.4</reporting.maven-plugin-plugin.version>
         <reporting.pmd-plugin.version>3.5</reporting.pmd-plugin.version>
-        <reporting.surefire-report-plugin.version>2.18.1</reporting.surefire-report-plugin.version>
         <reporting.versions-plugin.version>2.2</reporting.versions-plugin.version>
     </properties>
     <distributionManagement>
@@ -389,6 +388,18 @@ Copyright (c) 2012 - Jeremy Long
                             <report>project-team</report>
                             <report>scm</report>
                             <report>license</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>2.18.1</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>report-only</report>
                         </reports>
                     </reportSet>
                 </reportSets>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,6 @@ Copyright (c) 2012 - Jeremy Long
         <logback.version>1.1.3</logback.version>
         <reporting.checkstyle-plugin.version>2.16</reporting.checkstyle-plugin.version>
         <reporting.cobertura-plugin.version>2.7</reporting.cobertura-plugin.version>
-        <reporting.javadoc-plugin.version>2.10.3</reporting.javadoc-plugin.version>
         <reporting.pmd-plugin.version>3.5</reporting.pmd-plugin.version>
         <reporting.versions-plugin.version>2.2</reporting.versions-plugin.version>
     </properties>
@@ -352,6 +351,23 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.3</version>
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <bottom>Copyright© 2012-15 Jeremy Long. All Rights Reserved.</bottom>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <id>default</id>
+                        <reports>
+                            <report>javadoc</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,6 @@ Copyright (c) 2012 - Jeremy Long
         <reporting.checkstyle-plugin.version>2.16</reporting.checkstyle-plugin.version>
         <reporting.cobertura-plugin.version>2.7</reporting.cobertura-plugin.version>
         <reporting.pmd-plugin.version>3.5</reporting.pmd-plugin.version>
-        <reporting.versions-plugin.version>2.2</reporting.versions-plugin.version>
     </properties>
     <distributionManagement>
         <site>
@@ -453,6 +452,19 @@ Copyright (c) 2012 - Jeremy Long
                         </tagClasses>
                     </tagListOptions>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.2</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>dependency-updates-report</report>
+                            <report>plugin-updates-report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
             </plugin>
         </plugins>
     </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -132,8 +132,6 @@ Copyright (c) 2012 - Jeremy Long
         <reporting.checkstyle-plugin.version>2.16</reporting.checkstyle-plugin.version>
         <reporting.cobertura-plugin.version>2.7</reporting.cobertura-plugin.version>
         <reporting.javadoc-plugin.version>2.10.3</reporting.javadoc-plugin.version>
-        <!-- todo(code review): only used in maven module? Not needed elsewhere -->
-        <reporting.maven-plugin-plugin.version>3.4</reporting.maven-plugin-plugin.version>
         <reporting.pmd-plugin.version>3.5</reporting.pmd-plugin.version>
         <reporting.versions-plugin.version>2.2</reporting.versions-plugin.version>
     </properties>
@@ -209,11 +207,6 @@ Copyright (c) 2012 - Jeremy Long
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.6</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-plugin-plugin</artifactId>
-                    <version>${reporting.maven-plugin-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -133,12 +133,9 @@ Copyright (c) 2012 - Jeremy Long
         <reporting.cobertura-plugin.version>2.6</reporting.cobertura-plugin.version>
         <reporting.findbugs-plugin.version>3.0.1</reporting.findbugs-plugin.version>
         <reporting.javadoc-plugin.version>2.10.3</reporting.javadoc-plugin.version>
-        <reporting.jxr-plugin.version>2.5</reporting.jxr-plugin.version>
         <!-- todo(code review): only used in maven module? Not needed elsewhere -->
         <reporting.maven-plugin-plugin.version>3.4</reporting.maven-plugin-plugin.version>
         <reporting.pmd-plugin.version>3.5</reporting.pmd-plugin.version>
-        <!-- TODO(code review) project-info-reports-plugin was/is not used in utils. Expected/intended? -->
-        <reporting.project-info-reports-plugin.version>2.8</reporting.project-info-reports-plugin.version>
         <reporting.surefire-report-plugin.version>2.18.1</reporting.surefire-report-plugin.version>
         <reporting.taglist-plugin.version>2.4</reporting.taglist-plugin.version>
         <reporting.versions-plugin.version>2.2</reporting.versions-plugin.version>
@@ -368,8 +365,13 @@ Copyright (c) 2012 - Jeremy Long
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+                <version>2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>${reporting.project-info-reports-plugin.version}</version>
+                <version>2.8</version>
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -393,6 +395,7 @@ Copyright (c) 2012 - Jeremy Long
                     </reportSet>
                 </reportSets>
             </plugin>
+
         </plugins>
     </reporting>
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,6 @@ Copyright (c) 2012 - Jeremy Long
         <logback.version>1.1.3</logback.version>
         <reporting.checkstyle-plugin.version>2.16</reporting.checkstyle-plugin.version>
         <reporting.cobertura-plugin.version>2.7</reporting.cobertura-plugin.version>
-        <reporting.findbugs-plugin.version>3.0.2</reporting.findbugs-plugin.version>
         <reporting.javadoc-plugin.version>2.10.3</reporting.javadoc-plugin.version>
         <!-- todo(code review): only used in maven module? Not needed elsewhere -->
         <reporting.maven-plugin-plugin.version>3.4</reporting.maven-plugin-plugin.version>
@@ -409,7 +408,7 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${reporting.findbugs-plugin.version}</version>
+                <version>3.0.2</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@ Copyright (c) 2012 - Jeremy Long
         <reporting.maven-plugin-plugin.version>3.4</reporting.maven-plugin-plugin.version>
         <reporting.pmd-plugin.version>3.5</reporting.pmd-plugin.version>
         <reporting.surefire-report-plugin.version>2.18.1</reporting.surefire-report-plugin.version>
-        <reporting.taglist-plugin.version>2.4</reporting.taglist-plugin.version>
         <reporting.versions-plugin.version>2.2</reporting.versions-plugin.version>
     </properties>
     <distributionManagement>
@@ -411,6 +410,30 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <version>${reporting.findbugs-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>taglist-maven-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <tagListOptions>
+                        <tagClasses>
+                            <tagClass>
+                                <displayName>Todo Work</displayName>
+                                <tags>
+                                    <tag>
+                                        <matchString>todo</matchString>
+                                        <matchType>ignoreCase</matchType>
+                                    </tag>
+                                    <tag>
+                                        <matchString>FIXME</matchString>
+                                        <matchType>exact</matchType>
+                                    </tag>
+                                </tags>
+                            </tagClass>
+                        </tagClasses>
+                    </tagListOptions>
+                </configuration>
             </plugin>
         </plugins>
     </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@ Copyright (c) 2012 - Jeremy Long
         <slf4j.version>1.7.12</slf4j.version>
         <logback.version>1.1.3</logback.version>
         <reporting.checkstyle-plugin.version>2.16</reporting.checkstyle-plugin.version>
-        <reporting.cobertura-plugin.version>2.6</reporting.cobertura-plugin.version>
+        <reporting.cobertura-plugin.version>2.7</reporting.cobertura-plugin.version>
         <reporting.findbugs-plugin.version>3.0.1</reporting.findbugs-plugin.version>
         <reporting.javadoc-plugin.version>2.10.3</reporting.javadoc-plugin.version>
         <!-- todo(code review): only used in maven module? Not needed elsewhere -->
@@ -395,7 +395,18 @@ Copyright (c) 2012 - Jeremy Long
                     </reportSet>
                 </reportSets>
             </plugin>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>${reporting.cobertura-plugin.version}</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>cobertura</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
         </plugins>
     </reporting>
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@ Copyright (c) 2012 - Jeremy Long
         <logback.version>1.1.3</logback.version>
         <reporting.checkstyle-plugin.version>2.16</reporting.checkstyle-plugin.version>
         <reporting.cobertura-plugin.version>2.7</reporting.cobertura-plugin.version>
-        <reporting.findbugs-plugin.version>3.0.1</reporting.findbugs-plugin.version>
+        <reporting.findbugs-plugin.version>3.0.2</reporting.findbugs-plugin.version>
         <reporting.javadoc-plugin.version>2.10.3</reporting.javadoc-plugin.version>
         <!-- todo(code review): only used in maven module? Not needed elsewhere -->
         <reporting.maven-plugin-plugin.version>3.4</reporting.maven-plugin-plugin.version>
@@ -406,6 +406,11 @@ Copyright (c) 2012 - Jeremy Long
                         </reports>
                     </reportSet>
                 </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>${reporting.findbugs-plugin.version}</version>
             </plugin>
         </plugins>
     </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,10 @@ Copyright (c) 2012 - Jeremy Long
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>${reporting.project-info-reports-plugin.version}</version>
                 <reportSets>


### PR DESCRIPTION
Moved a lot of the reporting plugins from each module to the parent pom.  This greatly decreases the level of repetition, making the project more consistent and easier to manage.

There were also some redundancies addressed -- like not needing to declare the `maven-compiler-plugin`, or no need to repeat elements like `license` which are already inherited from the _parent pom_.

The cobertura plugin was upgraded and made consistent between version build and reporting.  (Previously 2.7 was used for build, but then 2.6 was used for reporting.)

The `maven-plugin-plugin` was moved to the _maven module_ since it is only used there.  Properties introduced (or renamed) to ensure plugin version consistency between _build_ and _reporting_.

Note that some plugins, like `jxr`, have no impact to modules that have no java source, so it is safe to move to parent pom and non-java modules like gradle and jenkins will not be impacted.

The `maven-project-info-reports-plugin` mentioned in modules referenced an invalid `help` report, as well duplicate reports from the parent pom, so this cleanup yields fewer build warnings.
