### PR TITLE
Updating gradle dependencyCheck documentation

### DIFF
--- a/src/site/markdown/dependency-check-gradle/configuration.md
+++ b/src/site/markdown/dependency-check-gradle/configuration.md
@@ -26,7 +26,7 @@ suppressionFile      | The file path to the XML suppression file \- used to supp
 dependencyCheck {
     autoUpdate=false
     cveValidForHours=1
-    format=ALL
+    format='ALL'
 }
 ```
 


### PR DESCRIPTION
I was trying to execute the gradle example, but I was getting this error:
`Could not get unknown property 'ALL' for object of type org.owasp.dependencycheck.gradle.extension.CheckExtension.`

This error is because the quotes are missing on the example.
