### PR TITLE
Fixed the creation of the GrokAssembly.exe temp file and the cleanup of the temp config file.

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
@@ -74,6 +74,10 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
      */
     private File grokAssemblyExe = null;
     /**
+     * The temp value for GrokAssembly.exe.config
+     */
+    private File grokAssemblyConfig = null;
+    /**
      * Logger
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(AssemblyAnalyzer.class);
@@ -201,22 +205,24 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
     @Override
     public void initializeFileTypeAnalyzer() throws InitializationException {
         final File tempFile;
-        final String cfg;
+        final File cfgFile;
         try {
             tempFile = File.createTempFile("GKA", ".exe", Settings.getTempDirectory());
-            cfg = tempFile.getPath() + ".config";
+            cfgFile = new File(tempFile.getPath() + ".config");
         } catch (IOException ex) {
             setEnabled(false);
             throw new InitializationException("Unable to create temporary file for the assembly analyzer", ex);
         }
         try (FileOutputStream fos = new FileOutputStream(tempFile);
-            InputStream is = FileUtils.getResourceAsStream("GrokAssembly.exe");
-            FileOutputStream fosCfg = new FileOutputStream(cfg);
-            InputStream isCfg = FileUtils.getResourceAsStream("GrokAssembly.exe.config")) {
+                InputStream is = FileUtils.getResourceAsStream("GrokAssembly.exe");
+                FileOutputStream fosCfg = new FileOutputStream(cfgFile);
+                InputStream isCfg = FileUtils.getResourceAsStream("GrokAssembly.exe.config")) {
+            IOUtils.copy(is, fos);
             grokAssemblyExe = tempFile;
             LOGGER.debug("Extracted GrokAssembly.exe to {}", grokAssemblyExe.getPath());
             IOUtils.copy(isCfg, fosCfg);
-            LOGGER.debug("Extracted GrokAssembly.exe.config to {}", cfg);
+            grokAssemblyConfig = cfgFile;
+            LOGGER.debug("Extracted GrokAssembly.exe.config to {}", cfgFile);
         } catch (IOException ioe) {
             this.setEnabled(false);
             LOGGER.warn("Could not extract GrokAssembly.exe: {}", ioe.getMessage());
@@ -286,6 +292,15 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
         } catch (SecurityException se) {
             LOGGER.debug("Can't delete temporary GrokAssembly.exe");
             grokAssemblyExe.deleteOnExit();
+        }
+        try {
+            if (grokAssemblyConfig != null && !grokAssemblyConfig.delete()) {
+                LOGGER.debug("Unable to delete temporary GrokAssembly.exe.config; attempting delete on exit");
+                grokAssemblyConfig.deleteOnExit();
+            }
+        } catch (SecurityException se) {
+            LOGGER.debug("Can't delete temporary GrokAssembly.exe.config");
+            grokAssemblyConfig.deleteOnExit();
         }
     }
 


### PR DESCRIPTION
## Fixes Issue #

The GrokAssembly.exe temp file was not created anymore. Probably accidentally removed in https://github.com/jeremylong/DependencyCheck/commit/0075a7e1ce2eab3bf2e543f362e9303ea101f6e5.

## Description of Change

I added back the line that creates the GrokAssembly.exe temp file from resource and added asserts to tests to verify that the GrokAssembly executable and config temp files are created and cleaned up. I also added code to cleanup the temp config file.

Please note that this fixes all tests except one (AssemblyAnalyzerTest.testNonexistent), which still fails, but the failure doesn't seem related to the changes in this PR.

## Have test cases been added to cover the new functionality?

yes