### PR TITLE
Add troubling JAR file name to the exception when JAR reading errors occur

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -243,7 +243,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
             final boolean addPackagesAsEvidence = !(hasManifest && hasPOM);
             analyzePackageNames(classNames, dependency, addPackagesAsEvidence);
         } catch (IOException ex) {
-            throw new AnalysisException("Exception occurred reading the JAR file.", ex);
+            throw new AnalysisException("Exception occurred reading the JAR file (" + dependency.getFileName() +").", ex);
         }
     }
 


### PR DESCRIPTION
Minor change: When JAR reading errors occur, at least add the file name to the exception. Without it, finding the troubling JAR is hard.