### PR TITLE
Proposed fix for issue #1145

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionParser.java
@@ -51,13 +51,17 @@ public class SuppressionParser {
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(SuppressionParser.class);
     /**
-     * The suppression schema file location.
+     * The suppression schema file location for v 1.2
      */
-    public static final String SUPPRESSION_SCHEMA = "schema/dependency-suppression.1.1.xsd";
+    public static final String SUPPRESSION_SCHEMA_1_2 = "schema/dependency-suppression.1.2.xsd";
     /**
-     * The old suppression schema file location.
+     * The suppression schema file location for v1.1.
      */
-    private static final String OLD_SUPPRESSION_SCHEMA = "schema/suppression.xsd";
+    public static final String SUPPRESSION_SCHEMA_1_1 = "schema/dependency-suppression.1.1.xsd";
+    /**
+     * The old suppression schema file location for v1.0.
+     */
+    private static final String SUPPRESSION_SCHEMA_1_0 = "schema/suppression.xsd";
 
     /**
      * Parses the given XML file and returns a list of the suppression rules
@@ -68,19 +72,11 @@ public class SuppressionParser {
      * @throws SuppressionParseException thrown if the XML file cannot be parsed
      */
     public List<SuppressionRule> parseSuppressionRules(File file) throws SuppressionParseException {
-        try {
-            try (FileInputStream fis = new FileInputStream(file)) {
-                return parseSuppressionRules(fis);
-            } catch (IOException ex) {
-                LOGGER.debug("", ex);
-                throw new SuppressionParseException(ex);
-            }
-        } catch (SAXException ex) {
-            try (FileInputStream fis = new FileInputStream(file)) {
-                return parseSuppressionRules(fis, OLD_SUPPRESSION_SCHEMA);
-            } catch (SAXException | IOException ex1) {
-                throw new SuppressionParseException(ex);
-            }
+        try (FileInputStream fis = new FileInputStream(file)) {
+            return parseSuppressionRules(fis);
+        } catch (SAXException | IOException ex) {
+            LOGGER.debug("", ex);
+            throw new SuppressionParseException(ex);
         }
     }
 
@@ -94,23 +90,13 @@ public class SuppressionParser {
      * @throws SAXException thrown if the XML cannot be parsed
      */
     public List<SuppressionRule> parseSuppressionRules(InputStream inputStream) throws SuppressionParseException, SAXException {
-        return parseSuppressionRules(inputStream, SUPPRESSION_SCHEMA);
-    }
-
-    /**
-     * Parses the given XML stream and returns a list of the suppression rules
-     * contained.
-     *
-     * @param inputStream an InputStream containing suppression rules
-     * @param schema the schema used to validate the XML stream
-     * @return a list of suppression rules
-     * @throws SuppressionParseException thrown if the XML cannot be parsed
-     * @throws SAXException thrown if the XML cannot be parsed
-     */
-    private List<SuppressionRule> parseSuppressionRules(InputStream inputStream, String schema) throws SuppressionParseException, SAXException {
-        try (InputStream schemaStream = FileUtils.getResourceAsStream(schema)) {
+        try (
+                InputStream schemaStream12 = FileUtils.getResourceAsStream(SUPPRESSION_SCHEMA_1_2);
+                InputStream schemaStream11 = FileUtils.getResourceAsStream(SUPPRESSION_SCHEMA_1_1);
+                InputStream schemaStream10 = FileUtils.getResourceAsStream(SUPPRESSION_SCHEMA_1_0);
+            ) {
             final SuppressionHandler handler = new SuppressionHandler();
-            final SAXParser saxParser = XmlUtils.buildSecureSaxParser(schemaStream);
+            final SAXParser saxParser = XmlUtils.buildSecureSaxParser(schemaStream12, schemaStream11, schemaStream10);
             final XMLReader xmlReader = saxParser.getXMLReader();
             xmlReader.setErrorHandler(new SuppressionErrorHandler());
             xmlReader.setContentHandler(handler);

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
@@ -18,11 +18,13 @@
 package org.owasp.dependencycheck.xml.suppression;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.concurrent.NotThreadSafe;
+import javax.xml.bind.DatatypeConverter;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Identifier;
 import org.owasp.dependencycheck.dependency.Vulnerability;
@@ -75,6 +77,30 @@ public class SuppressionRule {
      * section.
      */
     private boolean base;
+
+    /**
+     * A date until which the suppression is to be retained. This can be used
+     * to make a temporary suppression that auto-expires to suppress a CVE
+     * while waiting for the vulnerability fix of the dependency to be
+     * released.
+     */
+    private Calendar until;
+
+    /**
+     * Get the (@code{nullable}) value of until
+     * @return the value of until
+     */
+    public Calendar getUntil() {
+        return until;
+    }
+
+    /**
+     * Set the value of until
+     * @param until new value of until
+     */
+    public void setUntil(Calendar until) {
+        this.until = until;
+    }
 
     /**
      * Get the value of filePath.
@@ -502,6 +528,9 @@ public class SuppressionRule {
     public String toString() {
         final StringBuilder sb = new StringBuilder(64);
         sb.append("SuppressionRule{");
+        if (until != null) {
+            sb.append("until=").append(DatatypeConverter.printDate(until)).append(',');
+        }
         if (filePath != null) {
             sb.append("filePath=").append(filePath).append(',');
         }

--- a/core/src/main/resources/schema/dependency-suppression.1.2.xsd
+++ b/core/src/main/resources/schema/dependency-suppression.1.2.xsd
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema id="suppressions"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           targetNamespace="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd"
+           xmlns:dc="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+
+    <xs:complexType name="regexStringType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="regex" use="optional" type="xs:boolean" default="false"/>
+                <xs:attribute name="caseSensitive" use="optional" type="xs:boolean" default="false"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:simpleType name="cvssScoreType">
+        <xs:restriction base="xs:decimal">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="10"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="cveType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="((\w+\-)?CVE\-\d\d\d\d\-\d+|\d+)"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="sha1Type">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-fA-F0-9]{40}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="suppressions">
+        <xs:complexType>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="suppress">
+                    <xs:complexType>
+                        <xs:sequence minOccurs="1" maxOccurs="1">
+                            <xs:sequence minOccurs="0" maxOccurs="1">
+                                <xs:element name="notes" type="xs:string"/>
+                            </xs:sequence>
+                            <xs:choice minOccurs="0" maxOccurs="1">
+                                <xs:element name="filePath" type="dc:regexStringType"/>
+                                <xs:element name="sha1" type="dc:sha1Type"/>
+                                <xs:element name="gav" type="dc:regexStringType"/>
+                            </xs:choice>
+                            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                                <xs:element name="cpe" type="dc:regexStringType"/>
+                                <xs:element name="cve" type="dc:cveType"/>
+                                <xs:element name="cwe" type="xs:positiveInteger"/>
+                                <xs:element name="cvssBelow" type="dc:cvssScoreType"/>
+                            </xs:choice>
+                        </xs:sequence>
+                        <xs:attribute name="base" use="optional" type="xs:boolean" default="false"/>
+                        <xs:attribute name="until" use="optional" type="xs:date">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    When specified the suppression will only be active when the specified date is still in the future. On and after the 'until' date the suppression will no longer be active.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionParserTest.java
@@ -19,6 +19,7 @@ package org.owasp.dependencycheck.xml.suppression;
 
 import java.io.File;
 import java.util.List;
+import org.junit.Assert;
 
 import static org.junit.Assert.assertTrue;
 
@@ -33,14 +34,36 @@ import org.owasp.dependencycheck.BaseTest;
 public class SuppressionParserTest extends BaseTest {
 
     /**
-     * Test of parseSuppressionRules method, of class SuppressionParser.
+     * Test of parseSuppressionRules method, of class SuppressionParser for the v1.0 suppressions XML Schema.
      */
     @Test
-    public void testParseSuppressionRules() throws Exception {
+    public void testParseSuppressionRulesV1_0() throws Exception {
         //File file = new File(this.getClass().getClassLoader().getResource("suppressions.xml").getPath());
         File file = BaseTest.getResourceAsFile(this, "suppressions.xml");
         SuppressionParser instance = new SuppressionParser();
         List<SuppressionRule> result = instance.parseSuppressionRules(file);
-        assertTrue(result.size() > 3);
+        Assert.assertEquals(5, result.size());
+    }
+    /**
+     * Test of parseSuppressionRules method, of class SuppressionParser for the v1.1 suppressions XML Schema.
+     */
+    @Test
+    public void testParseSuppressionRulesV1_1() throws Exception {
+        //File file = new File(this.getClass().getClassLoader().getResource("suppressions.xml").getPath());
+        File file = BaseTest.getResourceAsFile(this, "suppressions_1_1.xml");
+        SuppressionParser instance = new SuppressionParser();
+        List<SuppressionRule> result = instance.parseSuppressionRules(file);
+        Assert.assertEquals(5, result.size());
+    }
+    /**
+     * Test of parseSuppressionRules method, of class SuppressionParser for the v1.2 suppressions XML Schema.
+     */
+    @Test
+    public void testParseSuppressionRulesV1_2() throws Exception {
+        //File file = new File(this.getClass().getClassLoader().getResource("suppressions.xml").getPath());
+        File file = BaseTest.getResourceAsFile(this, "suppressions_1_2.xml");
+        SuppressionParser instance = new SuppressionParser();
+        List<SuppressionRule> result = instance.parseSuppressionRules(file);
+        Assert.assertEquals(4, result.size());
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionParserTest.java
@@ -21,8 +21,6 @@ import java.io.File;
 import java.util.List;
 import org.junit.Assert;
 
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
 
@@ -37,7 +35,7 @@ public class SuppressionParserTest extends BaseTest {
      * Test of parseSuppressionRules method, of class SuppressionParser for the v1.0 suppressions XML Schema.
      */
     @Test
-    public void testParseSuppressionRulesV1_0() throws Exception {
+    public void testParseSuppressionRulesV1dot0() throws Exception {
         //File file = new File(this.getClass().getClassLoader().getResource("suppressions.xml").getPath());
         File file = BaseTest.getResourceAsFile(this, "suppressions.xml");
         SuppressionParser instance = new SuppressionParser();
@@ -48,7 +46,7 @@ public class SuppressionParserTest extends BaseTest {
      * Test of parseSuppressionRules method, of class SuppressionParser for the v1.1 suppressions XML Schema.
      */
     @Test
-    public void testParseSuppressionRulesV1_1() throws Exception {
+    public void testParseSuppressionRulesV1dot1() throws Exception {
         //File file = new File(this.getClass().getClassLoader().getResource("suppressions.xml").getPath());
         File file = BaseTest.getResourceAsFile(this, "suppressions_1_1.xml");
         SuppressionParser instance = new SuppressionParser();
@@ -59,7 +57,7 @@ public class SuppressionParserTest extends BaseTest {
      * Test of parseSuppressionRules method, of class SuppressionParser for the v1.2 suppressions XML Schema.
      */
     @Test
-    public void testParseSuppressionRulesV1_2() throws Exception {
+    public void testParseSuppressionRulesV1dot2() throws Exception {
         //File file = new File(this.getClass().getClassLoader().getResource("suppressions.xml").getPath());
         File file = BaseTest.getResourceAsFile(this, "suppressions_1_2.xml");
         SuppressionParser instance = new SuppressionParser();

--- a/core/src/test/resources/suppressions_1_1.xml
+++ b/core/src/test/resources/suppressions_1_1.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions
+    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+    xmlns='https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd'
+    xsi:schemaLocation='https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd'>
+    <suppress>
+        <notes><![CDATA[
+        This suppresses cpe:/a:csv:csv:1.0 for some.jar in the "c:\path\to" directory.
+        ]]></notes>
+        <filePath>c:\path\to\some.jar</filePath>
+        <cpe>cpe:/a:csv:csv:1.0</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        This suppresses any jboss:jboss cpe for any test.jar in any directory.
+        ]]></notes>
+        <filePath regex="true">.*\btest\.jar</filePath>
+        <cpe>cpe:/a:jboss:jboss</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        This suppresses a specific cve for any test.jar in any directory.
+        ]]></notes>
+        <filePath regex="true">.*\btest\.jar</filePath>
+        <cve>CVE-2013-1337</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        This suppresses a specific cve for any dependency in any directory that has the specified sha1 checksum.
+        ]]></notes>
+        <sha1>384FAA82E193D4E4B0546059CA09572654BC3970</sha1>
+        <cve>CVE-2013-1337</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        This suppresses all CVE entries that have a score below CVSS 7.
+        ]]></notes>
+        <cvssBelow>7</cvssBelow>
+    </suppress>
+</suppressions>

--- a/core/src/test/resources/suppressions_1_2.xml
+++ b/core/src/test/resources/suppressions_1_2.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions
+    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+    xmlns='https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd'
+    xsi:schemaLocation='https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd'>
+    <suppress>
+        <notes><![CDATA[
+        This suppresses cpe:/a:csv:csv:1.0 for some.jar in the "c:\path\to" directory.
+        ]]></notes>
+        <filePath>c:\path\to\some.jar</filePath>
+        <cpe>cpe:/a:csv:csv:1.0</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        This suppresses any jboss:jboss cpe for any test.jar in any directory.
+        ]]></notes>
+        <filePath regex="true">.*\btest\.jar</filePath>
+        <cpe>cpe:/a:jboss:jboss</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        This suppresses a specific cve for any test.jar in any directory.
+        ]]></notes>
+        <filePath regex="true">.*\btest\.jar</filePath>
+        <cve>CVE-2013-1337</cve>
+    </suppress>
+    <suppress until="2014-01-01Z">
+        <notes><![CDATA[
+        This suppresses a specific cve for any dependency in any directory that has the specified sha1 checksum. If current date is not yet on or beyond 1 Jan 2014
+        ]]></notes>
+        <sha1>384FAA82E193D4E4B0546059CA09572654BC3970</sha1>
+        <cve>CVE-2013-1337</cve>
+    </suppress>
+    <suppress until="9999-03-25Z">
+        <notes><![CDATA[
+        This suppresses all CVE entries that have a score below CVSS 7.  
+        But only if current date is not yet on or beyond 31 Dec 9999 
+        (which is expected to be sufficiently far in the future to have this 
+            rule still be active when the test-cases run)
+        ]]></notes>
+        <cvssBelow>7</cvssBelow>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
## Fixes Issue #1145 

## Description of Change
- Implemented single-pass multi-xml-schema-validating parser similar to existing code for hints parsing
- Added new suppression xmlschema version with the 'until' for a suppression rule implemented as attribute of suppress (which seems more logical to me than a child element)
- updated code to support this temporary suppression of issues
- Added testcases for the proper parsing of the version 1.1 (existing) and 1.2 (new) suppressionfile xmlschema

## Have test cases been added to cover the new functionality?

yes (validating that suppressions with until 'in-the-past' do not appear in the suppression-rules and suppressions without until and with until 'in-the-future' do appear in the suppression-rules after parsing)