### PR TITLE
Enabled Compiler Lint Check and Deprecation Warnings

### DIFF
--- a/dependency-check-ant/pom.xml
+++ b/dependency-check-ant/pom.xml
@@ -192,10 +192,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/dependency-check-ant/src/main/java/org/owasp/dependencycheck/ant/logging/AntLoggerAdapter.java
+++ b/dependency-check-ant/src/main/java/org/owasp/dependencycheck/ant/logging/AntLoggerAdapter.java
@@ -31,6 +31,11 @@ import org.slf4j.helpers.MessageFormatter;
 public class AntLoggerAdapter extends MarkerIgnoringBase {
 
     /**
+     * The serial version UID for serialization.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * A reference to the Ant task used for logging.
      */
     private Task task;

--- a/dependency-check-cli/src/main/java/org/owasp/dependencycheck/InvalidScanPathException.java
+++ b/dependency-check-cli/src/main/java/org/owasp/dependencycheck/InvalidScanPathException.java
@@ -25,6 +25,11 @@ package org.owasp.dependencycheck;
 class InvalidScanPathException extends Exception {
 
     /**
+     * The serial version UID for serialization.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new InvalidScanPathException.
      */
     public InvalidScanPathException() {

--- a/dependency-check-core/pom.xml
+++ b/dependency-check-core/pom.xml
@@ -210,13 +210,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                     </systemProperties>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerArgument>-Xlint:unchecked</compilerArgument>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
     <reporting>

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -28,7 +28,8 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.utils.Checksum;
 import org.slf4j.Logger;
@@ -712,21 +713,24 @@ public class Dependency implements Serializable, Comparable<Dependency> {
             return false;
         }
         final Dependency other = (Dependency) obj;
-        return ObjectUtils.equals(this.actualFilePath, other.actualFilePath)
-                && ObjectUtils.equals(this.filePath, other.filePath)
-                && ObjectUtils.equals(this.fileName, other.fileName)
-                && ObjectUtils.equals(this.md5sum, other.md5sum)
-                && ObjectUtils.equals(this.sha1sum, other.sha1sum)
-                && ObjectUtils.equals(this.identifiers, other.identifiers)
-                && ObjectUtils.equals(this.vendorEvidence, other.vendorEvidence)
-                && ObjectUtils.equals(this.productEvidence, other.productEvidence)
-                && ObjectUtils.equals(this.versionEvidence, other.versionEvidence)
-                && ObjectUtils.equals(this.description, other.description)
-                && ObjectUtils.equals(this.license, other.license)
-                && ObjectUtils.equals(this.vulnerabilities, other.vulnerabilities)
-                //&& ObjectUtils.equals(this.relatedDependencies, other.relatedDependencies)
-                && ObjectUtils.equals(this.projectReferences, other.projectReferences)
-                && ObjectUtils.equals(this.availableVersions, other.availableVersions);
+        return new EqualsBuilder()
+            .appendSuper(super.equals(obj))
+            .append(this.actualFilePath, other.actualFilePath)
+            .append(this.filePath, other.filePath)
+            .append(this.fileName, other.fileName)
+            .append(this.md5sum, other.md5sum)
+            .append(this.sha1sum, other.sha1sum)
+            .append(this.identifiers, other.identifiers)
+            .append(this.vendorEvidence, other.vendorEvidence)
+            .append(this.productEvidence, other.productEvidence)
+            .append(this.versionEvidence, other.versionEvidence)
+            .append(this.description, other.description)
+            .append(this.license, other.license)
+            .append(this.vulnerabilities, other.vulnerabilities)
+            //.append(this.relatedDependencies, other.relatedDependencies)
+            .append(this.projectReferences, other.projectReferences)
+            .append(this.availableVersions, other.availableVersions)
+            .isEquals();
     }
 
     /**
@@ -736,15 +740,23 @@ public class Dependency implements Serializable, Comparable<Dependency> {
      */
     @Override
     public int hashCode() {
-        int hash = MAGIC_HASH_INIT_VALUE;
-        for (Object field : new Object[]{this.actualFilePath, this.filePath, this.fileName, this.md5sum,
-            this.sha1sum, this.identifiers, this.vendorEvidence, this.productEvidence, this.versionEvidence,
-            this.description, this.license, this.vulnerabilities,
-            //this.relatedDependencies,
-            this.projectReferences, this.availableVersions}) {
-            hash = MAGIC_HASH_MULTIPLIER * hash + ObjectUtils.hashCode(field);
-        }
-        return hash;
+        return new HashCodeBuilder(MAGIC_HASH_INIT_VALUE, MAGIC_HASH_MULTIPLIER)
+            .append(actualFilePath)
+            .append(filePath)
+            .append(fileName)
+            .append(md5sum)
+            .append(sha1sum)
+            .append(identifiers)
+            .append(vendorEvidence)
+            .append(productEvidence)
+            .append(versionEvidence)
+            .append(description)
+            .append(license)
+            .append(vulnerabilities)
+            //.append(relatedDependencies)
+            .append(projectReferences)
+            .append(availableVersions)
+            .toHashCode();
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Evidence.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Evidence.java
@@ -19,6 +19,7 @@ package org.owasp.dependencycheck.dependency;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.io.Serializable;
 
@@ -198,12 +199,12 @@ public class Evidence implements Serializable, Comparable<Evidence> {
      */
     @Override
     public int hashCode() {
-        int hash = MAGIC_HASH_INIT_VALUE;
-        hash = MAGIC_HASH_MULTIPLIER * hash + ObjectUtils.hashCode(StringUtils.lowerCase(this.name));
-        hash = MAGIC_HASH_MULTIPLIER * hash + ObjectUtils.hashCode(StringUtils.lowerCase(this.source));
-        hash = MAGIC_HASH_MULTIPLIER * hash + ObjectUtils.hashCode(StringUtils.lowerCase(this.value));
-        hash = MAGIC_HASH_MULTIPLIER * hash + ObjectUtils.hashCode(this.confidence);
-        return hash;
+        return new HashCodeBuilder(MAGIC_HASH_INIT_VALUE, MAGIC_HASH_MULTIPLIER)
+            .append(StringUtils.lowerCase(name))
+            .append(StringUtils.lowerCase(source))
+            .append(StringUtils.lowerCase(value))
+            .append(confidence)
+            .toHashCode();
     }
 
     /**

--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/slf4j/MavenLoggerAdapter.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/slf4j/MavenLoggerAdapter.java
@@ -29,6 +29,11 @@ import org.slf4j.helpers.MessageFormatter;
 public class MavenLoggerAdapter extends MarkerIgnoringBase {
 
     /**
+     * The serial version UID for serialization.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
      * A reference to the Maven log.
      */
     private final Log log;

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,8 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <showDeprecation>false</showDeprecation>
+                    <compilerArgument>-Xlint</compilerArgument>
+                    <showDeprecation>true</showDeprecation>
                     <source>1.6</source>
                     <target>1.6</target>
                 </configuration>


### PR DESCRIPTION
Now that the old Ant code has been removed, enabling deprecation warning and a lint check does not create so much noise.

_(There are a few remaining compiler issues -- but honestly, that is like a todo; I wouldn't just ignore them by disabling deprecation warnings.)_
