### PR TITLE
Make it possible to suppress vulnerabilities from OSVDB

### DIFF
--- a/dependency-check-core/src/main/resources/schema/suppression.xsd
+++ b/dependency-check-core/src/main/resources/schema/suppression.xsd
@@ -21,7 +21,7 @@
     </xs:simpleType>
     <xs:simpleType name="cveType">
         <xs:restriction base="xs:string">
-            <xs:pattern value="(\w+\-)?CVE\-\d\d\d\d\-\d+"/>
+            <xs:pattern value="((\w+\-)?CVE\-\d\d\d\d\-\d+|\d+)"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="sha1Type">


### PR DESCRIPTION
Bundle-audit pulls data from OSVDB (in addition to CVEs), through ruby-advisory-db. OSVDB uses another pattern for vulnerabilities, and it is not currently possible to suppress these vulnerabilities.
