### PR TITLE
Fixed CVSS for Ruby.

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
@@ -20,6 +20,7 @@ package org.owasp.dependencycheck.analyzer;
 import org.apache.commons.io.FileUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.data.nvdcve.CveDB;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Reference;
@@ -57,6 +58,10 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
     public static final String VERSION = "Version: ";
     public static final String ADVISORY = "Advisory: ";
     public static final String CRITICALITY = "Criticality: ";
+
+    public static CveDB CVEDB = new CveDB();
+    //instance.open();
+    //Vulnerability result = instance.getVulnerability("CVE-2015-3225");
 
     /**
      * @return a filter that accepts files named Gemfile.lock
@@ -300,6 +305,7 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
             } else if ("Low".equals(criticality)) {
                 vulnerability.setCvssScore(2.0f);
             } else {
+                //vulnerability.getName()
                 vulnerability.setCvssScore(-1.0f);
             }
         }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -372,7 +372,7 @@ public class CveDB {
      * @return a vulnerability object
      * @throws DatabaseException if an exception occurs
      */
-    private Vulnerability getVulnerability(String cve) throws DatabaseException {
+    public Vulnerability getVulnerability(String cve) throws DatabaseException {
         PreparedStatement psV = null;
         PreparedStatement psR = null;
         PreparedStatement psS = null;

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzerTest.java
@@ -18,6 +18,7 @@
 package org.owasp.dependencycheck.analyzer;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -32,6 +33,7 @@ import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.Vulnerability;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,16 +108,42 @@ public class RubyBundleAuditAnalyzerTest extends BaseTest {
             analyzer.analyze(result, engine);
             int size = engine.getDependencies().size();
             assertThat(size, is(1));
-            
+
             Dependency dependency = engine.getDependencies().get(0);
             assertTrue(dependency.getProductEvidence().toString().toLowerCase().contains("redcarpet"));
             assertTrue(dependency.getVersionEvidence().toString().toLowerCase().contains("2.2.2"));
-            
+
+
         } catch (Exception e) {
             LOGGER.warn("Exception setting up RubyBundleAuditAnalyzer. Make sure Ruby gem bundle-audit is installed. You may also need to set property \"analyzer.bundle.audit.path\".", e);
             Assume.assumeNoException("Exception setting up RubyBundleAuditAnalyzer; bundle audit may not be installed, or property \"analyzer.bundle.audit.path\" may not be set.", e);
         }
     }
+
+    /**
+     * Test Ruby addCriticalityToVulnerability
+     */
+    @Test
+    public void testAddCriticalityToVulnerability() throws AnalysisException, DatabaseException {
+        try {
+            analyzer.initialize();
+
+            final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
+                    "ruby/vulnerable/gems/sinatra/Gemfile.lock"));
+            final Engine engine = new Engine();
+            analyzer.analyze(result, engine);
+
+
+            Dependency dependency = engine.getDependencies().get(0);
+            Vulnerability vulnerability = dependency.getVulnerabilities().first();
+            assertEquals(vulnerability.getCvssScore(), 5.0f, 0.0);
+
+        } catch (Exception e) {
+            LOGGER.warn("Exception setting up RubyBundleAuditAnalyzer. Make sure Ruby gem bundle-audit is installed. You may also need to set property \"analyzer.bundle.audit.path\".", e);
+            Assume.assumeNoException("Exception setting up RubyBundleAuditAnalyzer; bundle audit may not be installed, or property \"analyzer.bundle.audit.path\" may not be set.", e);
+        }
+    }
+
 
     /**
      * Test when Ruby bundle-audit is not available on the system.
@@ -137,4 +165,6 @@ public class RubyBundleAuditAnalyzerTest extends BaseTest {
 			LOGGER.info("phantom-bundle-audit is not available. Ruby Bundle Audit Analyzer is disabled as expected.");
         }
     }
+
+
 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/nvdcve/CveDBIntegrationTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/nvdcve/CveDBIntegrationTest.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import org.junit.Assert;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.owasp.dependencycheck.dependency.Vulnerability;
@@ -66,6 +68,24 @@ public class CveDBIntegrationTest extends BaseDBTestCase {
             instance.open();
             Set<VulnerableSoftware> result = instance.getCPEs(vendor, product);
             assertTrue(result.size() > 5);
+        } finally {
+            if (instance != null) {
+                instance.close();
+            }
+        }
+    }
+    /**
+     * Test of getVulnerability method, of class CveDB.
+     */
+    @Test
+    public void testgetVulnerability() throws Exception {
+        CveDB instance = null;
+        try {
+            instance = new CveDB();
+            instance.open();
+            Vulnerability result = instance.getVulnerability("CVE-2015-3225");
+            assertTrue(result.getDescription().contains("lib/rack/utils.rb in Rack before 1.5.4 and 1.6.x before 1.6.2"));
+
         } finally {
             if (instance != null) {
                 instance.close();

--- a/dependency-check-core/src/test/resources/ruby/vulnerable/gems/sinatra/Gemfile
+++ b/dependency-check-core/src/test/resources/ruby/vulnerable/gems/sinatra/Gemfile
@@ -1,0 +1,4 @@
+# encoding: utf-8
+source 'https://rubygems.org'
+
+gem 'sinatra'

--- a/dependency-check-core/src/test/resources/ruby/vulnerable/gems/sinatra/Gemfile.lock
+++ b/dependency-check-core/src/test/resources/ruby/vulnerable/gems/sinatra/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (1.5.2)
+    rack-protection (1.5.2)
+      rack
+    sinatra (1.4.4)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sinatra


### PR DESCRIPTION
this bug was discovered when scanning ruby applications and getting back
`-1` cvss. this turns out to be a problem with bundle-audit cve
database.

Our solution was to use the NVD database, which dependency check uses to
get the CVSS scores for Ruby only if the Criticality is missing from
bundle-audit output. 

Keep in mind there are compilation errors with the
commit atm.

Fixes #485

Signed-off-by: Gabriel Ramirez gabriel.e.ramirez@gmail.com
