### PR TITLE
Support NuGet Package References in MSBuild Project Files

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzer.java
@@ -1,0 +1,149 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.analyzer;
+
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.data.nuget.MSBuildProjectParseException;
+import org.owasp.dependencycheck.data.nuget.MSBuildProjectParser;
+import org.owasp.dependencycheck.data.nuget.NugetPackageReference;
+import org.owasp.dependencycheck.data.nuget.XPathMSBuildProjectParser;
+import org.owasp.dependencycheck.dependency.Confidence;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.EvidenceType;
+import org.owasp.dependencycheck.exception.InitializationException;
+import org.owasp.dependencycheck.utils.FileFilterBuilder;
+import org.owasp.dependencycheck.utils.Settings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.List;
+
+import static org.owasp.dependencycheck.analyzer.NuspecAnalyzer.DEPENDENCY_ECOSYSTEM;
+
+@ThreadSafe
+public class MSBuildProjectAnalyzer extends AbstractFileTypeAnalyzer {
+
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(NuspecAnalyzer.class);
+
+    /**
+     * The name of the analyzer.
+     */
+    private static final String ANALYZER_NAME = "MSBuild Project Analyzer";
+
+    /**
+     * The phase in which the analyzer runs.
+     */
+    private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.INFORMATION_COLLECTION;
+
+    /**
+     * The types of files on which this will work.
+     */
+    private static final String[] SUPPORTED_EXTENSIONS = new String[] { "csproj", "vbproj" };
+
+    /**
+     * The file filter used to determine which files this analyzer supports.
+     */
+    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addExtensions(SUPPORTED_EXTENSIONS).build();
+
+    @Override
+    public String getName() {
+        return ANALYZER_NAME;
+    }
+
+    @Override
+    public AnalysisPhase getAnalysisPhase() {
+        return ANALYSIS_PHASE;
+    }
+
+    @Override
+    protected FileFilter getFileFilter() {
+        return FILTER;
+    }
+
+    @Override
+    protected String getAnalyzerEnabledSettingKey() {
+        return Settings.KEYS.ANALYZER_MSBUILD_PROJECT_ENABLED;
+    }
+
+    @Override
+    protected void prepareFileTypeAnalyzer(Engine engine) throws InitializationException {
+        // intentionally left blank
+    }
+
+    @Override
+    protected void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
+        LOGGER.debug("Checking MSBuild project file {}", dependency);
+        try {
+            final MSBuildProjectParser parser = new XPathMSBuildProjectParser();
+            List<NugetPackageReference> packages;
+
+            try (FileInputStream fis = new FileInputStream(dependency.getActualFilePath())) {
+                packages = parser.parse(fis);
+            } catch (MSBuildProjectParseException | FileNotFoundException ex) {
+                throw new AnalysisException(ex);
+            }
+
+            if (packages == null || packages.isEmpty()) {
+                return;
+            }
+
+            for (NugetPackageReference npr : packages) {
+                Dependency child = new Dependency(dependency.getActualFile(), true);
+
+                String id = npr.getId();
+                String version = npr.getVersion();
+
+                child.setEcosystem(DEPENDENCY_ECOSYSTEM);
+                child.setName(id);
+                child.setVersion(version);
+                child.addEvidence(EvidenceType.PRODUCT, "msbuild", "id", id, Confidence.HIGHEST);
+                child.addEvidence(EvidenceType.VERSION, "msbuild", "version", version, Confidence.HIGHEST);
+
+                if (id.indexOf(".") > 0) {
+                    String[] parts = id.split("\\.");
+
+                    // example: Microsoft.EntityFrameworkCore
+                    child.addEvidence(EvidenceType.VENDOR, "msbuild", "id", parts[0], Confidence.MEDIUM);
+                    child.addEvidence(EvidenceType.PRODUCT, "msbuild", "id", parts[1], Confidence.MEDIUM);
+
+                    if (parts.length > 2) {
+                        String rest = id.substring(id.indexOf(".") + 1);
+                        child.addEvidence(EvidenceType.PRODUCT, "msbuild", "id", rest, Confidence.MEDIUM);
+                    }
+                } else {
+                    // example: jQuery
+                    child.addEvidence(EvidenceType.VENDOR, "msbuild", "id", id, Confidence.LOW);
+                }
+
+                engine.addDependency(child);
+            }
+
+        } catch (Throwable e) {
+            throw new AnalysisException(e);
+        }
+    }
+
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/MSBuildProjectParseException.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/MSBuildProjectParseException.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.nuget;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Exception during the parsing of a MSBuild Project file.
+ *
+ * @author paulirwin
+ */
+@ThreadSafe
+public class MSBuildProjectParseException extends Exception {
+
+    /**
+     * The serialVersionUID
+     */
+    private static final long serialVersionUID = 1;
+
+    /**
+     * Constructs a new exception with <code>null</code> as its detail message.
+     *
+     * The cause is not initialized, and may subsequently be initialized by a
+     * call to {@link java.lang.Throwable#initCause(java.lang.Throwable)}.
+     */
+    public MSBuildProjectParseException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause
+     * is not initialized, and may subsequently be initialized by a call to
+     * {@link java.lang.Throwable#initCause(java.lang.Throwable)}.
+     *
+     * @param message the detail message. The detail message is saved for later
+     * retrieval by the {@link java.lang.Throwable#getMessage()} method.
+     */
+    public MSBuildProjectParseException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * Note that the detail message associated with <code>cause</code> is
+     * <em>not</em>
+     * automatically incorporated in this exception's detail message.
+     *
+     * @param message the detail message (which is saved for later retrieval by
+     * the {@link java.lang.Throwable#getMessage()} method.
+     * @param cause the cause (which is saved for later retrieval by the
+     * {@link java.lang.Throwable#getCause()} method). (A <code>null</code>
+     * value is permitted, and indicates that the cause is nonexistent or
+     * unknown).
+     */
+    public MSBuildProjectParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/MSBuildProjectParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/MSBuildProjectParser.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.nuget;
+
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * Interface defining methods for parsing a MSBuild project file.
+ *
+ * @author paulirwin
+ *
+ */
+public interface MSBuildProjectParser {
+    /**
+     * Parse an input stream and returns a collection of {@link NugetPackageReference} objects.
+     *
+     * @param stream the input stream to parse
+     * @return a collection of discovered package references
+     * @throws MSBuildProjectParseException when an exception occurs
+     */
+    List<NugetPackageReference> parse(InputStream stream) throws MSBuildProjectParseException;
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetPackage.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetPackage.java
@@ -25,17 +25,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * @author colezlaw
  */
 @ThreadSafe
-public class NugetPackage {
-
-    /**
-     * The id.
-     */
-    private String id;
-
-    /**
-     * The version.
-     */
-    private String version;
+public class NugetPackage extends NugetPackageReference {
 
     /**
      * The title.
@@ -56,42 +46,6 @@ public class NugetPackage {
      * The licenseUrl.
      */
     private String licenseUrl;
-
-    /**
-     * Sets the id.
-     *
-     * @param id the id
-     */
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    /**
-     * Gets the id.
-     *
-     * @return the id
-     */
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * Sets the version.
-     *
-     * @param version the version
-     */
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    /**
-     * Gets the version.
-     *
-     * @return the version
-     */
-    public String getVersion() {
-        return version;
-    }
 
     /**
      * Sets the title.
@@ -174,8 +128,7 @@ public class NugetPackage {
             return false;
         }
         final NugetPackage o = (NugetPackage) other;
-        return o.getId().equals(id)
-                && o.getVersion().equals(version)
+        return super.equals(this)
                 && o.getTitle().equals(title)
                 && o.getAuthors().equals(authors)
                 && o.getOwners().equals(owners)
@@ -185,8 +138,7 @@ public class NugetPackage {
     @Override
     public int hashCode() {
         int hash = 7;
-        hash = 31 * hash + (null == id ? 0 : id.hashCode());
-        hash = 31 * hash + (null == version ? 0 : version.hashCode());
+        hash = 31 * hash + super.hashCode();
         hash = 31 * hash + (null == title ? 0 : title.hashCode());
         hash = 31 * hash + (null == authors ? 0 : authors.hashCode());
         hash = 31 * hash + (null == owners ? 0 : owners.hashCode());

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetPackageReference.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetPackageReference.java
@@ -1,0 +1,93 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.nuget;
+
+/**
+ * Represents a reference to a NuGet package and version.
+ *
+ * @author paulirwin
+ *
+ */
+public class NugetPackageReference {
+    /**
+     * The id.
+     */
+    private String id;
+
+    /**
+     * The version.
+     */
+    private String version;
+
+    /**
+     * Sets the id.
+     *
+     * @param id the id
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the id.
+     *
+     * @return the id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the version.
+     *
+     * @param version the version
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * Gets the version.
+     *
+     * @return the version
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || other.getClass() != this.getClass()) {
+            return false;
+        }
+        final NugetPackageReference o = (NugetPackageReference) other;
+        return o.getId().equals(id)
+                && o.getVersion().equals(version);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 31 * hash + (null == id ? 0 : id.hashCode());
+        hash = 31 * hash + (null == version ? 0 : version.hashCode());
+        return hash;
+    }
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/XPathMSBuildProjectParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/XPathMSBuildProjectParser.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.nuget;
+
+import org.owasp.dependencycheck.utils.XmlUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parses a MSBuild project file for NuGet references using XPath.
+ *
+ * @author paulirwin
+ */
+public class XPathMSBuildProjectParser implements MSBuildProjectParser {
+
+    /**
+     * Parses the given stream for MSBuild PackageReference elements.
+     *
+     * @param stream the input stream to parse
+     * @return a collection of discovered NuGet package references
+     * @throws MSBuildProjectParseException if an exception occurs
+     */
+    @Override
+    public List<NugetPackageReference> parse(InputStream stream) throws MSBuildProjectParseException {
+        try {
+            final DocumentBuilder db = XmlUtils.buildSecureDocumentBuilder();
+            final Document d = db.parse(stream);
+
+            final XPath xpath = XPathFactory.newInstance().newXPath();
+            final List<NugetPackageReference> packages = new ArrayList<>();
+
+            NodeList nodeList = (NodeList) xpath.evaluate("//PackageReference", d, XPathConstants.NODESET);
+
+            if (nodeList == null) {
+                throw new MSBuildProjectParseException("Unable to parse MSBuild project file");
+            }
+
+            for (int i = 0; i < nodeList.getLength(); i++) {
+                Node node = nodeList.item(i);
+                NamedNodeMap attrs = node.getAttributes();
+
+                Node include = attrs.getNamedItem("Include");
+                Node version = attrs.getNamedItem("Version");
+
+                if (include != null && version != null) {
+                    NugetPackageReference npr = new NugetPackageReference();
+
+                    npr.setId(include.getNodeValue());
+                    npr.setVersion(version.getNodeValue());
+
+                    packages.add(npr);
+                }
+            }
+
+            return packages;
+        } catch (ParserConfigurationException | SAXException | IOException | XPathExpressionException | MSBuildProjectParseException e) {
+            throw new MSBuildProjectParseException("Unable to parse MSBuild project file", e);
+        }
+    }
+
+}

--- a/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
+++ b/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
@@ -12,6 +12,7 @@ org.owasp.dependencycheck.analyzer.CentralAnalyzer
 org.owasp.dependencycheck.analyzer.NexusAnalyzer
 org.owasp.dependencycheck.analyzer.NuspecAnalyzer
 org.owasp.dependencycheck.analyzer.MSBuildProjectAnalyzer
+org.owasp.dependencycheck.analyzer.AssemblyAnalyzer
 org.owasp.dependencycheck.analyzer.PythonDistributionAnalyzer
 org.owasp.dependencycheck.analyzer.PythonPackageAnalyzer
 org.owasp.dependencycheck.analyzer.AutoconfAnalyzer

--- a/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
+++ b/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
@@ -11,7 +11,7 @@ org.owasp.dependencycheck.analyzer.VulnerabilitySuppressionAnalyzer
 org.owasp.dependencycheck.analyzer.CentralAnalyzer
 org.owasp.dependencycheck.analyzer.NexusAnalyzer
 org.owasp.dependencycheck.analyzer.NuspecAnalyzer
-org.owasp.dependencycheck.analyzer.AssemblyAnalyzer
+org.owasp.dependencycheck.analyzer.MSBuildProjectAnalyzer
 org.owasp.dependencycheck.analyzer.PythonDistributionAnalyzer
 org.owasp.dependencycheck.analyzer.PythonPackageAnalyzer
 org.owasp.dependencycheck.analyzer.AutoconfAnalyzer

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -110,6 +110,7 @@ analyzer.autoconf.enabled=true
 analyzer.cmake.enabled=true
 analyzer.assembly.enabled=true
 analyzer.nuspec.enabled=true
+analyzer.msbuildproject.enabled=true
 analyzer.openssl.enabled=true
 analyzer.central.enabled=true
 analyzer.nexus.enabled=false

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzerTest.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.analyzer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.EvidenceType;
+
+import java.io.File;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.owasp.dependencycheck.analyzer.NuspecAnalyzer.DEPENDENCY_ECOSYSTEM;
+
+public class MSBuildProjectAnalyzerTest extends BaseTest {
+
+    private MSBuildProjectAnalyzer instance;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        instance = new MSBuildProjectAnalyzer();
+        instance.initialize(getSettings());
+        instance.prepare(null);
+        instance.setEnabled(true);
+    }
+
+    @Test
+    public void testGetAnalyzerName() {
+        assertEquals("MSBuild Project Analyzer", instance.getName());
+    }
+
+    @Test
+    public void testSupportsFileExtensions() {
+        assertTrue(instance.accept(new File("test.csproj")));
+        assertTrue(instance.accept(new File("test.vbproj")));
+        assertFalse(instance.accept(new File("test.nuspec")));
+    }
+
+    @Test
+    public void testGetAnalysisPhaze() {
+        assertEquals(AnalysisPhase.INFORMATION_COLLECTION, instance.getAnalysisPhase());
+    }
+
+    @Test
+    public void testMSBuildProjectAnalysis() throws Exception {
+
+        try (Engine engine = new Engine(getSettings())) {
+            File file = BaseTest.getResourceAsFile(this, "msbuild/test.csproj");
+            Dependency toScan = new Dependency(file);
+            MSBuildProjectAnalyzer analyzer = new MSBuildProjectAnalyzer();
+            analyzer.setFilesMatched(true);
+            analyzer.initialize(getSettings());
+            analyzer.prepare(engine);
+            analyzer.setEnabled(true);
+            analyzer.analyze(toScan, engine);
+
+            assertEquals("3 dependencies should be found", 3, engine.getDependencies().length);
+
+            int foundCount = 0;
+
+            for (Dependency result : engine.getDependencies()) {
+                assertEquals(DEPENDENCY_ECOSYSTEM, result.getEcosystem());
+                assertTrue(result.isVirtual());
+
+                if ("Humanizer".equals(result.getName())) {
+                    foundCount++;
+                    assertTrue(result.getEvidence(EvidenceType.VENDOR).toString().contains("Humanizer"));
+                    assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("Humanizer"));
+                    assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains("2.2.0"));
+                } else if ("JetBrains.Annotations".equals(result.getName())) {
+                    foundCount++;
+                    assertTrue(result.getEvidence(EvidenceType.VENDOR).toString().contains("JetBrains"));
+                    assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("JetBrains.Annotations"));
+                    assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("Annotations"));
+                    assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains("11.1.0"));
+                } else if ("Microsoft.AspNetCore.All".equals(result.getName())) {
+                    foundCount++;
+                    assertTrue(result.getEvidence(EvidenceType.VENDOR).toString().contains("Microsoft"));
+                    assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("Microsoft.AspNetCore.All"));
+                    assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("AspNetCore"));
+                    assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("AspNetCore.All"));
+                    assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains("2.0.5"));
+                }
+            }
+
+            assertEquals("3 expected dependencies should be found", 3, foundCount);
+        }
+    }
+}

--- a/core/src/test/resources/dependencycheck.properties
+++ b/core/src/test/resources/dependencycheck.properties
@@ -105,6 +105,7 @@ analyzer.autoconf.enabled=true
 analyzer.cmake.enabled=true
 analyzer.assembly.enabled=true
 analyzer.nuspec.enabled=true
+analyzer.msbuildproject.enabled=true
 analyzer.openssl.enabled=true
 analyzer.central.enabled=true
 analyzer.nexus.enabled=false

--- a/core/src/test/resources/msbuild/test.csproj
+++ b/core/src/test/resources/msbuild/test.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net471</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Humanizer" Version="2.2.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+  </ItemGroup>
+
+</Project>

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -316,6 +316,10 @@ public final class Settings {
          */
         public static final String ANALYZER_NUSPEC_ENABLED = "analyzer.nuspec.enabled";
         /**
+         * The properties key for whether the .NET MSBuild Project analyzer is enabled.
+         */
+        public static final String ANALYZER_MSBUILD_PROJECT_ENABLED = "analyzer.msbuildproject.enabled";
+        /**
          * The properties key for whether the Nexus analyzer is enabled.
          */
         public static final String ANALYZER_NEXUS_ENABLED = "analyzer.nexus.enabled";


### PR DESCRIPTION
## Fixes Issue #1131 

## Description of Change

Adds a new MSBuildProjectAnalyzer for analyzing the new MSBuild format for NuGet package dependency references.

## Have test cases been added to cover the new functionality?

Yes