### PR TITLE
Fix build warnings and add default goal 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,9 +150,6 @@ Copyright (c) 2012 - Jeremy Long
             <url>https://jeremylong.github.io/DependencyCheck/</url>
         </site>
     </distributionManagement>
-    <prerequisites>
-        <maven>3.1</maven>
-    </prerequisites>
     <build>
     <defaultGoal>clean install</defaultGoal>
         <pluginManagement>
@@ -191,6 +188,21 @@ Copyright (c) 2012 - Jeremy Long
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>1.4.1</version>
+                    <executions>
+                        <execution>
+                          <id>enforce-minimal-maven-version</id>
+                          <goals>
+                              <goal>enforce</goal>
+                          </goals>
+                          <configuration>
+                              <rules>
+                                  <requireMavenVersion>
+                                      <version>3.1</version>
+                                  </requireMavenVersion>
+                              </rules>
+                          </configuration>
+                      </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -368,7 +380,7 @@ Copyright (c) 2012 - Jeremy Long
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>            
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@ Copyright (c) 2012 - Jeremy Long
         <maven>3.1</maven>
     </prerequisites>
     <build>
+    <defaultGoal>clean install</defaultGoal>
         <pluginManagement>
             <plugins>
                 <plugin>


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

* Maven warning about wrong usage of prerequisites for non-maven-plugin projects. Use enforcer plugin instead to enforce at least Maven 3.1.
* Add defaultGoal to allow easier local usage by just calling mvn instead of mvn clean install.

## Have test cases been added to cover the new functionality?

*no*, just a Maven change.