### PR TITLE
Removed unnecessary countCharacter method.

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/suppression/SuppressionRule.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/suppression/SuppressionRule.java
@@ -20,6 +20,7 @@ package org.owasp.dependencycheck.suppression;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Identifier;
 import org.owasp.dependencycheck.dependency.Vulnerability;
@@ -381,30 +382,7 @@ public class SuppressionRule {
      * @return true if the property type does not specify a version; otherwise false
      */
     boolean cpeHasNoVersion(PropertyType c) {
-        if (c.isRegex()) {
-            return false;
-        }
-        if (countCharacter(c.getValue(), ':') == 3) {
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Counts the number of occurrences of the character found within the string.
-     *
-     * @param str the string to check
-     * @param c the character to count
-     * @return the number of times the character is found in the string
-     */
-    int countCharacter(String str, char c) {
-        int count = 0;
-        int pos = str.indexOf(c) + 1;
-        while (pos > 0) {
-            count += 1;
-            pos = str.indexOf(c, pos) + 1;
-        }
-        return count;
+        return !c.isRegex() && StringUtils.countMatches(c.getValue(), ':') == 3;
     }
 
     /**

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/suppression/SuppressionRuleTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/suppression/SuppressionRuleTest.java
@@ -307,27 +307,6 @@ public class SuppressionRuleTest {
     }
 
     /**
-     * Test of countCharacter method, of class SuppressionRule.
-     */
-    @Test
-    public void testCountCharacter() {
-        String str = "cpe:/a:microsoft:.net_framework:4.5";
-        char c = ':';
-        SuppressionRule instance = new SuppressionRule();
-        int expResult = 4;
-        int result = instance.countCharacter(str, c);
-        assertEquals(expResult, result);
-        str = "::";
-        expResult = 2;
-        result = instance.countCharacter(str, c);
-        assertEquals(expResult, result);
-        str = "these are not the characters you are looking for";
-        expResult = 0;
-        result = instance.countCharacter(str, c);
-        assertEquals(expResult, result);
-    }
-
-    /**
      * Test of identifierMatches method, of class SuppressionRule.
      */
     @Test


### PR DESCRIPTION
Removed unnecessary countCharacter method by leveraging [StringUtils.countMatches](http://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/StringUtils.html#countMatches%28java.lang.CharSequence,%20char%29).
