### PR TITLE
Fix groovy script failure because of unescaped Windows File.separator.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,9 +351,9 @@ Copyright (c) 2012 - Jeremy Long
                             <scripts>
                                 <script><![CDATA[
                                 if ("dependency-check-parent".equals("${project.artifactId}")) {
-                                    config = "file:///${project.basedir}/src/main/config"
+                                    config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/src/main/config"
                                 } else {
-                                    config = "file:///${project.basedir}/../src/main/config"
+                                    config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/../src/main/config"
                                 }
                                 project.properties['odc.config']= config
                                 ]]></script>
@@ -370,9 +370,9 @@ Copyright (c) 2012 - Jeremy Long
                             <scripts>
                                 <script><![CDATA[
                                 if ("dependency-check-parent".equals("${project.artifactId}")) {
-                                    config = "file:///${project.basedir}/src/main/config"
+                                    config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/src/main/config"
                                 } else {
-                                    config = "file:///${project.basedir}/../src/main/config"
+                                    config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/../src/main/config"
                                 }
                                 project.properties['odc.config']= config
                                 ]]></script>
@@ -390,9 +390,9 @@ Copyright (c) 2012 - Jeremy Long
                             <scripts>
                                 <script><![CDATA[
                                 if ("dependency-check-parent".equals("${project.artifactId}")) {
-                                    config = "file:///${project.basedir}/src/main/config"
+                                    config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/src/main/config"
                                 } else {
-                                    config = "file:///${project.basedir}/../src/main/config"
+                                    config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/../src/main/config"
                                 }
                                 project.properties['odc.config']= config
                                 ]]></script>


### PR DESCRIPTION
[ERROR] gmavenplus-plugin:execute (add-dynamic-properties-clean) on project dependency-check-parent
              Error occurred while calling a method on a Groovy class from classpath.:
              InvocationTargetException: startup failed:
[ERROR] Script1.groovy: 2: unexpected char: '\' @ line 2, column 57.
[ERROR]              config = "file:///C:\dev\projects\DependencyCheck/src/main/config
