### PR TITLE
Upgrade maven-dependency-tree version

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -720,7 +720,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      */
     protected ExceptionCollection scanArtifacts(MavenProject project, Engine engine) {
         try {
-            final DependencyNode dn = dependencyGraphBuilder.buildDependencyGraph(project, null, reactorProjects);
+            final DependencyNode dn = dependencyGraphBuilder.buildDependencyGraph(project.getProjectBuildingRequest(), null, reactorProjects);
             final ProjectBuildingRequest buildingRequest = newResolveArtifactProjectBuildingRequest();
             return collectDependencies(engine, project, dn.getChildren(), buildingRequest);
         } catch (DependencyGraphBuilderException ex) {

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Locale;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.execution.MavenSession;

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Locale;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.execution.MavenSession;
@@ -720,7 +721,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      */
     protected ExceptionCollection scanArtifacts(MavenProject project, Engine engine) {
         try {
-            final DependencyNode dn = dependencyGraphBuilder.buildDependencyGraph(project.getProjectBuildingRequest(), null, reactorProjects);
+            final DependencyNode dn = dependencyGraphBuilder.buildDependencyGraph(newResolveArtifactProjectBuildingRequest(), null, reactorProjects);
             final ProjectBuildingRequest buildingRequest = newResolveArtifactProjectBuildingRequest();
             return collectDependencies(engine, project, dn.getChildren(), buildingRequest);
         } catch (DependencyGraphBuilderException ex) {
@@ -905,6 +906,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     public ProjectBuildingRequest newResolveArtifactProjectBuildingRequest() {
         final ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
         buildingRequest.setRemoteRepositories(remoteRepositories);
+        buildingRequest.setProject(project);
         return buildingRequest;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@ Copyright (c) 2012 - Jeremy Long
         <plexus-sec-dispatcher.version>1.4</plexus-sec-dispatcher.version>
 
         <!-- upgrading beyond 2.2 requires reworking the dependency resolution -->
-        <maven-dependency-tree.version>2.2</maven-dependency-tree.version>
+        <maven-dependency-tree.version>3.0.1</maven-dependency-tree.version>
 
         <org.glassfish.javax.json.version>1.0.4</org.glassfish.javax.json.version>
         <maven-artifact-transfer.version>0.9.1</maven-artifact-transfer.version>


### PR DESCRIPTION
## Description of Change
As a follow up to comments in issue #740
* Update maven shared library dependency-tree to the current version
* Adapt the DependencyCheckMojo where needed to restore compatibility with this newer lib

## Have test cases been added to cover the new functionality?
no new functionality; existing testcases pass and are assumed to cover dependency-resolution