### PR TITLE
Update initialize_mysql.sql

### DIFF
--- a/dependency-check-core/src/main/resources/data/initialize_mysql.sql
+++ b/dependency-check-core/src/main/resources/data/initialize_mysql.sql
@@ -54,4 +54,4 @@ DELIMITER ;
 
 GRANT EXECUTE ON PROCEDURE dependencycheck.save_property TO 'dcuser';
 
-UPDATE Properties SET value='3.0' WHERE ID='version';
+UPDATE properties SET value='3.0' WHERE ID='version';


### PR DESCRIPTION
lower cased "properties" in UPDATE statement

I get an error with MySQL 5.5.48-37.8 on executing this file:

```
ERROR 1146 (42S02) at line 57: Table 'dependencycheck.Properties' doesn't exist
```

It seems, this is just an upper/lower case issue, which is easy to change.
