### PR TITLE
Added support for retired analyzers. Retired NodePackageAnalyzer.

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AnalyzerService.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AnalyzerService.java
@@ -86,10 +86,12 @@ public class AnalyzerService {
         final List<Analyzer> analyzers = new ArrayList<>();
         final Iterator<Analyzer> iterator = service.iterator();
         boolean experimentalEnabled = false;
+        boolean retiredEnabled = false;
         try {
             experimentalEnabled = Settings.getBoolean(Settings.KEYS.ANALYZER_EXPERIMENTAL_ENABLED, false);
+            retiredEnabled = Settings.getBoolean(Settings.KEYS.ANALYZER_RETIRED_ENABLED, false);
         } catch (InvalidSettingException ex) {
-            LOGGER.error("invalid experimental setting", ex);
+            LOGGER.error("invalid experimental or retired setting", ex);
         }
         while (iterator.hasNext()) {
             final Analyzer a = iterator.next();
@@ -97,6 +99,9 @@ public class AnalyzerService {
                 continue;
             }
             if (!experimentalEnabled && a.getClass().isAnnotationPresent(Experimental.class)) {
+                continue;
+            }
+            if (!retiredEnabled && a.getClass().isAnnotationPresent(Retired.class)) {
                 continue;
             }
             LOGGER.debug("Loaded Analyzer {}", a.getName());

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
@@ -46,7 +46,7 @@ import org.owasp.dependencycheck.exception.InitializationException;
  *
  * @author Dale Visser
  */
-@Experimental
+@Retired
 public class NodePackageAnalyzer extends AbstractFileTypeAnalyzer {
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/Retired.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/Retired.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2017 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.analyzer;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used to flag an analyzer as retired.
+ *
+ * @author Steve Springett
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Retired {
+
+}

--- a/dependency-check-core/src/main/resources/dependencycheck.properties
+++ b/dependency-check-core/src/main/resources/dependencycheck.properties
@@ -88,7 +88,10 @@ archive.scan.depth=3
 downloader.quick.query.timestamp=true
 downloader.tls.protocols=TLSv1,TLSv1.1,TLSv1.2,TLSv1.3
 
+# defines if the experimental and retired analyzers can be enabled
 analyzer.experimental.enabled=false
+analyzer.retired.enabled=false
+
 analyzer.jar.enabled=true
 analyzer.archive.enabled=true
 analyzer.node.package.enabled=true

--- a/dependency-check-core/src/test/resources/dependencycheck.properties
+++ b/dependency-check-core/src/test/resources/dependencycheck.properties
@@ -83,7 +83,10 @@ archive.scan.depth=3
 downloader.quick.query.timestamp=true
 downloader.tls.protocols=TLSv1,TLSv1.1,TLSv1.2,TLSv1.3
 
+# defines if the experimental and retired analyzers can be enabled
 analyzer.experimental.enabled=true
+analyzer.retired.enabled=true
+
 analyzer.jar.enabled=true
 analyzer.archive.enabled=true
 analyzer.node.package.enabled=true

--- a/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -257,6 +257,10 @@ public final class Settings {
          */
         public static final String ANALYZER_EXPERIMENTAL_ENABLED = "analyzer.experimental.enabled";
         /**
+         * The properties key for whether experimental analyzers are loaded.
+         */
+        public static final String ANALYZER_RETIRED_ENABLED = "analyzer.retired.enabled";
+        /**
          * The properties key for whether the Archive analyzer is enabled.
          */
         public static final String ANALYZER_ARCHIVE_ENABLED = "analyzer.archive.enabled";


### PR DESCRIPTION
Jeremy, The idea in retiring analyzers rather than simply removing them is to:

- allow users to continue to use dependency-check in rare scenarios where the analyzer may actually be useful
- prevent users from discovering an analyzer does not exist and spending time creating something we've previously deemed unsuccessful and removed

A @Retired annotation was created and the same mechanisms that provide the ability to enable/disable experimental analyzers have been applied to retired analyzers as well.

I envision the path from experimental analyzer to take one of two paths - they will either graduate to production, or be retired.