### PR TITLE
H2 Fast Database Import.

### DIFF
--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -23,7 +23,7 @@ data.file_name=dc.h2.db
 ### the gradle PurgeDataExtension.
 data.version=3.0
 
-data.connection_string=jdbc:h2:file:%s;MV_STORE=FALSE;AUTOCOMMIT=ON;
+data.connection_string=jdbc:h2:file:%s;MV_STORE=FALSE;AUTOCOMMIT=ON;LOG=0;CACHE_SIZE=65536;
 #data.connection_string=jdbc:mysql://localhost:3306/dependencycheck
 
 # user name and password for the database connection. The inherent case is to use H2.

--- a/core/src/test/resources/dependencycheck.properties
+++ b/core/src/test/resources/dependencycheck.properties
@@ -18,7 +18,7 @@ data.directory=[JAR]/data
 #if the filename has a %s it will be replaced with the current expected version
 data.file_name=dc.h2.db
 data.version=3.0
-data.connection_string=jdbc:h2:file:%s;MV_STORE=FALSE;AUTOCOMMIT=ON;
+data.connection_string=jdbc:h2:file:%s;MV_STORE=FALSE;AUTOCOMMIT=ON;LOG=0;CACHE_SIZE=65536;
 #data.connection_string=jdbc:mysql://localhost:3306/dependencycheck
 
 # user name and password for the database connection. The inherent case is to use H2.

--- a/utils/src/test/resources/dependencycheck.properties
+++ b/utils/src/test/resources/dependencycheck.properties
@@ -17,7 +17,7 @@ engine.version.url=http://jeremylong.github.io/DependencyCheck/current.txt
 data.directory=[JAR]/data
 data.file_name=dc.h2.db
 data.version=3.0
-data.connection_string=jdbc:h2:file:%s;MV_STORE=FALSE;AUTOCOMMIT=ON;
+data.connection_string=jdbc:h2:file:%s;MV_STORE=FALSE;AUTOCOMMIT=ON;LOG=0;CACHE_SIZE=65536;
 #data.connection_string=jdbc:h2:file:%s;AUTO_SERVER=TRUE;AUTOCOMMIT=ON;
 #data.connection_string=jdbc:mysql://localhost:3306/dependencycheck
 


### PR DESCRIPTION
## Fixes Issue #1102

## Description of Change

Based on performance testing a [Dependency Check NIST NVD Backup Maven Artifact](https://gitlab.com/freedumbytes/dependency-check-nist-nvd) for the H2 Database. 

The artifact restore in the end didn't improve performance. But a subset of [Fast Database Import](https://www.h2database.com/html/performance.html#fast_import) settings did (see also [Summary](https://gitlab.com/freedumbytes/dependency-check-nist-nvd#summary) and mvn build measurements).

## Have test cases been added to cover the new functionality?

no