### PR TITLE
UTs on Windows when project path contains space & some exception review

### DIFF
--- a/dependency-check-cli/src/test/java/org/owasp/dependencycheck/CliParserTest.java
+++ b/dependency-check-cli/src/test/java/org/owasp/dependencycheck/CliParserTest.java
@@ -196,7 +196,7 @@ public class CliParserTest {
      */
     @Test
     public void testParse_scan_withFileExists() throws Exception {
-        File path = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").getPath());
+        File path = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").toURI().getPath());
         String[] args = {"-scan", path.getCanonicalPath(), "-out", "./", "-app", "test"};
 
         CliParser instance = new CliParser();

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DriverShim.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DriverShim.java
@@ -115,7 +115,6 @@ class DriverShim implements Driver {
      * @throws SQLFeatureNotSupportedException thrown if the feature is not supported
      * @see java.sql.Driver#getParentLogger()
      */
-    @Override
     public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
         //return driver.getParentLogger();
         Method m = null;

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/BaseDBTestCase.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/BaseDBTestCase.java
@@ -65,7 +65,7 @@ public abstract class BaseDBTestCase extends BaseTest {
             FileInputStream fis = null;
             ZipInputStream zin = null;
             try {
-                File path = new File(BaseDBTestCase.class.getClassLoader().getResource("data.zip").getPath());
+                File path = new File(BaseDBTestCase.class.getClassLoader().getResource("data.zip").toURI().getPath());
                 fis = new FileInputStream(path);
                 zin = new ZipInputStream(new BufferedInputStream(fis));
                 ZipEntry entry;

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/BaseTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/BaseTest.java
@@ -17,6 +17,8 @@ package org.owasp.dependencycheck;
 
 import java.io.File;
 import java.io.InputStream;
+import java.net.URISyntaxException;
+
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -69,8 +71,12 @@ public class BaseTest {
      * @return the resource as an File
      */
     public static File getResourceAsFile(Object o, String resource) {
-        File f = new File(o.getClass().getClassLoader().getResource(resource).getPath());
-        Assume.assumeTrue(String.format("%n%n[SEVERE] Unable to load resource for test case: %s%n%n", resource), f.exists());
-        return f;
+        try{
+            File f = new File(o.getClass().getClassLoader().getResource(resource).toURI().getPath());
+            Assume.assumeTrue(String.format("%n%n[SEVERE] Unable to load resource for test case: %s%n%n", resource), f.exists());
+            return f;
+        }catch (URISyntaxException e){
+            throw new UnsupportedOperationException(e);
+        }
     }
 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/update/nvd/UpdateableNvdCveTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/update/nvd/UpdateableNvdCveTest.java
@@ -42,8 +42,7 @@ public class UpdateableNvdCveTest extends BaseTest {
     public void testIsUpdateNeeded() throws MalformedURLException, DownloadFailedException, IOException {
         String id = "key";
         //use a local file as this test will load the result and check the timestamp
-        File f = new File("target/test-classes/nvdcve-2.0-2012.xml");
-        String url = "file:///" + f.getCanonicalPath();
+        String url = new File("target/test-classes/nvdcve-2.0-2012.xml").toURI().toString();
         UpdateableNvdCve instance = new UpdateableNvdCve();
         instance.add(id, url, url, false);
 
@@ -64,9 +63,8 @@ public class UpdateableNvdCveTest extends BaseTest {
     @Test
     public void testAdd_3args() throws Exception {
         String id = "key";
-        File f = new File("target/test-classes/nvdcve-2.0-2012.xml");
         //use a local file as this test will load the result and check the timestamp
-        String url = "file:///" + f.getCanonicalPath();
+        String url = "file:///" + new File("target/test-classes/nvdcve-2.0-2012.xml").toURI().toString();
         UpdateableNvdCve instance = new UpdateableNvdCve();
         instance.add(id, url, url);
         NvdCveInfo results = instance.get(id);
@@ -82,8 +80,7 @@ public class UpdateableNvdCveTest extends BaseTest {
     public void testAdd_4args() throws Exception {
         String id = "key";
         //use a local file as this test will load the result and check the timestamp
-        File f = new File("target/test-classes/nvdcve-2.0-2012.xml");
-        String url = "file:///" + f.getCanonicalPath();
+        String url = new File("target/test-classes/nvdcve-2.0-2012.xml").toURI().toString();
         UpdateableNvdCve instance = new UpdateableNvdCve();
         instance.add(id, url, url, false);
 
@@ -107,8 +104,7 @@ public class UpdateableNvdCveTest extends BaseTest {
     public void testClear() throws MalformedURLException, DownloadFailedException, IOException {
         String id = "key";
         //use a local file as this test will load the result and check the timestamp
-        File f = new File("target/test-classes/nvdcve-2.0-2012.xml");
-        String url = "file:///" + f.getCanonicalPath();
+        String url = new File("target/test-classes/nvdcve-2.0-2012.xml").toURI().toString();
         UpdateableNvdCve instance = new UpdateableNvdCve();
         instance.add(id, url, url, false);
         assertFalse(instance.getCollection().isEmpty());
@@ -122,8 +118,7 @@ public class UpdateableNvdCveTest extends BaseTest {
     @Test
     public void testIterator() throws IOException {
         //use a local file as this test will load the result and check the timestamp
-        File f = new File("target/test-classes/nvdcve-2.0-2012.xml");
-        String url = "file:///" + f.getCanonicalPath();
+        String url = new File("target/test-classes/nvdcve-2.0-2012.xml").toURI().toString();
         UpdateableNvdCve instance = new UpdateableNvdCve();
         instance.add("one", url, url, false);
         instance.add("two", url, url, false);

--- a/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
+++ b/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
@@ -102,7 +102,7 @@ public final class Downloader {
                     org.apache.commons.io.FileUtils.copyFile(file, outputPath);
                 } catch (IOException ex) {
                     final String msg = format("Download failed, unable to copy '%s' to '%s'", url.toString(), outputPath.getAbsolutePath());
-                    throw new DownloadFailedException(msg);
+                    throw new DownloadFailedException(msg, ex);
                 }
             } else {
                 final String msg = format("Download failed, file ('%s') does not exist", url.toString());
@@ -186,7 +186,7 @@ public final class Downloader {
                 final String msg = format("Error saving '%s' to file '%s'%nConnection Timeout: %d%nEncoding: %s%n",
                         url.toString(), outputPath.getAbsolutePath(), conn.getConnectTimeout(), encoding);
                 throw new DownloadFailedException(msg, ex);
-            } catch (Throwable ex) {
+            } catch (Exception ex) {
                 final String msg = format("Unexpected exception saving '%s' to file '%s'%nConnection Timeout: %d%nEncoding: %s%n",
                         url.toString(), outputPath.getAbsolutePath(), conn.getConnectTimeout(), encoding);
                 throw new DownloadFailedException(msg, ex);
@@ -249,7 +249,7 @@ public final class Downloader {
                 lastModifiedFile = new File(url.toURI());
             } catch (URISyntaxException ex) {
                 final String msg = format("Unable to locate '%s'", url.toString());
-                throw new DownloadFailedException(msg);
+                throw new DownloadFailedException(msg, ex);
             }
             timestamp = lastModifiedFile.lastModified();
         } else {
@@ -281,7 +281,7 @@ public final class Downloader {
                         return getLastModified(url, true);
                     }
                 } catch (InvalidSettingException ex1) {
-                    LOGGER.debug("invalid setting?", ex);
+                    LOGGER.debug("invalid setting?", ex1);
                 }
                 throw new DownloadFailedException(format("Error making HTTP %s request.", httpMethod), ex);
             } finally {
@@ -351,6 +351,9 @@ public final class Downloader {
         try {
             quickQuery = Settings.getBoolean(Settings.KEYS.DOWNLOADER_QUICK_QUERY_TIMESTAMP, true);
         } catch (InvalidSettingException e) {
+            if (LOGGER.isTraceEnabled()){
+                LOGGER.trace("Invalid settings : {}", e.getMessage(), e);
+            }
             quickQuery = true;
         }
         return quickQuery;

--- a/dependency-check-utils/src/test/java/org/owasp/dependencycheck/utils/ChecksumTest.java
+++ b/dependency-check-utils/src/test/java/org/owasp/dependencycheck/utils/ChecksumTest.java
@@ -44,7 +44,7 @@ public class ChecksumTest {
     @Test
     public void testGetChecksum() throws Exception {
         String algorithm = "MD5";
-        File file = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").getPath());
+        File file = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").toURI().getPath());
         byte[] expResult = {-16, -111, 92, 95, 70, -72, -49, -94, -125, -27, -83, 103, -96, -101, 55, -109};
         byte[] result = Checksum.getChecksum(algorithm, file);
         boolean arraysAreEqual = true;
@@ -94,7 +94,7 @@ public class ChecksumTest {
      */
     @Test
     public void testGetMD5Checksum() throws Exception {
-        File file = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").getPath());
+        File file = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").toURI().getPath());
         //String expResult = "F0915C5F46B8CFA283E5AD67A09B3793";
         String expResult = "f0915c5f46b8cfa283e5ad67a09b3793";
         String result = Checksum.getMD5Checksum(file);
@@ -108,7 +108,7 @@ public class ChecksumTest {
      */
     @Test
     public void testGetSHA1Checksum() throws Exception {
-        File file = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").getPath());
+        File file = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").toURI().getPath());
         //String expResult = "B8A9FF28B21BCB1D0B50E24A5243D8B51766851A";
         String expResult = "b8a9ff28b21bcb1d0b50e24a5243d8b51766851a";
         String result = Checksum.getSHA1Checksum(file);

--- a/dependency-check-utils/src/test/java/org/owasp/dependencycheck/utils/DownloaderTest.java
+++ b/dependency-check-utils/src/test/java/org/owasp/dependencycheck/utils/DownloaderTest.java
@@ -18,7 +18,6 @@
 package org.owasp.dependencycheck.utils;
 
 import java.io.File;
-import java.net.URL;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.owasp.dependencycheck.utils.Downloader;
@@ -31,9 +30,7 @@ public class DownloaderTest {
 
     @Test
     public void testGetLastModified_file() throws Exception {
-        File f = new File("target/test-classes/dependencycheck.properties");
-        URL url = new URL("file:///" + f.getCanonicalPath());
-        long timestamp = Downloader.getLastModified(url);
+        long timestamp = Downloader.getLastModified(new File("target/test-classes/dependencycheck.properties").toURI().toURL());
         assertTrue("timestamp equal to zero?", timestamp > 0);
     }
 }


### PR DESCRIPTION
On Windows, when project path contains spaces (common case: `c/Users/Firstname Lastname/git/DependencyCheck`), some UTs fail.

And quick quality flaws on exceptions in some file.

----

FYI, ITs always fail, but not sure related to project location path:
```
'dependency-check-core' ITs - Failed tests: 
  CPEAnalyzerIntegrationTest.testDetermineCPE_full:105
  VulnerabilitySuppressionAnalyzerIntegrationTest.testAnalyze:86
  CveDBIntegrationTest.testGetVulnerabilities:112
```

----

And one UT always fails:
```
'dependency-check-ant' - Tests in error: 
  DependencyCheckTaskTest.setUp:52 » Build java.io.FileNotFoundException: C:\Use...
  DependencyCheckTaskTest.setUp:52 » Build java.io.FileNotFoundException: C:\Use...
  DependencyCheckTaskTest.setUp:52 » Build java.io.FileNotFoundException: C:\Use...
  DependencyCheckTaskTest.setUp:52 » Build java.io.FileNotFoundException: C:\Use...  
```
But can't found    the root cause:
```
testAddFileList(org.owasp.dependencycheck.taskdefs.DependencyCheckTaskTest)  Time elapsed: 0.005 sec  <<< ERROR!
org.apache.tools.ant.BuildException: java.io.FileNotFoundException: C:\Users\Firstname%20Lastname\git\DependencyCheck\dependency-check-ant\target\test-classes\build.xml (Le chemin d’accès spécifié est introuvable)
	at org.owasp.dependencycheck.taskdefs.DependencyCheckTaskTest.setUp(DependencyCheckTaskTest.java:52)
Caused by: java.io.FileNotFoundException: C:\Users\Firstname%20Lastname\git\DependencyCheck\dependency-check-ant\target\test-classes\build.xml (Le chemin d’accès spécifié est introuvable)
	at org.owasp.dependencycheck.taskdefs.DependencyCheckTaskTest.setUp(DependencyCheckTaskTest.java:52)
```