### PR TITLE
Optimized CLEANUP_ORPHANS query for H2 1.4.x

### DIFF
--- a/dependency-check-core/src/main/resources/data/dbStatements_h2.properties
+++ b/dependency-check-core/src/main/resources/data/dbStatements_h2.properties
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 MERGE_PROPERTY=MERGE INTO properties (id, value) KEY(id) VALUES(?, ?)
+CLEANUP_ORPHANS=DELETE FROM cpeEntry WHERE id IN (SELECT id FROM cpeEntry LEFT JOIN software ON cpeEntry.id = software.CPEEntryId WHERE software.CPEEntryId IS NULL)


### PR DESCRIPTION
`CLEANUP_ORPHANS` query from `dbStatements.properties` writes millions of records from subselect to file system for H2 database 1.4.x due to default [MAX_MEMORY_ROWS](http://www.h2database.com/html/grammar.html?highlight=max_memory_rows&search=MAX_MEM#set_max_memory_rows) setting.
Database maintenance task therefore takes forever.
The new query (copied from postgresql) works way faster (in seconds). Works with H2 1.3.x as well.

This is a convenience fix for SBT projects (e.g. all Play Framework projects) that have an H2 database v1.4.x in their classpath which by default evicts the provided v1.3.x from DependencyCheck.

See #436 for original issue.
