### PR TITLE
Replaced StringBuffer with more efficient StringBuilder.

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/suppression/SuppressionHandler.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/suppression/SuppressionHandler.java
@@ -86,7 +86,7 @@ public class SuppressionHandler extends DefaultHandler {
     /**
      * The current node text being extracted from the element.
      */
-    private StringBuffer currentText;
+    private StringBuilder currentText;
 
     /**
      * Handles the start element event.
@@ -100,7 +100,7 @@ public class SuppressionHandler extends DefaultHandler {
     @Override
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
         currentAttributes = attributes;
-        currentText = new StringBuffer();
+        currentText = new StringBuilder();
         if (SUPPRESS.equals(qName)) {
             rule = new SuppressionRule();
             final String base = currentAttributes.getValue("base");

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/xml/pom/PomHandler.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/xml/pom/PomHandler.java
@@ -100,7 +100,7 @@ public class PomHandler extends DefaultHandler {
     /**
      * The current node text being extracted from the element.
      */
-    private StringBuffer currentText;
+    private StringBuilder currentText;
 
     /**
      * Handles the start element event.
@@ -113,7 +113,7 @@ public class PomHandler extends DefaultHandler {
      */
     @Override
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-        currentText = new StringBuffer();
+        currentText = new StringBuilder();
         stack.push(qName);
         if (LICENSE.equals(qName)) {
             license = new License();

--- a/dependency-check-utils/src/main/java/org/owasp/dependencycheck/org/apache/tools/ant/Location.java
+++ b/dependency-check-utils/src/main/java/org/owasp/dependencycheck/org/apache/tools/ant/Location.java
@@ -131,14 +131,13 @@ public class Location implements Serializable {
      *         and the empty string for unknown locations.
      */
     public String toString() {
-        StringBuffer buf = new StringBuffer();
+        final StringBuilder buf = new StringBuilder();
 
         if (fileName != null) {
             buf.append(fileName);
 
             if (lineNumber != 0) {
-                buf.append(":");
-                buf.append(lineNumber);
+                buf.append(':').append(lineNumber);
             }
 
             buf.append(": ");

--- a/dependency-check-utils/src/main/java/org/owasp/dependencycheck/org/apache/tools/ant/launch/Locator.java
+++ b/dependency-check-utils/src/main/java/org/owasp/dependencycheck/org/apache/tools/ant/launch/Locator.java
@@ -239,7 +239,7 @@ public final class Locator {
         if (url == null || !("file".equals(url.getProtocol()))) {
             throw new IllegalArgumentException(ERROR_NOT_FILE_URI + uri);
         }
-        StringBuffer buf = new StringBuffer(url.getHost());
+        final StringBuilder buf = new StringBuilder(url.getHost());
         if (buf.length() > 0) {
             buf.insert(0, File.separatorChar).insert(0, File.separatorChar);
         }
@@ -336,7 +336,7 @@ public final class Locator {
         int i = 0;
         int len = path.length();
         int ch = 0;
-        StringBuffer sb = null;
+        StringBuilder sb = null;
         for (; i < len; i++) {
             ch = path.charAt(i);
             // if it's not an ASCII character, break here, and use UTF-8 encoding
@@ -345,7 +345,7 @@ public final class Locator {
             }
             if (gNeedEscaping[ch]) {
                 if (sb == null) {
-                    sb = new StringBuffer(path.substring(0, i));
+                    sb = new StringBuilder(path.substring(0, i));
                 }
                 sb.append('%');
                 sb.append(gAfterEscaping1[ch]);
@@ -359,7 +359,7 @@ public final class Locator {
         // we saw some non-ascii character
         if (i < len) {
             if (sb == null) {
-                sb = new StringBuffer(path.substring(0, i));
+                sb = new StringBuilder(path.substring(0, i));
             }
             // get UTF-8 bytes for the remaining sub-string
             byte[] bytes = null;

--- a/dependency-check-utils/src/main/java/org/owasp/dependencycheck/org/apache/tools/ant/types/selectors/SelectorUtils.java
+++ b/dependency-check-utils/src/main/java/org/owasp/dependencycheck/org/apache/tools/ant/types/selectors/SelectorUtils.java
@@ -664,9 +664,9 @@ public final class SelectorUtils {
      * @return a String that has had all whitespace removed.
      */
     public static String removeWhitespace(String input) {
-        StringBuffer result = new StringBuffer();
+        final StringBuilder result = new StringBuilder();
         if (input != null) {
-            StringTokenizer st = new StringTokenizer(input);
+            final StringTokenizer st = new StringTokenizer(input);
             while (st.hasMoreTokens()) {
                 result.append(st.nextToken());
             }

--- a/dependency-check-utils/src/main/java/org/owasp/dependencycheck/org/apache/tools/ant/util/FileUtils.java
+++ b/dependency-check-utils/src/main/java/org/owasp/dependencycheck/org/apache/tools/ant/util/FileUtils.java
@@ -672,8 +672,8 @@ public class FileUtils {
         if (toProcess == null || toProcess.length() == 0) {
             return "";
         }
-        StringBuffer path = new StringBuffer(toProcess.length() + EXPAND_SPACE);
-        PathTokenizer tokenizer = new PathTokenizer(toProcess);
+        final StringBuilder path = new StringBuilder(toProcess.length() + EXPAND_SPACE);
+        final PathTokenizer tokenizer = new PathTokenizer(toProcess);
         while (tokenizer.hasMoreTokens()) {
             String pathComponent = tokenizer.nextToken();
             pathComponent = pathComponent.replace('/', File.separatorChar);
@@ -725,7 +725,7 @@ public class FileUtils {
                 s.push(thisToken);
             }
         }
-        StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
         final int size = s.size();
         for (int i = 0; i < size; i++) {
             if (i > 1) {
@@ -765,7 +765,7 @@ public class FileUtils {
             //remove the initial separator; the root has it.
             next = (ca[next] == sep) ? next + 1 : next;
 
-            StringBuffer sbPath = new StringBuffer();
+            final StringBuilder sbPath = new StringBuilder();
             // Eliminate consecutive slashes after the drive spec:
             for (int i = next; i < ca.length; i++) {
                 if (ca[i] != sep || ca[i - 1] != sep) {
@@ -805,7 +805,7 @@ public class FileUtils {
                 && !name.regionMatches(true, name.length() - 4, ".DIR", 0, 4);
         // CheckStyle:MagicNumber ON
         String device = null;
-        StringBuffer directory = null;
+        StringBuilder directory = null;
         String file = null;
 
         int index = 0;
@@ -818,13 +818,13 @@ public class FileUtils {
             device = path.substring(1, index++);
         }
         if (isDirectory) {
-            directory = new StringBuffer(path.substring(index).replace(File.separatorChar, '.'));
+            directory = new StringBuilder(path.substring(index).replace(File.separatorChar, '.'));
         } else {
             int dirEnd = path.lastIndexOf(File.separatorChar, path.length());
             if (dirEnd == -1 || dirEnd < index) {
                 file = path.substring(index);
             } else {
-                directory = new StringBuffer(path.substring(index, dirEnd).
+                directory = new StringBuilder(path.substring(index, dirEnd).
                         replace(File.separatorChar, '.'));
                 index = dirEnd + 1;
                 if (path.length() > index) {
@@ -1016,11 +1016,11 @@ public class FileUtils {
         }
         final char[] buffer = new char[bufferSize];
         int bufferLength = 0;
-        StringBuffer textBuffer = null;
+        StringBuilder textBuffer = null;
         while (bufferLength != -1) {
             bufferLength = rdr.read(buffer);
             if (bufferLength > 0) {
-                textBuffer = (textBuffer == null) ? new StringBuffer() : textBuffer;
+                textBuffer = (textBuffer == null) ? new StringBuilder() : textBuffer;
                 textBuffer.append(new String(buffer, 0, bufferLength));
             }
         }
@@ -1632,7 +1632,7 @@ public class FileUtils {
      * @since Ant 1.7
      */
     public static String getPath(final List pathStack, final char separatorChar) {
-        final StringBuffer buffer = new StringBuffer();
+        final StringBuilder buffer = new StringBuilder();
 
         final Iterator iter = pathStack.iterator();
         if (iter.hasNext()) {


### PR DESCRIPTION
`StringBuffer` is synchronized, while `StringBuilder` is not.
`StringBuilder` is designed to be a drop-in replacement for `StringBuffer`.
Since synchronization is not an issue, `StringBuilder` should be used.
