### PR TITLE
Accelerate CVE DB update: parallelize fetching last modification timestamps

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
@@ -125,7 +125,7 @@ public class NvdCveUpdater extends BaseUpdater implements CachedWebDataSource {
         }
     }
 
-    private void initializeExecutorServices() {
+    void initializeExecutorServices() {
         processingExecutorService = Executors.newFixedThreadPool(PROCESSING_THREAD_POOL_SIZE);
         downloadExecutorService = Executors.newFixedThreadPool(DOWNLOAD_THREAD_POOL_SIZE);
         LOGGER.debug("#download   threads: {}", DOWNLOAD_THREAD_POOL_SIZE);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
@@ -225,7 +225,7 @@ public class NvdCveUpdater extends BaseUpdater implements CachedWebDataSource {
         //next, move the future future processTasks to just future processTasks
         final Set<Future<ProcessTask>> processFutures = new HashSet<Future<ProcessTask>>(maxUpdates);
         for (Future<Future<ProcessTask>> future : downloadFutures) {
-            Future<ProcessTask> task = null;
+            Future<ProcessTask> task;
             try {
                 task = future.get();
             } catch (InterruptedException ex) {
@@ -280,8 +280,9 @@ public class NvdCveUpdater extends BaseUpdater implements CachedWebDataSource {
      * @throws UpdateException Is thrown if there is an issue with the last
      * updated properties file
      */
-    protected final UpdateableNvdCve getUpdatesNeeded() throws MalformedURLException, DownloadFailedException, UpdateException {
-        UpdateableNvdCve updates = null;
+    final UpdateableNvdCve getUpdatesNeeded() throws MalformedURLException, DownloadFailedException, UpdateException {
+        LOGGER.info("starting getUpdatesNeeded() ...");
+        UpdateableNvdCve updates;
         try {
             updates = retrieveCurrentTimestampsFromWeb();
         } catch (InvalidDataException ex) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/nvd/UpdateableNvdCve.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/nvd/UpdateableNvdCve.java
@@ -25,8 +25,6 @@ import java.util.Map.Entry;
 import java.util.TreeMap;
 import org.owasp.dependencycheck.utils.DownloadFailedException;
 import org.owasp.dependencycheck.utils.Downloader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Contains a collection of updateable NvdCveInfo objects. This is used to determine which files need to be downloaded and
@@ -36,10 +34,6 @@ import org.slf4j.LoggerFactory;
  */
 public class UpdateableNvdCve implements Iterable<NvdCveInfo>, Iterator<NvdCveInfo> {
 
-    /**
-     * A reference to the logger.
-     */
-    private static final Logger LOGGER = LoggerFactory.getLogger(UpdateableNvdCve.class);
     /**
      * A collection of sources of data.
      */
@@ -66,19 +60,6 @@ public class UpdateableNvdCve implements Iterable<NvdCveInfo>, Iterator<NvdCveIn
             }
         }
         return false;
-    }
-
-    /**
-     * Adds a new entry of updateable information to the contained collection.
-     *
-     * @param id the key for the item to be added
-     * @param url the URL to download the item
-     * @param oldUrl the URL for the old version of the item (the NVD CVE old schema still contains useful data we need).
-     * @throws MalformedURLException thrown if the URL provided is invalid
-     * @throws DownloadFailedException thrown if the download fails.
-     */
-    public void add(String id, String url, String oldUrl) throws MalformedURLException, DownloadFailedException {
-        add(id, url, oldUrl, false);
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/nvd/UpdateableNvdCve.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/nvd/UpdateableNvdCve.java
@@ -17,14 +17,10 @@
  */
 package org.owasp.dependencycheck.data.update.nvd;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
-import org.owasp.dependencycheck.utils.DownloadFailedException;
-import org.owasp.dependencycheck.utils.Downloader;
 
 /**
  * Contains a collection of updateable NvdCveInfo objects. This is used to determine which files need to be downloaded and
@@ -68,18 +64,16 @@ public class UpdateableNvdCve implements Iterable<NvdCveInfo>, Iterator<NvdCveIn
      * @param id the key for the item to be added
      * @param url the URL to download the item
      * @param oldUrl the URL for the old version of the item (the NVD CVE old schema still contains useful data we need).
+     * @param timestamp the last modified date of the downloaded item
      * @param needsUpdate whether or not the data needs to be updated
-     * @throws MalformedURLException thrown if the URL provided is invalid
-     * @throws DownloadFailedException thrown if the download fails.
      */
-    public void add(String id, String url, String oldUrl, boolean needsUpdate) throws MalformedURLException, DownloadFailedException {
+    public void add(String id, String url, String oldUrl, long timestamp, boolean needsUpdate) {
         final NvdCveInfo item = new NvdCveInfo();
         item.setNeedsUpdate(needsUpdate); //the others default to true, to make life easier later this should default to false.
         item.setId(id);
         item.setUrl(url);
         item.setOldSchemaVersionUrl(oldUrl);
-        LOGGER.debug("Checking for updates from: {}", url);
-        item.setTimestamp(Downloader.getLastModified(new URL(url)));
+        item.setTimestamp(timestamp);
         collection.put(id, item);
     }
 

--- a/dependency-check-core/src/main/resources/dependencycheck.properties
+++ b/dependency-check-core/src/main/resources/dependencycheck.properties
@@ -1,7 +1,7 @@
 application.name=${pom.name}
 application.version=${pom.version}
 autoupdate=true
-max.download.threads=3
+max.download.threads=50
 
 # the url to obtain the current engine version from
 engine.version.url=https://jeremylong.github.io/DependencyCheck/current.txt

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/update/NvdCveUpdaterIntegrationTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/update/NvdCveUpdaterIntegrationTest.java
@@ -33,6 +33,7 @@ public class NvdCveUpdaterIntegrationTest extends BaseTest {
 
     public NvdCveUpdater getUpdater() throws MalformedURLException, DownloadFailedException, UpdateException {
         NvdCveUpdater instance = new NvdCveUpdater();
+        instance.initializeExecutorServices();
         return instance;
     }
 

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/update/NvdCveUpdaterIntegrationTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/update/NvdCveUpdaterIntegrationTest.java
@@ -17,13 +17,10 @@
  */
 package org.owasp.dependencycheck.data.update;
 
-import java.net.MalformedURLException;
 import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.data.update.exception.UpdateException;
 import org.owasp.dependencycheck.data.update.nvd.UpdateableNvdCve;
-import org.owasp.dependencycheck.utils.DownloadFailedException;
 
 /**
  *
@@ -31,23 +28,23 @@ import org.owasp.dependencycheck.utils.DownloadFailedException;
  */
 public class NvdCveUpdaterIntegrationTest extends BaseTest {
 
-    public NvdCveUpdater getUpdater() throws MalformedURLException, DownloadFailedException, UpdateException {
+    public NvdCveUpdater getUpdater() {
         NvdCveUpdater instance = new NvdCveUpdater();
         instance.initializeExecutorServices();
         return instance;
     }
 
-// test removed as it is duplicative of the EngineIntegrationTest and the NvdCveUpdaterIntergraionTest
-//    /**
-//     * Test of update method, of class StandardUpdate.
-//     */
+    /**
+     * Test of update method.
+     */
     @Test
     public void testUpdate() throws Exception {
         NvdCveUpdater instance = getUpdater();
         instance.update();
     }
+
     /**
-     * Test of updatesNeeded method, of class StandardUpdate.
+     * Test of updatesNeeded method.
      */
     @Test
     public void testUpdatesNeeded() throws Exception {

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/update/nvd/UpdateableNvdCveTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/update/nvd/UpdateableNvdCveTest.java
@@ -17,17 +17,12 @@
  */
 package org.owasp.dependencycheck.data.update.nvd;
 
-import org.owasp.dependencycheck.data.update.nvd.UpdateableNvdCve;
-import org.owasp.dependencycheck.data.update.nvd.NvdCveInfo;
 import java.io.File;
-import java.io.IOException;
-import java.net.MalformedURLException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.utils.DownloadFailedException;
 
 /**
  *
@@ -39,18 +34,18 @@ public class UpdateableNvdCveTest extends BaseTest {
      * Test of isUpdateNeeded method, of class UpdateableNvdCve.
      */
     @Test
-    public void testIsUpdateNeeded() throws MalformedURLException, DownloadFailedException, IOException {
+    public void testIsUpdateNeeded() {
         String id = "key";
-        //use a local file as this test will load the result and check the timestamp
         String url = new File("target/test-classes/nvdcve-2.0-2012.xml").toURI().toString();
+        long timestamp = 42;
         UpdateableNvdCve instance = new UpdateableNvdCve();
-        instance.add(id, url, url, false);
+        instance.add(id, url, url, timestamp, false);
 
         boolean expResult = false;
         boolean result = instance.isUpdateNeeded();
         assertEquals(expResult, result);
 
-        instance.add("nextId", url, url, true);
+        instance.add("nextId", url, url, 23, true);
 
         expResult = true;
         result = instance.isUpdateNeeded();
@@ -63,34 +58,34 @@ public class UpdateableNvdCveTest extends BaseTest {
     @Test
     public void testAdd() throws Exception {
         String id = "key";
-        //use a local file as this test will load the result and check the timestamp
         String url = new File("target/test-classes/nvdcve-2.0-2012.xml").toURI().toString();
+        long timestamp = 42;
         UpdateableNvdCve instance = new UpdateableNvdCve();
-        instance.add(id, url, url, false);
+        instance.add(id, url, url, timestamp, false);
 
         boolean expResult = false;
         boolean result = instance.isUpdateNeeded();
         assertEquals(expResult, result);
 
-        instance.add("nextId", url, url, false);
+        instance.add("nextId", url, url, 23, false);
         NvdCveInfo results = instance.get(id);
 
         assertEquals(id, results.getId());
         assertEquals(url, results.getUrl());
         assertEquals(url, results.getOldSchemaVersionUrl());
-
+        assertEquals(timestamp, results.getTimestamp());
     }
 
     /**
      * Test of clear method, of class UpdateableNvdCve.
      */
     @Test
-    public void testClear() throws MalformedURLException, DownloadFailedException, IOException {
+    public void testClear() {
         String id = "key";
-        //use a local file as this test will load the result and check the timestamp
         String url = new File("target/test-classes/nvdcve-2.0-2012.xml").toURI().toString();
+        long timestamp = 42;
         UpdateableNvdCve instance = new UpdateableNvdCve();
-        instance.add(id, url, url, false);
+        instance.add(id, url, url, timestamp, false);
         assertFalse(instance.getCollection().isEmpty());
         instance.clear();
         assertTrue(instance.getCollection().isEmpty());
@@ -100,13 +95,12 @@ public class UpdateableNvdCveTest extends BaseTest {
      * Test of iterator method, of class UpdatableNvdCve.
      */
     @Test
-    public void testIterator() throws IOException {
-        //use a local file as this test will load the result and check the timestamp
+    public void testIterator() {
         String url = new File("target/test-classes/nvdcve-2.0-2012.xml").toURI().toString();
         UpdateableNvdCve instance = new UpdateableNvdCve();
-        instance.add("one", url, url, false);
-        instance.add("two", url, url, false);
-        instance.add("three", url, url, false);
+        instance.add("one", url, url, 42, false);
+        instance.add("two", url, url, 23, false);
+        instance.add("three", url, url, 17, false);
         int itemsProcessed = 0;
         for (NvdCveInfo item : instance) {
             if ("one".equals(item.getId())) {

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/update/nvd/UpdateableNvdCveTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/data/update/nvd/UpdateableNvdCveTest.java
@@ -61,23 +61,7 @@ public class UpdateableNvdCveTest extends BaseTest {
      * Test of add method, of class UpdateableNvdCve.
      */
     @Test
-    public void testAdd_3args() throws Exception {
-        String id = "key";
-        //use a local file as this test will load the result and check the timestamp
-        String url = "file:///" + new File("target/test-classes/nvdcve-2.0-2012.xml").toURI().toString();
-        UpdateableNvdCve instance = new UpdateableNvdCve();
-        instance.add(id, url, url);
-        NvdCveInfo results = instance.get(id);
-        assertEquals(id, results.getId());
-        assertEquals(url, results.getUrl());
-        assertEquals(url, results.getOldSchemaVersionUrl());
-    }
-
-    /**
-     * Test of add method, of class UpdateableNvdCve.
-     */
-    @Test
-    public void testAdd_4args() throws Exception {
+    public void testAdd() throws Exception {
         String id = "key";
         //use a local file as this test will load the result and check the timestamp
         String url = new File("target/test-classes/nvdcve-2.0-2012.xml").toURI().toString();

--- a/dependency-check-core/src/test/resources/dependencycheck.properties
+++ b/dependency-check-core/src/test/resources/dependencycheck.properties
@@ -1,7 +1,7 @@
 application.name=${pom.name}
 application.version=${pom.version}
 autoupdate=true
-max.download.threads=3
+max.download.threads=50
 
 # the url to obtain the current engine version from
 engine.version.url=https://jeremylong.github.io/DependencyCheck/current.txt

--- a/dependency-check-utils/src/test/resources/dependencycheck.properties
+++ b/dependency-check-utils/src/test/resources/dependencycheck.properties
@@ -1,7 +1,7 @@
 application.name=${pom.name}
 application.version=${pom.version}
 autoupdate=true
-max.download.threads=3
+max.download.threads=50
 
 # the url to obtain the current engine version from
 engine.version.url=http://jeremylong.github.io/DependencyCheck/current.txt


### PR DESCRIPTION
Proposed solution for issue #661.

On my machine/internet connection the speedup for DB update was ~10 secs. It dropped from 11 secs to 1 sec.