### PR TITLE
Accelerate CVE DB update: replace TreeSets in Vulnerability by HashSets

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
@@ -18,6 +18,7 @@
 package org.owasp.dependencycheck.dependency;
 
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -82,7 +83,7 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
     /**
      * References for this vulnerability.
      */
-    private SortedSet<Reference> references = new TreeSet<Reference>();
+    private Set<Reference> references = new HashSet<Reference>();
 
     /**
      * Get the value of references.
@@ -98,7 +99,7 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
      *
      * @param references new value of references
      */
-    public void setReferences(SortedSet<Reference> references) {
+    public void setReferences(Set<Reference> references) {
         this.references = references;
     }
 
@@ -128,7 +129,7 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
     /**
      * A set of vulnerable software.
      */
-    private SortedSet<VulnerableSoftware> vulnerableSoftware = new TreeSet<VulnerableSoftware>();
+    private Set<VulnerableSoftware> vulnerableSoftware = new HashSet<VulnerableSoftware>();
 
     /**
      * Get the value of vulnerableSoftware.
@@ -144,7 +145,7 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
      *
      * @param vulnerableSoftware new value of vulnerableSoftware
      */
-    public void setVulnerableSoftware(SortedSet<VulnerableSoftware> vulnerableSoftware) {
+    public void setVulnerableSoftware(Set<VulnerableSoftware> vulnerableSoftware) {
         this.vulnerableSoftware = vulnerableSoftware;
     }
 
@@ -391,13 +392,15 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
         final StringBuilder sb = new StringBuilder("Vulnerability ");
         sb.append(this.name);
         sb.append("\nReferences:\n");
-        for (Reference reference : this.references) {
+        SortedSet<Reference> sortedReferences = new TreeSet<Reference>(this.references);
+        for (Reference reference : sortedReferences) {
             sb.append("=> ");
             sb.append(reference);
             sb.append("\n");
         }
         sb.append("\nSoftware:\n");
-        for (VulnerableSoftware software : this.vulnerableSoftware) {
+        SortedSet<VulnerableSoftware> sortedVulnerableSoftware = new TreeSet<VulnerableSoftware>(this.vulnerableSoftware);
+        for (VulnerableSoftware software : sortedVulnerableSoftware) {
             sb.append("=> ");
             sb.append(software);
             sb.append("\n");

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/dependency/VulnerabilityTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/dependency/VulnerabilityTest.java
@@ -17,10 +17,8 @@
  */
 package org.owasp.dependencycheck.dependency;
 
-import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
@@ -82,77 +80,4 @@ public class VulnerabilityTest extends BaseTest {
         obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.12-200", "1");
         assertEquals(31, obj.getVulnerableSoftware().size());
     }
-
-    @Test
-    public void testSoftwareSorting() {
-        Vulnerability obj = new Vulnerability();
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.0-103%28a%29", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.0-118", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.3.132", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.12-200", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.2-127", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.9", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.10", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.11", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.12-118", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.4-143", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.0-109", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.6-156", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.4", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.3", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.10-186", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.6", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.5", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.5-146", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.8", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.7", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.2", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.0.2", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.1", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.8-177", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.0.1", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.0.0", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.7-168", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.0-103", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.11-197", null);
-        obj.addVulnerableSoftware("cpe:/a:hp:system_management_homepage:2.1.9-178", null);
-
-        Set<VulnerableSoftware> software = obj.getVulnerableSoftware();
-        VulnerableSoftware vs[] = software.toArray(new VulnerableSoftware[software.size()]);
-
-        assertTrue("cpe:/a:hp:system_management_homepage:2.0.0".equals(vs[0].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.0.1".equals(vs[1].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.0.2".equals(vs[2].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1".equals(vs[3].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.0-103".equals(vs[4].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.0-103%28a%29".equals(vs[5].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.0-109".equals(vs[6].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.0-118".equals(vs[7].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.1".equals(vs[8].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.2".equals(vs[9].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.2-127".equals(vs[10].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.3".equals(vs[11].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.3.132".equals(vs[12].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.4".equals(vs[13].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.4-143".equals(vs[14].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.5".equals(vs[15].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.5-146".equals(vs[16].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.6".equals(vs[17].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.6-156".equals(vs[18].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.7".equals(vs[19].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.7-168".equals(vs[20].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.8".equals(vs[21].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.8-177".equals(vs[22].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.9".equals(vs[23].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.9-178".equals(vs[24].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.10".equals(vs[25].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.10-186".equals(vs[26].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.11".equals(vs[27].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.11-197".equals(vs[28].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.12-118".equals(vs[29].getName()));
-        assertTrue("cpe:/a:hp:system_management_homepage:2.1.12-200".equals(vs[30].getName()));
-        
-    }
-
 }


### PR DESCRIPTION
Solves issue #656.
Vulnerability: switch vulnerableSoftware and references from expensive TreeSet to HashSet.