### PR TITLE
Option to skip Nvd check (cveValidForHours)

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DatabaseProperties.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DatabaseProperties.java
@@ -46,6 +46,10 @@ public class DatabaseProperties {
      */
     public static final String MODIFIED = "Modified";
     /**
+     * The properties file key for the last checked field - used to store the last check time of the Modified NVD CVE xml file.
+     */
+    public static final String LAST_CHECKED = "NVD CVE Checked";
+    /**
      * The properties file key for the last updated field - used to store the last updated time of the Modified NVD CVE xml file.
      */
     public static final String LAST_UPDATED = "NVD CVE Modified";

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/DateUtil.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/DateUtil.java
@@ -36,11 +36,12 @@ public final class DateUtil {
      *
      * @param date the date to be checked.
      * @param compareTo the date to compare to.
-     * @param range the range in days to be considered valid.
+     * @param dayRange the range in days to be considered valid.
      * @return whether or not the date is within the range.
      */
-    public static boolean withinDateRange(long date, long compareTo, int range) {
-        final double differenceInDays = (compareTo - date) / 1000.0 / 60.0 / 60.0 / 24.0;
-        return differenceInDays < range;
+    public static boolean withinDateRange(long date, long compareTo, int dayRange) {
+        // ms = dayRange x 24 hours/day x 60 min/hour x 60 sec/min x 1000 ms/sec
+        final long msRange = dayRange * 24L * 60L * 60L * 1000L;
+        return (compareTo - date) < msRange;
     }
 }

--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -289,6 +289,11 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      */
     @Parameter(property = "cveUrl20Base", defaultValue = "", required = false)
     private String cveUrl20Base;
+    /**
+     * Optionally skip excessive CVE update checks for a designated duration in hours.
+     */
+    @Parameter(property = "cveValidForHours", defaultValue = "", required = false)
+    private String cveValidForHours;
 
     /**
      * The path to mono for .NET Assembly analysis on non-windows systems.
@@ -677,6 +682,9 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         }
         if (cveUrl20Base != null && !cveUrl20Base.isEmpty()) {
             Settings.setString(Settings.KEYS.CVE_SCHEMA_2_0, cveUrl20Base);
+        }
+        if (cveValidForHours != null && !cveValidForHours.isEmpty()) {
+            Settings.setString(Settings.KEYS.CVE_CHECK_VALID_FOR_HOURS, cveValidForHours);
         }
     }
 

--- a/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -118,6 +118,10 @@ public final class Settings {
          */
         public static final String CVE_MODIFIED_VALID_FOR_DAYS = "cve.url.modified.validfordays";
         /**
+         * The properties key to control the skipping of the check for CVE updates.
+         */
+        public static final String CVE_CHECK_VALID_FOR_HOURS = "cve.check.validforhours";
+        /**
          * The properties key for the telling us how many cve.url.* URLs exists. This is used in combination with CVE_BASE_URL to
          * be able to retrieve the URLs for all of the files that make up the NVD CVE listing.
          */


### PR DESCRIPTION
In response to my [Runtime Performance Observations](https://groups.google.com/forum/#!topic/dependency-check/5FDw9imKGQ0) post, this PR adds an option to skip redundant, repetitive (and expensive) checks for NVD updates.

There is a new, optional setting called `cve.check.validforhours`.  This is exposed in the Maven plugin as `cveValidForHours`.  If it is not set, it is business as usual -- same behavior.  But, if the value is positive, then an NVD check done with the specified hours will be skip the NVD check and just proceed with the analysis.
