### PR TITLE
Commons-IO 2.5 upgrade

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AutoconfAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AutoconfAnalyzer.java
@@ -30,6 +30,7 @@ import org.owasp.dependencycheck.utils.UrlStringUtils;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -220,14 +221,12 @@ public class AutoconfAnalyzer extends AbstractFileTypeAnalyzer {
      */
     private String getFileContents(final File actualFile)
             throws AnalysisException {
-        String contents = "";
         try {
-            contents = FileUtils.readFileToString(actualFile).trim();
+            return FileUtils.readFileToString(actualFile, Charset.defaultCharset()).trim();
         } catch (IOException e) {
             throw new AnalysisException(
                     "Problem occurred while reading dependency file.", e);
         }
-        return contents;
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.regex.Matcher;
@@ -156,7 +157,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
         dependency.setDisplayFileName(String.format("%s%c%s", parentName, File.separatorChar, name));
         String contents;
         try {
-            contents = FileUtils.readFileToString(file).trim();
+            contents = FileUtils.readFileToString(file, Charset.defaultCharset()).trim();
         } catch (IOException e) {
             throw new AnalysisException(
                     "Problem occurred while reading dependency file.", e);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/OpenSSLAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/OpenSSLAnalyzer.java
@@ -28,6 +28,7 @@ import org.owasp.dependencycheck.utils.Settings;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,14 +159,12 @@ public class OpenSSLAnalyzer extends AbstractFileTypeAnalyzer {
      */
     private String getFileContents(final File actualFile)
             throws AnalysisException {
-        String contents;
         try {
-            contents = FileUtils.readFileToString(actualFile).trim();
+            return FileUtils.readFileToString(actualFile, Charset.defaultCharset()).trim();
         } catch (IOException e) {
             throw new AnalysisException(
                     "Problem occurred while reading dependency file.", e);
         }
-        return contents;
     }
 
     @Override

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
@@ -32,6 +32,7 @@ import org.owasp.dependencycheck.utils.UrlStringUtils;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -208,7 +209,7 @@ public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
             throws AnalysisException {
         String contents;
         try {
-            contents = FileUtils.readFileToString(file).trim();
+            contents = FileUtils.readFileToString(file, Charset.defaultCharset()).trim();
         } catch (IOException e) {
             throw new AnalysisException(
                     "Problem occurred while reading dependency file.", e);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.nio.charset.Charset;
 import java.util.*;
 
 /**
@@ -332,7 +333,7 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
     private Dependency createDependencyForGem(Engine engine, String parentName, String fileName, String gem) throws IOException {
         final File tempFile = File.createTempFile("Gemfile-" + gem, ".lock", Settings.getTempDirectory());
         final String displayFileName = String.format("%s%c%s:%s", parentName, File.separatorChar, fileName, gem);
-        FileUtils.write(tempFile, displayFileName); // unique contents to avoid dependency bundling
+        FileUtils.write(tempFile, displayFileName, Charset.defaultCharset()); // unique contents to avoid dependency bundling
         final Dependency dependency = new Dependency(tempFile);
         dependency.getProductEvidence().addEvidence("bundler-audit", "Name", gem, Confidence.HIGHEST);
         dependency.setDisplayFileName(displayFileName);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzer.java
@@ -28,6 +28,7 @@ import org.owasp.dependencycheck.utils.Settings;
 
 import java.io.FileFilter;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -110,7 +111,7 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
             throws AnalysisException {
         String contents;
         try {
-            contents = FileUtils.readFileToString(dependency.getActualFile());
+            contents = FileUtils.readFileToString(dependency.getActualFile(), Charset.defaultCharset());
         } catch (IOException e) {
             throw new AnalysisException(
                     "Problem occurred while reading dependency file.", e);

--- a/pom.xml
+++ b/pom.xml
@@ -560,7 +560,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.4</version>
+                <version>2.5</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -690,7 +690,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.8.3</version>
+                <version>1.9.1</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Minor tweaks to avoid implicit default Charset methods, which are deprecated.
