### PR TITLE
Fix save_properties on Postgres

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -512,7 +512,7 @@ public final class CveDB implements AutoCloseable {
             if (mergeProperty != null) {
                 mergeProperty.setString(1, key);
                 mergeProperty.setString(2, value);
-                mergeProperty.executeUpdate();
+                mergeProperty.execute();
             } else {
                 // No Merge statement, so doing an Update/Insert...
                 final PreparedStatement updateProperty = getPreparedStatement(UPDATE_PROPERTY);

--- a/dependency-check-core/src/main/resources/data/dbStatements_postgresql.properties
+++ b/dependency-check-core/src/main/resources/data/dbStatements_postgresql.properties
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-MERGE_PROPERTY=CALL save_property(?, ?)
+MERGE_PROPERTY=SELECT save_property(?, ?)
 CLEANUP_ORPHANS=DELETE FROM cpeEntry WHERE id IN (SELECT id FROM cpeEntry LEFT JOIN software ON cpeEntry.id = software.CPEEntryId WHERE software.CPEEntryId IS NULL);


### PR DESCRIPTION
Fixes issue #828.

Note that I had to call `execute()` instead of `executeUpdate()`on the PreparedStatement as otherwise an exception was thrown:
```
org.postgresql.util.PSQLException: A result was returned when none was expected.
        at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:140)
        at org.owasp.dependencycheck.data.nvdcve.CveDB.saveProperty(CveDB.java:517)
```

I verified the fix with the latest Postgres release and with 9.2 (Postgres 9.0 and 9.1 were not tested as the definition of the stored function `save_property`in `initialize_postgres.sql` is not valid with these releases.).

I also verified that H2 (the only other DB that defines MERGE_PROPERTY) still works with the `execute()` call.