### PR TITLE
filter out version from jar filename for package name

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzer.java
@@ -93,26 +93,27 @@ public class FileNameAnalyzer extends AbstractAnalyzer implements Analyzer {
 
         //add version evidence
         final DependencyVersion version = DependencyVersionUtil.parseVersion(fileName);
+        final String packageName = DependencyVersionUtil.parsePreVersion(fileName);
         if (version != null) {
             // If the version number is just a number like 2 or 23, reduce the confidence
             // a shade. This should hopefully correct for cases like log4j.jar or
             // struts2-core.jar
             if (version.getVersionParts() == null || version.getVersionParts().size() < 2) {
-                dependency.getVersionEvidence().addEvidence("file", "name",
+                dependency.getVersionEvidence().addEvidence("file", "version",
                         version.toString(), Confidence.MEDIUM);
             } else {
                 dependency.getVersionEvidence().addEvidence("file", "version",
                         version.toString(), Confidence.HIGHEST);
             }
             dependency.getVersionEvidence().addEvidence("file", "name",
-                    fileName, Confidence.MEDIUM);
+                    packageName, Confidence.MEDIUM);
         }
 
         if (!IGNORED_FILES.accept(f)) {
             dependency.getProductEvidence().addEvidence("file", "name",
-                    fileName, Confidence.HIGH);
+            		packageName, Confidence.HIGH);
             dependency.getVendorEvidence().addEvidence("file", "name",
-                    fileName, Confidence.HIGH);
+            		packageName, Confidence.HIGH);
         }
     }
 }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -685,7 +685,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
                     foundSomething = true;
                     versionEvidence.addEvidence(source, key, value, Confidence.HIGH);
                 } else if ("specification-version".equalsIgnoreCase(key)) {
-                    specificationVersion = key;
+                    specificationVersion = value;
                 } else if (key.equalsIgnoreCase(Attributes.Name.IMPLEMENTATION_VENDOR.toString())) {
                     foundSomething = true;
                     vendorEvidence.addEvidence(source, key, value, Confidence.HIGH);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/DependencyVersionUtil.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/DependencyVersionUtil.java
@@ -39,6 +39,11 @@ public final class DependencyVersionUtil {
      * are missing a version number using the previous regex.
      */
     private static final Pattern RX_SINGLE_VERSION = Pattern.compile("\\d+(\\.?([_-](release|beta|alpha)|[a-zA-Z_-]{1,3}\\d{1,8}))?");
+    
+    /**
+     * Regular expression to extract the part before the version numbers if there are any based on RX_VERSION. In most cases, this part represents a more accurate name.
+     */
+    private static final Pattern RX_PRE_VERSION = Pattern.compile("^(.+)[_-](\\d+\\.\\d{1,6})+");
 
     /**
      * Private constructor for utility class.
@@ -94,5 +99,28 @@ public final class DependencyVersionUtil {
             version = version.substring(0, version.length() - 4);
         }
         return new DependencyVersion(version);
+    }
+
+    /**
+     * <p>
+     * A utility class to extract the part before version numbers from file names (or other strings containing version numbers. 
+     * In most cases, this part represents a more accurate name than the full file name.</p>
+     * <pre>
+     * Example:
+     * Give the file name: library-name-1.4.1r2-release.jar
+     * This function would return: library-name</pre>
+     *
+     * @param text the text being analyzed
+     * @return the part before the version numbers if any, otherwise return the text itself.
+     */
+    public static String parsePreVersion(String text) {
+    	if(parseVersion(text) == null)
+    		return text;
+    	
+    	Matcher matcher = RX_PRE_VERSION.matcher(text);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return text;
     }
 }


### PR DESCRIPTION
A small improvement to FileNameAnalyzer:  if there's version number identified in file name, filter that out for the package name to get more accurate names.  e.g.  "library-name-1.4.1r2-release.jar", version number was identified, use "library-name" as the package name instead of the full file name "library-name-1.4.1r2-release".

Changes:
1. added a new function DependencyVersionUtil#parsePreVersion() to parse the package name if there's version number already identified.
2. use the new function in FileNameAnalyzer#analyze() to set a more accurate name if available.
