### PR TITLE
fix spelling

### DIFF
--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -803,7 +803,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                                 dependencyNode.getArtifact().getId(), dependencyNode.getArtifact().getScope(), project.getName());
                         getLog().debug(msg);
                     } else {
-                        final String msg = String.format("No analzer could be found for '%s:%s' in project %s",
+                        final String msg = String.format("No analyzer could be found for '%s:%s' in project %s",
                                 dependencyNode.getArtifact().getId(), dependencyNode.getArtifact().getScope(), project.getName());
                         getLog().warn(msg);
                     }


### PR DESCRIPTION
## Fixes Issue #

Mis-spelling of warning

## Description of Change

Fix the spelling of a warning from "analzer" to "anal**y**zer"

## Have test cases been added to cover the new functionality?

N/A