### PR TITLE
Removed unnecessary OutputStream closing.

### DIFF
--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -918,20 +918,11 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                         parent.getAbsolutePath()));
             }
 
-            OutputStream os = null;
-            OutputStream bos = null;
             ObjectOutputStream out = null;
             try {
                 if (dependencies != null) {
-                    os = new FileOutputStream(file);
-                    bos = new BufferedOutputStream(os);
-                    out = new ObjectOutputStream(bos);
+                    out = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(file)));
                     out.writeObject(dependencies);
-                    out.flush();
-
-                    //call reset to prevent resource leaks per
-                    //https://www.securecoding.cert.org/confluence/display/java/SER10-J.+Avoid+memory+and+resource+leaks+during+serialization
-                    out.reset();
                 }
                 if (getLog().isDebugEnabled()) {
                     getLog().debug(String.format("Serialized data file written to '%s' for %s, referenced by key %s",
@@ -948,24 +939,6 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 if (out != null) {
                     try {
                         out.close();
-                    } catch (IOException ex) {
-                        if (getLog().isDebugEnabled()) {
-                            getLog().debug("ignore", ex);
-                        }
-                    }
-                }
-                if (bos != null) {
-                    try {
-                        bos.close();
-                    } catch (IOException ex) {
-                        if (getLog().isDebugEnabled()) {
-                            getLog().debug("ignore", ex);
-                        }
-                    }
-                }
-                if (os != null) {
-                    try {
-                        os.close();
                     } catch (IOException ex) {
                         if (getLog().isDebugEnabled()) {
                             getLog().debug("ignore", ex);


### PR DESCRIPTION
Closing `ObjectOutputStream` and `BufferedOutputStream` will simply close the underlying `FileOutputStream` so it is easy to chain these and avoid maintaining multiple references.

Also the flush and reset are not necessary since the stream is being closed right away.  I read the link as to why [reset](https://www.securecoding.cert.org/confluence/display/java/SER10-J.+Avoid+memory+and+resource+leaks+during+serialization) was being called, but that example is different (there was a for loop).  In this case, the stream is being closed right away, so there is no risk of garbage collection.
