### PR TITLE
Fix issues in Gradle's dependencyCheckPurge task site page

### DIFF
--- a/src/site/markdown/dependency-check-gradle/configuration-purge.md
+++ b/src/site/markdown/dependency-check-gradle/configuration-purge.md
@@ -4,7 +4,7 @@ Tasks
 Task                                                | Description
 ----------------------------------------------------|-----------------------
 [dependencyCheck](configuration.html)               | Runs dependency-check against the project and generates a report.
-[dependencyCheckUpdate]](configuration-update.html) | Updates the local cache of the NVD data from NIST.
+[dependencyCheckUpdate](configuration-update.html)  | Updates the local cache of the NVD data from NIST.
 dependencyCheckPurge                                | Deletes the local copy of the NVD. This is used to force a refresh of the data.
 
 Configuration: dependencyCheckPurge
@@ -24,7 +24,7 @@ Config Group | Property          | Description                                  
 -------------|-------------------|---------------------------------------------------------------------------------------------|------------------
 data         | directory         | Sets the data directory to hold SQL CVEs contents. This should generally not be changed.    | &nbsp;
 
-$H$H$H$H Example
+#### Example
 ```groovy
 dependencyCheckPurge {
     data {


### PR DESCRIPTION
Fix broken link to dependencyCheckUpdate task page, remove repeated
closing character ']'.
Replace $H with # in the heading of the example.
