### PR TITLE
Upgrade for Maven Site Plugin 3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@ Copyright (c) 2012 - Jeremy Long
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>3.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -335,7 +335,7 @@ Copyright (c) 2012 - Jeremy Long
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>
                         <artifactId>doxia-module-markdown</artifactId>
-                        <version>1.6</version>
+                        <version>1.7</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <skin>
         <groupId>org.apache.maven.skins</groupId>
         <artifactId>maven-fluido-skin</artifactId>
-        <version>1.4</version>
+        <version>1.5</version>
     </skin>
     <custom>
         <fluidoSkin>
@@ -65,9 +65,9 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
 
     <body>
         <head>
-            <style type="text/css">
+            <![CDATA[<style type="text/css">
                 #bannerLeft { margin-top:-20px;margin-bottom:5px !important }
-            </style>
+            </style>]]>
         </head>
         <breadcrumbs>
             <item name=" " href="#"/>


### PR DESCRIPTION
- Maven Site Plugin 3.5 uses Doxia 1.7
- Maven Fluido Skin 1.5 is required for Doxia 1.7
- The head configuration in the site descriptor needed to be surrounded as CDATA; see http://maven.apache.org/plugins/maven-site-plugin/examples/sitedescriptor.html#Inject_xhtml_into_head
