### PR TITLE
Fix handling of numerical versions

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/VulnerableSoftware.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/VulnerableSoftware.java
@@ -226,18 +226,21 @@ public class VulnerableSoftware extends IndexEntry implements Serializable, Comp
 
     /**
      * Determines if the string passed in is a positive integer.
+     * To be counted as a positive integer, the string must only contain 0-9
+     * and must not have any leading zeros (though "0" is a valid positive
+     * integer).
      *
      * @param str the string to test
      * @return true if the string only contains 0-9, otherwise false.
      */
-    private static boolean isPositiveInteger(final String str) {
+    static boolean isPositiveInteger(final String str) {
         if (str == null || str.isEmpty()) {
             return false;
         }
 
-        // numbers/versions with leading zeros should not be treated as numbers
+        // numbers with leading zeros should not be treated as numbers
         // (e.g. when comparing "01" <-> "1")
-        if (str.charAt(0) == '0') {
+        if (str.charAt(0) == '0' && str.length() > 1) {
             return false;
         }
 

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/VulnerableSoftware.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/VulnerableSoftware.java
@@ -234,6 +234,13 @@ public class VulnerableSoftware extends IndexEntry implements Serializable, Comp
         if (str == null || str.isEmpty()) {
             return false;
         }
+
+        // numbers/versions with leading zeros should not be treated as numbers
+        // (e.g. when comparing "01" <-> "1")
+        if (str.charAt(0) == '0') {
+            return false;
+        }
+
         for (int i = 0; i < str.length(); i++) {
             final char c = str.charAt(i);
             if (c < '0' || c > '9') {

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/dependency/VulnerableSoftwareTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/dependency/VulnerableSoftwareTest.java
@@ -125,6 +125,10 @@ public class VulnerableSoftwareTest extends BaseTest {
         vs1.setCpe("cpe:/a:hp:system_management_homepage:2.1.10-186");
         assertTrue(vs.compareTo(vs1) < 0);
         //assertTrue(vs1.compareTo(vs)>0);
+
+        vs.setCpe("cpe:/a:ibm:security_guardium_database_activity_monitor:10.01");
+        vs1.setCpe("cpe:/a:ibm:security_guardium_database_activity_monitor:10.1");
+        assertTrue(vs.compareTo(vs1) < 0);
     }
 
     @Test

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/dependency/VulnerableSoftwareTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/dependency/VulnerableSoftwareTest.java
@@ -109,6 +109,10 @@ public class VulnerableSoftwareTest extends BaseTest {
         vs1.setCpe("2.1.10");
         assertTrue(vs.compareTo(vs1) < 0);
 
+        vs.setCpe("2.1.42");
+        vs1.setCpe("2.3.21");
+        assertTrue(vs.compareTo(vs1) < 0);
+
         vs.setCpe("cpe:/a:hp:system_management_homepage:2.1.1");
         vs1.setCpe("cpe:/a:hp:system_management_homepage:2.1.10");
         assertTrue(vs.compareTo(vs1) < 0);
@@ -128,6 +132,10 @@ public class VulnerableSoftwareTest extends BaseTest {
 
         vs.setCpe("cpe:/a:ibm:security_guardium_database_activity_monitor:10.01");
         vs1.setCpe("cpe:/a:ibm:security_guardium_database_activity_monitor:10.1");
+        assertTrue(vs.compareTo(vs1) < 0);
+
+        vs.setCpe("2.0");
+        vs1.setCpe("2.1");
         assertTrue(vs.compareTo(vs1) < 0);
     }
 
@@ -151,5 +159,19 @@ public class VulnerableSoftwareTest extends BaseTest {
         assertEquals("mysql", vs.getVendor());
         assertEquals("mysql", vs.getProduct());
         assertEquals("5.1.23a", vs.getVersion());
+    }
+
+    @Test
+    public void testIspositiveInteger() {
+        assertTrue(VulnerableSoftware.isPositiveInteger("1"));
+        assertTrue(VulnerableSoftware.isPositiveInteger("10"));
+        assertTrue(VulnerableSoftware.isPositiveInteger("666"));
+        assertTrue(VulnerableSoftware.isPositiveInteger("0"));
+
+        assertFalse(VulnerableSoftware.isPositiveInteger("+1"));
+        assertFalse(VulnerableSoftware.isPositiveInteger("-1"));
+        assertFalse(VulnerableSoftware.isPositiveInteger("2.1"));
+        assertFalse(VulnerableSoftware.isPositiveInteger("01"));
+        assertFalse(VulnerableSoftware.isPositiveInteger("00"));
     }
 }


### PR DESCRIPTION
The proposed fix is to compare parts of the version in an alphanumerical way, if the part contains a leading zero.