### PR TITLE
make Error on personal Suppression File to not fatal

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
@@ -117,7 +117,7 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
      * @throws SuppressionParseException thrown if the XML cannot be parsed.
      */
     private void loadSuppressionData() throws SuppressionParseException {
-        List<SuppressionRule> ruleList = new ArrayList<>()
+        List<SuppressionRule> ruleList = new ArrayList<>();
         final SuppressionParser parser = new SuppressionParser();
         final String[] suppressionFilePaths = getSettings().getArray(Settings.KEYS.SUPPRESSION_FILE);
         final List<String> failedLoadingFiles = new ArrayList<>();


### PR DESCRIPTION
## Fixes Issue #

if one personal suppression file fails to load, analyzer stops after prepare step and base suppression File Rules are not processed

## Description of Change
I change to make not fatal Error, if personal suppression file fails to load

## Have test cases been added to cover the new functionality?
?