### PR TITLE
#842 Honor skip configuration in reports

### DIFF
--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -593,6 +593,11 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * @throws MavenReportException if a maven report exception occurs
      */
     public void generate(Sink sink, Locale locale) throws MavenReportException {
+        if (skip) {
+            getLog().info("Skipping report generation " + getName(Locale.US));
+            return;
+        }
+
         generatingSite = true;
         try {
             validateAggregate();


### PR DESCRIPTION
## Fixes Issue #842 

## Description of Change

In dependency-check-maven, checks the skip configuration option during report generation and honors the value.

## Have test cases been added to cover the new functionality?

No. I was unable to find a suitable location for a report test in the maven module. I did test it manually and locally. The report generation was successfully skipped by including the following into the `reporting` section of my child pom.

````
<plugin>
  <groupId>org.owasp</groupId>
  <artifactId>dependency-check-maven</artifactId>
  <version>2.1.1-SNAPSHOT</version>
  <configuration>
    <skip>true</skip>
  </configuration>
 </plugin>
````

I also tested `skip` being set to `false` as well as not setting it. Results in those cases were also as expected (and had the reports generate)