### PR TITLE
Do not need or want to call toString for a logger parameter.

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
@@ -192,7 +192,7 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
             final List<MavenArtifact> mas = searcher.searchSha1(dependency.getSha1sum());
             final Confidence confidence = mas.size() > 1 ? Confidence.HIGH : Confidence.HIGHEST;
             for (MavenArtifact ma : mas) {
-                LOGGER.debug("Central analyzer found artifact ({}) for dependency ({})", ma.toString(), dependency.getFileName());
+                LOGGER.debug("Central analyzer found artifact ({}) for dependency ({})", ma, dependency.getFileName());
                 dependency.addAsEvidence("central", ma, confidence);
                 boolean pomAnalyzed = false;
                 for (Evidence e : dependency.getVendorEvidence()) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NuspecAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NuspecAnalyzer.java
@@ -126,7 +126,7 @@ public class NuspecAnalyzer extends AbstractFileTypeAnalyzer {
      */
     @Override
     public void analyzeFileType(Dependency dependency, Engine engine) throws AnalysisException {
-        LOGGER.debug("Checking Nuspec file {}", dependency.toString());
+        LOGGER.debug("Checking Nuspec file {}", dependency);
         try {
             final NuspecParser parser = new XPathNuspecParser();
             NugetPackage np = null;

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
@@ -90,7 +90,7 @@ public class CentralSearch {
 
         final URL url = new URL(rootURL + String.format("?q=1:\"%s\"&wt=xml", sha1));
 
-        LOGGER.debug("Searching Central url {}", url.toString());
+        LOGGER.debug("Searching Central url {}", url);
 
         // Determine if we need to use a proxy. The rules:
         // 1) If the proxy is set, AND the setting is set to true, use the proxy

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -341,7 +341,7 @@ public class Dependency implements Serializable, Comparable<Dependency> {
                 }
             }
             if (!found) {
-                LOGGER.debug("Adding new maven identifier {}", mavenArtifact.toString());
+                LOGGER.debug("Adding new maven identifier {}", mavenArtifact);
                 this.addIdentifier("maven", mavenArtifact.toString(), mavenArtifact.getArtifactUrl(), Confidence.HIGHEST);
             }
         }


### PR DESCRIPTION
Any logger parameter will be turned into a `String`, but you want that to happen by the `debug` method.  If _Debug logging_ is not enabled, then the overhead of calling `toString` is avoided.
