### PR TITLE
Upgraded Fluido Skin to 1.4 (from 1.3.1).

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <skin>
         <groupId>org.apache.maven.skins</groupId>
         <artifactId>maven-fluido-skin</artifactId>
-        <version>1.3.1</version>
+        <version>1.4</version>
     </skin>
     <custom>
         <fluidoSkin>


### PR DESCRIPTION
[Apache Maven Fluido Skin](https://maven.apache.org/skins/maven-fluido-skin/) version 1.4 was released May 3, 2015.
