### PR TITLE
Throw db errors

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -857,6 +857,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * them.
      *
      * @throws UpdateException thrown if the operation fails
+     * @throws DatabaseException if the operation fails due to a local database failure
      */
     public void doUpdates() throws UpdateException {
         doUpdates(false);
@@ -869,8 +870,9 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param remainOpen whether or not the database connection should remain
      * open
      * @throws UpdateException thrown if the operation fails
+     * @throws DatabaseException if the operation fails due to a local database failure
      */
-    public void doUpdates(boolean remainOpen) throws UpdateException {
+    public void doUpdates(boolean remainOpen) throws UpdateException, DatabaseException {
         if (mode.isDatabaseRequired()) {
             H2DBLock dblock = null;
             try {
@@ -894,8 +896,6 @@ public class Engine implements FileFilter, AutoCloseable {
                 if (remainOpen) {
                     openDatabase(true, false);
                 }
-            } catch (DatabaseException ex) {
-                throw new UpdateException(ex.getMessage(), ex.getCause());
             } catch (H2DBLockException ex) {
                 throw new UpdateException("Unable to obtain an exclusive lock on the H2 database to perform updates", ex);
             } finally {

--- a/core/src/test/java/org/owasp/dependencycheck/data/update/EngineVersionCheckTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/update/EngineVersionCheckTest.java
@@ -83,7 +83,7 @@ public class EngineVersionCheckTest extends BaseTest {
 
         DatabaseProperties properties = Deencapsulation.newUninitializedInstance(DatabaseProperties.class);
 
-                String updateToVersion = "1.2.6";
+        String updateToVersion = "1.2.6";
         String currentVersion = "1.2.6";
         
         long lastChecked = dateToMilliseconds("2014-12-01");

--- a/core/src/test/java/org/owasp/dependencycheck/data/update/EngineVersionCheckTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/update/EngineVersionCheckTest.java
@@ -16,6 +16,8 @@
 package org.owasp.dependencycheck.data.update;
 
 import java.util.Properties;
+
+import mockit.Deencapsulation;
 import mockit.Mock;
 import mockit.MockUp;
 import org.joda.time.DateTime;
@@ -64,7 +66,7 @@ public class EngineVersionCheckTest extends BaseTest {
      */
     @Test
     public void testShouldUpdate() throws Exception {
-        DatabaseProperties properties = new MockUp<DatabaseProperties>() {
+        new MockUp<DatabaseProperties>() {
             final private Properties properties = new Properties();
             
             @Mock
@@ -77,9 +79,11 @@ public class EngineVersionCheckTest extends BaseTest {
                 return properties.getProperty(key);
             }
             
-        }.getMockInstance();
-        
-        String updateToVersion = "1.2.6";
+        };
+
+        DatabaseProperties properties = Deencapsulation.newUninitializedInstance(DatabaseProperties.class);
+
+                String updateToVersion = "1.2.6";
         String currentVersion = "1.2.6";
         
         long lastChecked = dateToMilliseconds("2014-12-01");

--- a/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
+++ b/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
@@ -68,7 +68,7 @@ public class BaseDependencyCheckMojoTest extends BaseTest {
     @Test
     public void testScanArtifacts() throws DatabaseException, InvalidSettingException {
         if (canRun()) {
-            MavenProject project = new MockUp<MavenProject>() {
+            new MockUp<MavenProject>() {
                 @Mock
                 public Set<Artifact> getArtifacts() {
                     Set<Artifact> artifacts = new HashSet<>();
@@ -89,7 +89,9 @@ public class BaseDependencyCheckMojoTest extends BaseTest {
                 public String getName() {
                     return "test-project";
                 }
-            }.getMockInstance();
+            };
+
+            MavenProject project = new MavenProject();
 
             boolean autoUpdate = getSettings().getBoolean(Settings.KEYS.AUTO_UPDATE);
             getSettings().setBoolean(Settings.KEYS.AUTO_UPDATE, false);


### PR DESCRIPTION
## Fixes Issue #1152 

## Description of Change

Allows DatabaseExceptions to cause a complete failure instead of being wrapped and treated as a failure to pull the National Vulnerability Database.

## Have test cases been added to cover the new functionality?

*no*

A few failing tests were fixed.