### PR TITLE
Added documentation entry for reportOutputDirectory configuration option

### DIFF
--- a/dependency-check-maven/src/site/markdown/configuration.md
+++ b/dependency-check-maven/src/site/markdown/configuration.md
@@ -22,6 +22,7 @@ failOnError                 | Whether the build should fail if there is an error
 format                      | The report format to be generated (HTML, XML, CSV, JSON, VULN, ALL). This configuration option has no affect if using this within the Site plugin unless the externalReport is set to true. | HTML
 name                        | The name of the report in the site. | dependency-check or dependency-check:aggregate
 outputDirectory             | The location to write the report(s). Note, this is not used if generating the report as part of a `mvn site` build. | 'target'
+reportOutputDirectory       | Specifies the destination directory for generated Dependency-Check report. Note, this is only used if generating the report as a part of a `mvn site` build. | &nbsp; 
 scanSet                     | An optional collection of filesets that specify additional files and/or directories to analyze as part of the scan. If not specified, defaults to standard Maven conventions. | src/main/resources, src/main/filters, src/main/webapp
 skip                        | Skips the dependency-check analysis.                       | false
 skipProvidedScope           | Skip analysis for artifacts with Provided Scope.           | false


### PR DESCRIPTION
## Fixes Issue #
#1018 

## Description of Change
Adds a documentation entry for the `reportOutputDirectory` Maven plugin configuration option

## Have test cases been added to cover the new functionality?
N/A