### PR TITLE
Upgraded slf4j to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ Copyright (c) 2012 - Jeremy Long
         <!-- new versions of lucene are compiled with JDK 1.7 and cannot be used ubiquitously in Jenkins
         thus, we cannot upgrade beyond 4.7.2 -->
         <apache.lucene.version>4.7.2</apache.lucene.version>
-        <slf4j.version>1.7.12</slf4j.version>
+        <slf4j.version>1.7.13</slf4j.version>
         <logback.version>1.1.3</logback.version>
         <reporting.checkstyle-plugin.version>2.17</reporting.checkstyle-plugin.version>
         <reporting.cobertura-plugin.version>2.7</reporting.cobertura-plugin.version>


### PR DESCRIPTION
I was looking at/testing #407, and I saw that there was a new version of slf4j available as well. 

`mvn clean install` ran successfully.
