### PR TITLE
updated lock file cleanup to be useable by other build plugins

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/H2DBShutdownHook.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/utils/H2DBShutdownHook.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2017 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.utils;
+
+/**
+ * Definition of the shutdown hook used during the unexpected shutdown during
+ * the update process of the H2 DB.
+ *
+ * @author Jeremy Long
+ */
+public abstract class H2DBShutdownHook extends Thread {
+
+    /**
+     * Adds the shutdown hook.
+     *
+     * @param lock the H2DB Lock reference
+     */
+    public abstract void add(H2DBLock lock);
+
+    /**
+     * Removes the shutdown hook.
+     */
+    public abstract void remove();
+}

--- a/dependency-check-core/src/main/resources/dependencycheck.properties
+++ b/dependency-check-core/src/main/resources/dependencycheck.properties
@@ -41,6 +41,8 @@ data.password=DC-Pass1337!
 data.driver_name=org.h2.Driver
 data.driver_path=
 
+# the class name of the H2 database shutdown hook
+data.h2.shutdownhook=org.owasp.dependencycheck.utils.H2DBCleanupHook
 
 proxy.disableSchemas=true
 # the number of days that the modified nvd cve data holds data for. We don't need

--- a/dependency-check-core/src/test/resources/dependencycheck.properties
+++ b/dependency-check-core/src/test/resources/dependencycheck.properties
@@ -36,6 +36,9 @@ data.password=DC-Pass1337!
 data.driver_name=org.h2.Driver
 data.driver_path=
 
+# the class name of the H2 database shutdown hook
+data.h2.shutdownhook=org.owasp.dependencycheck.utils.H2DBCleanupHook
+
 proxy.disableSchemas=true
 # the number of days that the modified nvd cve data holds data for. We don't need
 # to update the other files if we are within this timespan. Per NIST this file

--- a/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/dependency-check-maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1106,7 +1106,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
             mojoProperties = this.getClass().getClassLoader().getResourceAsStream(PROPERTIES_FILE);
             settings.mergeProperties(mojoProperties);
         } catch (IOException ex) {
-            getLog().warn("Unable to load the dependency-check ant task.properties file.");
+            getLog().warn("Unable to load the dependency-check maven mojo.properties file.");
             if (getLog().isDebugEnabled()) {
                 getLog().debug("", ex);
             }

--- a/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/dependency-check-utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -456,6 +456,10 @@ public final class Settings {
          * Size of database batch inserts
          */
         public static final String MAX_BATCH_SIZE = "database.batchinsert.maxsize";
+        /**
+         * The key that specifies the class name of the H2 database shutdown hook.
+         */
+        public static String H2DB_SHUTDOWN_HOOK = "data.h2.shutdownhook";
 
         /**
          * private constructor because this is a "utility" class containing
@@ -958,6 +962,7 @@ public final class Settings {
         }
         if (connStr.contains("%s")) {
             final File directory = getDataDirectory();
+            LOGGER.debug("Data directory: {}", directory);
             String fileName = null;
             if (dbFileNameKey != null) {
                 fileName = getString(dbFileNameKey);


### PR DESCRIPTION
## Fixes Issue #1030 

Updated the shutdown hook mechanism so that other build plugins can utilize their own shutdown mechanism. See https://github.com/jeremylong/DependencyCheck/pull/1030#issuecomment-352187395