### PR TITLE
Upgrade mailapi to 1.5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -572,7 +572,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>com.sun.mail</groupId>
                 <artifactId>mailapi</artifactId>
-                <version>1.5.5</version>
+                <version>1.5.6</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Dependency  CPE     GAV     Highest Severity    CVE Count   CPE Confidence  Evidence Count
mailapi-1.5.5.jar   cpe:/a:sun:javamail:1.5.5   com.sun.mail:mailapi:1.5.5  Medium  1   LOW     28

Javamail does not properly handle a series of invalid login attempts in which the same e-mail address is entered as username and password, and the domain portion of this address yields a Java UnknownHostException error, which allows remote attackers to cause a denial of service (connection pool exhaustion) via a large number of requests, resulting in a SQLNestedException.
