### PR TITLE
Issue #754: Allow exclusion of artifacts by type (regex)

### DIFF
--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/ArtifactTypeExcluded.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/ArtifactTypeExcluded.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of dependency-check-maven.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.owasp.dependencycheck.maven;
+
+import org.apache.commons.lang.StringUtils;
+import org.owasp.dependencycheck.utils.Filter;
+
+/**
+ * {@link Filter} implementation to exclude artifacts whose type matches a regular expression
+ */
+public class ArtifactTypeExcluded extends Filter<String> {
+
+    private final String regex;
+
+    /**
+     * Creates a new instance
+     * @param excludeRegex The regular expression to match the artifacts type against
+     */
+    public ArtifactTypeExcluded(final String excludeRegex) {
+        this.regex = excludeRegex;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean passes(final String artifactType) {
+
+        return StringUtils.isNotEmpty(regex) && StringUtils.isNotEmpty(artifactType) && artifactType.matches(regex);
+    }
+}

--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -408,6 +408,14 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     @SuppressWarnings("CanBeFinal")
     @Parameter(property = "skipSystemScope", defaultValue = "false", required = false)
     private boolean skipSystemScope = false;
+
+    /**
+     * Skip analysis for dependencies which type matches this regular expression.
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "skipArtifactType", required = false)
+    private String skipArtifactType;
+
     /**
      * The data directory, hold DC SQL DB.
      */
@@ -469,6 +477,12 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * The artifact scope filter.
      */
     private Filter<String> artifactScopeExcluded;
+
+    /**
+     * Filter for artifact type.
+     */
+    private Filter<String> artifactTypeExcluded;
+
 
     // </editor-fold>
     //<editor-fold defaultstate="collapsed" desc="Base Maven implementation">
@@ -641,7 +655,8 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
             List<DependencyNode> nodes, ProjectBuildingRequest buildingRequest) {
         ExceptionCollection exCol = null;
         for (DependencyNode dependencyNode : nodes) {
-            if (artifactScopeExcluded.passes(dependencyNode.getArtifact().getScope())) {
+            if (artifactScopeExcluded.passes(dependencyNode.getArtifact().getScope()) ||
+                artifactTypeExcluded.passes(dependencyNode.getArtifact().getType())) {
                 continue;
             }
             exCol = collectDependencies(engine, project, dependencyNode.getChildren(), buildingRequest);
@@ -990,6 +1005,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         Settings.setIntIfNotNull(Settings.KEYS.CVE_CHECK_VALID_FOR_HOURS, cveValidForHours);
 
         artifactScopeExcluded = new ArtifactScopeExcluded(skipTestScope, skipProvidedScope, skipSystemScope, skipRuntimeScope);
+        artifactTypeExcluded = new ArtifactTypeExcluded(skipArtifactType);
     }
 
     /**


### PR DESCRIPTION
## Fixes Issue #

* #754 - "Error resolving X in project Y" for dependencies without analyzer

## Description of Change

This patch adds a new configuration option `skipArtifactType` which may contain a regular expression to match against the type of an artifact. If the regex matches, the artifact is excluded from the analysis (similar to the exclusion via scope).

## Have test cases been added to cover the new functionality?

No