### PR TITLE
Support parallelism for analyzers of the same type

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/AnalysisTask.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/AnalysisTask.java
@@ -1,0 +1,61 @@
+package org.owasp.dependencycheck;
+
+import org.owasp.dependencycheck.analyzer.Analyzer;
+import org.owasp.dependencycheck.analyzer.FileTypeAnalyzer;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.utils.Settings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+class AnalysisTask implements Callable<Void> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AnalysisTask.class);
+
+    private final Analyzer analyzer;
+    private final Dependency dependency;
+    private final Engine engine;
+    private final List<Throwable> exceptions;
+
+    AnalysisTask(Analyzer analyzer, Dependency dependency, Engine engine, List<Throwable> exceptions) {
+        this.analyzer = analyzer;
+        this.dependency = dependency;
+        this.engine = engine;
+        this.exceptions = exceptions;
+    }
+
+    @Override
+    public Void call() throws Exception {
+        Settings.initialize();
+
+        if (shouldAnalyze()) {
+            LOGGER.debug("Begin Analysis of '{}' ({})", dependency.getActualFilePath(), analyzer.getName());
+            try {
+                analyzer.analyze(dependency, engine);
+            } catch (AnalysisException ex) {
+                LOGGER.warn("An error occurred while analyzing '{}' ({}).", dependency.getActualFilePath(), analyzer.getName());
+                LOGGER.debug("", ex);
+                exceptions.add(ex);
+            } catch (Throwable ex) {
+                LOGGER.warn("An unexpected error occurred during analysis of '{}' ({}): {}",
+                        dependency.getActualFilePath(), analyzer.getName(), ex.getMessage());
+                LOGGER.debug("", ex);
+                exceptions.add(ex);
+            }
+        }
+
+        return null;
+    }
+
+    private boolean shouldAnalyze() {
+        if (analyzer instanceof FileTypeAnalyzer) {
+            final FileTypeAnalyzer fAnalyzer = (FileTypeAnalyzer) analyzer;
+            return fAnalyzer.accept(dependency.getActualFile());
+        }
+
+        return true;
+    }
+}

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -17,7 +17,6 @@
  */
 package org.owasp.dependencycheck;
 
-import com.google.common.base.Stopwatch;
 import org.owasp.dependencycheck.analyzer.AnalysisPhase;
 import org.owasp.dependencycheck.analyzer.Analyzer;
 import org.owasp.dependencycheck.analyzer.AnalyzerService;
@@ -398,7 +397,7 @@ public class Engine implements FileFilter {
             final List<Analyzer> analyzerList = analyzers.get(phase);
 
             for (final Analyzer a : analyzerList) {
-                Stopwatch watch = Stopwatch.createStarted();
+                final long analyzerStart = System.currentTimeMillis();
                 try {
                     initializeAnalyzer(a);
                 } catch (InitializationException ex) {
@@ -407,7 +406,10 @@ public class Engine implements FileFilter {
                 }
 
                 executeAnalysisTasks(exceptions, a);
-                LOGGER.info("Finished {}. Took {} secs.", a.getName(), watch.elapsed(TimeUnit.SECONDS));
+
+                final long analyzerDurationMillis = System.currentTimeMillis() - analyzerStart;
+                final long analyzerDurationSeconds = TimeUnit.MILLISECONDS.toSeconds(analyzerDurationMillis);
+                LOGGER.info("Finished {}. Took {} secs.", a.getName(), analyzerDurationSeconds);
             }
         }
         for (AnalysisPhase phase : AnalysisPhase.values()) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractAnalyzer.java
@@ -46,4 +46,12 @@ public abstract class AbstractAnalyzer implements Analyzer {
     public void close() throws Exception {
         //do nothing
     }
+
+    /**
+     * The default is to support parallel processing.
+     */
+    @Override
+    public boolean supportsParallelProcessing() {
+        return true;
+    }
 }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractFileTypeAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractFileTypeAnalyzer.java
@@ -83,7 +83,7 @@ public abstract class AbstractFileTypeAnalyzer extends AbstractAnalyzer implemen
     /**
      * A flag indicating whether or not the analyzer is enabled.
      */
-    private boolean enabled = true;
+    private volatile boolean enabled = true;
 
     /**
      * Get the value of enabled.

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/Analyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/Analyzer.java
@@ -75,4 +75,12 @@ public interface Analyzer {
      * @throws Exception is thrown if an exception occurs closing the analyzer.
      */
     void close() throws Exception;
+
+    /**
+     * Returns whether multiple instances of the same type of analyzer can run in parallel.
+     * Note that running analyzers of different types in parallel is not supported at all.
+     *
+     * @return {@code true} if the analyzer supports parallel processing, {@code false} else
+     */
+    boolean supportsParallelProcessing();
 }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
@@ -221,6 +221,17 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
     }
 
     /**
+     * Does not support parallel processing as it both modifies and iterates over the engine's list of dependencies.
+     *
+     * @see #analyzeFileType(Dependency, Engine)
+     * @see #findMoreDependencies(Engine, File)
+     */
+    @Override
+    public boolean supportsParallelProcessing() {
+        return false;
+    }
+
+    /**
      * Analyzes a given dependency. If the dependency is an archive, such as a
      * WAR or EAR, the contents are extracted, scanned, and added to the list of
      * dependencies within the engine.

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
@@ -73,10 +73,6 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
      */
     private File grokAssemblyExe = null;
     /**
-     * The DocumentBuilder for parsing the XML
-     */
-    private DocumentBuilder builder;
-    /**
      * Logger
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(AssemblyAnalyzer.class);
@@ -128,6 +124,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
         try {
             final Process proc = pb.start();
 
+            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
             doc = builder.parse(proc.getInputStream());
 
             // Try evacuating the error stream
@@ -176,6 +173,8 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
                         product, Confidence.HIGH));
             }
 
+        } catch (ParserConfigurationException pce) {
+            throw new AnalysisException("Error initializing the assembly analyzer", pce);
         } catch (IOException ioe) {
             throw new AnalysisException(ioe);
         } catch (SAXException saxe) {
@@ -233,9 +232,9 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
 
         // Now, need to see if GrokAssembly actually runs from this location.
         final List<String> args = buildArgumentList();
-        //TODO this creaes an "unreported" error - if someone doesn't look
+        //TODO this creates an "unreported" error - if someone doesn't look
         // at the command output this could easily be missed (especially in an
-        // Ant or Mmaven build.
+        // Ant or Maven build.
         //
         // We need to create a non-fatal warning error type that will
         // get added to the report.
@@ -274,12 +273,6 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
             LOGGER.debug("Could not execute GrokAssembly {}", e.getMessage());
             setEnabled(false);
             throw new InitializationException("An error occurred with the .NET AssemblyAnalyzer", e);
-        }
-        try {
-            builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-        } catch (ParserConfigurationException ex) {
-            setEnabled(false);
-            throw new InitializationException("Error initializing the assembly analyzer", ex);
         }
     }
 

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AutoconfAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AutoconfAnalyzer.java
@@ -178,11 +178,7 @@ public class AutoconfAnalyzer extends AbstractFileTypeAnalyzer {
                 }
             }
         } else {
-            // copy, alter and set in case some other thread is iterating over
-            final List<Dependency> dependencies = new ArrayList<Dependency>(
-                    engine.getDependencies());
-            dependencies.remove(dependency);
-            engine.setDependencies(dependencies);
+            engine.getDependencies().remove(dependency);
         }
     }
 

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Jeremy Long
  */
-public class CPEAnalyzer implements Analyzer {
+public class CPEAnalyzer extends AbstractAnalyzer {
 
     /**
      * The Logger.

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
@@ -75,7 +75,7 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
      * The analyzer should be disabled if there are errors, so this is a flag to
      * determine if such an error has occurred.
      */
-    private boolean errorFlag = false;
+    private volatile boolean errorFlag = false;
 
     /**
      * The searcher itself.

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzer.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Jeremy Long
  */
-public class DependencyBundlingAnalyzer extends AbstractAnalyzer implements Analyzer {
+public class DependencyBundlingAnalyzer extends AbstractAnalyzer {
 
     /**
      * The Logger.
@@ -93,6 +93,16 @@ public class DependencyBundlingAnalyzer extends AbstractAnalyzer implements Anal
         return ANALYSIS_PHASE;
     }
     //</editor-fold>
+
+    /**
+     * Does not support parallel processing as it both modifies and iterates over the engine's list of dependencies.
+     *
+     * @see #analyze(Dependency, Engine)
+     */
+    @Override
+    public boolean supportsParallelProcessing() {
+        return false;
+    }
 
     /**
      * Analyzes a set of dependencies. If they have been found to have the same

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzer.java
@@ -34,7 +34,7 @@ import org.owasp.dependencycheck.utils.DependencyVersionUtil;
  *
  * @author Jeremy Long
  */
-public class FileNameAnalyzer extends AbstractAnalyzer implements Analyzer {
+public class FileNameAnalyzer extends AbstractAnalyzer {
 
     //<editor-fold defaultstate="collapsed" desc="All standard implementation details of Analyzer">
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/HintAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/HintAnalyzer.java
@@ -51,7 +51,7 @@ import org.xml.sax.SAXException;
  *
  * @author Jeremy Long
  */
-public class HintAnalyzer extends AbstractAnalyzer implements Analyzer {
+public class HintAnalyzer extends AbstractAnalyzer {
 
     //<editor-fold defaultstate="collapsed" desc="All standard implementation details of Analyzer">
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -26,7 +26,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -35,6 +34,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -76,7 +76,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
      * The count of directories created during analysis. This is used for
      * creating temporary directories.
      */
-    private static int dirCount = 0;
+    private static final AtomicInteger DIR_COUNT = new AtomicInteger(0);
     /**
      * The system independent newline character.
      */
@@ -318,7 +318,6 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
                     pom.processProperties(pomProperties);
                     setPomEvidence(newDependency, pom, null);
                     engine.getDependencies().add(newDependency);
-                    Collections.sort(engine.getDependencies());
                 } else {
                     if (externalPom == null) {
                         pom = PomUtils.readPom(path, jar);
@@ -1218,7 +1217,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
      * @throws AnalysisException thrown if unable to create temporary directory
      */
     private File getNextTempDirectory() throws AnalysisException {
-        dirCount += 1;
+        final int dirCount = DIR_COUNT.incrementAndGet();
         final File directory = new File(tempFileLocation, String.valueOf(dirCount));
         //getting an exception for some directories not being able to be created; might be because the directory already exists?
         if (directory.exists()) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NvdCveAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NvdCveAnalyzer.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Jeremy Long
  */
-public class NvdCveAnalyzer implements Analyzer {
+public class NvdCveAnalyzer extends AbstractAnalyzer {
     /**
      * The Logger for use throughout the class
      */

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
@@ -45,6 +45,7 @@ import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.owasp.dependencycheck.utils.FileUtils;
 import org.owasp.dependencycheck.utils.Settings;
 import org.owasp.dependencycheck.utils.UrlStringUtils;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Used to analyze a Wheel or egg distribution files, or their contents in
@@ -76,7 +77,7 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
      * The count of directories created during analysis. This is used for
      * creating temporary directories.
      */
-    private static int dirCount = 0;
+    private static final AtomicInteger DIR_COUNT = new AtomicInteger(0);
 
     /**
      * The name of the analyzer.
@@ -391,7 +392,7 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
         // getting an exception for some directories not being able to be
         // created; might be because the directory already exists?
         do {
-            dirCount += 1;
+            final int dirCount = DIR_COUNT.incrementAndGet();
             directory = new File(tempFileLocation, String.valueOf(dirCount));
         } while (directory.exists());
         if (!directory.mkdirs()) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
@@ -193,11 +193,7 @@ public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
                 }
             }
         } else {
-            // copy, alter and set in case some other thread is iterating over
-            final List<Dependency> dependencies = new ArrayList<Dependency>(
-                    engine.getDependencies());
-            dependencies.remove(dependency);
-            engine.setDependencies(dependencies);
+            engine.getDependencies().remove(dependency);
         }
     }
 

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
@@ -51,7 +51,7 @@ public class CentralSearch {
     /**
      * Whether to use the Proxy when making requests
      */
-    private boolean useProxy;
+    private final boolean useProxy;
 
     /**
      * Used for logging.

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusSearch.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusSearch.java
@@ -25,6 +25,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathFactory;
+
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
 import org.owasp.dependencycheck.utils.URLConnectionFactory;
@@ -47,7 +48,7 @@ public class NexusSearch {
     /**
      * Whether to use the Proxy when making requests.
      */
-    private boolean useProxy;
+    private final boolean useProxy;
     /**
      * Used for logging.
      */
@@ -61,17 +62,17 @@ public class NexusSearch {
      */
     public NexusSearch(URL rootURL) {
         this.rootURL = rootURL;
+        useProxy = useProxy();
+        LOGGER.debug("Using proxy: {}", useProxy);
+    }
+
+    private boolean useProxy() {
         try {
-            if (null != Settings.getString(Settings.KEYS.PROXY_SERVER)
-                    && Settings.getBoolean(Settings.KEYS.ANALYZER_NEXUS_USES_PROXY)) {
-                useProxy = true;
-                LOGGER.debug("Using proxy");
-            } else {
-                useProxy = false;
-                LOGGER.debug("Not using proxy");
-            }
+            return Settings.getString(Settings.KEYS.PROXY_SERVER) != null
+                    && Settings.getBoolean(Settings.KEYS.ANALYZER_NEXUS_USES_PROXY);
         } catch (InvalidSettingException ise) {
-            useProxy = false;
+            LOGGER.warn("Failed to parse proxy settings.", ise);
+            return false;
         }
     }
 

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -119,7 +119,7 @@ public class CveDB {
      * @throws DatabaseException thrown if there is an error opening the
      * database connection
      */
-    public final void open() throws DatabaseException {
+    public synchronized final void open() throws DatabaseException {
         if (!isOpen()) {
             conn = ConnectionFactory.getConnection();
         }
@@ -129,7 +129,7 @@ public class CveDB {
      * Closes the DB4O database. Close should be called on this object when it
      * is done being used.
      */
-    public void close() {
+    public synchronized void close() {
         if (conn != null) {
             try {
                 conn.close();
@@ -149,7 +149,7 @@ public class CveDB {
      *
      * @return whether the database connection is open or closed
      */
-    public boolean isOpen() {
+    public synchronized boolean isOpen() {
         return conn != null;
     }
 
@@ -158,7 +158,7 @@ public class CveDB {
      *
      * @throws SQLException thrown if a SQL Exception occurs
      */
-    public void commit() throws SQLException {
+    public synchronized void commit() throws SQLException {
         //temporary remove this as autocommit is on.
         //if (conn != null) {
         //    conn.commit();
@@ -202,7 +202,7 @@ public class CveDB {
      * analyzed
      * @return a set of vulnerable software
      */
-    public Set<VulnerableSoftware> getCPEs(String vendor, String product) {
+    public synchronized Set<VulnerableSoftware> getCPEs(String vendor, String product) {
         final Set<VulnerableSoftware> cpe = new HashSet<VulnerableSoftware>();
         ResultSet rs = null;
         PreparedStatement ps = null;
@@ -234,7 +234,7 @@ public class CveDB {
      * @throws DatabaseException thrown when there is an error retrieving the
      * data from the DB
      */
-    public Set<Pair<String, String>> getVendorProductList() throws DatabaseException {
+    public synchronized Set<Pair<String, String>> getVendorProductList() throws DatabaseException {
         final Set<Pair<String, String>> data = new HashSet<Pair<String, String>>();
         ResultSet rs = null;
         PreparedStatement ps = null;
@@ -328,7 +328,7 @@ public class CveDB {
      * @return a list of Vulnerabilities
      * @throws DatabaseException thrown if there is an exception retrieving data
      */
-    public List<Vulnerability> getVulnerabilities(String cpeStr) throws DatabaseException {
+    public synchronized List<Vulnerability> getVulnerabilities(String cpeStr) throws DatabaseException {
         final VulnerableSoftware cpe = new VulnerableSoftware();
         try {
             cpe.parseName(cpeStr);
@@ -389,7 +389,7 @@ public class CveDB {
      * @return a vulnerability object
      * @throws DatabaseException if an exception occurs
      */
-    public Vulnerability getVulnerability(String cve) throws DatabaseException {
+    public synchronized Vulnerability getVulnerability(String cve) throws DatabaseException {
         PreparedStatement psV = null;
         PreparedStatement psR = null;
         PreparedStatement psS = null;
@@ -462,7 +462,7 @@ public class CveDB {
      * @param vuln the vulnerability to add to the database
      * @throws DatabaseException is thrown if the database
      */
-    public void updateVulnerability(Vulnerability vuln) throws DatabaseException {
+    public synchronized void updateVulnerability(Vulnerability vuln) throws DatabaseException {
         PreparedStatement selectVulnerabilityId = null;
         PreparedStatement deleteVulnerability = null;
         PreparedStatement deleteReferences = null;
@@ -638,7 +638,7 @@ public class CveDB {
      *
      * @return <code>true</code> if data exists; otherwise <code>false</code>
      */
-    public boolean dataExists() {
+    public synchronized boolean dataExists() {
         Statement cs = null;
         ResultSet rs = null;
         try {
@@ -674,7 +674,7 @@ public class CveDB {
      * updates. This should be called after all updates have been completed to
      * ensure orphan entries are removed.
      */
-    public void cleanupDatabase() {
+    public synchronized void cleanupDatabase() {
         PreparedStatement ps = null;
         try {
             ps = getConnection().prepareStatement(statementBundle.getString("CLEANUP_ORPHANS"));
@@ -812,7 +812,7 @@ public class CveDB {
      *
      * Deletes unused dictionary entries from the database.
      */
-    public void deleteUnusedCpe() {
+    public synchronized void deleteUnusedCpe() {
         PreparedStatement ps = null;
         try {
             ps = getConnection().prepareStatement(statementBundle.getString("DELETE_UNUSED_DICT_CPE"));
@@ -834,7 +834,7 @@ public class CveDB {
      * @param vendor the CPE vendor
      * @param product the CPE product
      */
-    public void addCpe(String cpe, String vendor, String product) {
+    public synchronized void addCpe(String cpe, String vendor, String product) {
         PreparedStatement ps = null;
         try {
             ps = getConnection().prepareStatement(statementBundle.getString("ADD_DICT_CPE"));


### PR DESCRIPTION
- Analyzer declares `boolean supportsParallelProcessing()`.
- If an Analyzer supports prallel processing, it will process its tasks with up to 4 \* #cores threads.
- Fixed some synchronization issues.
- minor changes
