### PR TITLE
Suppress UnitTestFramework false positives.

### DIFF
--- a/dependency-check-core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/dependency-check-core/src/main/resources/dependencycheck-base-suppression.xml
@@ -2,6 +2,13 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
     <suppress base="true">
        <notes><![CDATA[
+       This suppresses false positives for Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll.
+       ]]></notes>
+       <filePath regex="true">.*Microsoft\.VisualStudio\.QualityTools\.UnitTestFramework*\.dll</filePath>
+       <cve>CVE-2014-3802</cve>
+    </suppress>
+    <suppress base="true">
+       <notes><![CDATA[
        This suppresses false positives for EntityFramework.SqlServer.dll.
        ]]></notes>
        <filePath regex="true">.*EntityFramework\.SqlServer*\.dll</filePath>


### PR DESCRIPTION
## Fixes Issue

False postive of `CVE-2014-3802` on `Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll`.

## Description of Change

Suppresses false positive of `CVE-2014-3802` on `Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll`.

## Have test cases been added to cover the new functionality?

No.