### PR TITLE
Engine execution modes

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -583,7 +583,7 @@ public class Engine implements FileFilter, AutoCloseable {
                 }
             }
         }
-        for (AnalysisPhase phase : AnalysisPhase.values()) {
+        for (AnalysisPhase phase : mode.phases) {
             final List<Analyzer> analyzerList = analyzers.get(phase);
 
             for (Analyzer a : analyzerList) {
@@ -788,7 +788,7 @@ public class Engine implements FileFilter, AutoCloseable {
      */
     public List<Analyzer> getAnalyzers() {
         final List<Analyzer> ret = new ArrayList<>();
-        for (AnalysisPhase phase : AnalysisPhase.values()) {
+        for (AnalysisPhase phase : mode.phases) {
             final List<Analyzer> analyzerList = analyzers.get(phase);
             ret.addAll(analyzerList);
         }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -57,7 +57,14 @@ import static org.owasp.dependencycheck.analyzer.AnalysisPhase.*;
  */
 public class Engine implements FileFilter {
 
+    /**
+     * {@link Engine} execution modes.
+     */
     public enum Mode {
+        /**
+         * In evidence collection mode the {@link Engine} only collect evidence from the scan targets,
+         * and doesn't require a database.
+         */
         EVIDENCE_COLLECTION(
             false,
             INITIAL,
@@ -65,6 +72,11 @@ public class Engine implements FileFilter {
             INFORMATION_COLLECTION,
             POST_INFORMATION_COLLECTION
         ),
+        /**
+         * In evidence processing mode the {@link Engine} processes the evidence collected using the
+         * {@link #EVIDENCE_COLLECTION} mode. Dependencies should be injected into the {@link Engine}
+         * using {@link Engine#setDependencies(List)}.
+         */
         EVIDENCE_PROCESSING(
             true,
             PRE_IDENTIFIER_ANALYSIS,
@@ -75,6 +87,9 @@ public class Engine implements FileFilter {
             POST_FINDING_ANALYSIS,
             FINAL
         ),
+        /**
+         * In standalone mode the {@link Engine} will collect and process evidence in a single execution.
+         */
         STANDALONE(true, AnalysisPhase.values());
 
         public final boolean requiresDatabase;
@@ -117,18 +132,21 @@ public class Engine implements FileFilter {
     private static final Logger LOGGER = LoggerFactory.getLogger(Engine.class);
 
     /**
-     * Creates a new Engine.
+     * Creates a new {@link Mode#STANDALONE} Engine.
      */
     public Engine() {
         this(Mode.STANDALONE);
     }
 
+    /**
+     * Creates a new Engine.
+     */
     public Engine(Mode mode) {
        this(Thread.currentThread().getContextClassLoader(), mode);
     }
 
     /**
-     * Creates a new Engine.
+     * Creates a new {@link Mode#STANDALONE} Engine.
      *
      * @param serviceClassLoader a reference the class loader being used
      */
@@ -140,6 +158,7 @@ public class Engine implements FileFilter {
      * Creates a new Engine.
      *
      * @param serviceClassLoader a reference the class loader being used
+     * @param mode the mode of the engine
      */
     public Engine(ClassLoader serviceClassLoader, Mode mode) {
         this.serviceClassLoader = serviceClassLoader;

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -194,7 +194,7 @@ public class Engine implements FileFilter, AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         cleanup();
     }
 

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -62,7 +62,7 @@ public class Engine implements FileFilter {
      */
     public enum Mode {
         /**
-         * In evidence collection mode the {@link Engine} only collect evidence from the scan targets,
+         * In evidence collection mode the {@link Engine} only collects evidence from the scan targets,
          * and doesn't require a database.
          */
         EVIDENCE_COLLECTION(

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -55,7 +55,7 @@ import static org.owasp.dependencycheck.analyzer.AnalysisPhase.*;
  *
  * @author Jeremy Long
  */
-public class Engine implements FileFilter {
+public class Engine implements FileFilter, AutoCloseable {
 
     /**
      * {@link Engine} execution modes.
@@ -191,6 +191,11 @@ public class Engine implements FileFilter {
             }
             ConnectionFactory.cleanup();
         }
+    }
+
+    @Override
+    public void close() throws Exception {
+        cleanup();
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -115,6 +115,9 @@ public class Engine implements FileFilter, AutoCloseable {
      */
     private final Set<FileTypeAnalyzer> fileTypeAnalyzers = new HashSet<>();
 
+    /**
+     * The engine execution mode indicating it will either collect evidence or process evidence or both.
+     */
     private final Mode mode;
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AnalyzerService.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AnalyzerService.java
@@ -17,13 +17,13 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ServiceLoader;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+import static java.util.Arrays.asList;
 
 /**
  * The Analyzer Service Loader. This class loads all services that implement
@@ -57,6 +57,24 @@ public class AnalyzerService {
      * @return a list of Analyzers.
      */
     public List<Analyzer> getAnalyzers() {
+        return getAnalyzers(AnalysisPhase.values());
+    }
+
+    /**
+     * Returns a list of all instances of the Analyzer interface that are bound to one of the given phases.
+     *
+     * @return a list of Analyzers.
+     */
+    public List<Analyzer> getAnalyzers(AnalysisPhase... phases) {
+        return getAnalyzers(asList(phases));
+    }
+
+    /**
+     * Returns a list of all instances of the Analyzer interface that are bound to one of the given phases.
+     *
+     * @return a list of Analyzers.
+     */
+    private List<Analyzer> getAnalyzers(List<AnalysisPhase> phases) {
         final List<Analyzer> analyzers = new ArrayList<>();
         final Iterator<Analyzer> iterator = service.iterator();
         boolean experimentalEnabled = false;
@@ -67,6 +85,9 @@ public class AnalyzerService {
         }
         while (iterator.hasNext()) {
             final Analyzer a = iterator.next();
+            if (!phases.contains(a.getAnalysisPhase())) {
+                continue;
+            }
             if (!experimentalEnabled && a.getClass().isAnnotationPresent(Experimental.class)) {
                 continue;
             }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DatabaseException.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DatabaseException.java
@@ -22,7 +22,7 @@ package org.owasp.dependencycheck.data.nvdcve;
  *
  * @author Jeremy Long
  */
-public class DatabaseException extends Exception {
+public class DatabaseException extends RuntimeException {
 
     /**
      * the serial version uid.

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/EngineModeTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/EngineModeTest.java
@@ -1,0 +1,81 @@
+package org.owasp.dependencycheck;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+import org.owasp.dependencycheck.analyzer.AnalysisPhase;
+import org.owasp.dependencycheck.utils.Settings;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * @author Mark Rekveld
+ */
+public class EngineModeTest extends BaseTest {
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+    @Rule
+    public TestName testName = new TestName();
+    private Engine engine;
+
+    @Before
+    public void setUp() throws Exception {
+        Settings.setString(Settings.KEYS.DATA_DIRECTORY, tempDir.newFolder().getAbsolutePath());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        engine.cleanup();
+    }
+
+    @Test
+    public void testEvidenceCollectionMode() throws Exception {
+        engine = new Engine(Engine.Mode.EVIDENCE_COLLECTION);
+        assertDatabase(false);
+        for (AnalysisPhase phase : Engine.Mode.EVIDENCE_COLLECTION.phases) {
+            assertThat(engine.getAnalyzers(phase), is(notNullValue()));
+        }
+        for (AnalysisPhase phase : Engine.Mode.EVIDENCE_PROCESSING.phases) {
+            assertThat(engine.getAnalyzers(phase), is(nullValue()));
+        }
+    }
+
+    @Test
+    public void testEvidenceProcessingMode() throws Exception {
+        engine = new Engine(Engine.Mode.EVIDENCE_PROCESSING);
+        assertDatabase(true);
+        for (AnalysisPhase phase : Engine.Mode.EVIDENCE_PROCESSING.phases) {
+            assertThat(engine.getAnalyzers(phase), is(notNullValue()));
+        }
+        for (AnalysisPhase phase : Engine.Mode.EVIDENCE_COLLECTION.phases) {
+            assertThat(engine.getAnalyzers(phase), is(nullValue()));
+        }
+    }
+
+    @Test
+    public void testStandaloneMode() throws Exception {
+        engine = new Engine(Engine.Mode.STANDALONE);
+        assertDatabase(true);
+        for (AnalysisPhase phase : Engine.Mode.STANDALONE.phases) {
+            assertThat(engine.getAnalyzers(phase), is(notNullValue()));
+        }
+    }
+
+    private void assertDatabase(boolean exists) throws Exception {
+        Path directory = Settings.getDataDirectory().toPath();
+        assertThat(Files.exists(directory), is(true));
+        assertThat(Files.isDirectory(directory), is(true));
+        Path database = directory.resolve(Settings.getString(Settings.KEYS.DB_FILE_NAME));
+        assertThat(Files.exists(database), is(exists));
+    }
+}

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/EngineModeTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/EngineModeTest.java
@@ -1,6 +1,5 @@
 package org.owasp.dependencycheck;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,48 +25,45 @@ public class EngineModeTest extends BaseTest {
     public TemporaryFolder tempDir = new TemporaryFolder();
     @Rule
     public TestName testName = new TestName();
-    private Engine engine;
 
     @Before
     public void setUp() throws Exception {
         Settings.setString(Settings.KEYS.DATA_DIRECTORY, tempDir.newFolder().getAbsolutePath());
     }
 
-    @After
-    public void tearDown() throws Exception {
-        engine.cleanup();
-    }
-
     @Test
     public void testEvidenceCollectionMode() throws Exception {
-        engine = new Engine(Engine.Mode.EVIDENCE_COLLECTION);
-        assertDatabase(false);
-        for (AnalysisPhase phase : Engine.Mode.EVIDENCE_COLLECTION.phases) {
-            assertThat(engine.getAnalyzers(phase), is(notNullValue()));
-        }
-        for (AnalysisPhase phase : Engine.Mode.EVIDENCE_PROCESSING.phases) {
-            assertThat(engine.getAnalyzers(phase), is(nullValue()));
+        try (Engine engine = new Engine(Engine.Mode.EVIDENCE_COLLECTION)) {
+            assertDatabase(false);
+            for (AnalysisPhase phase : Engine.Mode.EVIDENCE_COLLECTION.phases) {
+                assertThat(engine.getAnalyzers(phase), is(notNullValue()));
+            }
+            for (AnalysisPhase phase : Engine.Mode.EVIDENCE_PROCESSING.phases) {
+                assertThat(engine.getAnalyzers(phase), is(nullValue()));
+            }
         }
     }
 
     @Test
     public void testEvidenceProcessingMode() throws Exception {
-        engine = new Engine(Engine.Mode.EVIDENCE_PROCESSING);
-        assertDatabase(true);
-        for (AnalysisPhase phase : Engine.Mode.EVIDENCE_PROCESSING.phases) {
-            assertThat(engine.getAnalyzers(phase), is(notNullValue()));
-        }
-        for (AnalysisPhase phase : Engine.Mode.EVIDENCE_COLLECTION.phases) {
-            assertThat(engine.getAnalyzers(phase), is(nullValue()));
+        try (Engine engine = new Engine(Engine.Mode.EVIDENCE_PROCESSING)) {
+            assertDatabase(true);
+            for (AnalysisPhase phase : Engine.Mode.EVIDENCE_PROCESSING.phases) {
+                assertThat(engine.getAnalyzers(phase), is(notNullValue()));
+            }
+            for (AnalysisPhase phase : Engine.Mode.EVIDENCE_COLLECTION.phases) {
+                assertThat(engine.getAnalyzers(phase), is(nullValue()));
+            }
         }
     }
 
     @Test
     public void testStandaloneMode() throws Exception {
-        engine = new Engine(Engine.Mode.STANDALONE);
-        assertDatabase(true);
-        for (AnalysisPhase phase : Engine.Mode.STANDALONE.phases) {
-            assertThat(engine.getAnalyzers(phase), is(notNullValue()));
+        try (Engine engine = new Engine(Engine.Mode.STANDALONE)) {
+            assertDatabase(true);
+            for (AnalysisPhase phase : Engine.Mode.STANDALONE.phases) {
+                assertThat(engine.getAnalyzers(phase), is(notNullValue()));
+            }
         }
     }
 

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/AnalyzerServiceTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/AnalyzerServiceTest.java
@@ -17,12 +17,17 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.util.List;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.utils.Settings;
+
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.owasp.dependencycheck.analyzer.AnalysisPhase.FINAL;
+import static org.owasp.dependencycheck.analyzer.AnalysisPhase.INITIAL;
 
 /**
  *
@@ -46,7 +51,22 @@ public class AnalyzerServiceTest extends BaseDBTestCase {
         }
         assertTrue("JarAnalyzer loaded", found);
     }
-    
+
+    /**
+     * Test of getAnalyzers method, of class AnalyzerService.
+     */
+    @Test
+    public void testGetAnalyzers_SpecificPhases() throws Exception {
+        AnalyzerService instance = new AnalyzerService(Thread.currentThread().getContextClassLoader());
+        List<Analyzer> result = instance.getAnalyzers(INITIAL, FINAL);
+
+        for (Analyzer a : result) {
+            if (a.getAnalysisPhase() != INITIAL && a.getAnalysisPhase() != FINAL) {
+                fail("Only expecting analyzers for phases " + INITIAL + " and " + FINAL);
+            }
+        }
+    }
+
     /**
      * Test of getAnalyzers method, of class AnalyzerService.
      */


### PR DESCRIPTION
## Fixes Issue #
This PR introduces a new feature, namely engine execution modes. 

## Description of Change
The change proposed introduces the concept of Execution Modes to the `Engine` with the following options:
1. Evidence Collection
2. Evidence Processing
3. Standalone (Default behaviour if no mode is specified)

### Evidence Collection
The `Engine` skips the database and only executes `Analyzers` of the following phases  `INITIAL`, `PRE_INFORMATION_COLLECTION`, `INFORMATION_COLLECTION`, `POST_INFORMATION_COLLECTION`.

### Evidence Processing
The `Engine` initialized the database and only executes `Analyzers` of the following phases  `PRE_IDENTIFIER_ANALYSIS`, `IDENTIFIER_ANALYSIS`, `POST_IDENTIFIER_ANALYSIS`, `PRE_FINDING_ANALYSIS`, `FINDING_ANALYSIS`, `POST_FINDING_ANALYSIS`, `FINAL`.

### Standalone
The `Engine` behaves just like it today on master, initializing the database, execution all `Analyzers` of all the phases.

## Have test cases been added to cover the new functionality?

*yes*