### PR TITLE
Solves the ISSUE #426. No need to update the CURRENT_ENGINE_RELEASE p…

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/EngineVersionCheck.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/EngineVersionCheck.java
@@ -133,8 +133,6 @@ public class EngineVersionCheck implements CachedWebDataSource {
                     updateToVersion = v.toString();
                     if (!currentRelease.equals(updateToVersion)) {
                         properties.save(CURRENT_ENGINE_RELEASE, updateToVersion);
-                    } else {
-                        properties.save(CURRENT_ENGINE_RELEASE, "");
                     }
                     properties.save(ENGINE_VERSION_CHECKED_ON, Long.toString(now));
                 }


### PR DESCRIPTION
…roperty when it has value.

In current code when the CURRENT_ENGINE_RELEASE contains the same version as in remote web, it overwrites
the property with the empty string, but in OracleDB there is no difference between empty string and null,
and it stores a null value, so when the plugin read all properties and it tries to store them in a HashMap,
the plugin fails with a NullPointerException.

And the code executes one of twice for the same version, when there is no need to save it until it changes.
