### PR TITLE
Correctly apply weightings when searching for CPEs

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -198,8 +198,8 @@ public class CPEAnalyzer implements Analyzer {
                 LOGGER.debug("product search: {}", products);
             }
             if (!vendors.isEmpty() && !products.isEmpty()) {
-                final List<IndexEntry> entries = searchCPE(vendors, products, dependency.getProductEvidence().getWeighting(),
-                        dependency.getVendorEvidence().getWeighting());
+                final List<IndexEntry> entries = searchCPE(vendors, products, dependency.getVendorEvidence().getWeighting(),
+                        dependency.getProductEvidence().getWeighting());
                 if (entries == null) {
                     continue;
                 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CPEAnalyzerIntegrationTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CPEAnalyzerIntegrationTest.java
@@ -240,7 +240,7 @@ public class CPEAnalyzerIntegrationTest extends BaseDBTestCase {
 
         Set<String> vendorWeightings = Collections.singleton("apache");
 
-        List<IndexEntry> result = instance.searchCPE(vendor, product, productWeightings, vendorWeightings);
+        List<IndexEntry> result = instance.searchCPE(vendor, product, vendorWeightings, productWeightings);
         instance.close();
 
         boolean found = false;


### PR DESCRIPTION
The signature of `searchCPE` method is:
`searchCPE(String vendor, String product, Set<String> vendorWeightings, Set<String> productWeightings)`

Therefore it seems that the parameters are in incorrect order now. 
