### PR TITLE
Update documentation and configuration for Retired Analyzers

### DIFF
--- a/dependency-check-ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/dependency-check-ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -179,6 +179,10 @@ public class Check extends Update {
      */
     private Boolean enableExperimental;
     /**
+     * Whether retired analyzers are enabled.
+     */
+    private Boolean enableRetired;
+    /**
      * Whether or not the Jar Analyzer is enabled.
      */
     private Boolean jarAnalyzerEnabled;
@@ -527,6 +531,24 @@ public class Check extends Update {
      */
     public void setEnableExperimental(Boolean enableExperimental) {
         this.enableExperimental = enableExperimental;
+    }
+
+    /**
+     * Get the value of enableRetired.
+     *
+     * @return the value of enableRetired
+     */
+    public Boolean isEnableRetired() {
+        return enableRetired;
+    }
+
+    /**
+     * Set the value of enableRetired.
+     *
+     * @param enableRetired new value of enableRetired
+     */
+    public void setEnableRetired(Boolean enableRetired) {
+        this.enableRetired = enableRetired;
     }
 
     /**
@@ -1033,6 +1055,7 @@ public class Check extends Update {
         getSettings().setArrayIfNotEmpty(Settings.KEYS.SUPPRESSION_FILE, suppressionFiles.toArray(new String[suppressionFiles.size()]));
         getSettings().setStringIfNotEmpty(Settings.KEYS.HINTS_FILE, hintsFile);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_EXPERIMENTAL_ENABLED, enableExperimental);
+        getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_RETIRED_ENABLED, enableRetired);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_JAR_ENABLED, jarAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_PYTHON_DISTRIBUTION_ENABLED, pyDistributionAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_PYTHON_PACKAGE_ENABLED, pyPackageAnalyzerEnabled);

--- a/dependency-check-ant/src/site/markdown/configuration.md
+++ b/dependency-check-ant/src/site/markdown/configuration.md
@@ -45,6 +45,7 @@ proxyUsername         | Defines the proxy user name.                            
 proxyPassword         | Defines the proxy password.                                                                                                                                                                        | &nbsp;
 connectionTimeout     | The URL Connection Timeout.                                                                                                                                                                        | &nbsp;
 enableExperimental    | Enable the [experimental analyzers](../analyzers/index.html). If not enabled the experimental analyzers (see below) will not be loaded or used.                                                    | false
+enableRetired         | Enable the [retired analyzers](../analyzers/index.html). If not enabled the retired analyzers (see below) will not be loaded or used.                                                              | false
 suppressionFile       | The file path to the XML suppression file \- used to suppress [false positives](../general/suppression.html).                                                                                      | &nbsp;
 
 The following nested elements can be set on the dependency-check task.
@@ -77,7 +78,7 @@ opensslAnalyzerEnabled        | Sets whether the openssl Analyzer should be used
 cmakeAnalyzerEnabled          | Sets whether the [experimental](../analyzers/index.html) CMake Analyzer should be used.                    | true
 autoconfAnalyzerEnabled       | Sets whether the [experimental](../analyzers/index.html) autoconf Analyzer should be used.                 | true
 composerAnalyzerEnabled       | Sets whether the [experimental](../analyzers/index.html) PHP Composer Lock File Analyzer should be used.   | true
-nodeAnalyzerEnabled           | Sets whether the [experimental](../analyzers/index.html) Node.js Analyzer should be used.                  | true
+nodeAnalyzerEnabled           | Sets whether the [retired](../analyzers/index.html) Node.js Analyzer should be used.                  | true
 nspAnalyzerEnabled            | Sets whether the NSP Analyzer should be used.                                                              | true
 nuspecAnalyzerEnabled         | Sets whether the .NET Nuget Nuspec Analyzer will be used.                                                  | true
 cocoapodsAnalyzerEnabled      | Sets whether the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used.                | true

--- a/dependency-check-cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/dependency-check-cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -421,6 +421,7 @@ public class App {
         final Integer cveValidForHours = cli.getCveValidForHours();
         final Boolean autoUpdate = cli.isAutoUpdate();
         final Boolean experimentalEnabled = cli.isExperimentalEnabled();
+        final Boolean retiredEnabled = cli.isRetiredEnabled();
 
         if (propertiesFile != null) {
             try {
@@ -460,6 +461,7 @@ public class App {
 
         //File Type Analyzer Settings
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_EXPERIMENTAL_ENABLED, experimentalEnabled);
+        settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_RETIRED_ENABLED, retiredEnabled);
 
         settings.setBoolean(Settings.KEYS.ANALYZER_JAR_ENABLED, !cli.isJarDisabled());
         settings.setBoolean(Settings.KEYS.ANALYZER_ARCHIVE_ENABLED, !cli.isArchiveDisabled());

--- a/dependency-check-cli/src/main/java/org/owasp/dependencycheck/CliParser.java
+++ b/dependency-check-cli/src/main/java/org/owasp/dependencycheck/CliParser.java
@@ -301,6 +301,10 @@ public final class CliParser {
                 .desc("Enables the experimental analyzers.")
                 .build();
 
+        final Option retiredEnabled = Option.builder().longOpt(ARGUMENT.RETIRED)
+                .desc("Enables the experimental analyzers.")
+                .build();
+
         final Option failOnCVSS = Option.builder().argName("score").hasArg().longOpt(ARGUMENT.FAIL_ON_CVSS)
                 .desc("Specifies if the build should be failed if a CVSS score above a specified level is identified. "
                         + "The default is 11; since the CVSS scores are 0-10, by default the build will never fail.")
@@ -329,6 +333,7 @@ public final class CliParser {
                 .addOption(hintsFile)
                 .addOption(cveValidForHours)
                 .addOption(experimentalEnabled)
+                .addOption(retiredEnabled)
                 .addOption(failOnCVSS);
     }
 
@@ -1189,6 +1194,15 @@ public final class CliParser {
     }
 
     /**
+     * Returns true if the retired analyzers are enabled.
+     *
+     * @return true if the retired analyzers are enabled; otherwise null
+     */
+    public Boolean isRetiredEnabled() {
+        return (line != null && line.hasOption(ARGUMENT.RETIRED)) ? true : null;
+    }
+
+    /**
      * Returns the CVSS value to fail on.
      *
      * @return 11 if nothing is set. Otherwise it returns the int passed from
@@ -1521,6 +1535,10 @@ public final class CliParser {
          * The CLI argument to enable the experimental analyzers.
          */
         private static final String EXPERIMENTAL = "enableExperimental";
+        /**
+         * The CLI argument to enable the retired analyzers.
+         */
+        private static final String RETIRED = "enableRetired";
         /**
          * The CLI argument to enable the experimental analyzers.
          */

--- a/dependency-check-cli/src/site/markdown/arguments.md
+++ b/dependency-check-cli/src/site/markdown/arguments.md
@@ -20,6 +20,7 @@ Short  | Argument&nbsp;Name&nbsp;&nbsp; | Parameter       | Description | Requir
  \-v   | \-\-version            |                 | Print the version information. | Optional
        | \-\-cveValidForHours   | \<hours\>       | The number of hours to wait before checking for new updates from the NVD. The default is 4 hours. | Optional
        | \-\-enableExperimental |                 | Enable the [experimental analyzers](../analyzers/index.html). If not set the analyzers marked as experimental below will not be loaded or used. | Optional
+       | \-\-enableRetired      |                 | Enable the [retired analyzers](../analyzers/index.html). If not set the analyzers marked as retired below will not be loaded or used. | Optional
 
 Advanced Options
 ================
@@ -33,12 +34,12 @@ Short  | Argument&nbsp;Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Paramete
        | \-\-updateonly         |                 | If set only the update phase of dependency-check will be executed; no scan will be executed and no report will be generated. | &nbsp;
        | \-\-disablePyDist      |                 | Sets whether the [experimental](../analyzers/index.html) Python Distribution Analyzer will be used.                      | false
        | \-\-disablePyPkg       |                 | Sets whether the [experimental](../analyzers/index.html) Python Package Analyzer will be used.                           | false
-       | \-\-disableNodeJS      |                 | Sets whether the [experimental](../analyzers/index.html) Node.js Package Analyzer will be used.                          | false
+       | \-\-disableNodeJS      |                 | Sets whether the [retired](../analyzers/index.html) Node.js Package Analyzer will be used.                               | false
        | \-\-disableNSP         |                 | Sets whether the NSP Analyzer will be used.                                                                              | false
        | \-\-disableRubygems    |                 | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used.                             | false
        | \-\-disableBundleAudit |                 | Sets whether the [experimental](../analyzers/index.html) Ruby Bundler Audit Analyzer will be used.                       | false
        | \-\-disableCocoapodsAnalyzer |           | Sets whether the [experimental](../analyzers/index.html) Cocoapods Analyzer will be used.                                | false
-       | \-\-disableSwiftPackageManagerAnalyzer | | Sets whether the [experimental](../analyzers/index.html) Swift Package Manager Analyzer will be used.                   | false
+       | \-\-disableSwiftPackageManagerAnalyzer | | Sets whether the [experimental](../analyzers/index.html) Swift Package Manager Analyzer will be used.                    | false
        | \-\-disableAutoconf    |                 | Sets whether the [experimental](../analyzers/index.html) Autoconf Analyzer will be used.                                 | false
        | \-\-disableOpenSSL     |                 | Sets whether the OpenSSL Analyzer will be used.                                                                          | false
        | \-\-disableCmake       |                 | Sets whether the [experimental](../analyzers/index.html) Cmake Analyzer will be disabled.                                | false

--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -185,6 +185,12 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     @Parameter(property = "enableExperimental")
     private Boolean enableExperimental;
     /**
+     * Sets whether retired analyzers are enabled. Default is false.
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "enableRetired")
+    private Boolean enableRetired;
+    /**
      * Generate aggregate reports in multi-module projects.
      *
      * @deprecated use the aggregate goal instead
@@ -1117,6 +1123,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         settings.setBooleanIfNotNull(Settings.KEYS.AUTO_UPDATE, autoUpdate);
 
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_EXPERIMENTAL_ENABLED, enableExperimental);
+        settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_RETIRED_ENABLED, enableRetired);
 
         if (externalReport != null) {
             getLog().warn("The 'externalReport' option was set; this configuration option has been removed. "

--- a/dependency-check-maven/src/site/markdown/configuration.md
+++ b/dependency-check-maven/src/site/markdown/configuration.md
@@ -32,6 +32,7 @@ skipArtifactType            | A regular expression used to filter/skip artifact 
 suppressionFiles            | The file paths to the XML suppression files \- used to suppress [false positives](../general/suppression.html). | &nbsp;
 hintsFile                   | The file path to the XML hints file \- used to resolve [false negatives](../general/hints.html).       | &nbsp;
 enableExperimental          | Enable the [experimental analyzers](../analyzers/index.html). If not enabled the experimental analyzers (see below) will not be loaded or used. | false
+enableRetired               | Enable the [retired analyzers](../analyzers/index.html). If not enabled the retired analyzers (see below) will not be loaded or used. | false
 
 Analyzer Configuration
 ====================
@@ -57,7 +58,7 @@ opensslAnalyzerEnabled        | Sets whether the openssl Analyzer should be used
 cmakeAnalyzerEnabled          | Sets whether the [experimental](../analyzers/index.html) CMake Analyzer should be used.                    | true
 autoconfAnalyzerEnabled       | Sets whether the [experimental](../analyzers/index.html) autoconf Analyzer should be used.                 | true
 composerAnalyzerEnabled       | Sets whether the [experimental](../analyzers/index.html) PHP Composer Lock File Analyzer should be used.   | true
-nodeAnalyzerEnabled           | Sets whether the [experimental](../analyzers/index.html) Node.js Analyzer should be used.                  | true
+nodeAnalyzerEnabled           | Sets whether the [retired](../analyzers/index.html) Node.js Analyzer should be used.                       | true
 nspAnalyzerEnabled            | Sets whether the NSP Analyzer should be used.                                                              | true
 nuspecAnalyzerEnabled         | Sets whether the .NET Nuget Nuspec Analyzer will be used.                                                  | true
 cocoapodsAnalyzerEnabled      | Sets whether the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used.                | true

--- a/src/site/markdown/analyzers/index.md
+++ b/src/site/markdown/analyzers/index.md
@@ -32,3 +32,14 @@ several teams have found them useful in their current state.
 | [Python](./python.html) | Python source files (\*.py); Package metadata files (PKG-INFO, METADATA); Package Distribution Files (\*.whl, \*.egg, \*.zip) | Regex scan of Python source files for setuptools metadata; Parse RFC822 header format for metadata in all other artifacts. |
 | [Ruby Gemspec](./ruby-gemspec.html) | Ruby makefiles (Rakefile); Ruby Gemspec files (\*.gemspec) | Regex scan Gemspec initialization blocks for metadata. |
 | [SWIFT](./swift.html) | SWIFT Package Manager's `Package.swift` | Extracts dependency information from swift package file. |
+
+Retired Analyzers
+----------------------
+The following analyzers can be enabled by enabling the _retired_ configuration
+option; see the documentation for the CLI, Ant, Maven, etc. for more information.
+These analyzers have been retired due to the higher false positive and
+false negative rates.
+
+| Analyzer | File Types Scanned | Analysis Method |
+| -------- | ------------------ | --------------- |
+| [Node.js](./nodejs.html) | NPM package specification files (package.json) | Parse JSON format for metadata. |

--- a/src/site/markdown/analyzers/nodejs.md
+++ b/src/site/markdown/analyzers/nodejs.md
@@ -1,9 +1,8 @@
 Node.js Analyzer
 ================
 
-*Experimental*: This analyzer is considered experimental. While this analyzer may 
-be useful and provide valid results more testing must be completed to ensure that
-the false negative/false positive rates are acceptable. 
+*Retired*: This analyzer has been retired due to an extremely high false positive
+rate. 
 
 OWASP dependency-check includes an analyzer that will scan [Node Package Manager](https://www.npmjs.com/)
 package specification files. The analyzer will collect as much information as
@@ -11,9 +10,5 @@ it can about the package. The information collected is internally referred to
 as evidence and is grouped into vendor, product, and version buckets. Other
 analyzers later use this evidence to identify any Common Platform Enumeration
 (CPE) identifiers that apply.
-
-*Note*: Consider using [Retire.js](http://retirejs.github.io/retire.js/) or the
-Node Security Project auditing tool, [nsp](https://nodesecurity.io/tools) instead
-of, or in addition to OWASP dependency-check to analyze Node.js packages.
 
 Files Types Scanned: [package.json](https://docs.npmjs.com/files/package.json)

--- a/src/site/markdown/dependency-check-gradle/configuration.md
+++ b/src/site/markdown/dependency-check-gradle/configuration.md
@@ -121,12 +121,13 @@ analyzers    | pathToMono            | The path to Mono for .NET assembly analys
 analyzers    | cmakeEnabled          | Sets whether or not the [experimental](../analyzers/index.html) CMake Analyzer should be used.                    | true
 analyzers    | autoconfEnabled       | Sets whether or not the [experimental](../analyzers/index.html) autoconf Analyzer should be used.                 | true
 analyzers    | composerEnabled       | Sets whether or not the [experimental](../analyzers/index.html) PHP Composer Lock File Analyzer should be used.   | true
-analyzers    | nodeEnabled           | Sets whether or not the [experimental](../analyzers/index.html) Node.js Analyzer should be used.                  | true
+analyzers    | nodeEnabled           | Sets whether or not the [retired](../analyzers/index.html) Node.js Analyzer should be used.                  | true
 analyzers    | nspEnabled            | Sets whether the NSP Analyzer should be used.                                                                     | true
 analyzers    | cocoapodsEnabled      | Sets whether or not the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used.                | true
 analyzers    | swiftEnabled          | Sets whether or not the [experimental](../analyzers/index.html) Swift Package Manager Analyzer should be used.    | true
 analyzers    | bundleAuditEnabled    | Sets whether or not the [experimental](../analyzers/index.html) Ruby Bundle Audit Analyzer should be used.        | true
 analyzers    | pathToBundleAudit     | The path to bundle audit.                                                                                         | &nbsp;
+analyzers    | retiredEnabled        | Sets whether the [retired analyzers](../analyzers/index.html) will be used. If not set to true the analyzers marked as experimental (see below) will not be used | false
 
 #### Example
 ```groovy


### PR DESCRIPTION
## Fixes Issue #937 

The documentation has been updated to indicate that the Node.js analyzer was retired. The NSP analyzer should be used going forward. Additionally, configuration options were added to re-enable the retired analyzers.
