### PR TITLE
Move version number for maven-dependency-plugin out into a variable s…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@ Copyright (c) 2012 - Jeremy Long
         <apache.lucene.version>4.7.2</apache.lucene.version>
         <slf4j.version>1.7.12</slf4j.version>
         <logback.version>1.1.3</logback.version>
+        <dependency-plugin.version>2.10</dependency-plugin.version>
         <reporting.checkstyle-plugin.version>2.16</reporting.checkstyle-plugin.version>
         <reporting.cobertura-plugin.version>2.7</reporting.cobertura-plugin.version>
         <reporting.pmd-plugin.version>3.5</reporting.pmd-plugin.version>
@@ -174,7 +175,7 @@ Copyright (c) 2012 - Jeremy Long
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
+                    <version>${dependency-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -350,6 +351,7 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>${dependency-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
…o we can also use it in the reporting section

Currently, when running for instance `mvn versions:display-dependency-updates`, I get several error messages saying that the plugin lacks a version number. Unfortunately it looks like plugins in the reporting section doesn't pick up version numbers from dependencyManagement, so I've added a property to keep it in one place. The warning went away, and we are able to keep the version number consistent, but I'm not too happy with this workaround, so if anyone has a better idea feel free to let me know.
