### PR TITLE
Upgraded dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,7 +424,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>com.sun.mail</groupId>
                 <artifactId>mailapi</artifactId>
-                <version>1.5.2</version>
+                <version>1.5.4</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
@@ -445,17 +445,17 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.9</version>
+                <version>1.10</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.9.5</version>
+                <version>1.9.6</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant-testutil</artifactId>
-                <version>1.9.5</version>
+                <version>1.9.6</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.lucene</groupId>
@@ -539,7 +539,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.7.2</version>
+                <version>1.8.3</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Mostly keen on JSoup upgrade since [1.8.3](http://jsoup.org/news/release-1.8.3) has performance improvements.
While we're at it, there are a few more upgrades that don't break Java 6 compliance.
