### PR TITLE
Update clone URL and script location

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The repository has some large files due to test resources. The team has tried to
 However, it is recommended that you perform a shallow clone to save yourself time:
 
 ```bash
-git clone --depth 1 git@github.com:jeremylong/DependencyCheck.git
+git clone --depth 1 https://github.com/jeremylong/DependencyCheck.git
 ```
 
 On *nix

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ git clone --depth 1 https://github.com/jeremylong/DependencyCheck.git
 On *nix
 ```
 $ mvn install
-$ ./dependency-check-cli/target/release/bin/dependency-check.sh -h
-$ ./dependency-check-cli/target/release/bin/dependency-check.sh --project Testing --out . --scan ./src/test/resources
+$ ./cli/target/release/bin/dependency-check.sh -h
+$ ./cli/target/release/bin/dependency-check.sh --project Testing --out . --scan ./src/test/resources
 ```
 On Windows
 ```


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

Updates the docs.

Git URL will only work for contributors.
Maven seems to build into a different dir, so have updated that as well.

## Have test cases been added to cover the new functionality?

Nope