### PR TITLE
Call populateSettings in CheckMojo#canGenerateReport to address NPE

### DIFF
--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/CheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/CheckMojo.java
@@ -62,6 +62,7 @@ public class CheckMojo extends BaseDependencyCheckMojo {
      */
     @Override
     public boolean canGenerateReport() {
+        populateSettings();
         boolean isCapable = false;
         for (Artifact a : getProject().getArtifacts()) {
             if (!getArtifactScopeExcluded().passes(a.getScope())) {


### PR DESCRIPTION
## Fixes Issue #

When using the `check` report there is a NPE due to the settings not being populated yet.

```
Caused by: java.lang.NullPointerException
	at org.owasp.dependencycheck.maven.CheckMojo.canGenerateReport(CheckMojo.java:67)
	at org.apache.maven.reporting.exec.MavenReportExecution.canGenerateReport(MavenReportExecution.java:89)
	at org.apache.maven.plugins.site.render.AbstractSiteRenderingMojo.getReports(AbstractSiteRenderingMojo.java:267)
	at org.apache.maven.plugins.site.render.SiteMojo.execute(SiteMojo.java:115)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	... 12 more
```

```xml
<plugin>
  <groupId>org.owasp</groupId>
  <artifactId>dependency-check-maven</artifactId>
  <reportSets>
    <reportSet>
      <reports>
        <report>check</report>
      </reports>
    </reportSet>
  </reportSets>
</plugin>
```

## Description of Change

Call `BaseDependencyCheckMojo#populateSettings` from `CheckMojo#canGenerateReport` to ensure that the necessary items have been initialized to determine if the report can be generated.

## Have test cases been added to cover the new functionality?

No, but tested with updated snapshot locally to get passed the NPE and generate the site report.