### PR TITLE
Updated broken links in markdown

### DIFF
--- a/src/site/markdown/data/database.md.vm
+++ b/src/site/markdown/data/database.md.vm
@@ -17,7 +17,7 @@ see the note about Central [here](./index.html).
 
 To setup a centralized database the following generalized steps can be used:
 
-<ol><li>Create the database and tables using either <a href="https://github.com/jeremylong/DependencyCheck/blob/master/dependency-check-core/src/main/resources/data/initialize.sql">initialize.sql</a>
+<ol><li>Create the database and tables using either <a href="https://github.com/jeremylong/DependencyCheck/blob/master/core/src/main/resources/data/initialize.sql">initialize.sql</a>
    or one of the other initialization scripts <a href="https://github.com/jeremylong/DependencyCheck/tree/master/dependency-check-core/src/main/resources/data">found here</a>.</li>
 <li>The account that the clients will connect using must have select granted on the tables.
      <ul><li>Note, the clients performing the scans should run with the noupdate setting. A single
@@ -31,9 +31,9 @@ To setup a centralized database the following generalized steps can be used:
        <li>The connection string, database user name, and the database user's password will also need to be configured.</li>
    </ul>
 </li></ol>
-Depending on the database being used, you may need to customize the [dbStatements.properties](https://github.com/jeremylong/DependencyCheck/blob/master/dependency-check-core/src/main/resources/data/dbStatements.properties).
+Depending on the database being used, you may need to customize the [dbStatements.properties](https://github.com/jeremylong/DependencyCheck/blob/master/core/src/main/resources/data/dbStatements.properties).
 Alternatively to modifying the dbStatements.properties it is possible to use a dialect file to support other databases.
-See [dbStatements_h2.properties](https://github.com/jeremylong/DependencyCheck/blob/master/dependency-check-core/src/main/resources/data/dbStatements_h2.properties)
+See [dbStatements_h2.properties](https://github.com/jeremylong/DependencyCheck/blob/master/core/src/main/resources/data/dbStatements_h2.properties)
 as an example.
 
 Also, if using an external database you will need to manually upgrade the schema. See [database upgrades](./upgrade.html) for more information.

--- a/src/site/markdown/general/hints.md
+++ b/src/site/markdown/general/hints.md
@@ -4,7 +4,7 @@ Due to how dependency-check identifies libraries, false negatives may occur (a C
 
 A possible reason for false negatives is re-naming of either the vendor or library name over time. Another case is when an artifact has missing info (manifest with no vendor).
 
-Dependency Check has a built in [hints](https://github.com/jeremylong/DependencyCheck/blob/master/dependency-check-core/src/main/resources/dependencycheck-base-hint.xml) file that is used in every check to help correct well known false negatives.
+Dependency Check has a built in [hints](https://github.com/jeremylong/DependencyCheck/blob/master/core/src/main/resources/dependencycheck-base-hint.xml) file that is used in every check to help correct well known false negatives.
 
 A sample hints file that add a product name and possible vendors for Spring framework dependencies would look like:
 
@@ -59,7 +59,7 @@ The following shows some other ways to add evidence
 ```
 
 
-The full schema for hints files can be found here: [dependency-hint.xsd](https://github.com/jeremylong/DependencyCheck/blob/master/dependency-check-core/src/main/resources/schema/dependency-hint.1.1.xsd "Hint Schema")
+The full schema for hints files can be found here: [dependency-hint.xsd](https://github.com/jeremylong/DependencyCheck/blob/master/core/src/main/resources/schema/dependency-hint.1.1.xsd "Hint Schema")
 
 Please see the appropriate configuration option in each interfaces configuration guide:
 

--- a/src/site/markdown/general/suppression.md
+++ b/src/site/markdown/general/suppression.md
@@ -73,7 +73,7 @@ HTML version of the report. The other common scenario would be to ignore all CVE
 </suppressions>
 ```
 
-The full schema for suppression files can be found here: [suppression.xsd](https://github.com/jeremylong/DependencyCheck/blob/master/dependency-check-core/src/main/resources/schema/suppression.xsd "Suppression Schema")
+The full schema for suppression files can be found here: [suppression.xsd](https://github.com/jeremylong/DependencyCheck/blob/master/core/src/main/resources/schema/suppression.xsd "Suppression Schema")
 
 Please see the appropriate configuration option in each interfaces configuration guide:
 


### PR DESCRIPTION
## Fixes Issue #1123 

## Description of Change
Updates broken links in the markdown to take into account that `dependency-check-core` is now just `core`.

## Have test cases been added to cover the new functionality?
No