### PR TITLE
Dependency name improvements

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -154,7 +154,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
     @Override
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
-    	    dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
+		dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
         final File file = dependency.getActualFile();
         final String name = file.getName();
         String contents;

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -58,9 +58,9 @@ import org.owasp.dependencycheck.exception.InitializationException;
 public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
 
     /**
-     * The dependency Ecosystem
+     * A descriptor for the type of dependencies processed or added by this analyzer
      */
-     static final String DEPENDENCY_ECOSYSTEM = "CMAKE";
+     public static final String DEPENDENCY_ECOSYSTEM = "CMAKE";
      
     /**
      * The logger.
@@ -154,9 +154,8 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
     @Override
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
-    	    dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
+    	    dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
         final File file = dependency.getActualFile();
-        final String parentName = file.getParentFile().getName();
         final String name = file.getName();
         String contents;
         try {
@@ -217,7 +216,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
             if (count > 1) {
                 //TODO - refactor so we do not assign to the parameter (checkstyle)
                 currentDep = new Dependency(dependency.getActualFile());
-                currentDep.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
+                currentDep.setEcosystem(DEPENDENCY_ECOSYSTEM);
                 final String filePath = String.format("%s:%s", dependency.getFilePath(), product);
                 currentDep.setFilePath(filePath);
 

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
@@ -44,6 +44,11 @@ import org.owasp.dependencycheck.utils.Settings;
 public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
 
     /**
+     * A descriptor for the type of dependencies processed or added by this analyzer
+     */
+     public static final String DEPENDENCY_ECOSYSTEM = "CocoaPod";
+     
+    /**
      * The logger.
      */
 //    private static final Logger LOGGER = LoggerFactory.getLogger(CocoaPodsAnalyzer.class);
@@ -51,11 +56,6 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
      * The name of the analyzer.
      */
     private static final String ANALYZER_NAME = "CocoaPods Package Analyzer";
-
-    /**
-     * The dependency Ecosystem
-     */
-     static final String DEPENDENCY_ECOSYSTEM = "CocoaPod";
     
     /**
      * The phase that this analyzer is intended to run in.
@@ -127,7 +127,7 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
 
-    		dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
+    		dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
         String contents;
         try {
             contents = FileUtils.readFileToString(dependency.getActualFile(), Charset.defaultCharset());

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
@@ -53,6 +53,11 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
     private static final String ANALYZER_NAME = "CocoaPods Package Analyzer";
 
     /**
+     * The dependency Ecosystem
+     */
+     static final String DEPENDENCY_ECOSYSTEM = "CocoaPod";
+    
+    /**
      * The phase that this analyzer is intended to run in.
      */
     private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.INFORMATION_COLLECTION;
@@ -122,6 +127,7 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
 
+    		dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
         String contents;
         try {
             contents = FileUtils.readFileToString(dependency.getActualFile(), Charset.defaultCharset());
@@ -141,6 +147,7 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
             final String name = addStringEvidence(product, contents, blockVariable, "name", "name", Confidence.HIGHEST);
             if (!name.isEmpty()) {
                 vendor.addEvidence(PODSPEC, "name_project", name, Confidence.HIGHEST);
+                dependency.setName(name);
             }
             addStringEvidence(product, contents, blockVariable, "summary", "summary", Confidence.HIGHEST);
 
@@ -148,7 +155,8 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
             addStringEvidence(vendor, contents, blockVariable, "homepage", "homepage", Confidence.HIGHEST);
             addStringEvidence(vendor, contents, blockVariable, "license", "licen[cs]es?", Confidence.HIGHEST);
 
-            addStringEvidence(version, contents, blockVariable, "version", "version", Confidence.HIGHEST);
+            final String versionStr = addStringEvidence(version, contents, blockVariable, "version", "version", Confidence.HIGHEST);
+            dependency.setVersion(versionStr);
         }
 
         setPackagePath(dependency);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
@@ -43,11 +43,11 @@ import org.owasp.dependencycheck.utils.Settings;
 @Experimental
 public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
 
-    /**
-     * A descriptor for the type of dependencies processed or added by this analyzer
-     */
-     public static final String DEPENDENCY_ECOSYSTEM = "CocoaPod";
-     
+	/**
+	 * A descriptor for the type of dependencies processed or added by this analyzer
+	 */
+	public static final String DEPENDENCY_ECOSYSTEM = "CocoaPod";
+  
     /**
      * The logger.
      */
@@ -127,7 +127,7 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
 
-    		dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
+		dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
         String contents;
         try {
             contents = FileUtils.readFileToString(dependency.getActualFile(), Charset.defaultCharset());

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
@@ -47,6 +47,11 @@ import java.security.NoSuchAlgorithmException;
 public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
 
     /**
+     * A descriptor for the type of dependencies processed or added by this analyzer
+     */
+     public static final String DEPENDENCY_ECOSYSTEM = "Composer";
+	
+    /**
      * The logger.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(ComposerLockAnalyzer.class);
@@ -55,11 +60,6 @@ public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
      * The analyzer name.
      */
     private static final String ANALYZER_NAME = "Composer.lock analyzer";
-
-    /**
-     * The dependency Ecosystem
-     */
-     static final String DEPENDENCY_ECOSYSTEM = "Composer";
     
     /**
      * composer.json.
@@ -119,7 +119,7 @@ public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
                 d.setName(dep.getProject());
                 d.setVersion(dep.getVersion());
                 
-                d.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
+                d.setEcosystem(DEPENDENCY_ECOSYSTEM);
                 
                 final MessageDigest sha1 = getSha1MessageDigest();
                 d.setFilePath(filePath);

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
@@ -103,20 +103,34 @@ public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
     protected void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
         try (FileInputStream fis = new FileInputStream(dependency.getActualFile())) {
             final ComposerLockParser clp = new ComposerLockParser(fis);
-            LOGGER.info("Checking composer.lock file {}", dependency.getActualFilePath());
+            LOGGER.debug("Checking composer.lock file {}", dependency.getActualFilePath());
             clp.process();
+            //if dependencies are found in the lock, then there is always an empty shell dependency left behind for the
+    	    		//composer.lock. The first pass through, reuse the top level dependency, and add new ones for the rest.
+            boolean processedAtLeastOneDep = false;
             for (ComposerDependency dep : clp.getDependencies()) {
                 final Dependency d = new Dependency(dependency.getActualFile());
-                d.setDisplayFileName(String.format("%s:%s/%s", dependency.getDisplayFileName(), dep.getGroup(), dep.getProject()));
-                final String filePath = String.format("%s:%s/%s", dependency.getFilePath(), dep.getGroup(), dep.getProject());
+                d.setDisplayFileName(String.format("%s:%s/%s/%s", dependency.getDisplayFileName(), dep.getGroup(), dep.getProject(), dep.getVersion()));
+                final String filePath = String.format("%s:%s/%s/%s", dependency.getFilePath(), dep.getGroup(), dep.getProject(), dep.getVersion());        			
+       
                 final MessageDigest sha1 = getSha1MessageDigest();
                 d.setFilePath(filePath);
                 d.setSha1sum(Checksum.getHex(sha1.digest(filePath.getBytes(Charset.defaultCharset()))));
                 d.getVendorEvidence().addEvidence(COMPOSER_LOCK, "vendor", dep.getGroup(), Confidence.HIGHEST);
                 d.getProductEvidence().addEvidence(COMPOSER_LOCK, "product", dep.getProject(), Confidence.HIGHEST);
                 d.getVersionEvidence().addEvidence(COMPOSER_LOCK, "version", dep.getVersion(), Confidence.HIGHEST);
-                LOGGER.info("Adding dependency {}", d);
+                LOGGER.debug("Adding dependency {}", d.getDisplayFileName());
                 engine.getDependencies().add(d);
+                
+                //make sure we only remove the main dependency if we went through this loop at least once.
+                	processedAtLeastOneDep = true;
+                }
+            //remove the dependency at the end because it's referenced in the loop itself.
+            //double check the name to be sure we only remove the generic entry.
+            if (processedAtLeastOneDep && dependency.getDisplayFileName().equalsIgnoreCase("composer.lock")) {
+            		LOGGER.debug("Removing main redundant dependency {}",dependency.getDisplayFileName());
+            		engine.getDependencies().remove(dependency);   
+
             }
         } catch (IOException ex) {
             LOGGER.warn("Error opening dependency {}", dependency.getActualFilePath());

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
@@ -57,6 +57,11 @@ public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
     private static final String ANALYZER_NAME = "Composer.lock analyzer";
 
     /**
+     * The dependency Ecosystem
+     */
+     static final String DEPENDENCY_ECOSYSTEM = "Composer";
+    
+    /**
      * composer.json.
      */
     private static final String COMPOSER_LOCK = "composer.lock";
@@ -110,9 +115,12 @@ public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
             boolean processedAtLeastOneDep = false;
             for (ComposerDependency dep : clp.getDependencies()) {
                 final Dependency d = new Dependency(dependency.getActualFile());
-                d.setDisplayFileName(String.format("%s:%s/%s/%s", dependency.getDisplayFileName(), dep.getGroup(), dep.getProject(), dep.getVersion()));
                 final String filePath = String.format("%s:%s/%s/%s", dependency.getFilePath(), dep.getGroup(), dep.getProject(), dep.getVersion());        			
-       
+                d.setName(dep.getProject());
+                d.setVersion(dep.getVersion());
+                
+                d.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
+                
                 final MessageDigest sha1 = getSha1MessageDigest();
                 d.setFilePath(filePath);
                 d.setSha1sum(Checksum.getHex(sha1.digest(filePath.getBytes(Charset.defaultCharset()))));

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
@@ -46,11 +46,11 @@ import java.security.NoSuchAlgorithmException;
 @Experimental
 public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
 
-    /**
-     * A descriptor for the type of dependencies processed or added by this analyzer
-     */
-     public static final String DEPENDENCY_ECOSYSTEM = "Composer";
-	
+	/**
+	 * A descriptor for the type of dependencies processed or added by this analyzer
+	 */
+	public static final String DEPENDENCY_ECOSYSTEM = "Composer";
+
     /**
      * The logger.
      */
@@ -117,10 +117,8 @@ public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
                 final Dependency d = new Dependency(dependency.getActualFile());
                 final String filePath = String.format("%s:%s/%s/%s", dependency.getFilePath(), dep.getGroup(), dep.getProject(), dep.getVersion());        			
                 d.setName(dep.getProject());
-                d.setVersion(dep.getVersion());
-                
-                d.setEcosystem(DEPENDENCY_ECOSYSTEM);
-                
+                d.setVersion(dep.getVersion());              
+				d.setEcosystem(DEPENDENCY_ECOSYSTEM);
                 final MessageDigest sha1 = getSha1MessageDigest();
                 d.setFilePath(filePath);
                 d.setSha1sum(Checksum.getHex(sha1.digest(filePath.getBytes(Charset.defaultCharset()))));
@@ -133,13 +131,12 @@ public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
                 //make sure we only remove the main dependency if we went through this loop at least once.
                 	processedAtLeastOneDep = true;
                 }
-            //remove the dependency at the end because it's referenced in the loop itself.
-            //double check the name to be sure we only remove the generic entry.
-            if (processedAtLeastOneDep && dependency.getDisplayFileName().equalsIgnoreCase("composer.lock")) {
-            		LOGGER.debug("Removing main redundant dependency {}",dependency.getDisplayFileName());
-            		engine.getDependencies().remove(dependency);   
-
-            }
+			// remove the dependency at the end because it's referenced in the loop itself.
+			// double check the name to be sure we only remove the generic entry.
+			if (processedAtLeastOneDep && dependency.getDisplayFileName().equalsIgnoreCase("composer.lock")) {
+				LOGGER.debug("Removing main redundant dependency {}", dependency.getDisplayFileName());
+				engine.getDependencies().remove(dependency);
+			}
         } catch (IOException ex) {
             LOGGER.warn("Error opening dependency {}", dependency.getActualFilePath());
         } catch (ComposerException ce) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
@@ -105,8 +105,14 @@ public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
             final ComposerLockParser clp = new ComposerLockParser(fis);
             LOGGER.info("Checking composer.lock file {}", dependency.getActualFilePath());
             clp.process();
+            //if dependencies are found in the lock, then there is always an empty shell dependency left behind for the
+    	    		//composer.lock. The first pass through, reuse the top level dependency, and add new ones for the rest.
+            boolean processedAtLeastOneDep = false;
             for (ComposerDependency dep : clp.getDependencies()) {
-                final Dependency d = new Dependency(dependency.getActualFile());
+            		
+            		final Dependency d = new Dependency(dependency.getActualFile());
+            	    
+            			
                 d.setDisplayFileName(String.format("%s:%s/%s", dependency.getDisplayFileName(), dep.getGroup(), dep.getProject()));
                 final String filePath = String.format("%s:%s/%s", dependency.getFilePath(), dep.getGroup(), dep.getProject());
                 final MessageDigest sha1 = getSha1MessageDigest();
@@ -115,8 +121,17 @@ public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
                 d.getVendorEvidence().addEvidence(COMPOSER_LOCK, "vendor", dep.getGroup(), Confidence.HIGHEST);
                 d.getProductEvidence().addEvidence(COMPOSER_LOCK, "product", dep.getProject(), Confidence.HIGHEST);
                 d.getVersionEvidence().addEvidence(COMPOSER_LOCK, "version", dep.getVersion(), Confidence.HIGHEST);
-                LOGGER.info("Adding dependency {}", d);
-                engine.getDependencies().add(d);
+                
+                LOGGER.info("Adding dependency {}", d.getDisplayFileName());
+        			engine.getDependencies().add(d);	
+                
+                //make sure we only remove the main dependency if we went through this loop at least once.
+                	processedAtLeastOneDep = true;
+                }
+            //remove the dependency at the end because it's referenced in the loop itself.
+            if (processedAtLeastOneDep) {
+            		LOGGER.info("Removing main redundant dependency {}",dependency.getDisplayFileName());
+            		engine.getDependencies().remove(dependency);   
             }
         } catch (IOException ex) {
             LOGGER.warn("Error opening dependency {}", dependency.getActualFilePath());

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
@@ -107,15 +107,15 @@ public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
             clp.process();
             for (ComposerDependency dep : clp.getDependencies()) {
                 final Dependency d = new Dependency(dependency.getActualFile());
-                d.setDisplayFileName(String.format("%s:%s/%s", dependency.getDisplayFileName(), dep.getGroup(), dep.getProject()));
-                final String filePath = String.format("%s:%s/%s", dependency.getFilePath(), dep.getGroup(), dep.getProject());
+                d.setDisplayFileName(String.format("%s:%s/%s/%s", dependency.getDisplayFileName(), dep.getGroup(), dep.getProject(), dep.getVersion()));
+                final String filePath = String.format("%s:%s/%s/%s", dependency.getFilePath(), dep.getGroup(), dep.getProject(), dep.getVersion());
                 final MessageDigest sha1 = getSha1MessageDigest();
                 d.setFilePath(filePath);
                 d.setSha1sum(Checksum.getHex(sha1.digest(filePath.getBytes(Charset.defaultCharset()))));
                 d.getVendorEvidence().addEvidence(COMPOSER_LOCK, "vendor", dep.getGroup(), Confidence.HIGHEST);
                 d.getProductEvidence().addEvidence(COMPOSER_LOCK, "product", dep.getProject(), Confidence.HIGHEST);
                 d.getVersionEvidence().addEvidence(COMPOSER_LOCK, "version", dep.getVersion(), Confidence.HIGHEST);
-                LOGGER.info("Adding dependency {}", d);
+                LOGGER.debug("Adding dependency {}", d);
                 engine.getDependencies().add(d);
             }
         } catch (IOException ex) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -158,6 +158,10 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
      */
     private static final String ANALYZER_NAME = "Jar Analyzer";
     /**
+     * The dependency ecosystem.
+     */
+    static final String DEPENDENCY_ECOSYSTEM = "Java";
+    /**
      * The phase that this analyzer is intended to run in.
      */
     private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.INFORMATION_COLLECTION;
@@ -258,6 +262,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
             final boolean hasPOM = analyzePOM(dependency, classNames, engine);
             final boolean addPackagesAsEvidence = !(hasManifest && hasPOM);
             analyzePackageNames(classNames, dependency, addPackagesAsEvidence);
+            dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
         } catch (IOException ex) {
             throw new AnalysisException("Exception occurred reading the JAR file (" + dependency.getFileName() + ").", ex);
         }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -74,6 +74,10 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
 
     //<editor-fold defaultstate="collapsed" desc="Constants and Member Variables">
     /**
+     * A descriptor for the type of dependencies processed or added by this analyzer
+     */
+    public static final String DEPENDENCY_ECOSYSTEM = "Java";
+    /**
      * The logger.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(JarAnalyzer.class);
@@ -157,10 +161,6 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
      * The name of the analyzer.
      */
     private static final String ANALYZER_NAME = "Jar Analyzer";
-    /**
-     * The dependency ecosystem.
-     */
-    static final String DEPENDENCY_ECOSYSTEM = "Java";
     /**
      * The phase that this analyzer is intended to run in.
      */
@@ -262,7 +262,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
             final boolean hasPOM = analyzePOM(dependency, classNames, engine);
             final boolean addPackagesAsEvidence = !(hasManifest && hasPOM);
             analyzePackageNames(classNames, dependency, addPackagesAsEvidence);
-            dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
+            dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
         } catch (IOException ex) {
             throw new AnalysisException("Exception occurred reading the JAR file (" + dependency.getFileName() + ").", ex);
         }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
@@ -194,7 +194,7 @@ public class NodePackageAnalyzer extends AbstractFileTypeAnalyzer {
             } else {
                 LOGGER.warn("JSON value not string or JSON object as expected: {}", value);
             }
-        }
-    		return evidenceStr;
-    }
+		}
+		return evidenceStr;
+	}
 }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
@@ -49,11 +49,11 @@ import org.owasp.dependencycheck.exception.InitializationException;
 @Experimental
 public class NodePackageAnalyzer extends AbstractFileTypeAnalyzer {
 
-    /**
-     * A descriptor for the type of dependencies processed or added by this analyzer
-     */
-    public static final String DEPENDENCY_ECOSYSTEM = "npm";
-    
+	/**
+	 * A descriptor for the type of dependencies processed or added by this analyzer
+	 */
+	public static final String DEPENDENCY_ECOSYSTEM = "npm";
+ 
 	/**
      * The logger.
      */
@@ -125,39 +125,40 @@ public class NodePackageAnalyzer extends AbstractFileTypeAnalyzer {
         return Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED;
     }
 
-    @Override
-    protected void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
-        dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
-    		final File file = dependency.getActualFile();
-        if (!file.isFile() || file.length()==0) {
-            return;
-        }
-        try (JsonReader jsonReader = Json.createReader(FileUtils.openInputStream(file))) {
-            final JsonObject json = jsonReader.readObject();
-            final EvidenceCollection productEvidence = dependency.getProductEvidence();
-            final EvidenceCollection vendorEvidence = dependency.getVendorEvidence();
-            if (json.containsKey("name")) {
-                final Object value = json.get("name");
-                if (value instanceof JsonString) {
-                    final String valueString = ((JsonString) value).getString();
-                    productEvidence.addEvidence(PACKAGE_JSON, "name", valueString, Confidence.HIGHEST);
-                    dependency.setName(valueString);
-                    vendorEvidence.addEvidence(PACKAGE_JSON, "name_project", String.format("%s_project", valueString), Confidence.LOW);
-                } else {
-                    LOGGER.warn("JSON value not string as expected: {}", value);
-                }
-            }
-            addToEvidence(json, productEvidence, "description");
-            addToEvidence(json, vendorEvidence, "author");
-            final String version = addToEvidence(json, dependency.getVersionEvidence(), "version");
-            dependency.setVersion(version);
-            
-        } catch (JsonException e) {
-            LOGGER.warn("Failed to parse package.json file.", e);
-        } catch (IOException e) {
-            throw new AnalysisException("Problem occurred while reading dependency file.", e);
-        }
-    }
+	@Override
+	protected void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
+		dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
+		final File file = dependency.getActualFile();
+		if (!file.isFile() || file.length() == 0) {
+			return;
+		}
+		try (JsonReader jsonReader = Json.createReader(FileUtils.openInputStream(file))) {
+			final JsonObject json = jsonReader.readObject();
+			final EvidenceCollection productEvidence = dependency.getProductEvidence();
+			final EvidenceCollection vendorEvidence = dependency.getVendorEvidence();
+			if (json.containsKey("name")) {
+				final Object value = json.get("name");
+				if (value instanceof JsonString) {
+					final String valueString = ((JsonString) value).getString();
+					productEvidence.addEvidence(PACKAGE_JSON, "name", valueString, Confidence.HIGHEST);
+					dependency.setName(valueString);
+					vendorEvidence.addEvidence(PACKAGE_JSON, "name_project", String.format("%s_project", valueString),
+							Confidence.LOW);
+				} else {
+					LOGGER.warn("JSON value not string as expected: {}", value);
+				}
+			}
+			addToEvidence(json, productEvidence, "description");
+			addToEvidence(json, vendorEvidence, "author");
+			final String version = addToEvidence(json, dependency.getVersionEvidence(), "version");
+			dependency.setVersion(version);
+
+		} catch (JsonException e) {
+			LOGGER.warn("Failed to parse package.json file.", e);
+		} catch (IOException e) {
+			throw new AnalysisException("Problem occurred while reading dependency file.", e);
+		}
+	}
 
     /**
      * Adds information to an evidence collection from the node json

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
@@ -50,6 +50,11 @@ import org.owasp.dependencycheck.exception.InitializationException;
 public class NodePackageAnalyzer extends AbstractFileTypeAnalyzer {
 
     /**
+     * A descriptor for the type of dependencies processed or added by this analyzer
+     */
+    public static final String DEPENDENCY_ECOSYSTEM = "npm";
+    
+	/**
      * The logger.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(NodePackageAnalyzer.class);
@@ -58,11 +63,6 @@ public class NodePackageAnalyzer extends AbstractFileTypeAnalyzer {
      * The name of the analyzer.
      */
     private static final String ANALYZER_NAME = "Node.js Package Analyzer";
-
-    /**
-     * The dependency ecosystem.
-     */
-    static final String DEPENDENCY_ECOSYSTEM = "npm";
     
     /**
      * The phase that this analyzer is intended to run in.
@@ -127,7 +127,7 @@ public class NodePackageAnalyzer extends AbstractFileTypeAnalyzer {
 
     @Override
     protected void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
-        dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
+        dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
     		final File file = dependency.getActualFile();
         if (!file.isFile() || file.length()==0) {
             return;

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
@@ -57,10 +57,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Experimental
 public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
 
-    /**
-     * A descriptor for the type of dependencies processed or added by this analyzer
-     */
-    public static final String DEPENDENCY_ECOSYSTEM = "Python.Dist";
+	/**
+	 * A descriptor for the type of dependencies processed or added by this analyzer
+	 */
+	public static final String DEPENDENCY_ECOSYSTEM = "Python.Dist";
     
     /**
      * Name of egg metadata files to analyze.
@@ -189,7 +189,7 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
     	
-    	    dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
+		dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
         final File actualFile = dependency.getActualFile();
         if (WHL_FILTER.accept(actualFile)) {
             collectMetadataFromArchiveFormat(dependency, DIST_INFO_FILTER,
@@ -304,11 +304,9 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
                 "Version", Confidence.HIGHEST);
         addPropertyToEvidence(headers, dependency.getProductEvidence(), "Name",
                 Confidence.HIGHEST);
-        
-        dependency.setName(headers.getHeader("Name", null));
-        dependency.setVersion(headers.getHeader("Version", null));
-        
-        final String url = headers.getHeader("Home-page", null);
+		dependency.setName(headers.getHeader("Name", null));
+		dependency.setVersion(headers.getHeader("Version", null));
+		final String url = headers.getHeader("Home-page", null);
         final EvidenceCollection vendorEvidence = dependency
                 .getVendorEvidence();
         if (StringUtils.isNotBlank(url)) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
@@ -58,14 +58,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
 
     /**
+     * A descriptor for the type of dependencies processed or added by this analyzer
+     */
+    public static final String DEPENDENCY_ECOSYSTEM = "Python.Dist";
+    
+    /**
      * Name of egg metadata files to analyze.
      */
     private static final String PKG_INFO = "PKG-INFO";
-    
-    /**
-     * The dependency Ecosystem
-     */
-     static final String DEPENDENCY_ECOSYSTEM = "Python.Dist";
 
     /**
      * Name of wheel metadata files to analyze.
@@ -189,7 +189,7 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
     	
-    	    dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
+    	    dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
         final File actualFile = dependency.getActualFile();
         if (WHL_FILTER.accept(actualFile)) {
             collectMetadataFromArchiveFormat(dependency, DIST_INFO_FILTER,

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
@@ -61,6 +61,11 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
      * Name of egg metadata files to analyze.
      */
     private static final String PKG_INFO = "PKG-INFO";
+    
+    /**
+     * The dependency Ecosystem
+     */
+     static final String DEPENDENCY_ECOSYSTEM = "Python.Dist";
 
     /**
      * Name of wheel metadata files to analyze.
@@ -183,6 +188,8 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
     @Override
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
+    	
+    	    dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
         final File actualFile = dependency.getActualFile();
         if (WHL_FILTER.accept(actualFile)) {
             collectMetadataFromArchiveFormat(dependency, DIST_INFO_FILTER,
@@ -196,7 +203,6 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
             if (metadata || PKG_INFO.equals(name)) {
                 final File parent = actualFile.getParentFile();
                 final String parentName = parent.getName();
-                dependency.setDisplayFileName(parentName + "/" + name);
                 if (parent.isDirectory()
                         && (metadata && parentName.endsWith(".dist-info")
                         || parentName.endsWith(".egg-info") || "EGG-INFO"
@@ -298,6 +304,10 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
                 "Version", Confidence.HIGHEST);
         addPropertyToEvidence(headers, dependency.getProductEvidence(), "Name",
                 Confidence.HIGHEST);
+        
+        dependency.setName(headers.getHeader("Name", null));
+        dependency.setVersion(headers.getHeader("Version", null));
+        
         final String url = headers.getHeader("Home-page", null);
         final EvidenceCollection vendorEvidence = dependency
                 .getVendorEvidence();

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
@@ -47,10 +47,10 @@ import org.owasp.dependencycheck.exception.InitializationException;
 public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
 
 	/**
-     * A descriptor for the type of dependencies processed or added by this analyzer
-     */
-    public static final String DEPENDENCY_ECOSYSTEM = "Python.Pkg";
-    
+	 * A descriptor for the type of dependencies processed or added by this analyzer
+	 */
+	public static final String DEPENDENCY_ECOSYSTEM = "Python.Pkg";
+
     /**
      * Used when compiling file scanning regex patterns.
      */
@@ -178,7 +178,7 @@ public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
     @Override
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
-        dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
+		dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
     	    final File file = dependency.getActualFile();
         final File parent = file.getParentFile();
         final String parentName = parent.getName();
@@ -186,7 +186,7 @@ public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
             //by definition, the containing folder of __init__.py is considered the package, even the file is empty:
             //"The __init__.py files are required to make Python treat the directories as containing packages"
             //see section "6.4 Packages" from https://docs.python.org/2/tutorial/modules.html;
-            dependency.setName(parentName);
+			dependency.setName(parentName);
             dependency.getProductEvidence().addEvidence(file.getName(),
                     "PackageName", parentName, Confidence.HIGHEST);
 
@@ -329,17 +329,16 @@ public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
      * @param confidence in evidence
      * @return whether evidence was found
      */
-    private boolean gatherVersionEvidence(Pattern pattern, String contents,
-            String source, EvidenceCollection evidence, String name,
-            Confidence confidence,Dependency d) {
-        final Matcher matcher = pattern.matcher(contents);
-        final boolean found = matcher.find();
-        if (found) {
-            evidence.addEvidence(source, name, matcher.group(4), confidence);
-            d.setVersion(matcher.group(4));
-        }
-        return found;
-    }
+	private boolean gatherVersionEvidence(Pattern pattern, String contents, String source, EvidenceCollection evidence,
+			String name, Confidence confidence, Dependency d) {
+		final Matcher matcher = pattern.matcher(contents);
+		final boolean found = matcher.find();
+		if (found) {
+			evidence.addEvidence(source, name, matcher.group(4), confidence);
+			d.setVersion(matcher.group(4));
+		}
+		return found;
+	}
 
     @Override
     protected String getAnalyzerEnabledSettingKey() {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
@@ -46,6 +46,11 @@ import org.owasp.dependencycheck.exception.InitializationException;
 @Experimental
 public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
 
+	/**
+     * A descriptor for the type of dependencies processed or added by this analyzer
+     */
+    public static final String DEPENDENCY_ECOSYSTEM = "Python.Pkg";
+    
     /**
      * Used when compiling file scanning regex patterns.
      */
@@ -111,11 +116,6 @@ public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
     private static final FileFilter FILTER = FileFilterBuilder.newInstance().addExtensions(EXTENSIONS).build();
     
     /**
-     * The dependency Ecosystem
-     */
-     static final String DEPENDENCY_ECOSYSTEM = "Python.Pkg";
-    
-    /**
      * Returns the name of the Python Package Analyzer.
      *
      * @return the name of the analyzer
@@ -178,7 +178,7 @@ public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
     @Override
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
-        dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
+        dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
     	    final File file = dependency.getActualFile();
         final File parent = file.getParentFile();
         final String parentName = parent.getName();

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundlerAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundlerAnalyzer.java
@@ -53,7 +53,10 @@ public class RubyBundlerAnalyzer extends RubyGemspecAnalyzer {
      * The name of the analyzer.
      */
     private static final String ANALYZER_NAME = "Ruby Bundler Analyzer";
-
+    /**
+     * The types of files on which this will work.
+     */
+    static final String DEPENDENCY_ECOSYSTEM = "Ruby.Bundle";
     /**
      * Folder name that contains .gemspec files created by "bundle install"
      */
@@ -97,7 +100,7 @@ public class RubyBundlerAnalyzer extends RubyGemspecAnalyzer {
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
         super.analyzeDependency(dependency, engine);
-
+        dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
         //find the corresponding gem folder for this .gemspec stub by "bundle install --deployment"
         final File gemspecFile = dependency.getActualFile();
         final String gemFileName = gemspecFile.getName();

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundlerAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundlerAnalyzer.java
@@ -50,13 +50,15 @@ import org.owasp.dependencycheck.dependency.Dependency;
 public class RubyBundlerAnalyzer extends RubyGemspecAnalyzer {
 
     /**
+     * A descriptor for the type of dependencies processed or added by this analyzer
+     */
+    public static final String DEPENDENCY_ECOSYSTEM = "Ruby.Bundle";
+    
+    /**
      * The name of the analyzer.
      */
     private static final String ANALYZER_NAME = "Ruby Bundler Analyzer";
-    /**
-     * The types of files on which this will work.
-     */
-    static final String DEPENDENCY_ECOSYSTEM = "Ruby.Bundle";
+
     /**
      * Folder name that contains .gemspec files created by "bundle install"
      */
@@ -100,7 +102,7 @@ public class RubyBundlerAnalyzer extends RubyGemspecAnalyzer {
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
         super.analyzeDependency(dependency, engine);
-        dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
+        dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
         //find the corresponding gem folder for this .gemspec stub by "bundle install --deployment"
         final File gemspecFile = dependency.getActualFile();
         final String gemFileName = gemspecFile.getName();

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzer.java
@@ -52,7 +52,7 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
 	 * A descriptor for the type of dependencies processed or added by this analyzer
 	 */
 	public static final String DEPENDENCY_ECOSYSTEM = "Ruby.Bundle";
-  
+
 	/**
      * The logger.
      */

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzer.java
@@ -49,10 +49,10 @@ import org.slf4j.LoggerFactory;
 public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
 
 	/**
-     * A descriptor for the type of dependencies processed or added by this analyzer
-     */
-    public static final String DEPENDENCY_ECOSYSTEM = "Ruby.Bundle";
-    
+	 * A descriptor for the type of dependencies processed or added by this analyzer
+	 */
+	public static final String DEPENDENCY_ECOSYSTEM = "Ruby.Bundle";
+  
 	/**
      * The logger.
      */
@@ -137,7 +137,7 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
     @Override
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
-    	    dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
+		dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
         String contents;
         try {
             contents = FileUtils.readFileToString(dependency.getActualFile(), Charset.defaultCharset());
@@ -153,10 +153,10 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
             final EvidenceCollection vendor = dependency.getVendorEvidence();
             final EvidenceCollection product = dependency.getProductEvidence();
             final String name = addStringEvidence(product, contents, blockVariable, "name", "name", Confidence.HIGHEST);
-            if (!name.isEmpty()) {
-            		dependency.setName(name);
-                vendor.addEvidence(GEMSPEC, "name_project", name + "_project", Confidence.LOW);
-            }
+			if (!name.isEmpty()) {
+				dependency.setName(name);
+				vendor.addEvidence(GEMSPEC, "name_project", name + "_project", Confidence.LOW);
+			}
             addStringEvidence(product, contents, blockVariable, "summary", "summary", Confidence.LOW);
 
             addStringEvidence(vendor, contents, blockVariable, "author", "authors?", Confidence.HIGHEST);
@@ -164,17 +164,15 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
             addStringEvidence(vendor, contents, blockVariable, "homepage", "homepage", Confidence.HIGHEST);
             addStringEvidence(vendor, contents, blockVariable, "license", "licen[cs]es?", Confidence.HIGHEST);
 
-            final String value = addStringEvidence(dependency.getVersionEvidence(), contents,
-                    blockVariable, "version", "version", Confidence.HIGHEST);            
+			final String value = addStringEvidence(dependency.getVersionEvidence(), contents, blockVariable, "version",
+					"version", Confidence.HIGHEST);          
             if (value.length() < 1) {
                 addEvidenceFromVersionFile(dependency.getActualFile(), dependency.getVersionEvidence());
             }
-            else
-            {
-            		dependency.setVersion(value);
-            }
+			else {
+				dependency.setVersion(value);
+			}
         }
-
         setPackagePath(dependency);
     }
 

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzer.java
@@ -48,7 +48,12 @@ import org.slf4j.LoggerFactory;
 @Experimental
 public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
 
-    /**
+	/**
+     * A descriptor for the type of dependencies processed or added by this analyzer
+     */
+    public static final String DEPENDENCY_ECOSYSTEM = "Ruby.Bundle";
+    
+	/**
      * The logger.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(RubyGemspecAnalyzer.class);
@@ -56,10 +61,7 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
      * The name of the analyzer.
      */
     private static final String ANALYZER_NAME = "Ruby Gemspec Analyzer";
-    /**
-     * The Dependency's ecosystem.
-     */
-    static final String DEPENDENCY_ECOSYSTEM = "Ruby.Bundle";
+    
     /**
      * The phase that this analyzer is intended to run in.
      */
@@ -135,7 +137,7 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
     @Override
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
-    	    dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
+    	    dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
         String contents;
         try {
             contents = FileUtils.readFileToString(dependency.getActualFile(), Charset.defaultCharset());

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzer.java
@@ -56,7 +56,10 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
      * The name of the analyzer.
      */
     private static final String ANALYZER_NAME = "Ruby Gemspec Analyzer";
-
+    /**
+     * The Dependency's ecosystem.
+     */
+    static final String DEPENDENCY_ECOSYSTEM = "Ruby.Bundle";
     /**
      * The phase that this analyzer is intended to run in.
      */
@@ -132,6 +135,7 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
     @Override
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
+    	    dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);
         String contents;
         try {
             contents = FileUtils.readFileToString(dependency.getActualFile(), Charset.defaultCharset());
@@ -148,6 +152,7 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
             final EvidenceCollection product = dependency.getProductEvidence();
             final String name = addStringEvidence(product, contents, blockVariable, "name", "name", Confidence.HIGHEST);
             if (!name.isEmpty()) {
+            		dependency.setName(name);
                 vendor.addEvidence(GEMSPEC, "name_project", name + "_project", Confidence.LOW);
             }
             addStringEvidence(product, contents, blockVariable, "summary", "summary", Confidence.LOW);
@@ -158,9 +163,13 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
             addStringEvidence(vendor, contents, blockVariable, "license", "licen[cs]es?", Confidence.HIGHEST);
 
             final String value = addStringEvidence(dependency.getVersionEvidence(), contents,
-                    blockVariable, "version", "version", Confidence.HIGHEST);
+                    blockVariable, "version", "version", Confidence.HIGHEST);            
             if (value.length() < 1) {
                 addEvidenceFromVersionFile(dependency.getActualFile(), dependency.getVersionEvidence());
+            }
+            else
+            {
+            		dependency.setVersion(value);
             }
         }
 

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageManagerAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageManagerAnalyzer.java
@@ -47,6 +47,11 @@ public class SwiftPackageManagerAnalyzer extends AbstractFileTypeAnalyzer {
      * The name of the analyzer.
      */
     private static final String ANALYZER_NAME = "SWIFT Package Manager Analyzer";
+    
+    /**
+     * The dependency Ecosystem
+     */
+    static final String DEPENDENCY_ECOSYSTEM = "Swift.PM";
 
     /**
      * The phase that this analyzer is intended to run in.
@@ -119,6 +124,8 @@ public class SwiftPackageManagerAnalyzer extends AbstractFileTypeAnalyzer {
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
 
+    	    dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);   
+    	
         String contents;
         try {
             contents = FileUtils.readFileToString(dependency.getActualFile(), Charset.defaultCharset());
@@ -141,11 +148,13 @@ public class SwiftPackageManagerAnalyzer extends AbstractFileTypeAnalyzer {
             final String name = addStringEvidence(product, packageDescription, "name", "name", Confidence.HIGHEST);
             if (name != null && !name.isEmpty()) {
                 vendor.addEvidence(SPM_FILE_NAME, "name_project", name, Confidence.HIGHEST);
+                dependency.setName(name);
             }
-            
-            final File actual = dependency.getActualFile();
-            final String parentName = actual.getParentFile().getName();
-            dependency.setDisplayFileName(parentName + "/" + actual.getName());
+            else
+            {
+            	    //if we can't get the name from the meta, then assume the name is the name of the parent folder containing the package.swift file.
+            		dependency.setName(dependency.getActualFile().getParentFile().getName());
+            }
         }
         setPackagePath(dependency);
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageManagerAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageManagerAnalyzer.java
@@ -142,6 +142,10 @@ public class SwiftPackageManagerAnalyzer extends AbstractFileTypeAnalyzer {
             if (name != null && !name.isEmpty()) {
                 vendor.addEvidence(SPM_FILE_NAME, "name_project", name, Confidence.HIGHEST);
             }
+            
+            final File actual = dependency.getActualFile();
+            final String parentName = actual.getParentFile().getName();
+            dependency.setDisplayFileName(parentName + "/" + actual.getName());
         }
         setPackagePath(dependency);
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageManagerAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageManagerAnalyzer.java
@@ -43,11 +43,11 @@ import org.owasp.dependencycheck.utils.Settings;
 @Experimental
 public class SwiftPackageManagerAnalyzer extends AbstractFileTypeAnalyzer {
 
-    /**
-     * A descriptor for the type of dependencies processed or added by this analyzer
-     */
-    public static final String DEPENDENCY_ECOSYSTEM = "Swift.PM";
-    
+	/**
+	 * A descriptor for the type of dependencies processed or added by this analyzer
+	 */
+	public static final String DEPENDENCY_ECOSYSTEM = "Swift.PM";
+
     /**
      * The name of the analyzer.
      */
@@ -124,8 +124,8 @@ public class SwiftPackageManagerAnalyzer extends AbstractFileTypeAnalyzer {
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
 
-    	    dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);   
-    	
+		dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
+  	
         String contents;
         try {
             contents = FileUtils.readFileToString(dependency.getActualFile(), Charset.defaultCharset());
@@ -143,18 +143,19 @@ public class SwiftPackageManagerAnalyzer extends AbstractFileTypeAnalyzer {
             final EvidenceCollection product = dependency.getProductEvidence();
             final EvidenceCollection vendor = dependency.getVendorEvidence();
 
-            //SPM is currently under development for SWIFT 3. Its current metadata includes package name and dependencies.
-            //Future interesting metadata: version, license, homepage, author, summary, etc.
-            final String name = addStringEvidence(product, packageDescription, "name", "name", Confidence.HIGHEST);
-            if (name != null && !name.isEmpty()) {
-                vendor.addEvidence(SPM_FILE_NAME, "name_project", name, Confidence.HIGHEST);
-                dependency.setName(name);
-            }
-            else
-            {
-            	    //if we can't get the name from the meta, then assume the name is the name of the parent folder containing the package.swift file.
-            		dependency.setName(dependency.getActualFile().getParentFile().getName());
-            }
+			// SPM is currently under development for SWIFT 3. Its current metadata includes
+			// package name and dependencies.
+			// Future interesting metadata: version, license, homepage, author, summary,
+			// etc.
+			final String name = addStringEvidence(product, packageDescription, "name", "name", Confidence.HIGHEST);
+			if (name != null && !name.isEmpty()) {
+				vendor.addEvidence(SPM_FILE_NAME, "name_project", name, Confidence.HIGHEST);
+				dependency.setName(name);
+			} else {
+				// if we can't get the name from the meta, then assume the name is the name of
+				// the parent folder containing the package.swift file.
+				dependency.setName(dependency.getActualFile().getParentFile().getName());
+			}
         }
         setPackagePath(dependency);
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageManagerAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageManagerAnalyzer.java
@@ -44,14 +44,14 @@ import org.owasp.dependencycheck.utils.Settings;
 public class SwiftPackageManagerAnalyzer extends AbstractFileTypeAnalyzer {
 
     /**
+     * A descriptor for the type of dependencies processed or added by this analyzer
+     */
+    public static final String DEPENDENCY_ECOSYSTEM = "Swift.PM";
+    
+    /**
      * The name of the analyzer.
      */
     private static final String ANALYZER_NAME = "SWIFT Package Manager Analyzer";
-    
-    /**
-     * The dependency Ecosystem
-     */
-    static final String DEPENDENCY_ECOSYSTEM = "Swift.PM";
 
     /**
      * The phase that this analyzer is intended to run in.
@@ -124,7 +124,7 @@ public class SwiftPackageManagerAnalyzer extends AbstractFileTypeAnalyzer {
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
 
-    	    dependency.setDependencyEcosystem(DEPENDENCY_ECOSYSTEM);   
+    	    dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);   
     	
         String contents;
         try {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/composer/ComposerLockParser.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/composer/ComposerLockParser.java
@@ -58,7 +58,7 @@ public class ComposerLockParser {
      * @param inputStream the InputStream to parse
      */
     public ComposerLockParser(InputStream inputStream) {
-        LOGGER.info("Creating a ComposerLockParser");
+        LOGGER.debug("Creating a ComposerLockParser");
         this.jsonReader = Json.createReader(inputStream);
         this.composerDependencies = new ArrayList<>();
     }
@@ -67,7 +67,7 @@ public class ComposerLockParser {
      * Process the input stream to create the list of dependencies.
      */
     public void process() {
-        LOGGER.info("Beginning Composer lock processing");
+        LOGGER.debug("Beginning Composer lock processing");
         try {
             final JsonObject composer = jsonReader.readObject();
             if (composer.containsKey("packages")) {

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -142,6 +142,21 @@ public class Dependency implements Serializable, Comparable<Dependency> {
      * Defines an actual or virtual dependency.
      */
     private boolean isVirtual = false;
+    
+    /**
+     * Defines the human-recognizable name for the dependency
+     */
+    private String name;
+    
+    /**
+     * Defines the human-recognizable version for the dependency
+     */
+    private String version;
+    
+    /**
+     * Defines the ecosystem identifier for this dependency
+     */
+    private String dependencyEcosystem;
 
     /**
      * Returns the package path.
@@ -283,13 +298,24 @@ public class Dependency implements Serializable, Comparable<Dependency> {
 
     /**
      * Returns the file name to display in reports; if no display file name has
-     * been set it will default to the actual file name.
+     * been set it will default to constructing a name based on the name and version 
+     * fields, otherwise it will return the actual file name.
      *
      * @return the file name to display
      */
     public String getDisplayFileName() {
         if (displayName == null) {
-            return this.fileName;
+        	   if(name != null) {
+        		   if (version != null) {
+        			   return name + ":" + version;
+        		   }
+        		   else {
+        			   return name;
+        		   }
+        	   }	   
+        	   else { 
+        		   return this.fileName;
+        	   }	   
         }
         return this.displayName;
     }
@@ -582,6 +608,20 @@ public class Dependency implements Serializable, Comparable<Dependency> {
     }
 
     /**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
      * Get the list of vulnerabilities.
      *
      * @return the list of vulnerabilities
@@ -830,4 +870,32 @@ public class Dependency implements Serializable, Comparable<Dependency> {
         return "Dependency{ fileName='" + fileName + "', actualFilePath='" + actualFilePath
                 + "', filePath='" + filePath + "', packagePath='" + packagePath + "'}";
     }
+
+	/**
+	 * @return the version
+	 */
+	public String getVersion() {
+		return version;
+	}
+
+	/**
+	 * @param version the version to set
+	 */
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	/**
+	 * @return the dependencyEcosystem
+	 */
+	public String getDependencyEcosystem() {
+		return dependencyEcosystem;
+	}
+
+	/**
+	 * @param dependencyEcosystem the dependencyEcosystem to set
+	 */
+	public void setDependencyEcosystem(String dependencyEcosystem) {
+		this.dependencyEcosystem = dependencyEcosystem;
+	}
 }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -154,9 +154,10 @@ public class Dependency implements Serializable, Comparable<Dependency> {
     private String version;
     
     /**
-     * Defines the ecosystem identifier for this dependency
+     * A descriptor for the type of dependency based on which analyzer added it
+     * or collected evidence about it
      */
-    private String dependencyEcosystem;
+    private String ecosystem;
 
     /**
      * Returns the package path.
@@ -886,16 +887,16 @@ public class Dependency implements Serializable, Comparable<Dependency> {
 	}
 
 	/**
-	 * @return the dependencyEcosystem
+	 * @return the ecosystem
 	 */
-	public String getDependencyEcosystem() {
-		return dependencyEcosystem;
+	public String getEcosystem() {
+		return ecosystem;
 	}
 
 	/**
-	 * @param dependencyEcosystem the dependencyEcosystem to set
+	 * @param ecosystem the ecosystem to set
 	 */
-	public void setDependencyEcosystem(String dependencyEcosystem) {
-		this.dependencyEcosystem = dependencyEcosystem;
+	public void setEcosystem(String ecosystem) {
+		this.ecosystem = ecosystem;
 	}
 }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -304,22 +304,18 @@ public class Dependency implements Serializable, Comparable<Dependency> {
      *
      * @return the file name to display
      */
-    public String getDisplayFileName() {
-        if (displayName == null) {
-        	   if(name != null) {
-        		   if (version != null) {
-        			   return name + ":" + version;
-        		   }
-        		   else {
-        			   return name;
-        		   }
-        	   }	   
-        	   else { 
-        		   return this.fileName;
-        	   }	   
-        }
-        return this.displayName;
-    }
+	public String getDisplayFileName() {
+		if (displayName != null) {
+			return displayName;
+		}
+		if (name == null) {
+			return fileName;
+		}
+		if (version == null) {
+			return name;
+		}
+		return name + ":" + version;
+	}
 
     /**
      * <p>
@@ -880,7 +876,8 @@ public class Dependency implements Serializable, Comparable<Dependency> {
 	}
 
 	/**
-	 * @param version the version to set
+	 * @param version
+	 *            the version to set
 	 */
 	public void setVersion(String version) {
 		this.version = version;
@@ -894,7 +891,8 @@ public class Dependency implements Serializable, Comparable<Dependency> {
 	}
 
 	/**
-	 * @param ecosystem the ecosystem to set
+	 * @param ecosystem
+	 *            the ecosystem to set
 	 */
 	public void setEcosystem(String ecosystem) {
 		this.ecosystem = ecosystem;

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzerTest.java
@@ -139,17 +139,15 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
         analyzer.analyze(result, null);
         
         //this one finds nothing so it falls through to the filename. Can we do better?
-        assertEquals("OpenCVDetectPython.cmake",result.getDisplayFileName());
-        
-        
+        assertEquals("OpenCVDetectPython.cmake",result.getDisplayFileName());       
     }
     
-    private void assertProductEvidence(Dependency result, String product) {
-    		assertEquals(product,result.getName());
-    	    assertTrue("Expected product evidence to contain \"" + product + "\".",
-                result.getProductEvidence().toString().contains(product));
-        assertEquals(CMakeAnalyzer.DEPENDENCY_ECOSYSTEM,result.getEcosystem());
-    }
+	private void assertProductEvidence(Dependency result, String product) {
+		assertEquals(product, result.getName());
+		assertTrue("Expected product evidence to contain \"" + product + "\".",
+				result.getProductEvidence().toString().contains(product));
+		assertEquals(CMakeAnalyzer.DEPENDENCY_ECOSYSTEM, result.getEcosystem());
+	}
 
     /**
      * Test whether expected version evidence is gathered from OpenCV's third party cmake files.
@@ -170,8 +168,7 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
         assertEquals("Number of additional dependencies should be 4.", 4, dependencies.size());
         final Dependency last = dependencies.get(3);
         assertProductEvidence(last, "libavresample");
-        assertVersionEvidence(last, "1.0.1");
-        
+        assertVersionEvidence(last, "1.0.1");      
     }
 
     private void assertVersionEvidence(Dependency result, String version) {

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzerTest.java
@@ -123,11 +123,32 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
         analyzer.analyze(result, null);
         final String product = "zlib";
         assertProductEvidence(result, product);
+        
+        
     }
 
+    /**
+     * Test whether expected evidence is gathered from OpenCV's CVDetectPython.
+     *
+     * @throws AnalysisException is thrown when an exception occurs.
+     */
+    @Test
+    public void testAnalyzeCMakeListsPython() throws AnalysisException {
+        final Dependency result = new Dependency(BaseTest.getResourceAsFile(
+                this, "cmake/opencv/cmake/OpenCVDetectPython.cmake"));
+        analyzer.analyze(result, null);
+        
+        //this one finds nothing so it falls through to the filename. Can we do better?
+        assertEquals("OpenCVDetectPython.cmake",result.getDisplayFileName());
+        
+        
+    }
+    
     private void assertProductEvidence(Dependency result, String product) {
-        assertTrue("Expected product evidence to contain \"" + product + "\".",
+    		assertEquals(product,result.getName());
+    	    assertTrue("Expected product evidence to contain \"" + product + "\".",
                 result.getProductEvidence().toString().contains(product));
+        assertEquals(CMakeAnalyzer.DEPENDENCY_ECOSYSTEM,result.getDependencyEcosystem());
     }
 
     /**
@@ -150,11 +171,13 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
         final Dependency last = dependencies.get(3);
         assertProductEvidence(last, "libavresample");
         assertVersionEvidence(last, "1.0.1");
+        
     }
 
     private void assertVersionEvidence(Dependency result, String version) {
         assertTrue("Expected version evidence to contain \"" + version + "\".",
                 result.getVersionEvidence().toString().contains(version));
+        assertEquals(version,result.getVersion());
     }
 
     @Test(expected = InitializationException.class)

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzerTest.java
@@ -148,7 +148,7 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
     		assertEquals(product,result.getName());
     	    assertTrue("Expected product evidence to contain \"" + product + "\".",
                 result.getProductEvidence().toString().contains(product));
-        assertEquals(CMakeAnalyzer.DEPENDENCY_ECOSYSTEM,result.getDependencyEcosystem());
+        assertEquals(CMakeAnalyzer.DEPENDENCY_ECOSYSTEM,result.getEcosystem());
     }
 
     /**

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
@@ -130,7 +130,7 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
         assertEquals("classpreloader",d.getName());
         assertEquals("2.0.0",d.getVersion());
         assertThat(d.getDisplayFileName(),equalTo("classpreloader:2.0.0"));
-        assertEquals(ComposerLockAnalyzer.DEPENDENCY_ECOSYSTEM,d.getDependencyEcosystem());
+        assertEquals(ComposerLockAnalyzer.DEPENDENCY_ECOSYSTEM,d.getEcosystem());
     }
     
 

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
@@ -91,6 +91,25 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
     }
 
     /**
+     * Test of basic additions to the depdnency list by parsing the composer.lock file
+     *
+     * @throws AnalysisException is thrown when an exception occurs.
+     */
+    @Test
+    public void testRemoveRedundantParent() throws Exception {
+        final Engine engine = new Engine();
+
+        final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
+                "composer.lock"));
+        ///test that we don't remove the parent if it's not redundant by name
+        result.setDisplayFileName("NotComposer.Lock");
+        engine.getDependencies().add(result);
+        analyzer.analyze(result, engine);
+        //make sure the composer.lock is not removed
+        assertTrue(engine.getDependencies().contains(result));
+    }
+
+    /**
      * Test of inspect method, of class PythonDistributionAnalyzer.
      *
      * @throws AnalysisException is thrown when an exception occurs.
@@ -98,13 +117,18 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
     @Test
     public void testAnalyzePackageJson() throws Exception {
         final Engine engine = new Engine();
+
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "composer.lock"));
+        //simulate normal operation when the composer.lock is already added to the engine as a dependency
+        engine.getDependencies().add(result);
         analyzer.analyze(result, engine);
+        //make sure the redundant composer.lock is removed
+        assertFalse(engine.getDependencies().contains(result));
         assertEquals(30,engine.getDependencies().size());
         assertThat(engine.getDependencies().get(0).getDisplayFileName(),equalTo("composer.lock:classpreloader/classpreloader/2.0.0"));
     }
-
+    
 
     @Test(expected = InitializationException.class)
     public void analyzerIsDisabledInCaseOfMissingMessageDigest() throws InitializationException {

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
@@ -126,7 +126,11 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
         //make sure the redundant composer.lock is removed
         assertFalse(engine.getDependencies().contains(result));
         assertEquals(30,engine.getDependencies().size());
-        assertThat(engine.getDependencies().get(0).getDisplayFileName(),equalTo("composer.lock:classpreloader/classpreloader/2.0.0"));
+        Dependency d = engine.getDependencies().get(0);
+        assertEquals("classpreloader",d.getName());
+        assertEquals("2.0.0",d.getVersion());
+        assertThat(d.getDisplayFileName(),equalTo("classpreloader:2.0.0"));
+        assertEquals(ComposerLockAnalyzer.DEPENDENCY_ECOSYSTEM,d.getDependencyEcosystem());
     }
     
 

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
@@ -36,6 +36,8 @@ import java.security.NoSuchAlgorithmException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 /**
  * Unit tests for NodePackageAnalyzer.
@@ -89,6 +91,25 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
     }
 
     /**
+     * Test of basic additions to the depdnency list by parsing the composer.lock file
+     *
+     * @throws AnalysisException is thrown when an exception occurs.
+     */
+    @Test
+    public void testRemoveRedundantParent() throws Exception {
+        final Engine engine = new Engine();
+
+        final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
+                "composer.lock"));
+        ///test that we don't remove the parent if it's not redundant by name
+        result.setDisplayFileName("NotComposer.Lock");
+        engine.getDependencies().add(result);
+        analyzer.analyze(result, engine);
+        //make sure the composer.lock is not removed
+        assertTrue(engine.getDependencies().contains(result));
+    }
+
+    /**
      * Test of inspect method, of class PythonDistributionAnalyzer.
      *
      * @throws AnalysisException is thrown when an exception occurs.
@@ -96,11 +117,18 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
     @Test
     public void testAnalyzePackageJson() throws Exception {
         final Engine engine = new Engine();
+
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "composer.lock"));
+        //simulate normal operation when the composer.lock is already added to the engine as a dependency
+        engine.getDependencies().add(result);
         analyzer.analyze(result, engine);
+        //make sure the redundant composer.lock is removed
+        assertFalse(engine.getDependencies().contains(result));
+        assertEquals(30,engine.getDependencies().size());
+        assertThat(engine.getDependencies().get(0).getDisplayFileName(),equalTo("composer.lock:classpreloader/classpreloader/2.0.0"));
     }
-
+    
 
     @Test(expected = InitializationException.class)
     public void analyzerIsDisabledInCaseOfMissingMessageDigest() throws InitializationException {

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
@@ -36,6 +36,8 @@ import java.security.NoSuchAlgorithmException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 /**
  * Unit tests for NodePackageAnalyzer.
@@ -99,6 +101,8 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "composer.lock"));
         analyzer.analyze(result, engine);
+        assertEquals(30,engine.getDependencies().size());
+        assertThat(engine.getDependencies().get(0).getDisplayFileName(),equalTo("composer.lock:classpreloader/classpreloader/2.0.0"));
     }
 
 

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
@@ -101,7 +101,7 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
 
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "composer.lock"));
-        ///test that we don't remove the parent if it's not redundant by name
+        //test that we don't remove the parent if it's not redundant by name
         result.setDisplayFileName("NotComposer.Lock");
         engine.getDependencies().add(result);
         analyzer.analyze(result, engine);

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/JarAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/JarAnalyzerTest.java
@@ -58,7 +58,7 @@ public class JarAnalyzerTest extends BaseTest {
         file = BaseTest.getResourceAsFile(this, "dwr.jar");
         result = new Dependency(file);
         instance.analyze(result, null);
-        assertEquals(JarAnalyzer.DEPENDENCY_ECOSYSTEM,result.getDependencyEcosystem());
+        assertEquals(JarAnalyzer.DEPENDENCY_ECOSYSTEM,result.getEcosystem());
         boolean found = false;
         for (Evidence e : result.getVendorEvidence()) {
             if (e.getName().equals("url")) {

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/JarAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/JarAnalyzerTest.java
@@ -58,6 +58,7 @@ public class JarAnalyzerTest extends BaseTest {
         file = BaseTest.getResourceAsFile(this, "dwr.jar");
         result = new Dependency(file);
         instance.analyze(result, null);
+        assertEquals(JarAnalyzer.DEPENDENCY_ECOSYSTEM,result.getDependencyEcosystem());
         boolean found = false;
         for (Evidence e : result.getVendorEvidence()) {
             if (e.getName().equals("url")) {

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzerTest.java
@@ -96,7 +96,7 @@ public class NodePackageAnalyzerTest extends BaseTest {
         assertThat(vendorString, containsString("dns-sync_project"));
         assertThat(result.getProductEvidence().toString(), containsString("dns-sync"));
         assertThat(result.getVersionEvidence().toString(), containsString("0.1.0"));
-        assertEquals(NodePackageAnalyzer.DEPENDENCY_ECOSYSTEM,result.getDependencyEcosystem());
+        assertEquals(NodePackageAnalyzer.DEPENDENCY_ECOSYSTEM,result.getEcosystem());
         assertEquals("dns-sync",result.getName());
         assertEquals("0.1.0",result.getVersion());
     }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzerTest.java
@@ -96,5 +96,8 @@ public class NodePackageAnalyzerTest extends BaseTest {
         assertThat(vendorString, containsString("dns-sync_project"));
         assertThat(result.getProductEvidence().toString(), containsString("dns-sync"));
         assertThat(result.getVersionEvidence().toString(), containsString("0.1.0"));
+        assertEquals(NodePackageAnalyzer.DEPENDENCY_ECOSYSTEM,result.getDependencyEcosystem());
+        assertEquals("dns-sync",result.getName());
+        assertEquals("0.1.0",result.getVersion());
     }
 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzerTest.java
@@ -115,8 +115,7 @@ public class PythonDistributionAnalyzerTest extends BaseTest {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                 this, "python/site-packages/Django-1.7.2.dist-info/METADATA"));
         djangoAssertions(result);
-        assertEquals("Django-1.7.2.dist-info/METADATA", result.getDisplayFileName());
-    }
+        }
 
     private void djangoAssertions(final Dependency result)
             throws AnalysisException {
@@ -131,6 +130,10 @@ public class PythonDistributionAnalyzerTest extends BaseTest {
             }
         }
         assertTrue("Version 1.7.2 not found in Django dependency.", found);
+        assertEquals("1.7.2",result.getVersion());
+        assertEquals("Django",result.getName());
+        assertEquals("Django:1.7.2",result.getDisplayFileName());
+        assertEquals(PythonDistributionAnalyzer.DEPENDENCY_ECOSYSTEM,result.getDependencyEcosystem());
     }
 
     @Test
@@ -183,5 +186,9 @@ public class PythonDistributionAnalyzerTest extends BaseTest {
             }
         }
         assertTrue("Version 0.0.1 not found in EggTest dependency.", found);
+        assertEquals("0.0.1",result.getVersion());
+        assertEquals("EggTest",result.getName());
+        assertEquals("EggTest:0.0.1",result.getDisplayFileName());
+        assertEquals(PythonDistributionAnalyzer.DEPENDENCY_ECOSYSTEM,result.getDependencyEcosystem());
     }
 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzerTest.java
@@ -133,7 +133,7 @@ public class PythonDistributionAnalyzerTest extends BaseTest {
         assertEquals("1.7.2",result.getVersion());
         assertEquals("Django",result.getName());
         assertEquals("Django:1.7.2",result.getDisplayFileName());
-        assertEquals(PythonDistributionAnalyzer.DEPENDENCY_ECOSYSTEM,result.getDependencyEcosystem());
+        assertEquals(PythonDistributionAnalyzer.DEPENDENCY_ECOSYSTEM,result.getEcosystem());
     }
 
     @Test
@@ -189,6 +189,6 @@ public class PythonDistributionAnalyzerTest extends BaseTest {
         assertEquals("0.0.1",result.getVersion());
         assertEquals("EggTest",result.getName());
         assertEquals("EggTest:0.0.1",result.getDisplayFileName());
-        assertEquals(PythonDistributionAnalyzer.DEPENDENCY_ECOSYSTEM,result.getDependencyEcosystem());
+        assertEquals(PythonDistributionAnalyzer.DEPENDENCY_ECOSYSTEM,result.getEcosystem());
     }
 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzerTest.java
@@ -101,7 +101,7 @@ public class PythonPackageAnalyzerTest extends BaseTest {
         assertEquals("0.0.1",result.getVersion());
         assertEquals("eggtest",result.getName());
         assertEquals("eggtest:0.0.1",result.getDisplayFileName());
-        assertEquals(PythonPackageAnalyzer.DEPENDENCY_ECOSYSTEM,result.getDependencyEcosystem());
+        assertEquals(PythonPackageAnalyzer.DEPENDENCY_ECOSYSTEM,result.getEcosystem());
     }
 
 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzerTest.java
@@ -98,6 +98,10 @@ public class PythonPackageAnalyzerTest extends BaseTest {
             }
         }
         assertTrue("Version 0.0.1 not found in EggTest dependency.", found);
+        assertEquals("0.0.1",result.getVersion());
+        assertEquals("eggtest",result.getName());
+        assertEquals("eggtest:0.0.1",result.getDisplayFileName());
+        assertEquals(PythonPackageAnalyzer.DEPENDENCY_ECOSYSTEM,result.getDependencyEcosystem());
     }
 
 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundlerAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundlerAnalyzerTest.java
@@ -105,7 +105,7 @@ public class RubyBundlerAnalyzerTest extends BaseTest {
         assertThat(result.getProductEvidence().toString(), containsString("High performance memcached client for Ruby"));
         assertThat(result.getVersionEvidence().toString(), containsString("2.7.5"));
         assertEquals("2.7.5",result.getVersion());
-        assertEquals(RubyBundlerAnalyzer.DEPENDENCY_ECOSYSTEM, result.getDependencyEcosystem());
+        assertEquals(RubyBundlerAnalyzer.DEPENDENCY_ECOSYSTEM, result.getEcosystem());
         assertEquals("dalli:2.7.5",result.getDisplayFileName());
         
     }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundlerAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundlerAnalyzerTest.java
@@ -80,6 +80,7 @@ public class RubyBundlerAnalyzerTest extends BaseTest {
     public void testSupportsFiles() {
         assertThat(analyzer.accept(new File("test.gemspec")), is(false));
         assertThat(analyzer.accept(new File("specifications" + File.separator + "test.gemspec")), is(true));
+        assertThat(analyzer.accept(new File("gemspec.lock")), is(false));
     }
 
     /**
@@ -100,7 +101,12 @@ public class RubyBundlerAnalyzerTest extends BaseTest {
         assertThat(vendorString, containsString("https://github.com/petergoldstein/dalli"));
         assertThat(vendorString, containsString("MIT"));
         assertThat(result.getProductEvidence().toString(), containsString("dalli"));
+        assertEquals("dalli",result.getName());
         assertThat(result.getProductEvidence().toString(), containsString("High performance memcached client for Ruby"));
         assertThat(result.getVersionEvidence().toString(), containsString("2.7.5"));
+        assertEquals("2.7.5",result.getVersion());
+        assertEquals(RubyBundlerAnalyzer.DEPENDENCY_ECOSYSTEM, result.getDependencyEcosystem());
+        assertEquals("dalli:2.7.5",result.getDisplayFileName());
+        
     }
 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzerTest.java
@@ -79,6 +79,7 @@ public class RubyGemspecAnalyzerTest extends BaseTest {
     @Test
     public void testSupportsFiles() {
         assertThat(analyzer.accept(new File("test.gemspec")), is(true));
+        assertThat(analyzer.accept(new File("gemspec.lock")), is(false));
 //        assertThat(analyzer.accept(new File("Rakefile")), is(true));
     }
 
@@ -93,12 +94,16 @@ public class RubyGemspecAnalyzerTest extends BaseTest {
                 "ruby/vulnerable/gems/specifications/rest-client-1.7.2.gemspec"));
         analyzer.analyze(result, null);
         final String vendorString = result.getVendorEvidence().toString();
+        assertEquals(RubyGemspecAnalyzer.DEPENDENCY_ECOSYSTEM, result.getDependencyEcosystem());
         assertThat(vendorString, containsString("REST Client Team"));
         assertThat(vendorString, containsString("rest-client_project"));
         assertThat(vendorString, containsString("rest.client@librelist.com"));
         assertThat(vendorString, containsString("https://github.com/rest-client/rest-client"));
         assertThat(result.getProductEvidence().toString(), containsString("rest-client"));
+        assertEquals("rest-client",result.getName());
         assertThat(result.getVersionEvidence().toString(), containsString("1.7.2"));
+        assertEquals("1.7.2",result.getVersion());
+        assertEquals("rest-client:1.7.2",result.getDisplayFileName());
     }
     
     /**
@@ -106,11 +111,16 @@ public class RubyGemspecAnalyzerTest extends BaseTest {
      *
      * @throws AnalysisException is thrown when an exception occurs.
      */
-    //@Test  TODO: place holder to test Rakefile support
+    //@Test  
+    //TODO: place holder to test Rakefile support
     public void testAnalyzeRakefile() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "ruby/vulnerable/gems/rails-4.1.15/vendor/bundle/ruby/2.2.0/gems/pg-0.18.4/Rakefile"));
         analyzer.analyze(result, null);
         assertTrue(result.getEvidence().size()>0);
+        assertEquals(RubyGemspecAnalyzer.DEPENDENCY_ECOSYSTEM, result.getDependencyEcosystem());
+        assertEquals("pg",result.getName());
+        assertEquals("0.18.4",result.getVersion());
+        assertEquals("pg:0.18.4",result.getDisplayFileName());
     }
 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzerTest.java
@@ -94,7 +94,7 @@ public class RubyGemspecAnalyzerTest extends BaseTest {
                 "ruby/vulnerable/gems/specifications/rest-client-1.7.2.gemspec"));
         analyzer.analyze(result, null);
         final String vendorString = result.getVendorEvidence().toString();
-        assertEquals(RubyGemspecAnalyzer.DEPENDENCY_ECOSYSTEM, result.getDependencyEcosystem());
+        assertEquals(RubyGemspecAnalyzer.DEPENDENCY_ECOSYSTEM, result.getEcosystem());
         assertThat(vendorString, containsString("REST Client Team"));
         assertThat(vendorString, containsString("rest-client_project"));
         assertThat(vendorString, containsString("rest.client@librelist.com"));
@@ -118,7 +118,7 @@ public class RubyGemspecAnalyzerTest extends BaseTest {
                 "ruby/vulnerable/gems/rails-4.1.15/vendor/bundle/ruby/2.2.0/gems/pg-0.18.4/Rakefile"));
         analyzer.analyze(result, null);
         assertTrue(result.getEvidence().size()>0);
-        assertEquals(RubyGemspecAnalyzer.DEPENDENCY_ECOSYSTEM, result.getDependencyEcosystem());
+        assertEquals(RubyGemspecAnalyzer.DEPENDENCY_ECOSYSTEM, result.getEcosystem());
         assertEquals("pg",result.getName());
         assertEquals("0.18.4",result.getVersion());
         assertEquals("pg:0.18.4",result.getDisplayFileName());

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
@@ -106,7 +106,10 @@ public class SwiftAnalyzersTest extends BaseTest {
         assertThat(vendorString, containsString("MIT"));
         assertThat(result.getProductEvidence().toString(), containsString("EasyPeasy"));
         assertThat(result.getVersionEvidence().toString(), containsString("0.2.3"));
-        assertThat(result.getDisplayFileName(),equalTo("EasyPeasy.podspec"));
+        assertThat(result.getName(),equalTo("EasyPeasy"));
+        assertThat(result.getVersion(),equalTo("0.2.3"));
+        assertThat(result.getDisplayFileName(),equalTo("EasyPeasy:0.2.3"));
+        assertThat(result.getDependencyEcosystem(),equalTo(CocoaPodsAnalyzer.DEPENDENCY_ECOSYSTEM));
     }
 
     /**
@@ -121,6 +124,10 @@ public class SwiftAnalyzersTest extends BaseTest {
         spmAnalyzer.analyze(result, null);
 
         assertThat(result.getProductEvidence().toString(), containsString("Gloss"));
-        assertThat(result.getDisplayFileName(),equalTo("Gloss/Package.swift"));
+        assertThat(result.getName(),equalTo("Gloss"));
+        //TODO: when version processing is added, update the expected name.
+        assertThat(result.getDisplayFileName(),equalTo("Gloss"));
+        
+        assertThat(result.getDependencyEcosystem(),equalTo(SwiftPackageManagerAnalyzer.DEPENDENCY_ECOSYSTEM));
     }
 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
@@ -10,6 +10,7 @@ import org.owasp.dependencycheck.dependency.Dependency;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 import java.io.File;
 
@@ -105,6 +106,7 @@ public class SwiftAnalyzersTest extends BaseTest {
         assertThat(vendorString, containsString("MIT"));
         assertThat(result.getProductEvidence().toString(), containsString("EasyPeasy"));
         assertThat(result.getVersionEvidence().toString(), containsString("0.2.3"));
+        assertThat(result.getDisplayFileName(),equalTo("EasyPeasy.podspec"));
     }
 
     /**
@@ -119,5 +121,6 @@ public class SwiftAnalyzersTest extends BaseTest {
         spmAnalyzer.analyze(result, null);
 
         assertThat(result.getProductEvidence().toString(), containsString("Gloss"));
+        assertThat(result.getDisplayFileName(),equalTo("Gloss/Package.swift"));
     }
 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
@@ -109,7 +109,7 @@ public class SwiftAnalyzersTest extends BaseTest {
         assertThat(result.getName(),equalTo("EasyPeasy"));
         assertThat(result.getVersion(),equalTo("0.2.3"));
         assertThat(result.getDisplayFileName(),equalTo("EasyPeasy:0.2.3"));
-        assertThat(result.getDependencyEcosystem(),equalTo(CocoaPodsAnalyzer.DEPENDENCY_ECOSYSTEM));
+        assertThat(result.getEcosystem(),equalTo(CocoaPodsAnalyzer.DEPENDENCY_ECOSYSTEM));
     }
 
     /**
@@ -128,6 +128,6 @@ public class SwiftAnalyzersTest extends BaseTest {
         //TODO: when version processing is added, update the expected name.
         assertThat(result.getDisplayFileName(),equalTo("Gloss"));
         
-        assertThat(result.getDependencyEcosystem(),equalTo(SwiftPackageManagerAnalyzer.DEPENDENCY_ECOSYSTEM));
+        assertThat(result.getEcosystem(),equalTo(SwiftPackageManagerAnalyzer.DEPENDENCY_ECOSYSTEM));
     }
 }


### PR DESCRIPTION
## Description of Change
This standardizes the collection of name and version such that it can be presented consistently in the report. Name and Version were added to the dependency object since in many parsers, it was not possible without significant refactoring to construct a string that had both of them in the same place.

I also added an eocystem element to track what type a dependency actually is. I think this can help with reporting of mixed dependencies and possibly be used to tweak search results down the road.

There are still some open issues including the nuget analyzer and serialization of these new fields, but I wanted to get this for you to validate the overall approach sooner.

## Have test cases been added to cover the new functionality?
Yes, full tests.
