### PR TITLE
rework the enabled / disabled logic

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -522,11 +522,16 @@ public class Engine implements FileFilter {
                     continue;
                 }
 
-                executeAnalysisTasks(analyzer, exceptions);
+                if (analyzer.isEnabled()) {
+                    executeAnalysisTasks(analyzer, exceptions);
 
-                final long analyzerDurationMillis = System.currentTimeMillis() - analyzerStart;
-                final long analyzerDurationSeconds = TimeUnit.MILLISECONDS.toSeconds(analyzerDurationMillis);
-                LOGGER.info("Finished {} ({} seconds)", analyzer.getName(), analyzerDurationSeconds);
+                    final long analyzerDurationMillis = System.currentTimeMillis() - analyzerStart;
+                    final long analyzerDurationSeconds = TimeUnit.MILLISECONDS.toSeconds(analyzerDurationMillis);
+                    LOGGER.info("Finished {} ({} seconds)", analyzer.getName(), analyzerDurationSeconds);
+                }
+                else {
+                    LOGGER.debug("Skipping {} (not enabled)", analyzer.getName());
+                }
             }
         }
         for (AnalysisPhase phase : AnalysisPhase.values()) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractAnalyzer.java
@@ -82,6 +82,23 @@ public abstract class AbstractAnalyzer implements Analyzer {
     protected abstract void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException;
 
     /**
+     * Initializes a given Analyzer. This will be skipped if the analyzer is disabled.
+     *
+     * @throws InitializationException thrown if there is an exception
+     */
+    protected void initializeAnalyzer() throws InitializationException {
+    }
+
+    /**
+     * Closes a given Analyzer. This will be skipped if the analyzer is disabled.
+     *
+     * @throws Exception thrown if there is an exception
+     */
+    protected void closeAnalyzer() throws Exception {
+    }
+
+
+    /**
      * Analyzes a given dependency. If the dependency is an archive, such as a
      * WAR or EAR, the contents are extracted, scanned, and added to the list of
      * dependencies within the engine.
@@ -103,14 +120,19 @@ public abstract class AbstractAnalyzer implements Analyzer {
      * @throws InitializationException thrown if there is an exception
      */
     @Override
-    public void initialize() throws InitializationException {
+    public final void initialize() throws InitializationException {
         final String key = getAnalyzerEnabledSettingKey();
         try {
             this.setEnabled(Settings.getBoolean(key, true));
         } catch (InvalidSettingException ex) {
             LOGGER.warn("Invalid setting for property '{}'", key);
             LOGGER.debug("", ex);
-            LOGGER.warn("{} has been disabled", getName());
+        }
+
+        if (isEnabled()) {
+            initializeAnalyzer();
+        } else {
+            LOGGER.debug("{} has been disabled", getName());
         }
     }
 
@@ -120,9 +142,12 @@ public abstract class AbstractAnalyzer implements Analyzer {
      * @throws Exception thrown if there is an exception
      */
     @Override
-    public void close() throws Exception {
-        //do nothing
+    public final void close() throws Exception {
+        if (isEnabled()) {
+            closeAnalyzer();
+        }
     }
+
 
     /**
      * The default is to support parallel processing.

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractFileTypeAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractFileTypeAnalyzer.java
@@ -74,8 +74,7 @@ public abstract class AbstractFileTypeAnalyzer extends AbstractAnalyzer implemen
      * initialization
      */
     @Override
-    public final void initialize() throws InitializationException {
-        super.initialize();
+    protected final void initializeAnalyzer() throws InitializationException {
         if (filesMatched) {
             initializeFileTypeAnalyzer();
         } else {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
@@ -67,8 +67,7 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
      * @throws InitializationException thrown if there is an exception
      */
     @Override
-    public void initialize() throws InitializationException {
-        super.initialize();
+    public void initializeAnalyzer() throws InitializationException {
         try {
             loadSuppressionData();
         } catch (SuppressionParseException ex) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
@@ -204,7 +204,7 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
      * files
      */
     @Override
-    public void close() throws Exception {
+    public void closeAnalyzer() throws Exception {
         if (tempFileLocation != null && tempFileLocation.exists()) {
             LOGGER.debug("Attempting to delete temporary files");
             final boolean success = FileUtils.delete(tempFileLocation);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
@@ -288,8 +288,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
      * @throws Exception thrown if there is a problem closing the analyzer
      */
     @Override
-    public void close() throws Exception {
-        super.close();
+    public void closeAnalyzer() throws Exception {
         try {
             if (grokAssemblyExe != null && !grokAssemblyExe.delete()) {
                 LOGGER.debug("Unable to delete temporary GrokAssembly.exe; attempting delete on exit");

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -138,8 +138,7 @@ public class CPEAnalyzer extends AbstractAnalyzer {
      * the index.
      */
     @Override
-    public void initialize() throws InitializationException {
-        super.initialize();
+    public void initializeAnalyzer() throws InitializationException {
         try {
             this.open();
         } catch (IOException ex) {
@@ -180,7 +179,7 @@ public class CPEAnalyzer extends AbstractAnalyzer {
      * Closes the data sources.
      */
     @Override
-    public void close() {
+    public void closeAnalyzer() {
         if (cpe != null) {
             cpe.close();
             cpe = null;

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/HintAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/HintAnalyzer.java
@@ -99,8 +99,7 @@ public class HintAnalyzer extends AbstractAnalyzer {
      * @throws InitializationException thrown if there is an exception
      */
     @Override
-    public void initialize() throws InitializationException {
-        super.initialize();
+    public void initializeAnalyzer() throws InitializationException {
         try {
             loadHintRules();
         } catch (HintParseException ex) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -912,7 +912,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
      * Deletes any files extracted from the JAR during analysis.
      */
     @Override
-    public void close() {
+    public void closeAnalyzer() {
         if (tempFileLocation != null && tempFileLocation.exists()) {
             LOGGER.debug("Attempting to delete temporary files");
             final boolean success = FileUtils.delete(tempFileLocation);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NvdCveAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NvdCveAnalyzer.java
@@ -71,7 +71,7 @@ public class NvdCveAnalyzer extends AbstractAnalyzer {
      * Closes the data source.
      */
     @Override
-    public void close() {
+    public void closeAnalyzer() {
         cveDB.close();
         cveDB = null;
     }
@@ -171,8 +171,7 @@ public class NvdCveAnalyzer extends AbstractAnalyzer {
      * the index.
      */
     @Override
-    public void initialize() throws InitializationException {
-        super.initialize();
+    public void initializeAnalyzer() throws InitializationException {
         try {
             this.open();
         } catch (SQLException ex) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
@@ -273,7 +273,7 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
      * Deletes any files extracted from the Wheel during analysis.
      */
     @Override
-    public void close() {
+    public void closeAnalyzer() {
         if (tempFileLocation != null && tempFileLocation.exists()) {
             LOGGER.debug("Attempting to delete temporary files");
             final boolean success = FileUtils.delete(tempFileLocation);


### PR DESCRIPTION
If an analyzer is disabled from the configuration, it should not be
initialized (because some of the may actually fail during that process
nor should the engine log in any way that those exist.

With these changes, it is possible for me to turn off unwanted
analyzers (e.g. Ruby analyzers for a java project) from the maven
plugin and not confuse my users with spurious misleading messages.