### PR TITLE
Added support for Java update version parsing.

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/utils/DependencyVersionUtil.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/DependencyVersionUtil.java
@@ -36,7 +36,7 @@ public final class DependencyVersionUtil {
     /**
      * Regular expression to extract version numbers from file names.
      */
-    private static final Pattern RX_VERSION = Pattern.compile("\\d+(\\.\\d{1,6})+(\\.?([_-](release|beta|alpha|\\d+)|[a-zA-Z_-]{1,3}\\d{0,8}))?");
+    private static final Pattern RX_VERSION = Pattern.compile("\\d+(\\.\\d{1,6})+(\\.?([_-](release|beta|alpha|\\d+)|update_[0-9]{1,3}|[a-zA-Z_-]{1,3}\\d{0,8}))?"); //
     /**
      * Regular expression to extract a single version number without periods.
      * This is a last ditch effort just to check in case we are missing a

--- a/core/src/test/java/org/owasp/dependencycheck/utils/DependencyVersionUtilTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/DependencyVersionUtilTest.java
@@ -88,4 +88,10 @@ public class DependencyVersionUtilTest extends BaseTest {
         assertEquals(expResult, result);
 
     }
+
+    @Test
+    public void testParseJavaVersion() {
+        assertEquals(DependencyVersionUtil.parseVersion("1.8.0.45"), DependencyVersionUtil.parseVersion("1.8.0.update_45"));
+        assertEquals(DependencyVersionUtil.parseVersion("1.8.0.145"), DependencyVersionUtil.parseVersion("1.8.0.update_145"));
+    }
 }


### PR DESCRIPTION
## Fixes Issue #760 (partially)

## Description of Change

Changes Java version parsing to parse Java update version correctly.

## Have test cases been added to cover the new functionality?

*yes*