### PR TITLE
False negative on xmlsec

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
@@ -429,19 +429,38 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
                     || identifier.getValue().startsWith("cpe:/a:oracle:opensso_enterprise:")
                     || identifier.getValue().startsWith("cpe:/a:sun:opensso_enterprise:")
                     || identifier.getValue().startsWith("cpe:/a:sun:opensso:"))) {
-                final String newCpe = String.format("cpe:/a:sun:opensso_enterprise:%s", identifier.getValue().substring(22));
-                final String newCpe2 = String.format("cpe:/a:oracle:opensso_enterprise:%s", identifier.getValue().substring(22));
-                final String newCpe3 = String.format("cpe:/a:sun:opensso:%s", identifier.getValue().substring(22));
-                final String newCpe4 = String.format("cpe:/a:oracle:opensso:%s", identifier.getValue().substring(22));
+                final String[] parts = identifier.getValue().split(":");
+                final int pos = parts[0].length() + parts[1].length() + parts[2].length() + parts[3].length() + 4;
+                final String newCpe = String.format("cpe:/a:sun:opensso_enterprise:%s", identifier.getValue().substring(pos));
+                final String newCpe2 = String.format("cpe:/a:oracle:opensso_enterprise:%s", identifier.getValue().substring(pos));
+                final String newCpe3 = String.format("cpe:/a:sun:opensso:%s", identifier.getValue().substring(pos));
+                final String newCpe4 = String.format("cpe:/a:oracle:opensso:%s", identifier.getValue().substring(pos));
                 try {
                     dependency.addIdentifier("cpe", newCpe,
-                            String.format(CPEAnalyzer.NVD_SEARCH_URL, URLEncoder.encode(newCpe, "UTF-8")));
+                            String.format(CPEAnalyzer.NVD_SEARCH_URL, URLEncoder.encode(newCpe, "UTF-8")),
+                            identifier.getConfidence());
                     dependency.addIdentifier("cpe", newCpe2,
-                            String.format(CPEAnalyzer.NVD_SEARCH_URL, URLEncoder.encode(newCpe2, "UTF-8")));
+                            String.format(CPEAnalyzer.NVD_SEARCH_URL, URLEncoder.encode(newCpe2, "UTF-8")),
+                            identifier.getConfidence());
                     dependency.addIdentifier("cpe", newCpe3,
-                            String.format(CPEAnalyzer.NVD_SEARCH_URL, URLEncoder.encode(newCpe3, "UTF-8")));
+                            String.format(CPEAnalyzer.NVD_SEARCH_URL, URLEncoder.encode(newCpe3, "UTF-8")),
+                            identifier.getConfidence());
                     dependency.addIdentifier("cpe", newCpe4,
-                            String.format(CPEAnalyzer.NVD_SEARCH_URL, URLEncoder.encode(newCpe4, "UTF-8")));
+                            String.format(CPEAnalyzer.NVD_SEARCH_URL, URLEncoder.encode(newCpe4, "UTF-8")),
+                            identifier.getConfidence());
+                } catch (UnsupportedEncodingException ex) {
+                    LOGGER.debug("", ex);
+                }
+            }
+            if ("cpe".equals(identifier.getType()) && identifier.getValue() != null
+                    && identifier.getValue().startsWith("cpe:/a:apache:santuario_xml_security_for_java:")) {
+                final String[] parts = identifier.getValue().split(":");
+                final int pos = parts[0].length() + parts[1].length() + parts[2].length() + parts[3].length() + 4;
+                final String newCpe = String.format("cpe:/a:apache:xml_security_for_java:%s", identifier.getValue().substring(pos));
+                try {
+                    dependency.addIdentifier("cpe", newCpe,
+                            String.format(CPEAnalyzer.NVD_SEARCH_URL, URLEncoder.encode(newCpe, "UTF-8")),
+                            identifier.getConfidence());
                 } catch (UnsupportedEncodingException ex) {
                     LOGGER.debug("", ex);
                 }

--- a/dependency-check-core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/dependency-check-core/src/main/resources/dependencycheck-base-suppression.xml
@@ -65,6 +65,7 @@
         9. mail_project is ruby library
         10. ldap_project is part of type3 written in php
         11. user import project is used in drupal (i.e. php)
+        12. xml_sec is a C library for XML security
         ]]></notes>
         <filePath regex="true">.*(\.(dll|jar|ear|war|pom|nupkg|nuspec)|pom\.xml|package.json)$</filePath>
         <cpe>cpe:/a:sandbox:sandbox</cpe>
@@ -81,6 +82,7 @@
         <cpe>cpe:/a:mail_project:mail</cpe>
         <cpe>cpe:/a:ldap_project:ldap</cpe>
         <cpe>cpe:/a:user_import_project:user_import</cpe>
+        <cpe>cpe:/a:xmlsec_project:xmlsec</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[


### PR DESCRIPTION
## Fixes Issue 1043

Added a hard-coded CPE for xmlsec.  If we see `cpe:/a:apache:santuario_xml_security_for_java:` then we will add `cpe:/a:apache:xml_security_for_java`. Higher confidence data creating a match on the first is causing this one to be missed.