### PR TITLE
Fixed URL of TLS Failures page

### DIFF
--- a/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
+++ b/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
@@ -154,7 +154,7 @@ public final class Downloader {
                 }
                 if ("Connection reset".equalsIgnoreCase(ex.getMessage())) {
                     final String msg = format("TLS Connection Reset%nPlease see "
-                            + "http://jeremylong.github.io/DependencyCheck/general/tlsfailures.html "
+                            + "http://jeremylong.github.io/DependencyCheck/data/tlsfailure.html "
                             + "for more information regarding how to resolve the issue.");
                     LOGGER.error(msg);
                     throw new DownloadFailedException(msg, ex);


### PR DESCRIPTION
## Fixes Issue #
Currently if there are TLS issues the following URL is printed to standard output:
[INFO] Download Started for NVD CVE - Modified
[ERROR] TLS Connection Reset
Please see http://jeremylong.github.io/DependencyCheck/general/tlsfailures.html for more information regarding how to resolve the issue.
[WARNING] Download Failed for NVD CVE - Modified

## Description of Change

I have fixed it to the following correct URL:
https://jeremylong.github.io/DependencyCheck/data/tlsfailure.html

## Have test cases been added to cover the new functionality?

N/A