### PR TITLE
Add projectReferences to xml and json output

### DIFF
--- a/core/src/main/resources/schema/dependency-check.1.7.xsd
+++ b/core/src/main/resources/schema/dependency-check.1.7.xsd
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema id="analysis"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           targetNamespace="https://jeremylong.github.io/DependencyCheck/dependency-check.1.7.xsd"
+           xmlns:dc="https://jeremylong.github.io/DependencyCheck/dependency-check.1.7.xsd">
+
+    <xs:complexType name="scanInfo">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element name="engineVersion" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="dataSource">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1" />
+                            <xs:element name="timestamp" type="xs:string" minOccurs="1" maxOccurs="1" />
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="projectInfo">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="groupID" type="xs:string" minOccurs="0" maxOccurs="1" />
+            <xs:element name="artifactID" type="xs:string" minOccurs="0" maxOccurs="1" />
+            <xs:element name="version" type="xs:string" minOccurs="0" maxOccurs="1" />
+            <xs:element name="reportDate" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="credits" type="xs:string" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="identifier">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="url" type="xs:string" minOccurs="0" maxOccurs="1" />
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1" />
+            <xs:element name="notes" type="xs:string" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="type" type="xs:string" use="required" />
+        <xs:attribute name="confidence" type="xs:string" use="optional" />
+    </xs:complexType>
+    <xs:complexType name="relatedDependency">
+        <xs:sequence>
+            <xs:element name="filePath" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="sha1" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="md5" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="identifier" type="dc:identifier" />
+            </xs:sequence>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="exception">
+        <xs:sequence>
+            <xs:element name="message" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="stackTrace" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="trace" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="innerException" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="message" minOccurs="0" maxOccurs="unbounded" />
+                        <xs:element name="stackTrace" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="trace" minOccurs="0" maxOccurs="unbounded" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="evidence">
+        <xs:sequence>
+            <xs:element name="source" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="value" type="xs:string" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="type" type="xs:string" use="required" />
+        <xs:attribute name="confidence" type="xs:string" use="required" />
+    </xs:complexType>
+    <xs:complexType name="reference">
+        <xs:sequence>
+            <xs:element name="source" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="url" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="software">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="allPreviousVersion" type="xs:boolean" />
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="vulnerability">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="cvssScore" type="xs:decimal" minOccurs="1" maxOccurs="1" />
+            <xs:element name="cvssAccessVector" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="cvssAccessComplexity" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="cvssAuthenticationr" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="cvssConfidentialImpact" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="cvssIntegrityImpact" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="cvssAvailabilityImpact" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="severity" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="cwe" type="xs:string" minOccurs="0" maxOccurs="1" />
+            <xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="notes" type="xs:string" minOccurs="0" maxOccurs="1" />
+            <xs:element name="references" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="reference" type="dc:reference" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="vulnerableSoftware" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="software" type="dc:software" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="source" type="xs:string" use="required" />
+    </xs:complexType>
+    <xs:complexType name="dependency">
+        <xs:sequence>
+            <xs:element name="fileName" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="filePath" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="md5" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="sha1" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1" />
+            <xs:element name="license" type="xs:string" minOccurs="0" maxOccurs="1" />
+            <xs:element name="projectReferences" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="projectReference" type="xs:string" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="relatedDependencies" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="relatedDependency" type="dc:relatedDependency" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="analysisExceptions" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="exception" type="dc:exception"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="evidenceCollected" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="evidence" type="dc:evidence"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="identifiers" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="identifier" type="dc:identifier" />
+                        </xs:sequence>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="suppressedIdentifier" type="dc:identifier"/>
+                        </xs:sequence>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="vulnerabilities" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="vulnerability" type="dc:vulnerability"/>
+                        </xs:sequence>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="suppressedVulnerability" type="dc:vulnerability"/>
+                        </xs:sequence>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="isVirtual" type="xs:boolean" use="required" />
+    </xs:complexType>
+
+    <xs:element name="analysis">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="scanInfo" type="dc:scanInfo"/>
+                <xs:element name="projectInfo" type="dc:projectInfo"/>
+                <xs:element name="dependencies">
+                    <xs:complexType>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="dependency" type="dc:dependency"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/core/src/main/resources/templates/jsonReport.vsl
+++ b/core/src/main/resources/templates/jsonReport.vsl
@@ -31,6 +31,16 @@
             "sha1": "$enc.json($dependency.Sha1sum)"
             #if($dependency.description),"description": "$enc.json($dependency.description)"#end
             #if($dependency.license),"license": "$enc.json($dependency.license)"#end
+            #if ($dependency.projectReferences.size()>0)
+            ,"projectReferences": [
+            #set($loopCount=0)
+            #foreach($ref in $dependency.projectReferences)
+                #set($loopCount=$loopCount+1)
+                #if($loopCount>1),#end
+                "$enc.json($ref)"
+            #end
+            ]
+            #end
             #if ($dependency.getRelatedDependencies().size()>0)
             ,"relatedDependencies": [
                 #foreach($related in $dependency.getRelatedDependencies()) #if($foreach.count > 1),#end {

--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -19,7 +19,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
 @version 1.2
 
 *#<?xml version="1.0"?>
-<analysis xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.1.6.xsd">
+<analysis xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.1.7.xsd">
     <scanInfo>
         <engineVersion>$version</engineVersion>
 #foreach($prop in $properties.getMetaData().entrySet())
@@ -55,6 +55,13 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
 #end
 #if ($dependency.license)
             <license>$enc.xml($dependency.license)</license>
+#end
+#if ($dependency.projectReferences.size()>0)
+            <projectReferences>
+#foreach($ref in $dependency.projectReferences)
+                <projectReference>$enc.xml($ref)</projectReference>
+#end
+            </projectReferences>
 #end
 #if ($dependency.getRelatedDependencies().size()>0)
             <relatedDependencies>

--- a/core/src/test/java/org/owasp/dependencycheck/reporting/ReportGeneratorIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/reporting/ReportGeneratorIT.java
@@ -75,7 +75,7 @@ public class ReportGeneratorIT extends BaseDBTestCase {
                 engine.analyzeDependencies();
                 engine.writeReports("Test Report", "org.owasp", "dependency-check-core", "1.4.7", writeTo, "XML");
             }
-            InputStream xsdStream = ReportGenerator.class.getClassLoader().getResourceAsStream("schema/dependency-check.1.6.xsd");
+            InputStream xsdStream = ReportGenerator.class.getClassLoader().getResourceAsStream("schema/dependency-check.1.7.xsd");
             StreamSource xsdSource = new StreamSource(xsdStream);
             StreamSource xmlSource = new StreamSource(writeTo);
             SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);


### PR DESCRIPTION
## Fixes Issue #1118 

## Description of Change

Add a projectReferences section to the `xml` and `json` output formats.
The section contains the information of the "Referenced In Projects/Scopes" section in the `html` output of the Aggregate task.

## Have test cases been added to cover the new functionality?

no