### PR TITLE
Changing the check phase from compile to verify.

### DIFF
--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/CheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/CheckMojo.java
@@ -34,7 +34,7 @@ import org.owasp.dependencycheck.utils.Settings;
  */
 @Mojo(
         name = "check",
-        defaultPhase = LifecyclePhase.COMPILE,
+        defaultPhase = LifecyclePhase.VERIFY,
         threadSafe = true,
         requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
         requiresOnline = true


### PR DESCRIPTION
If you look at the [Maven Build Lifecycle](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html) documentation the `verify` phase is the natural choice for the `check` goal:  _run any checks to verify the package is valid and meets quality criteria._
