### PR TITLE
Patch for jeremylong/DependencyCheck/#466

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzer.java
@@ -18,7 +18,9 @@
 package org.owasp.dependencycheck.analyzer;
 
 import java.io.File;
+
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.filefilter.NameFileFilter;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Confidence;
@@ -65,6 +67,13 @@ public class FileNameAnalyzer extends AbstractAnalyzer implements Analyzer {
     }
     //</editor-fold>
 
+    // Python init files
+    private static final NameFileFilter IGNORED_FILES = new NameFileFilter(new String[] {
+        "__init__.py",
+        "__init__.pyc",
+        "__init__.pyo"
+    });
+
     /**
      * Collects information about the file name.
      *
@@ -102,7 +111,7 @@ public class FileNameAnalyzer extends AbstractAnalyzer implements Analyzer {
                     fileName, Confidence.HIGHEST);
             dependency.getVendorEvidence().addEvidence("file", "name",
                     fileName, Confidence.HIGHEST);
-        } else {
+        } else if (!IGNORED_FILES.accept(f)) {
             dependency.getProductEvidence().addEvidence("file", "name",
                     fileName, Confidence.HIGH);
             dependency.getVendorEvidence().addEvidence("file", "name",

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
@@ -185,7 +185,7 @@ public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
         if (found) {
             dependency.setDisplayFileName(parentName + "/__init__.py");
             dependency.getProductEvidence().addEvidence(file.getName(),
-                    "PackageName", parentName, Confidence.MEDIUM);
+                    "PackageName", parentName, Confidence.HIGH);
         } else {
             // copy, alter and set in case some other thread is iterating over
             final List<Dependency> dependencies = new ArrayList<Dependency>(


### PR DESCRIPTION
This does two things:
1) Updates the PythonPackageAnalyzer to HIGH evidence for **init**.py
2) Removes evidence from the FileNameAnalyzer for **init**.py[co]?

TODO: Need for the PythonPackageAnalyzer to still add evidence for
**init**.py[co] even though it won't be able to analyze the contents of
it. Also, need to work up the tree for **init**.py files to get the
parent folders (not sure why subfolders are not being inspected).
