### PR TITLE
Upgrade jmockit to 1.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -605,9 +605,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>org.jmockit</groupId>
                 <artifactId>jmockit</artifactId>
-                <!-- Upgrading to 1.17 introduces build failures when building
-                with OpenJDK. -->
-                <version>1.16</version>
+                <version>1.19</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
https://github.com/jmockit/jmockit1/issues/196 has been resolved and the latest version of jmockit works fine with openJDK again. `mvn clean install` ran successfully.
