### PR TITLE
Remove out-dated comment that the check tasks dependsOn dependencyChe…

### DIFF
--- a/src/site/markdown/dependency-check-gradle/index.md.vm
+++ b/src/site/markdown/dependency-check-gradle/index.md.vm
@@ -32,12 +32,10 @@ apply plugin: 'org.owasp.dependencycheck'
 
 $H$H$H Step 2, Run the dependencyCheckAnalyze task
 
-Once the dependency-check plugin is applied, if the [Java plugin](https://docs.gradle.org/current/userguide/java_plugin.html)
-is being used dependency-check will automatically be added to the `check` task.
-Alternatively, you can run dependency-check directly:
+You can run dependency-check by executing:
 
 ```bash
-gradle dependencyCheckAnalyze --info
+./gradlew dependencyCheckAnalyze
 ```
 
 The reports will be generated automatically under `build/reports` folder.


### PR DESCRIPTION
The [Documentation](https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/index.html#Step_2_Run_the_dependencyCheckAnalyze_task) of the Gradle plugin states:

> Once the dependency-check plugin is applied, if the Java plugin is being used dependency-check will automatically be added to the check task.

 This feature has been removed with jeremylong/dependency-check-gradle#26 . I updated the documentation accordingly.