### PR TITLE
NexusAnalyzer should not ignore analyzer.nexus.proxy

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
@@ -239,7 +239,7 @@ public class NexusAnalyzer extends AbstractFileTypeAnalyzer {
                         LOGGER.debug("Unable to delete temp file");
                     }
                     LOGGER.debug("Downloading {}", ma.getPomUrl());
-                    Downloader.fetchFile(new URL(ma.getPomUrl()), pomFile);
+                    Downloader.fetchFile(new URL(ma.getPomUrl()), pomFile, searcher.isUseProxy());
                     PomUtils.analyzePOM(dependency, pomFile);
                 } catch (DownloadFailedException ex) {
                     LOGGER.warn("Unable to download pom.xml for {} from Nexus repository; "

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusSearch.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusSearch.java
@@ -193,6 +193,10 @@ public class NexusSearch {
 
         return true;
     }
+
+    public boolean isUseProxy() {
+        return useProxy;
+    }
 }
 
 // vim: cc=120:sw=4:ts=4:sts=4


### PR DESCRIPTION
NexusSearch honours the analyzer.nexus.proxy setting to identify the jar via a SHA1 hash and receives a URL to download the POM.  NexusAnalyzer then attempts to download the POM ignoring the analyzer.nexus.proxy setting, which fails if Nexus is within the local network (and doesn't require a proxy)