### PR TITLE
Improve dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM java:8
 
 MAINTAINER Timo Pagel <dependencycheckmaintainer@timo-pagel.de>
 
+ENV user=dockeruser
+
 RUN wget -O /tmp/current.txt http://jeremylong.github.io/DependencyCheck/current.txt && \
  current=$(cat /tmp/current.txt) && \
  wget https://dl.bintray.com/jeremy-long/owasp/dependency-check-$current-release.zip && \
@@ -9,12 +11,12 @@ RUN wget -O /tmp/current.txt http://jeremylong.github.io/DependencyCheck/current
  rm dependency-check-$current-release.zip && \
  mv dependency-check /usr/share/
 
-RUN useradd -ms /bin/bash dockeruser && \
- chown -R dockeruser:dockeruser /usr/share/dependency-check && \
+RUN useradd -ms /bin/bash ${user} && \
+ chown -R ${user}:${user} /usr/share/dependency-check && \
  mkdir /report && \
- chown -R dockeruser:dockeruser /report
+ chown -R ${user}:${user} /report
 
-USER dockeruser
+USER ${user}
 
 VOLUME ["/src" "/usr/share/dependency-check/data" "/report"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ VOLUME ["/src" "/usr/share/dependency-check/data" "/report"]
 
 WORKDIR /report
 
-ENTRYPOINT ["/usr/share/dependency-check/bin/dependency-check.sh", "--scan", "/src"]
+CMD ["--help"]
+ENTRYPOINT ["/usr/share/dependency-check/bin/dependency-check.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,20 @@ FROM java:8
 
 MAINTAINER Timo Pagel <dependencycheckmaintainer@timo-pagel.de>
 
-RUN wget -O /tmp/current.txt http://jeremylong.github.io/DependencyCheck/current.txt && current=$(cat /tmp/current.txt) && wget https://dl.bintray.com/jeremy-long/owasp/dependency-check-$current-release.zip && unzip dependency-check-$current-release.zip && mv dependency-check /usr/share/
+RUN wget -O /tmp/current.txt http://jeremylong.github.io/DependencyCheck/current.txt && \
+ current=$(cat /tmp/current.txt) && \
+ wget https://dl.bintray.com/jeremy-long/owasp/dependency-check-$current-release.zip && \
+ unzip dependency-check-$current-release.zip && \
+ mv dependency-check /usr/share/
 
-RUN useradd -ms /bin/bash dockeruser && chown -R dockeruser:dockeruser /usr/share/dependency-check && mkdir /report && chown -R dockeruser:dockeruser /report
+RUN useradd -ms /bin/bash dockeruser && \
+ chown -R dockeruser:dockeruser /usr/share/dependency-check && \
+ mkdir /report && \
+ chown -R dockeruser:dockeruser /report
+
 USER dockeruser
 
-VOLUME "/src /usr/share/dependency-check/data /report"
+VOLUME ["/src" "/usr/share/dependency-check/data" "/report"]
 
 WORKDIR /report
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN wget -O /tmp/current.txt http://jeremylong.github.io/DependencyCheck/current
  current=$(cat /tmp/current.txt) && \
  wget https://dl.bintray.com/jeremy-long/owasp/dependency-check-$current-release.zip && \
  unzip dependency-check-$current-release.zip && \
+ rm dependency-check-$current-release.zip && \
  mv dependency-check /usr/share/
 
 RUN useradd -ms /bin/bash dockeruser && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM java:8
 
 MAINTAINER Timo Pagel <dependencycheckmaintainer@timo-pagel.de>
 
-ENV user=dockeruser
+ENV user=dependencycheck
 
 RUN wget -O /tmp/current.txt http://jeremylong.github.io/DependencyCheck/current.txt && \
  current=$(cat /tmp/current.txt) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,15 @@ FROM java:8
 MAINTAINER Timo Pagel <dependencycheckmaintainer@timo-pagel.de>
 
 ENV user=dependencycheck
+ENV version_url=https://jeremylong.github.io/DependencyCheck/current.txt
+ENV download_url=https://dl.bintray.com/jeremy-long/owasp
 
-RUN wget -O /tmp/current.txt http://jeremylong.github.io/DependencyCheck/current.txt && \
- current=$(cat /tmp/current.txt) && \
- wget https://dl.bintray.com/jeremy-long/owasp/dependency-check-$current-release.zip && \
- unzip dependency-check-$current-release.zip && \
- rm dependency-check-$current-release.zip && \
+RUN wget -O /tmp/current.txt ${version_url} && \
+ version=$(cat /tmp/current.txt) && \
+ file="dependency-check-${version}-release.zip" && \
+ wget "$download_url/$file" && \
+ unzip ${file} && \
+ rm ${file} && \
  mv dependency-check /usr/share/
 
 RUN useradd -ms /bin/bash ${user} && \

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ docker run --rm \
         --name dependency-check \
         owasp/dependency-check \
         --scan /src \
-        --suppression "/src/security/dependency-check-suppression.xml"\
         --format "ALL" \
         --project "My OWASP Dependency Check Project" \
+        --suppression "/src/security/dependency-check-suppression.xml"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ if [ ! -d $DATA_DIRECTORY ]; then
 	echo "Initially creating persistent directories"
         mkdir -p $DATA_DIRECTORY
         chmod -R 777 $DATA_DIRECTORY
-    
+
         mkdir -p $REPORT_DIRECTORY
         chmod -R 777 $REPORT_DIRECTORY
 fi
@@ -123,7 +123,8 @@ docker run --rm \
         --volume $DATA_DIRECTORY:/usr/share/dependency-check/data \
         --volume $REPORT_DIRECTORY:/report \
         --name dependency-check \
-        dc \
+        owasp/dependency-check \
+        --scan /src \
         --suppression "/src/security/dependency-check-suppression.xml"\
         --format "ALL" \
         --project "My OWASP Dependency Check Project" \

--- a/README.md
+++ b/README.md
@@ -101,33 +101,38 @@ Then load the resulting 'DependencyCheck-Report.html' into your favorite browser
 
 ### Docker
 
-In the following example it is assumed that the source to be checked is in the actual directory. A persistent data directory and a persistent report directory is used so that the container can be destroyed after running it to make sure that you use the newest version, always.
+In the following example it is assumed that the source to be checked is in the current working directory. Persistent data and report directories are used, allowing you to destroy the container after running.
+
 ```
-# After the first run, feel free to change the owner of the directories to the owner of the created files and the permissions to 744
-DATA_DIRECTORY=$HOME/OWASP-Dependency-Check/data
-REPORT_DIRECTORY=/$HOME/OWASP-Dependency-Check/reports
+#!/bin/sh
 
-if [ ! -d $DATA_DIRECTORY ]; then
-	echo "Initially creating persistent directories"
-        mkdir -p $DATA_DIRECTORY
-        chmod -R 777 $DATA_DIRECTORY
+OWASPDC_DIRECTORY=$HOME/OWASP-Dependency-Check
+DATA_DIRECTORY="$OWASPDC_DIRECTORY/data"
+REPORT_DIRECTORY="$OWASPDC_DIRECTORY/reports"
 
-        mkdir -p $REPORT_DIRECTORY
-        chmod -R 777 $REPORT_DIRECTORY
+if [ ! -d "$DATA_DIRECTORY" ]; then
+    echo "Initially creating persistent directories"
+    mkdir -p "$DATA_DIRECTORY"
+    chmod -R 777 "$DATA_DIRECTORY"
+
+    mkdir -p "$REPORT_DIRECTORY"
+    chmod -R 777 "$REPORT_DIRECTORY"
 fi
 
-docker pull owasp/dependency-check # Make sure it is the actual version
+# Make sure we are using the latest version
+docker pull owasp/dependency-check
 
 docker run --rm \
-        --volume $(pwd):/src \
-        --volume $DATA_DIRECTORY:/usr/share/dependency-check/data \
-        --volume $REPORT_DIRECTORY:/report \
-        --name dependency-check \
-        owasp/dependency-check \
-        --scan /src \
-        --format "ALL" \
-        --project "My OWASP Dependency Check Project" \
-        --suppression "/src/security/dependency-check-suppression.xml"
+    --volume $(pwd):/src \
+    --volume "$DATA_DIRECTORY":/usr/share/dependency-check/data \
+    --volume "$REPORT_DIRECTORY":/report \
+    owasp/dependency-check \
+    --scan /src \
+    --format "ALL" \
+    --project "My OWASP Dependency Check Project"
+    # Use suppression like this: (/src == $pwd)
+    # --suppression "/src/security/dependency-check-suppression.xml"
+
 ```
 
 


### PR DESCRIPTION
## Fixes Issue #

None.

## Description of Change

I've improved the Dockerfile to allow end users to use complete CLI functionality easier, without having to override `--entrypoint`.

Now it is possible to run 

```
docker run --rm owasp/dependency-check --version
```

which would before have been

```
docker run --rm --entrypoint "/usr/share/dependency-check/bin/dependency-check.sh" /owasp/dependency-check --version
```

### Breaking change

This is a breaking change. However, as the docker image is not published to Dockerhub at the moment, there is no breakage of officially documented behavior.



## Have test cases been added to cover the new functionality?

Not required.

## Additional notes

It would be great if the docker image could be published to Dockerhub as it is documented in README.

In lack of an official copy I created an automated build for our fork, here https://hub.docker.com/r/hochzehn/dependency-check/. This is not ideal, however, because we'd have to keep our fork in-sync to have an up-to-date image.

Therefore I hope that the official image can be published to Dockerhub, as mentioned in October in this comment: https://github.com/jeremylong/DependencyCheck/pull/588#issuecomment-252508904

CC @wurstbrot