### PR TITLE
Fix issue #799 - Initialize exCol to prevent NPE

### DIFF
--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -691,6 +691,9 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                     }
                     if (!isResolved) {
                         getLog().error("Unable to resolve system scoped dependency: " + dependencyNode.toNodeString());
+                        if (exCol == null) {
+                            exCol = new ExceptionCollection();
+                        }
                         exCol.addException(new DependencyNotFoundException("Unable to resolve system scoped dependency: "
                                 + dependencyNode.toNodeString()));
                     }


### PR DESCRIPTION
Fixes issue #799 

Initialize the exCol when still `null` prior to adding the DependencyNotFoundException for a system dependency

## Have test cases been added to cover the new functionality?

no