### PR TITLE
Support parallel bundler audit runs

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
@@ -479,9 +479,6 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
         } catch (IOException ioe) {
             throw new IOException("Unable to create temporary gem file");
         }
-        // if (!gemFile.createNewFile()) {
-        //     throw new IOException("Unable to create temporary gem file");
-        // }
         final String displayFileName = String.format("%s%c%s:%s", parentName, File.separatorChar, fileName, gem);
 
         FileUtils.write(gemFile, displayFileName, Charset.defaultCharset()); // unique contents to avoid dependency bundling

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
@@ -473,10 +473,15 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
      * @throws IOException thrown if a temporary gem file could not be written
      */
     private Dependency createDependencyForGem(Engine engine, String parentName, String fileName, String filePath, String gem) throws IOException {
-        final File gemFile = new File(getSettings().getTempDirectory(), gem + "_Gemfile.lock");
-        if (!gemFile.createNewFile()) {
+        final File gemFile;
+        try {
+            gemFile = File.createTempFile(gem, "_Gemfile.lock", getSettings().getTempDirectory());
+        } catch (IOException ioe) {
             throw new IOException("Unable to create temporary gem file");
         }
+        // if (!gemFile.createNewFile()) {
+        //     throw new IOException("Unable to create temporary gem file");
+        // }
         final String displayFileName = String.format("%s%c%s:%s", parentName, File.separatorChar, fileName, gem);
 
         FileUtils.write(gemFile, displayFileName, Charset.defaultCharset()); // unique contents to avoid dependency bundling


### PR DESCRIPTION
## Fixes Issue #

This will address the "Could not create temporary gem file" error mentioned in #1086.

## Description of Change
createTempFile will ensure that we have unique filenames for the gem
file, which will in turn ensure that we don't get an error when two
projects being checked at the same time have the same dependency.

## Have test cases been added to cover the new functionality?

No (sorry)