### PR TITLE
fixed check for bundle-audit's return code

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
@@ -286,7 +286,7 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
         } catch (InterruptedException ie) {
             throw new AnalysisException("bundle-audit process interrupted", ie);
         }
-        if (exitValue != 0) {
+        if (exitValue > 1) {
             final String msg = String.format("Unexpected exit code from bundle-audit process; exit code: %s", exitValue);
             throw new AnalysisException(msg);
         }


### PR DESCRIPTION
bundler-audit has a return code of 1 if a vulnerability is found. Therefore the check (!=0) raises the AnalysisException in error.

This has been introduced in commit 9fcf23c8022724b56758a4d7c1e91e36f183dfb6.

The problem is, that bundle-audit's results are then omitted for the scan and it produces an error, which e.g. within the Jenkins plugin leads to failed job.

bundle-audits exit code could be reviewed at
- https://github.com/rubysec/bundler-audit/blob/master/lib/bundler/audit/cli.rb#L54-L56

To reproduce, run

`dependency-check -s ../test4free/ --project test4free --enableExperimental`

Output should be similar to

```
$ dependency-check -s ../test4free/ --project test4free --enableExperimental
[INFO] Checking for updates
[INFO] Skipping NVD check since last check was within 4 hours.
[INFO] Check for updates complete (1877 ms)
[INFO] Analysis Started
[INFO] Launching: [bundle-audit, check, --verbose] from /var/folders/5s/p0rvxfj53n71j2wb594nqn3wq7833g/T/dctemp
[INFO] Ruby Bundle Audit Analyzer is enabled. It is necessary to manually run "bundle-audit update" occasionally to keep its database up to date.
[INFO] Disabled org.owasp.dependencycheck.analyzer.RubyBundlerAnalyzer to avoid noisy duplicate results.
[INFO] Disabled org.owasp.dependencycheck.analyzer.RubyGemspecAnalyzer to avoid noisy duplicate results.
[INFO] Launching: [bundle-audit, check, --verbose] from /Users/xxxxxxxx.xxxxxxxx/tmp/test4free
[WARN] An error occurred while analyzing '/Users/xxxxxxxx.xxxxxxxx/tmp/test4free/Gemfile.lock'.
[INFO] Creating the CPE Index
[INFO] CPE Index Created (1101 ms)
[INFO] Analysis Complete (4022 ms)
[ERROR] Unexpected exit code from bundle-audit process; exit code: 1
```
