### PR TITLE
Update to 1.3.1 and fix 'apply-plugin' name

### DIFF
--- a/dependency-check-gradle/README.md
+++ b/dependency-check-gradle/README.md
@@ -30,7 +30,7 @@ buildscript {
     }
 }
 
-apply plugin: 'dependency.check'
+apply plugin: 'dependency-check'
 ```
 
 ### Step 2, Run gradle task

--- a/dependency-check-gradle/build.gradle
+++ b/dependency-check-gradle/build.gradle
@@ -49,8 +49,8 @@ dependencies {
     compile(
             localGroovy(),
             gradleApi(),
-            'org.owasp:dependency-check-core:1.3.0',
-            'org.owasp:dependency-check-utils:1.3.0'
+            'org.owasp:dependency-check-core:1.3.1',
+            'org.owasp:dependency-check-utils:1.3.1'
     )
 
     testCompile ('com.netflix.nebula:nebula-test:2.2.2'){


### PR DESCRIPTION
I think the 1.3.1 update was missed in the gradle build file.

Also the readme had a small typo on one of the `apply-plugin:` lines 

@jeremylong 
