### PR TITLE
Compatibility fixes for MariaDB JDBC driver

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/ConnectionFactory.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/ConnectionFactory.java
@@ -20,7 +20,7 @@ package org.owasp.dependencycheck.data.nvdcve;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -352,11 +352,11 @@ public final class ConnectionFactory {
      */
     private static void ensureSchemaVersion(Connection conn) throws DatabaseException {
         ResultSet rs = null;
-        CallableStatement cs = null;
+        PreparedStatement ps = null;
         try {
             //TODO convert this to use DatabaseProperties
-            cs = conn.prepareCall("SELECT value FROM properties WHERE id = 'version'");
-            rs = cs.executeQuery();
+            ps = conn.prepareStatement("SELECT value FROM properties WHERE id = 'version'");
+            rs = ps.executeQuery();
             if (rs.next()) {
                 final DependencyVersion appDbVersion = DependencyVersionUtil.parseVersion(DB_SCHEMA_VERSION);
                 final DependencyVersion db = DependencyVersionUtil.parseVersion(rs.getString(1));
@@ -376,7 +376,7 @@ public final class ConnectionFactory {
             throw new DatabaseException("Unable to check the database schema version");
         } finally {
             DBUtils.closeResultSet(rs);
-            DBUtils.closeStatement(cs);
+            DBUtils.closeStatement(ps);
         }
     }
 }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -19,7 +19,6 @@ package org.owasp.dependencycheck.data.nvdcve;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -813,14 +812,14 @@ public class CveDB {
      * Deletes unused dictionary entries from the database.
      */
     public void deleteUnusedCpe() {
-        CallableStatement cs = null;
+        PreparedStatement ps = null;
         try {
-            cs = getConnection().prepareCall(statementBundle.getString("DELETE_UNUSED_DICT_CPE"));
-            cs.executeUpdate();
+            ps = getConnection().prepareStatement(statementBundle.getString("DELETE_UNUSED_DICT_CPE"));
+            ps.executeUpdate();
         } catch (SQLException ex) {
             LOGGER.error("Unable to delete CPE dictionary entries", ex);
         } finally {
-            DBUtils.closeStatement(cs);
+            DBUtils.closeStatement(ps);
         }
     }
 
@@ -837,7 +836,7 @@ public class CveDB {
     public void addCpe(String cpe, String vendor, String product) {
         PreparedStatement ps = null;
         try {
-            ps = getConnection().prepareCall(statementBundle.getString("ADD_DICT_CPE"));
+            ps = getConnection().prepareStatement(statementBundle.getString("ADD_DICT_CPE"));
             ps.setString(1, cpe);
             ps.setString(2, vendor);
             ps.setString(3, product);


### PR DESCRIPTION
This pull request adds compatibility for MariaDB's JDBC driver.

Background:
While most JDBC drivers silently accept a conn.prepareCall(sql) with sql **not** containing "? = CALL(...)" (and return a PreparedStatement instead), MariaDB's driver is a little bit more restrictive and throws an exception in this case.

MariaBD developers consider this not an error, but actually an improvement.
See: https://jira.mariadb.org/browse/CONJ-63

Fortunately, DependencyCheck does **not** need CallableStatements anywhere, because none of the called functions return any value. Thus using a CallableStatement is superfluous anyway.

Rule of Thumb:
Use CallableStatement cs = conn.prepareCall(...) **only** if the sql actually uses an OUT parameter.
