### PR TITLE
Fix NspAnalyzer

### DIFF
--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/NspAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/NspAnalyzerTest.java
@@ -1,0 +1,82 @@
+package org.owasp.dependencycheck.analyzer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.dependency.Dependency;
+
+import java.io.File;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class NspAnalyzerTest extends BaseTest {
+    private NspAnalyzer analyzer;
+
+    @Before
+    public void setUp() throws Exception {
+        analyzer = new NspAnalyzer();
+        analyzer.setFilesMatched(true);
+        analyzer.initialize();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        analyzer.close();
+        analyzer = null;
+    }
+
+    @Test
+    public void testGetName() {
+        assertThat(analyzer.getName(), is("Node Security Platform Analyzer"));
+    }
+
+    @Test
+    public void testSupportsFiles() {
+        assertThat(analyzer.accept(new File("package.json")), is(true));
+    }
+
+    @Test
+    public void testAnalyzePackage() throws AnalysisException {
+        final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "nsp/package.json"));
+        analyzer.analyze(result, null);
+
+        assertEquals(result.getVendorEvidence().toString(), "owasp-nodejs-goat_project ");
+        assertEquals(result.getProductEvidence().toString(), "A tool to learn OWASP Top 10 for node.js developers owasp-nodejs-goat ");
+        assertEquals(result.getVersionEvidence().toString(), "1.3.0 ");
+    }
+
+    @Test
+    public void testAnalyzePackageJsonWithBundledDeps() throws AnalysisException {
+        final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "nsp/bundled.deps.package.json"));
+        analyzer.analyze(result, null);
+
+        assertEquals(result.getVendorEvidence().toString(), "Philipp Dunkel <pip@pipobscure.com> fsevents_project ");
+        assertEquals(result.getProductEvidence().toString(), "Native Access to Mac OS-X FSEvents fsevents ");
+        assertEquals(result.getVersionEvidence().toString(), "1.1.1 ");
+    }
+
+    @Test
+    public void testAnalyzePackageJsonWithLicenseObject() throws AnalysisException {
+        final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "nsp/license.obj.package.json"));
+        analyzer.analyze(result, null);
+
+        assertEquals(result.getVendorEvidence().toString(), "Twitter, Inc. bootstrap_project ");
+        assertEquals(result.getProductEvidence().toString(), "The most popular front-end framework for developing responsive, mobile first projects on the web. bootstrap ");
+        assertEquals(result.getVersionEvidence().toString(), "3.2.0 ");
+    }
+
+    @Test
+    public void testAnalyzePackageJsonInNodeModulesDirectory() throws AnalysisException {
+        final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "nodejs/node_modules/dns-sync/package.json"));
+        analyzer.analyze(result, null);
+        final String vendorString = result.getVendorEvidence().toString();
+
+        // node modules are not scanned
+        assertTrue(vendorString.isEmpty());
+        assertEquals(result.getProductEvidence().size(), 0);
+        assertEquals(result.getVersionEvidence().size(), 0);
+    }
+}

--- a/dependency-check-core/src/test/resources/nsp/bundled.deps.package.json
+++ b/dependency-check-core/src/test/resources/nsp/bundled.deps.package.json
@@ -1,0 +1,48 @@
+{
+  "name": "fsevents",
+  "version": "1.1.1",
+  "description": "Native Access to Mac OS-X FSEvents",
+  "main": "fsevents.js",
+  "dependencies": {
+    "nan": "^2.3.0",
+    "node-pre-gyp": "^0.6.29"
+  },
+  "os": [
+    "darwin"
+  ],
+  "engines": {
+    "node": ">=0.8.0"
+  },
+  "scripts": {
+    "install": "node install",
+    "prepublish": "if [ $(npm -v | head -c 1) -lt 3 ]; then exit 1; fi && npm dedupe",
+    "test": "tap ./test"
+  },
+  "binary": {
+    "module_name": "fse",
+    "module_path": "./lib/binding/{configuration}/{node_abi}-{platform}-{arch}/",
+    "remote_path": "./v{version}/",
+    "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}.tar.gz",
+    "host": "https://fsevents-binaries.s3-us-west-2.amazonaws.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strongloop/fsevents.git"
+  },
+  "keywords": [
+    "fsevents",
+    "mac"
+  ],
+  "author": "Philipp Dunkel <pip@pipobscure.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/strongloop/fsevents/issues"
+  },
+  "bundledDependencies": [
+    "node-pre-gyp"
+  ],
+  "homepage": "https://github.com/strongloop/fsevents",
+  "devDependencies": {
+    "tap": "~0.4.8"
+  }
+}

--- a/dependency-check-core/src/test/resources/nsp/license.obj.package.json
+++ b/dependency-check-core/src/test/resources/nsp/license.obj.package.json
@@ -1,0 +1,81 @@
+{
+  "name": "bootstrap",
+  "description": "The most popular front-end framework for developing responsive, mobile first projects on the web.",
+  "version": "3.2.0",
+  "keywords": [
+    "css",
+    "less",
+    "mobile-first",
+    "responsive",
+    "front-end",
+    "framework",
+    "web"
+  ],
+  "homepage": "http://getbootstrap.com",
+  "author": "Twitter, Inc.",
+  "scripts": {
+    "test": "grunt test"
+  },
+  "style": "dist/css/bootstrap.css",
+  "less": "less/bootstrap.less",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/twbs/bootstrap.git"
+  },
+  "bugs": {
+    "url": "https://github.com/twbs/bootstrap/issues"
+  },
+  "license": {
+    "type": "MIT",
+    "url": "https://github.com/twbs/bootstrap/blob/master/LICENSE"
+  },
+  "devDependencies": {
+    "btoa": "~1.1.2",
+    "glob": "~4.0.2",
+    "grunt": "~0.4.5",
+    "grunt-autoprefixer": "~0.7.6",
+    "grunt-banner": "~0.2.3",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-concat": "~0.4.0",
+    "grunt-contrib-connect": "~0.8.0",
+    "grunt-contrib-copy": "~0.5.0",
+    "grunt-contrib-csslint": "~0.2.0",
+    "grunt-contrib-cssmin": "~0.10.0",
+    "grunt-contrib-jade": "~0.12.0",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-less": "~0.11.3",
+    "grunt-contrib-qunit": "~0.5.1",
+    "grunt-contrib-uglify": "~0.5.0",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-csscomb": "~2.0.1",
+    "grunt-exec": "~0.4.5",
+    "grunt-html-validation": "~0.1.18",
+    "grunt-jekyll": "~0.4.2",
+    "grunt-jscs-checker": "~0.6.0",
+    "grunt-saucelabs": "~8.1.0",
+    "grunt-sed": "~0.1.1",
+    "load-grunt-tasks": "~0.6.0",
+    "markdown": "~0.5.0",
+    "npm-shrinkwrap": "~3.1.6",
+    "time-grunt": "~0.3.2"
+  },
+  "engines": {
+    "node": "~0.10.1"
+  },
+  "jspm": {
+    "main": "js/bootstrap",
+    "directories": {
+      "example": "examples",
+      "lib": "dist"
+    },
+    "shim": {
+      "js/bootstrap": {
+        "imports": "jquery",
+        "exports": "$"
+      }
+    },
+    "buildConfig": {
+      "uglify": true
+    }
+  }
+}


### PR DESCRIPTION
## Fixes Issue #835

## Root Cause
`NspAnalyzer` fails to parse `package.json` files that contain the following keys:

```javascript

{
  // Should be parsed as a JsonArray but was parsed as JsonObject
  "bundledDependencies": [
    "node-pre-gyp"
  ],

  // Older libraries use license objects rather than JsonString
  {
  "license": {
    "type": "MIT",
    "url": "https://github.com/twbs/bootstrap/blob/master/LICENSE"
  }
}
```

## Changes

* `NspAnalyzer`: parse `"bundleDependencies"` as `JsonArray`
* `NspAnalyzer`: parse `"bundledDependencies"` as `JsonArray`
* `NspAnalyzer`: parse `"license"` as `JsonObject` and subelement `"type"` as `JsonString` in cases where older libraries used a [license object](https://docs.npmjs.com/files/package.json#license)
