### PR TITLE
Adds configurable batch insert for References and Vulnerabilities

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -658,7 +658,6 @@ public final class CveDB implements AutoCloseable {
         ResultSet rs = null;
         try {
             int vulnerabilityId = 0;
-            long countVulnerabilities = 0;
             final PreparedStatement selectVulnerabilityId = getPreparedStatement(SELECT_VULNERABILITY_ID);
             selectVulnerabilityId.setString(1, vuln.getName());
             rs = selectVulnerabilityId.executeQuery();

--- a/dependency-check-core/src/main/resources/dependencycheck.properties
+++ b/dependency-check-core/src/main/resources/dependencycheck.properties
@@ -50,7 +50,7 @@ cve.url.modified.validfordays=7
 # the number of hours to wait before checking if updates are available from the NVD.
 cve.check.validforhours=4
 #first year to pull data from the URLs below
-cve.startyear=2017
+cve.startyear=2002
 # the path to the modified nvd cve xml file.
 cve.url-1.2.modified=https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
 #cve.url-1.2.modified=http://nvd.nist.gov/download/nvdcve-modified.xml

--- a/dependency-check-core/src/main/resources/dependencycheck.properties
+++ b/dependency-check-core/src/main/resources/dependencycheck.properties
@@ -50,7 +50,7 @@ cve.url.modified.validfordays=7
 # the number of hours to wait before checking if updates are available from the NVD.
 cve.check.validforhours=4
 #first year to pull data from the URLs below
-cve.startyear=2002
+cve.startyear=2017
 # the path to the modified nvd cve xml file.
 cve.url-1.2.modified=https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
 #cve.url-1.2.modified=http://nvd.nist.gov/download/nvdcve-modified.xml
@@ -127,3 +127,5 @@ analyzer.vulnerabilitysuppression.enabled=true
 updater.nvdcve.enabled=true
 updater.versioncheck.enabled=true
 analyzer.versionfilter.enabled=true
+database.batchinsert.enabled=true
+database.batchinsert.maxsize=1000

--- a/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -444,6 +444,16 @@ public final class Settings {
         public static final String UPDATE_VERSION_CHECK_ENABLED = "updater.versioncheck.enabled";
 
         /**
+         *
+         * Adds capabilities to batch insert. Tested on PostgreSQL and H2.
+         */
+        public static final String ENABLE_BATCH_UPDATES = "database.batchinsert.enabled";
+        /**
+         * Size of database batch inserts
+         */
+        public static final String MAX_BATCH_SIZE = "database.batchinsert.maxsize";
+
+        /**
          * private constructor because this is a "utility" class containing
          * constants
          */


### PR DESCRIPTION
## Fixes Issue #
Makes use of batch capabilities of PreparedStatement. Executes updates every n rows (configurable), slowing down time for vulnerabilities updates by a near 10x factor on external databases (Postgresql for instance).
Tested on H2 (default), and Postgresql.

## Description of Change
Applies batch inserts for reference and vulnerability tables, solves
    slow one-by-one insert process, for Vulnerabilities with several
    references/vulnerabilities associated.
    Feature is configurable through properties: `database.batchinsert.enabled`
    and `database.batchinsert.maxsize`.

## Have test cases been added to cover the new functionality?
no

Tests available already cover the process. All tests where executed before pushing code to forked repository