### PR TITLE
Improve centralanalyzer stability

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
@@ -218,20 +218,6 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
     }
 
     /**
-     * Does not support parallel processing as it both modifies and iterates
-     * over the engine's list of dependencies.
-     *
-     * @return <code>true</code> if the analyzer supports parallel processing;
-     * otherwise <code>false</code>
-     * @see #analyzeDependency(Dependency, Engine)
-     * @see #findMoreDependencies(Engine, File)
-     */
-    @Override
-    public boolean supportsParallelProcessing() {
-        return true;
-    }
-
-    /**
      * Analyzes a given dependency. If the dependency is an archive, such as a
      * WAR or EAR, the contents are extracted, scanned, and added to the list of
      * dependencies within the engine.

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
@@ -210,7 +210,7 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
      * Performs the analysis.
      *
      * @param dependency the dependency to analyze
-     * @param engine the engine
+     * @param engine     the engine
      * @throws AnalysisException when there's an exception during analysis
      */
     @Override

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
@@ -93,11 +93,6 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
     protected CentralSearch searcher;
 
     /**
-     * Field indicating if the analyzer is enabled.
-     */
-    private boolean enabled = true;
-
-    /**
      * Initializes the analyzer with the configured settings.
      *
      * @param settings the configured settings to use
@@ -105,17 +100,7 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
     @Override
     public void initialize(Settings settings) {
         super.initialize(settings);
-        enabled = checkEnabled();
-    }
-
-    /**
-     * Determine whether to enable this analyzer or not.
-     *
-     * @return whether the analyzer should be enabled
-     */
-    @Override
-    public boolean isEnabled() {
-        return enabled;
+        setEnabled(checkEnabled());
     }
 
     /**
@@ -215,7 +200,7 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
      */
     @Override
     public void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
-        if (errorFlag || !isEnabled()) {
+        if (errorFlag) {
             return;
         }
 

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
@@ -90,7 +90,7 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * The searcher itself.
      */
-    CentralSearch searcher;
+    protected CentralSearch searcher;
 
     /**
      * Field indicating if the analyzer is enabled.
@@ -281,7 +281,7 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
      * @throws FileNotFoundException if the specified artifact is not found
      * @throws IOException           if connecting to MavenCentral finally failed
      */
-    List<MavenArtifact> fetchMavenArtifacts(Dependency dependency) throws IOException {
+    protected List<MavenArtifact> fetchMavenArtifacts(Dependency dependency) throws IOException {
         IOException lastException = null;
         long sleepingTimeBetweenRetriesInMillis = 1000;
         int triesLeft = NUMBER_OF_TRIES;

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
@@ -101,8 +101,9 @@ public class CentralSearch {
      *
      * @param sha1 the SHA-1 hash string for which to search
      * @return the populated Maven GAV.
-     * @throws IOException if it's unable to connect to the specified repository
-     * or if the specified artifact is not found.
+     * @throws FileNotFoundException if the specified artifact is not found
+     * @throws IOException           if it's unable to connect to the specified
+     *                               repository
      */
     public List<MavenArtifact> searchSha1(String sha1) throws IOException {
         if (null == sha1 || !sha1.matches("^[0-9A-Fa-f]{40}$")) {
@@ -178,9 +179,8 @@ public class CentralSearch {
                 throw new FileNotFoundException("Artifact not found in Central");
             }
         } else {
-            LOGGER.debug("Could not connect to Central received response code: {} {}",
-                    conn.getResponseCode(), conn.getResponseMessage());
-            throw new IOException("Could not connect to Central");
+            String errorMessage = "Could not connect to MavenCentral (" + conn.getResponseCode() + "): " + conn.getResponseMessage();
+            throw new IOException(errorMessage);
         }
         return result;
     }

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
@@ -74,7 +74,7 @@ public class CentralSearch {
      *
      * @param settings the configured settings
      * @throws MalformedURLException thrown if the configured URL is
-     * invalid
+     *                               invalid
      */
     public CentralSearch(Settings settings) throws MalformedURLException {
         this.settings = settings;

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -148,7 +148,7 @@ public class Dependency extends EvidenceCollection implements Serializable, Comp
      * Constructs a new Dependency object.
      */
     public Dependency() {
-        //empty contructor
+        //empty constructor
     }
 
     /**

--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/EvidenceCollection.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/dependency/EvidenceCollection.java
@@ -25,8 +25,6 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.owasp.dependencycheck.utils.Filter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Used to maintain a collection of Evidence.
@@ -40,10 +38,6 @@ class EvidenceCollection implements Serializable {
      * The serial version UID for serialization.
      */
     private static final long serialVersionUID = 1L;
-    /**
-     * The logger.
-     */
-    private static final Logger LOGGER = LoggerFactory.getLogger(EvidenceCollection.class);
     /**
      * A collection of vendor evidence.
      */

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
@@ -30,6 +30,7 @@ public class CentralAnalyzerTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.NonStaticInitializer")
     public void testFetchMavenArtifactsWithoutException(@Mocked final CentralSearch centralSearch,
                                                         @Mocked final Dependency dependency)
             throws IOException {

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
@@ -53,6 +53,7 @@ public class CentralAnalyzerTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.NonStaticInitializer")
     public void testFetchMavenArtifactsWithSporadicIOException(@Mocked final CentralSearch centralSearch,
                                                                @Mocked final Dependency dependency)
             throws IOException {
@@ -77,6 +78,7 @@ public class CentralAnalyzerTest {
     }
 
     @Test(expected = FileNotFoundException.class)
+    @SuppressWarnings("PMD.NonStaticInitializer")
     public void testFetchMavenArtifactsRethrowsFileNotFoundException(@Mocked final CentralSearch centralSearch,
                                                                      @Mocked final Dependency dependency)
             throws IOException {
@@ -96,6 +98,7 @@ public class CentralAnalyzerTest {
     }
 
     @Test(expected = IOException.class)
+    @SuppressWarnings("PMD.NonStaticInitializer")
     public void testFetchMavenArtifactsAlwaysThrowsIOException(@Mocked final CentralSearch centralSearch,
                                                                @Mocked final Dependency dependency)
             throws IOException {

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2017 Jeremy Long. All Rights Reserved.
+ */
 package org.owasp.dependencycheck.analyzer;
 
 import mockit.Expectations;

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
@@ -1,0 +1,127 @@
+package org.owasp.dependencycheck.analyzer;
+
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.owasp.dependencycheck.data.central.CentralSearch;
+import org.owasp.dependencycheck.data.nexus.MavenArtifact;
+import org.owasp.dependencycheck.dependency.Dependency;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the CentralAnalyzer.
+ */
+public class CentralAnalyzerTest {
+
+    private static final String SHA1_SUM = "my-sha1-sum";
+
+    @BeforeClass
+    public static void beforeClass() {
+        doNotSleepBetweenRetries();
+    }
+
+    @Test
+    public void testFetchMavenArtifactsWithoutException(@Mocked final CentralSearch centralSearch,
+                                                        @Mocked final Dependency dependency)
+            throws IOException {
+
+        CentralAnalyzer instance = new CentralAnalyzer();
+        instance.searcher = centralSearch;
+
+        final List<MavenArtifact> expectedMavenArtifacts = Collections.emptyList();
+        new Expectations() {{
+            dependency.getSha1sum();
+            returns(SHA1_SUM);
+
+            centralSearch.searchSha1(SHA1_SUM);
+            returns(expectedMavenArtifacts);
+        }};
+
+        final List<MavenArtifact> actualMavenArtifacts = instance.fetchMavenArtifacts(dependency);
+
+        assertEquals(expectedMavenArtifacts, actualMavenArtifacts);
+    }
+
+    @Test
+    public void testFetchMavenArtifactsWithSporadicIOException(@Mocked final CentralSearch centralSearch,
+                                                               @Mocked final Dependency dependency)
+            throws IOException {
+
+        CentralAnalyzer instance = new CentralAnalyzer();
+        instance.searcher = centralSearch;
+
+        final List<MavenArtifact> expectedMavenArtifacts = Collections.emptyList();
+        new Expectations() {{
+            dependency.getSha1sum();
+            returns(SHA1_SUM);
+
+            centralSearch.searchSha1(SHA1_SUM);
+            result = new IOException("Could not connect to MavenCentral (500): Internal Server Error");
+            result = new IOException("Could not connect to MavenCentral (500): Internal Server Error");
+            result = expectedMavenArtifacts;
+        }};
+
+        final List<MavenArtifact> actualMavenArtifacts = instance.fetchMavenArtifacts(dependency);
+
+        assertEquals(expectedMavenArtifacts, actualMavenArtifacts);
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void testFetchMavenArtifactsRethrowsFileNotFoundException(@Mocked final CentralSearch centralSearch,
+                                                                     @Mocked final Dependency dependency)
+            throws IOException {
+
+        CentralAnalyzer instance = new CentralAnalyzer();
+        instance.searcher = centralSearch;
+
+        new Expectations() {{
+            dependency.getSha1sum();
+            returns(SHA1_SUM);
+
+            centralSearch.searchSha1(SHA1_SUM);
+            result = new FileNotFoundException("Artifact not found in Central");
+        }};
+
+        instance.fetchMavenArtifacts(dependency);
+    }
+
+    @Test(expected = IOException.class)
+    public void testFetchMavenArtifactsAlwaysThrowsIOException(@Mocked final CentralSearch centralSearch,
+                                                               @Mocked final Dependency dependency)
+            throws IOException {
+
+        CentralAnalyzer instance = new CentralAnalyzer();
+        instance.searcher = centralSearch;
+
+        new Expectations() {{
+            dependency.getSha1sum();
+            returns(SHA1_SUM);
+
+            centralSearch.searchSha1(SHA1_SUM);
+            result = new IOException("no internet connection");
+        }};
+
+        instance.fetchMavenArtifacts(dependency);
+    }
+
+    /**
+     * We do not want to waste time in unit tests.
+     */
+    private static void doNotSleepBetweenRetries() {
+        new MockUp<Thread>() {
+            @Mock
+            void sleep(long millis) {
+                // do not sleep
+            }
+        };
+    }
+}

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
@@ -23,6 +23,7 @@ import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.central.CentralSearch;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.dependency.Dependency;
@@ -132,6 +133,26 @@ public class CentralAnalyzerTest {
         }};
 
         instance.fetchMavenArtifacts(dependency);
+    }
+
+    @Test(expected = AnalysisException.class)
+    @SuppressWarnings("PMD.NonStaticInitializer")
+    public void testFetchMavenArtifactsAlwaysThrowsIOExceptionLetsTheAnalysisFail(@Mocked final CentralSearch centralSearch,
+                                                                                  @Mocked final Dependency dependency)
+            throws AnalysisException, IOException {
+
+        CentralAnalyzer instance = new CentralAnalyzer();
+        instance.searcher = centralSearch;
+
+        new Expectations() {{
+            dependency.getSha1sum();
+            returns(SHA1_SUM);
+
+            centralSearch.searchSha1(SHA1_SUM);
+            result = new IOException("no internet connection");
+        }};
+
+        instance.analyze(dependency, null);
     }
 
     /**

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
@@ -55,12 +55,10 @@ public class CentralAnalyzerTest {
 
         CentralAnalyzer instance = new CentralAnalyzer();
         instance.searcher = centralSearch;
+        specifySha1SumFor(dependency);
 
         final List<MavenArtifact> expectedMavenArtifacts = Collections.emptyList();
         new Expectations() {{
-            dependency.getSha1sum();
-            returns(SHA1_SUM);
-
             centralSearch.searchSha1(SHA1_SUM);
             returns(expectedMavenArtifacts);
         }};
@@ -78,12 +76,10 @@ public class CentralAnalyzerTest {
 
         CentralAnalyzer instance = new CentralAnalyzer();
         instance.searcher = centralSearch;
+        specifySha1SumFor(dependency);
 
         final List<MavenArtifact> expectedMavenArtifacts = Collections.emptyList();
         new Expectations() {{
-            dependency.getSha1sum();
-            returns(SHA1_SUM);
-
             centralSearch.searchSha1(SHA1_SUM);
             result = new IOException("Could not connect to MavenCentral (500): Internal Server Error");
             result = new IOException("Could not connect to MavenCentral (500): Internal Server Error");
@@ -103,11 +99,9 @@ public class CentralAnalyzerTest {
 
         CentralAnalyzer instance = new CentralAnalyzer();
         instance.searcher = centralSearch;
+        specifySha1SumFor(dependency);
 
         new Expectations() {{
-            dependency.getSha1sum();
-            returns(SHA1_SUM);
-
             centralSearch.searchSha1(SHA1_SUM);
             result = new FileNotFoundException("Artifact not found in Central");
         }};
@@ -123,11 +117,9 @@ public class CentralAnalyzerTest {
 
         CentralAnalyzer instance = new CentralAnalyzer();
         instance.searcher = centralSearch;
+        specifySha1SumFor(dependency);
 
         new Expectations() {{
-            dependency.getSha1sum();
-            returns(SHA1_SUM);
-
             centralSearch.searchSha1(SHA1_SUM);
             result = new IOException("no internet connection");
         }};
@@ -143,11 +135,9 @@ public class CentralAnalyzerTest {
 
         CentralAnalyzer instance = new CentralAnalyzer();
         instance.searcher = centralSearch;
+        specifySha1SumFor(dependency);
 
         new Expectations() {{
-            dependency.getSha1sum();
-            returns(SHA1_SUM);
-
             centralSearch.searchSha1(SHA1_SUM);
             result = new IOException("no internet connection");
         }};
@@ -165,5 +155,18 @@ public class CentralAnalyzerTest {
                 // do not sleep
             }
         };
+    }
+
+    /**
+     * Specifies the mock dependency's SHA1 sum.
+     *
+     * @param dependency then dependency
+     */
+    @SuppressWarnings("PMD.NonStaticInitializer")
+    private void specifySha1SumFor(final Dependency dependency) {
+        new Expectations() {{
+            dependency.getSha1sum();
+            returns(SHA1_SUM);
+        }};
     }
 }


### PR DESCRIPTION
## Fixes Issue #897 

## Description of Change

I observed sporadic connection errors when fetching the MavenArtifacts from MavenCentral (500). I implemented a retry (5 retries, initial delay 500 msec, double delay each time) for fetching these. Only if the last retry fails, the CentralAnalyzer gets disabled.

## Have test cases been added to cover the new functionality?

yes:
* Unit tests for the retry
* Manual integration test