### PR TITLE
Added some caching for CveDB in order to speedup some scans

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -24,6 +24,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -95,7 +96,7 @@ public final class CveDB implements AutoCloseable {
     private final EnumMap<PreparedStatementCveDb, PreparedStatement> preparedStatements = new EnumMap<>(PreparedStatementCveDb.class);
 
     @SuppressWarnings("unchecked")
-    private final Map<String, List<Vulnerability>> vulnerabilitiesForCpeCache = new ReferenceMap(HARD, SOFT);
+    private final Map<String, List<Vulnerability>> vulnerabilitiesForCpeCache = Collections.synchronizedMap(new ReferenceMap(HARD, SOFT));
 
     /**
      * The enum value names must match the keys of the statements in the
@@ -271,11 +272,11 @@ public final class CveDB implements AutoCloseable {
      */
     @Override
     public synchronized void close() {
-        clearCache();
         if (instance != null) {
             instance.usageCount -= 1;
             if (instance.usageCount <= 0 && instance.isOpen()) {
                 instance.usageCount = 0;
+                clearCache();
                 instance.closeStatements();
                 try {
                     instance.connection.close();


### PR DESCRIPTION
## Fixes Issue #

Some items (e.g., Linux kernel) have many CVE entries, which takes much time to load it. When such CPE is matched for multiple dependencies, the scan takes much time and can easily hit the 10 minutes limit.

## Description of Change

Result of getVulnerabilities(String cpeStr) is cached under a soft reference. Other parts of CveDB are prepared for caching.

## Have test cases been added to cover the new functionality?

*no*

There is no new functionality, it is just enhancement of the old functionality. I've thought about tests, but it should just improve performance and I am not sure if it is appropriate to test it in unit/integration tests.