### PR TITLE
Deprecated aggregate is truly optional

### DIFF
--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -352,7 +352,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * @throws MojoExecutionException thrown if aggregate is set to true
      */
     private void validateAggregate() throws MojoExecutionException {
-        if (aggregate) {
+        if (null != aggregate) {
             final String msg = "Aggregate configuration detected - as of dependency-check 1.2.8 this no longer supported. "
                     + "Please use the aggregate goal instead.";
             throw new MojoExecutionException(msg);


### PR DESCRIPTION
If aggregate is truly optional, need to do a null check otherwise risk an NPE.
See issue #393 -- looks like a bug was introduced by PR #390.
