### PR TITLE
Issue #419 - Avoiding a duplicate CPE Index Created message

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -134,17 +134,19 @@ public class CPEAnalyzer implements Analyzer {
      * process.
      */
     public void open() throws IOException, DatabaseException {
-        cve = new CveDB();
-        cve.open();
-        cpe = CpeMemoryIndex.getInstance();
-        try {
-            LOGGER.info("Creating the CPE Index");
-            final long creationStart = System.currentTimeMillis();
-            cpe.open(cve);
-            LOGGER.info("CPE Index Created ({} ms)", System.currentTimeMillis() - creationStart);
-        } catch (IndexException ex) {
-            LOGGER.debug("IndexException", ex);
-            throw new DatabaseException(ex);
+        if (!isOpen()) {
+            cve = new CveDB();
+            cve.open();
+            cpe = CpeMemoryIndex.getInstance();
+            try {
+                LOGGER.info("Creating the CPE Index");
+                final long creationStart = System.currentTimeMillis();
+                cpe.open(cve);
+                LOGGER.info("CPE Index Created ({} ms)", System.currentTimeMillis() - creationStart);
+            } catch (IndexException ex) {
+                LOGGER.debug("IndexException", ex);
+                throw new DatabaseException(ex);
+            }
         }
     }
 


### PR DESCRIPTION
And avoid a resource leak.  Removing `open` from `initialize` didn't work, but avoiding a double-open seems to be a logical solution.
