### PR TITLE
Leverage FilenameUtils

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzer.java
@@ -18,6 +18,7 @@
 package org.owasp.dependencycheck.analyzer;
 
 import java.io.File;
+import org.apache.commons.io.FilenameUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Confidence;
@@ -76,13 +77,7 @@ public class FileNameAnalyzer extends AbstractAnalyzer implements Analyzer {
 
         //strip any path information that may get added by ArchiveAnalyzer, etc.
         final File f = dependency.getActualFile();
-        String fileName = f.getName();
-
-        //remove file extension
-        final int pos = fileName.lastIndexOf(".");
-        if (pos > 0) {
-            fileName = fileName.substring(0, pos);
-        }
+        final String fileName = FilenameUtils.removeExtension(f.getName());
 
         //add version evidence
         final DependencyVersion version = DependencyVersionUtil.parseVersion(fileName);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -42,6 +42,7 @@ import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.jsoup.Jsoup;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
@@ -269,8 +270,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
         }
         File externalPom = null;
         if (pomEntries.isEmpty()) {
-            String pomPath = dependency.getActualFilePath();
-            pomPath = pomPath.substring(0, pomPath.lastIndexOf('.')) + ".pom";
+            final String pomPath = FilenameUtils.removeExtension(dependency.getActualFilePath()) + ".pom";
             externalPom = new File(pomPath);
             if (externalPom.isFile()) {
                 pomEntries.add(pomPath);

--- a/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
+++ b/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
@@ -17,6 +17,7 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,12 +59,8 @@ public final class FileUtils {
      * @return the file extension.
      */
     public static String getFileExtension(String fileName) {
-        String ret = null;
-        final int pos = fileName.lastIndexOf(".");
-        if (pos >= 0) {
-            ret = fileName.substring(pos + 1).toLowerCase();
-        }
-        return ret;
+        final String fileExt = FilenameUtils.getExtension(fileName);
+        return null != fileExt ? fileExt.toLowerCase() : null;
     }
 
     /**
@@ -73,9 +70,8 @@ public final class FileUtils {
      * @return true if the file was deleted successfully, otherwise false
      */
     public static boolean delete(File file) {
-        boolean success = true;
-        if (!org.apache.commons.io.FileUtils.deleteQuietly(file)) {
-            success = false;
+        final boolean success = org.apache.commons.io.FileUtils.deleteQuietly(file);
+        if (!success) {
             LOGGER.debug("Failed to delete file: {}; attempting to delete on exit.", file.getPath());
             file.deleteOnExit();
         }

--- a/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
+++ b/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
@@ -60,7 +60,7 @@ public final class FileUtils {
      */
     public static String getFileExtension(String fileName) {
         final String fileExt = FilenameUtils.getExtension(fileName);
-        return null != fileExt ? fileExt.toLowerCase() : null;
+        return null == fileExt || fileExt.isEmpty() ? null : fileExt.toLowerCase();
     }
 
     /**

--- a/dependency-check-utils/src/test/java/org/owasp/dependencycheck/utils/FileUtilsTest.java
+++ b/dependency-check-utils/src/test/java/org/owasp/dependencycheck/utils/FileUtilsTest.java
@@ -35,8 +35,8 @@ public class FileUtilsTest extends BaseTest {
      */
     @Test
     public void testGetFileExtension() {
-        String[] fileName = {"something-0.9.5.jar", "lib2-1.1.js"};
-        String[] expResult = {"jar", "js"};
+        String[] fileName = {"something-0.9.5.jar", "lib2-1.1.js", "dir.tmp/noext"};
+        String[] expResult = {"jar", "js", null};
 
         for (int i = 0; i < fileName.length; i++) {
             String result = FileUtils.getFileExtension(fileName[i]);


### PR DESCRIPTION
String dissection to isolate the filename extension is not always 100%.  Check out the _Apache Commons IO_ [FilenameUtils.removeExtension](http://commons.apache.org/proper/commons-io/javadocs/api-2.4/org/apache/commons/io/FilenameUtils.html#removeExtension%28java.lang.String%29) for examples.

This PR leverages the `FilenameUtils` class from `commons-io`.
