### PR TITLE
Fixed broken CVE2.0 url links in property and markdown files

### DIFF
--- a/ant/src/site/markdown/config-update.md
+++ b/ant/src/site/markdown/config-update.md
@@ -33,9 +33,9 @@ may be the cvedUrl properties, which can be used to host a mirror of the NVD wit
 
 Property             | Description                                                                                           | Default Value
 ---------------------|-------------------------------------------------------------------------------------------------------|------------------
-cveUrl12Modified     | URL for the modified CVE 1.2.                                                                         | https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
+cveUrl12Modified     | URL for the modified CVE 1.2.                                                                         | https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-modified.xml.gz
 cveUrl20Modified     | URL for the modified CVE 2.0.                                                                         | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
-cveUrl12Base         | Base URL for each year's CVE 1.2, the %d will be replaced with the year.                              | https://nvd.nist.gov/download/nvdcve-%d.xml.gz
+cveUrl12Base         | Base URL for each year's CVE 1.2, the %d will be replaced with the year.                              | https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-%d.xml.gz
 cveUrl20Base         | Base URL for each year's CVE 2.0, the %d will be replaced with the year.                              | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 dataDirectory        | Data directory that is used to store the local copy of the NVD. This should generally not be changed. | data
 databaseDriverName   | The name of the database driver. Example: org.h2.Driver.                                              | &nbsp;

--- a/ant/src/site/markdown/config-update.md
+++ b/ant/src/site/markdown/config-update.md
@@ -34,9 +34,9 @@ may be the cvedUrl properties, which can be used to host a mirror of the NVD wit
 Property             | Description                                                                                           | Default Value
 ---------------------|-------------------------------------------------------------------------------------------------------|------------------
 cveUrl12Modified     | URL for the modified CVE 1.2.                                                                         | https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
-cveUrl20Modified     | URL for the modified CVE 2.0.                                                                         | https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
+cveUrl20Modified     | URL for the modified CVE 2.0.                                                                         | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
 cveUrl12Base         | Base URL for each year's CVE 1.2, the %d will be replaced with the year.                              | https://nvd.nist.gov/download/nvdcve-%d.xml.gz
-cveUrl20Base         | Base URL for each year's CVE 2.0, the %d will be replaced with the year.                              | https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml.gz
+cveUrl20Base         | Base URL for each year's CVE 2.0, the %d will be replaced with the year.                              | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 dataDirectory        | Data directory that is used to store the local copy of the NVD. This should generally not be changed. | data
 databaseDriverName   | The name of the database driver. Example: org.h2.Driver.                                              | &nbsp;
 databaseDriverPath   | The path to the database driver JAR file; only used if the driver is not in the class path.           | &nbsp;

--- a/cli/src/site/markdown/arguments.md
+++ b/cli/src/site/markdown/arguments.md
@@ -27,7 +27,7 @@ Advanced Options
 Short  | Argument&nbsp;Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Parameter | Description                                     | Default&nbsp;Value
 -------|------------------------|-----------------|----------------------------------------------------------------------------------|-------------------
        | \-\-cveUrl12Modified   | \<url\>         | URL for the modified CVE 1.2                                                     | https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
-       | \-\-cveUrl20Modified   | \<url\>         | URL for the modified CVE 2.0                                                     | https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
+       | \-\-cveUrl20Modified   | \<url\>         | URL for the modified CVE 2.0                                                     | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
        | \-\-cveUrl12Base       | \<url\>         | Base URL for each year's CVE 1.2, the %d will be replaced with the year          | https://nvd.nist.gov/download/nvdcve-%d.xml.gz
        | \-\-cveUrl20Base       | \<url\>         | Base URL for each year's CVE 2.0, the %d will be replaced with the year          | https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml.gz
  \-P   | \-\-propertyfile       | \<file\>        | Specifies a file that contains properties to use instead of applicaion defaults. | &nbsp;

--- a/cli/src/site/markdown/arguments.md
+++ b/cli/src/site/markdown/arguments.md
@@ -26,10 +26,10 @@ Advanced Options
 ================
 Short  | Argument&nbsp;Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Parameter | Description                                     | Default&nbsp;Value
 -------|------------------------|-----------------|----------------------------------------------------------------------------------|-------------------
-       | \-\-cveUrl12Modified   | \<url\>         | URL for the modified CVE 1.2                                                     | https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
+       | \-\-cveUrl12Modified   | \<url\>         | URL for the modified CVE 1.2                                                     | https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-modified.xml.gz
        | \-\-cveUrl20Modified   | \<url\>         | URL for the modified CVE 2.0                                                     | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
-       | \-\-cveUrl12Base       | \<url\>         | Base URL for each year's CVE 1.2, the %d will be replaced with the year          | https://nvd.nist.gov/download/nvdcve-%d.xml.gz
-       | \-\-cveUrl20Base       | \<url\>         | Base URL for each year's CVE 2.0, the %d will be replaced with the year          | https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml.gz
+       | \-\-cveUrl12Base       | \<url\>         | Base URL for each year's CVE 1.2, the %d will be replaced with the year          | https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-%d.xml.gz
+       | \-\-cveUrl20Base       | \<url\>         | Base URL for each year's CVE 2.0, the %d will be replaced with the year          | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
  \-P   | \-\-propertyfile       | \<file\>        | Specifies a file that contains properties to use instead of applicaion defaults. | &nbsp;
        | \-\-updateonly         |                 | If set only the update phase of dependency-check will be executed; no scan will be executed and no report will be generated. | &nbsp;
        | \-\-disablePyDist      |                 | Sets whether the [experimental](../analyzers/index.html) Python Distribution Analyzer will be used.                      | false

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -57,12 +57,12 @@ cve.startyear=2002
 cve.url-1.2.modified=https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
 #cve.url-1.2.modified=http://nvd.nist.gov/download/nvdcve-modified.xml
 #the original URL and modified URL should be the same; this is used to detect if we are using an internal NVD CVE copy
-cve.url-2.0.original=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
-cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
+cve.url-2.0.original=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
+cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
 #cve.url-2.0.modified=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-modified.xml
 cve.url-1.2.base=https://nvd.nist.gov/download/nvdcve-%d.xml.gz
 #cve.url-1.2.base=http://nvd.nist.gov/download/nvdcve-%d.xml
-cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml.gz
+cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 #cve.url-2.0.base=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml
 cve.cpe.startswith.filter=cpe:/a:
 
@@ -75,7 +75,7 @@ analyzer.nexus.url=https://repository.sonatype.org/service/local/
 # If set to true, the proxy will still ONLY be used if the proxy properties (proxy.url, proxy.port)
 # are configured
 analyzer.nexus.proxy=true
-
+s
 # the URL for searching search.maven.org for SHA-1 and whether it's enabled
 analyzer.central.enabled=true
 analyzer.central.url=https://search.maven.org/solrsearch/select

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -54,13 +54,13 @@ cve.check.validforhours=4
 #first year to pull data from the URLs below
 cve.startyear=2002
 # the path to the modified nvd cve xml file.
-cve.url-1.2.modified=https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
+cve.url-1.2.modified=https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-modified.xml.gz
 #cve.url-1.2.modified=http://nvd.nist.gov/download/nvdcve-modified.xml
 #the original URL and modified URL should be the same; this is used to detect if we are using an internal NVD CVE copy
 cve.url-2.0.original=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
 cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
 #cve.url-2.0.modified=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-modified.xml
-cve.url-1.2.base=https://nvd.nist.gov/download/nvdcve-%d.xml.gz
+cve.url-1.2.base=https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-%d.xml.gz
 #cve.url-1.2.base=http://nvd.nist.gov/download/nvdcve-%d.xml
 cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 #cve.url-2.0.base=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml
@@ -75,7 +75,7 @@ analyzer.nexus.url=https://repository.sonatype.org/service/local/
 # If set to true, the proxy will still ONLY be used if the proxy properties (proxy.url, proxy.port)
 # are configured
 analyzer.nexus.proxy=true
-s
+
 # the URL for searching search.maven.org for SHA-1 and whether it's enabled
 analyzer.central.enabled=true
 analyzer.central.url=https://search.maven.org/solrsearch/select

--- a/core/src/test/resources/dependencycheck.properties
+++ b/core/src/test/resources/dependencycheck.properties
@@ -49,13 +49,13 @@ cve.check.validforhours=0
 #first year to pull data from the URLs below
 cve.startyear=2014
 # the path to the modified nvd cve xml file.
-cve.url-1.2.modified=https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
+cve.url-1.2.modified=https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-modified.xml.gz
 #cve.url-1.2.modified=http://nvd.nist.gov/download/nvdcve-modified.xml
 #the original URL and modified URL should be the same; this is used to detect if we are using an internal NVD CVE copy
 cve.url-2.0.original=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
 cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
 #cve.url-2.0.modified=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-modified.xml
-cve.url-1.2.base=https://nvd.nist.gov/download/nvdcve-%d.xml.gz
+cve.url-1.2.base=https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-%d.xml.gz
 #cve.url-1.2.base=http://nvd.nist.gov/download/nvdcve-%d.xml
 cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 #cve.url-2.0.base=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml

--- a/core/src/test/resources/dependencycheck.properties
+++ b/core/src/test/resources/dependencycheck.properties
@@ -52,12 +52,12 @@ cve.startyear=2014
 cve.url-1.2.modified=https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
 #cve.url-1.2.modified=http://nvd.nist.gov/download/nvdcve-modified.xml
 #the original URL and modified URL should be the same; this is used to detect if we are using an internal NVD CVE copy
-cve.url-2.0.original=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
-cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
+cve.url-2.0.original=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
+cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
 #cve.url-2.0.modified=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-modified.xml
 cve.url-1.2.base=https://nvd.nist.gov/download/nvdcve-%d.xml.gz
 #cve.url-1.2.base=http://nvd.nist.gov/download/nvdcve-%d.xml
-cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml.gz
+cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 #cve.url-2.0.base=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml
 cve.cpe.startswith.filter=cpe:/a:
 

--- a/maven/src/site/markdown/configuration.md
+++ b/maven/src/site/markdown/configuration.md
@@ -77,9 +77,9 @@ may be the cvedUrl properties, which can be used to host a mirror of the NVD wit
 Property             | Description                                                                                 | Default Value
 ---------------------|---------------------------------------------------------------------------------------------|------------------
 cveUrl12Modified     | URL for the modified CVE 1.2.                                                               | https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
-cveUrl20Modified     | URL for the modified CVE 2.0.                                                               | https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
+cveUrl20Modified     | URL for the modified CVE 2.0.                                                               | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
 cveUrl12Base         | Base URL for each year's CVE 1.2, the %d will be replaced with the year.                    | https://nvd.nist.gov/download/nvdcve-%d.xml.gz
-cveUrl20Base         | Base URL for each year's CVE 2.0, the %d will be replaced with the year.                    | https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml.gz
+cveUrl20Base         | Base URL for each year's CVE 2.0, the %d will be replaced with the year.                    | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 connectionTimeout    | Sets the URL Connection Timeout used when downloading external data.                        | &nbsp;
 dataDirectory        | Sets the data directory to hold SQL CVEs contents. This should generally not be changed.    | ~/.m2/repository/org/owasp/dependency-check-data/
 databaseDriverName   | The name of the database driver. Example: org.h2.Driver.                                    | &nbsp;

--- a/maven/src/site/markdown/configuration.md
+++ b/maven/src/site/markdown/configuration.md
@@ -76,9 +76,9 @@ may be the cvedUrl properties, which can be used to host a mirror of the NVD wit
 
 Property             | Description                                                                                 | Default Value
 ---------------------|---------------------------------------------------------------------------------------------|------------------
-cveUrl12Modified     | URL for the modified CVE 1.2.                                                               | https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
+cveUrl12Modified     | URL for the modified CVE 1.2.                                                               | https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-modified.xml.gz
 cveUrl20Modified     | URL for the modified CVE 2.0.                                                               | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
-cveUrl12Base         | Base URL for each year's CVE 1.2, the %d will be replaced with the year.                    | https://nvd.nist.gov/download/nvdcve-%d.xml.gz
+cveUrl12Base         | Base URL for each year's CVE 1.2, the %d will be replaced with the year.                    | https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-%d.xml.gz
 cveUrl20Base         | Base URL for each year's CVE 2.0, the %d will be replaced with the year.                    | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 connectionTimeout    | Sets the URL Connection Timeout used when downloading external data.                        | &nbsp;
 dataDirectory        | Sets the data directory to hold SQL CVEs contents. This should generally not be changed.    | ~/.m2/repository/org/owasp/dependency-check-data/

--- a/src/site/markdown/dependency-check-gradle/configuration-update.md
+++ b/src/site/markdown/dependency-check-gradle/configuration-update.md
@@ -63,10 +63,10 @@ Note, if ANY of the cve configuration group are set - they should all be set to 
 
 Config Group | Property          | Description                                                                                 | Default Value
 -------------|-------------------|---------------------------------------------------------------------------------------------|------------------
-cve          | url12Modified     | URL for the modified CVE 1.2.                                                               | https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
-cve          | url20Modified     | URL for the modified CVE 2.0.                                                               | https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
-cve          | url12Base         | Base URL for each year's CVE 1.2, the %d will be replaced with the year.                    | https://nvd.nist.gov/download/nvdcve-%d.xml.gz
-cve          | url20Base         | Base URL for each year's CVE 2.0, the %d will be replaced with the year.                    | https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml.gz
+cve          | url12Modified     | URL for the modified CVE 1.2.                                                               | https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-modified.xml.gz
+cve          | url20Modified     | URL for the modified CVE 2.0.                                                               | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
+cve          | url12Base         | Base URL for each year's CVE 1.2, the %d will be replaced with the year.                    | https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-%d.xml.gz
+cve          | url20Base         | Base URL for each year's CVE 2.0, the %d will be replaced with the year.                    | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 data         | directory         | Sets the data directory to hold SQL CVEs contents. This should generally not be changed.    | &nbsp;
 data         | driver            | The name of the database driver. Example: org.h2.Driver.                                    | &nbsp;
 data         | driverPath        | The path to the database driver JAR file; only used if the driver is not in the class path. | &nbsp;

--- a/src/site/markdown/dependency-check-gradle/configuration.md
+++ b/src/site/markdown/dependency-check-gradle/configuration.md
@@ -76,9 +76,9 @@ Note, if ANY of the cve configuration group are set - they should all be set to 
 Config Group | Property          | Description                                                                                 | Default Value
 -------------|-------------------|---------------------------------------------------------------------------------------------|------------------
 cve          | url12Modified     | URL for the modified CVE 1.2.                                                               | https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
-cve          | url20Modified     | URL for the modified CVE 2.0.                                                               | https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
+cve          | url20Modified     | URL for the modified CVE 2.0.                                                               | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
 cve          | url12Base         | Base URL for each year's CVE 1.2, the %d will be replaced with the year.                    | https://nvd.nist.gov/download/nvdcve-%d.xml.gz
-cve          | url20Base         | Base URL for each year's CVE 2.0, the %d will be replaced with the year.                    | https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml.gz
+cve          | url20Base         | Base URL for each year's CVE 2.0, the %d will be replaced with the year.                    | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 data         | directory         | Sets the data directory to hold SQL CVEs contents. This should generally not be changed.    | &nbsp;
 data         | driver            | The name of the database driver. Example: org.h2.Driver.                                    | &nbsp;
 data         | driverPath        | The path to the database driver JAR file; only used if the driver is not in the class path. | &nbsp;

--- a/src/site/markdown/dependency-check-gradle/configuration.md
+++ b/src/site/markdown/dependency-check-gradle/configuration.md
@@ -75,9 +75,9 @@ Note, if ANY of the cve configuration group are set - they should all be set to 
 
 Config Group | Property          | Description                                                                                 | Default Value
 -------------|-------------------|---------------------------------------------------------------------------------------------|------------------
-cve          | url12Modified     | URL for the modified CVE 1.2.                                                               | https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
+cve          | url12Modified     | URL for the modified CVE 1.2.                                                               | https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-modified.xml.gz
 cve          | url20Modified     | URL for the modified CVE 2.0.                                                               | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
-cve          | url12Base         | Base URL for each year's CVE 1.2, the %d will be replaced with the year.                    | https://nvd.nist.gov/download/nvdcve-%d.xml.gz
+cve          | url12Base         | Base URL for each year's CVE 1.2, the %d will be replaced with the year.                    | https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-%d.xml.gz
 cve          | url20Base         | Base URL for each year's CVE 2.0, the %d will be replaced with the year.                    | https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 data         | directory         | Sets the data directory to hold SQL CVEs contents. This should generally not be changed.    | &nbsp;
 data         | driver            | The name of the database driver. Example: org.h2.Driver.                                    | &nbsp;

--- a/utils/src/test/resources/dependencycheck.properties
+++ b/utils/src/test/resources/dependencycheck.properties
@@ -51,11 +51,11 @@ cve.url.modified.validfordays=7
 cve.startyear=2014
 cve.url-1.2.modified=https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
 #cve.url-1.2.modified=http://nvd.nist.gov/download/nvdcve-modified.xml
-cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
+cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
 #cve.url-2.0.modified=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-modified.xml
 cve.url-1.2.base=https://nvd.nist.gov/download/nvdcve-%d.xml.gz
 #cve.url-1.2.base=http://nvd.nist.gov/download/nvdcve-%d.xml
-cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml.gz
+cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 #cve.url-2.0.base=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml
 
 # the URL for searching Nexus for SHA-1 hashes and whether it's enabled

--- a/utils/src/test/resources/dependencycheck.properties
+++ b/utils/src/test/resources/dependencycheck.properties
@@ -49,11 +49,11 @@ cve.url.modified.validfordays=7
 
 # the path to the modified nvd cve xml file.
 cve.startyear=2014
-cve.url-1.2.modified=https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
+cve.url-1.2.modified=https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-modified.xml.gz
 #cve.url-1.2.modified=http://nvd.nist.gov/download/nvdcve-modified.xml
 cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
 #cve.url-2.0.modified=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-modified.xml
-cve.url-1.2.base=https://nvd.nist.gov/download/nvdcve-%d.xml.gz
+cve.url-1.2.base=https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-%d.xml.gz
 #cve.url-1.2.base=http://nvd.nist.gov/download/nvdcve-%d.xml
 cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 #cve.url-2.0.base=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml


### PR DESCRIPTION
## Fixes Issue #1171 

## Description of Change

Changed the urls for CVE 2.0 original and modified entries to the new addres

## Have test cases been added to cover the new functionality?

no, existing are already testing this functionalitiy