### PR TITLE
Bootclasspath fixes

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
@@ -107,7 +107,7 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
         final SuppressionParser parser = new SuppressionParser();
         File file = null;
         try {
-            final InputStream in = this.getClass().getClassLoader().getResourceAsStream("dependencycheck-base-suppression.xml");
+            final InputStream in = FileUtils.getResourceAsStream("dependencycheck-base-suppression.xml");
             rules = parser.parseSuppressionRules(in);
         } catch (SAXException ex) {
             throw new SuppressionParseException("Unable to parse the base suppression data file", ex);
@@ -132,7 +132,7 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
                 file = new File(suppressionFilePath);
 
                 if (!file.exists()) {
-                    try (InputStream suppressionsFromClasspath = this.getClass().getClassLoader().getResourceAsStream(suppressionFilePath)) {
+                    try (InputStream suppressionsFromClasspath = FileUtils.getResourceAsStream(suppressionFilePath)) {
                         if (suppressionsFromClasspath != null) {
                             deleteTempFile = true;
                             file = FileUtils.getTempFile("suppression", "xml");

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
@@ -30,6 +30,7 @@ import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
 import org.owasp.dependencycheck.utils.FileFilterBuilder;
+import org.owasp.dependencycheck.utils.FileUtils;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -208,10 +209,9 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
             throw new InitializationException("Unable to create temporary file for the assembly analyzer", ex);
         }
         try (FileOutputStream fos = new FileOutputStream(tempFile);
-                InputStream is = AssemblyAnalyzer.class.getClassLoader().getResourceAsStream("GrokAssembly.exe");
-                FileOutputStream fosCfg = new FileOutputStream(cfg);
-                InputStream isCfg = AssemblyAnalyzer.class.getClassLoader().getResourceAsStream("GrokAssembly.exe.config")) {
-            IOUtils.copy(is, fos);
+            InputStream is = FileUtils.getResourceAsStream("GrokAssembly.exe");
+            FileOutputStream fosCfg = new FileOutputStream(cfg);
+            InputStream isCfg = FileUtils.getResourceAsStream("GrokAssembly.exe.config")) {
             grokAssemblyExe = tempFile;
             LOGGER.debug("Extracted GrokAssembly.exe to {}", grokAssemblyExe.getPath());
             IOUtils.copy(isCfg, fosCfg);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/HintAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/HintAnalyzer.java
@@ -219,7 +219,7 @@ public class HintAnalyzer extends AbstractAnalyzer {
         final HintParser parser = new HintParser();
         File file = null;
         try {
-            hints = parser.parseHints(this.getClass().getClassLoader().getResourceAsStream(HINT_RULE_FILE_NAME));
+            hints = parser.parseHints(FileUtils.getResourceAsStream(HINT_RULE_FILE_NAME));
         } catch (HintParseException | SAXException ex) {
             LOGGER.error("Unable to parse the base hint data file");
             LOGGER.debug("Unable to parse the base hint data file", ex);
@@ -243,7 +243,7 @@ public class HintAnalyzer extends AbstractAnalyzer {
             } else {
                 file = new File(filePath);
                 if (!file.exists()) {
-                    try (InputStream fromClasspath = this.getClass().getClassLoader().getResourceAsStream(filePath)) {
+                    try (InputStream fromClasspath = FileUtils.getResourceAsStream(filePath)) {
                         if (fromClasspath != null) {
                             deleteTempFile = true;
                             file = FileUtils.getTempFile("hint", "xml");

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/cwe/CweDB.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/cwe/CweDB.java
@@ -17,6 +17,7 @@
  */
 package org.owasp.dependencycheck.data.cwe;
 
+import org.owasp.dependencycheck.utils.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +56,7 @@ public final class CweDB {
      */
     private static Map<String, String> loadData() {
         final String filePath = "data/cwe.hashmap.serialized";
-        try (InputStream input = CweDB.class.getClassLoader().getResourceAsStream(filePath);
+        try (InputStream input = FileUtils.getResourceAsStream(filePath);
                 ObjectInputStream oin = new ObjectInputStream(input)) {
 
             final Map<String, String> ret = (HashMap<String, String>) oin.readObject();

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/ConnectionFactory.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/ConnectionFactory.java
@@ -31,6 +31,7 @@ import org.apache.commons.io.IOUtils;
 import org.owasp.dependencycheck.utils.DBUtils;
 import org.owasp.dependencycheck.utils.DependencyVersion;
 import org.owasp.dependencycheck.utils.DependencyVersionUtil;
+import org.owasp.dependencycheck.utils.FileUtils;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -277,7 +278,7 @@ public final class ConnectionFactory {
         LOGGER.debug("Creating database structure");
         InputStream is = null;
         try {
-            is = ConnectionFactory.class.getClassLoader().getResourceAsStream(DB_STRUCTURE_RESOURCE);
+            is = FileUtils.getResourceAsStream(DB_STRUCTURE_RESOURCE);
             final String dbStructure = IOUtils.toString(is, "UTF-8");
 
             Statement statement = null;
@@ -325,7 +326,7 @@ public final class ConnectionFactory {
             String updateFile = null;
             try {
                 updateFile = String.format(DB_STRUCTURE_UPDATE_RESOURCE, currentDbVersion.toString());
-                is = ConnectionFactory.class.getClassLoader().getResourceAsStream(updateFile);
+                is = FileUtils.getResourceAsStream(updateFile);
                 if (is == null) {
                     throw new DatabaseException(String.format("Unable to load update file '%s'", updateFile));
                 }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
@@ -203,8 +203,8 @@ public class DownloadTask implements Callable<Future<ProcessTask>> {
      * Attempts to delete the files that were downloaded.
      */
     public void cleanup() {
-        if (first != null && first.exists() && first.delete()) {
-            LOGGER.debug("Failed to delete first temporary file {}", second.toString());
+        if (first != null && first.exists() && !first.delete()) {
+            LOGGER.debug("Failed to delete first temporary file {}", first.toString());
             first.deleteOnExit();
         }
         if (second != null && second.exists() && !second.delete()) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
@@ -46,6 +46,7 @@ import org.owasp.dependencycheck.analyzer.Analyzer;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseProperties;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.exception.ReportException;
+import org.owasp.dependencycheck.utils.FileUtils;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -339,11 +340,11 @@ public class ReportGenerator {
                 }
             } else {
                 logTag = "templates/" + templateName + ".vsl";
-                input = this.getClass().getClassLoader().getResourceAsStream(logTag);
+                input = FileUtils.getResourceAsStream(logTag);
             }
             if (input == null) {
                 logTag = templateName;
-                input = this.getClass().getClassLoader().getResourceAsStream(templateName);
+                input = FileUtils.getResourceAsStream(templateName);
             }
             if (input == null) {
                 throw new ReportException("Template file doesn't exist: " + logTag);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/xml/hints/HintParser.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/xml/hints/HintParser.java
@@ -26,6 +26,8 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
+
+import org.owasp.dependencycheck.utils.FileUtils;
 import org.owasp.dependencycheck.utils.XmlUtils;
 
 import org.slf4j.Logger;
@@ -120,7 +122,7 @@ public class HintParser {
      * @throws SAXException thrown if the XML cannot be parsed
      */
     private Hints parseHints(InputStream inputStream, String schema) throws HintParseException, SAXException {
-        try (InputStream schemaStream = this.getClass().getClassLoader().getResourceAsStream(schema)) {
+        try (InputStream schemaStream = FileUtils.getResourceAsStream(schema)) {
             final HintHandler handler = new HintHandler();
             final SAXParser saxParser = XmlUtils.buildSecureSaxParser(schemaStream);
             final XMLReader xmlReader = saxParser.getXMLReader();

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionParser.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionParser.java
@@ -27,6 +27,8 @@ import java.io.Reader;
 import java.util.List;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
+
+import org.owasp.dependencycheck.utils.FileUtils;
 import org.owasp.dependencycheck.utils.XmlUtils;
 
 import org.slf4j.Logger;
@@ -104,7 +106,7 @@ public class SuppressionParser {
      * @throws SAXException thrown if the XML cannot be parsed
      */
     private List<SuppressionRule> parseSuppressionRules(InputStream inputStream, String schema) throws SuppressionParseException, SAXException {
-        try (InputStream schemaStream = this.getClass().getClassLoader().getResourceAsStream(schema)) {
+        try (InputStream schemaStream = FileUtils.getResourceAsStream(schema)) {
             final SuppressionHandler handler = new SuppressionHandler();
             final SAXParser saxParser = XmlUtils.buildSecureSaxParser(schemaStream);
             final XMLReader xmlReader = saxParser.getXMLReader();

--- a/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
+++ b/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.UUID;
 import org.apache.commons.lang3.SystemUtils;
 
@@ -147,5 +148,14 @@ public final class FileUtils {
                 LOGGER.trace("", ex);
             }
         }
+    }
+    
+    /**
+     * Gets the {@link InputStream} for this resource
+     * @param resource path
+     * @return
+     */
+    public static InputStream getResourceAsStream(String resource) {
+    	return FileUtils.class.getClassLoader()!=null?FileUtils.class.getClassLoader().getResourceAsStream(resource):ClassLoader.getSystemResourceAsStream(resource);
     }
 }

--- a/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -29,6 +29,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.security.ProtectionDomain;
 import java.util.Enumeration;
 import java.util.Properties;
 
@@ -440,7 +441,7 @@ public final class Settings {
      */
     private Settings(String propertiesFilePath) {
         props = new Properties();
-        try (InputStream in = this.getClass().getClassLoader().getResourceAsStream(propertiesFilePath)) {
+        try (InputStream in = FileUtils.getResourceAsStream(propertiesFilePath)) {
             props.load(in);
         } catch (NullPointerException ex) {
             LOGGER.error("Did not find settings file '{}'.", propertiesFilePath);
@@ -733,8 +734,12 @@ public final class Settings {
      * @return a File object
      */
     private static File getJarPath() {
-        final String jarPath = Settings.class.getProtectionDomain().getCodeSource().getLocation().getPath();
         String decodedPath = ".";
+        String jarPath = "";
+        ProtectionDomain domain = Settings.class.getProtectionDomain();
+        if(domain!=null&& domain.getCodeSource()!=null && domain.getCodeSource().getLocation()!=null) {
+        	 jarPath = Settings.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+        }
         try {
             decodedPath = URLDecoder.decode(jarPath, "UTF-8");
         } catch (UnsupportedEncodingException ex) {


### PR DESCRIPTION
## Fixes Issue #761

## Description of Change

*Current dependency check version does not work if it is loaded on bootclasspath. This patch fixes issues related with this by inserting an utility method in FileUtils that all classes call to load their resources. Additionally a minor trace fix is included*

## Have test cases been added to cover the new functionality?

*no*