### PR TITLE
Fix the package.swift DisplayFileName to be something recognizable and unique in a report

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageManagerAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageManagerAnalyzer.java
@@ -142,6 +142,10 @@ public class SwiftPackageManagerAnalyzer extends AbstractFileTypeAnalyzer {
             if (name != null && !name.isEmpty()) {
                 vendor.addEvidence(SPM_FILE_NAME, "name_project", name, Confidence.HIGHEST);
             }
+            
+            final File actual = dependency.getActualFile();
+            final String parentName = actual.getParentFile().getName();
+            dependency.setDisplayFileName(parentName + "/" + actual.getName());
         }
         setPackagePath(dependency);
     }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
@@ -10,6 +10,7 @@ import org.owasp.dependencycheck.dependency.Dependency;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 import java.io.File;
 
@@ -105,6 +106,7 @@ public class SwiftAnalyzersTest extends BaseTest {
         assertThat(vendorString, containsString("MIT"));
         assertThat(result.getProductEvidence().toString(), containsString("EasyPeasy"));
         assertThat(result.getVersionEvidence().toString(), containsString("0.2.3"));
+        assertThat(result.getDisplayFileName(),equalTo("EasyPeasy.podspec"));
     }
 
     /**
@@ -119,5 +121,6 @@ public class SwiftAnalyzersTest extends BaseTest {
         spmAnalyzer.analyze(result, null);
 
         assertThat(result.getProductEvidence().toString(), containsString("Gloss"));
+        assertThat(result.getDisplayFileName(),equalTo("Gloss/Package.swift"));
     }
 }


### PR DESCRIPTION
so the report doesn't list dozens of "package.swift" entries

## Fixes Issue #

## Description of Change

*Please add a description of the proposed change*
Taking a similar approach as used in other analyzers that always have the same filename. Include the parent name since it likely is more recognizable. Without this, scanning many swift packages ends up with a report loaded with "package.swift" entries repeated each time.
## Have test cases been added to cover the new functionality?

*yes*