### PR TITLE
Update CVE 2.0 urls to use latest from NVD

### DIFF
--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -57,12 +57,12 @@ cve.startyear=2002
 cve.url-1.2.modified=https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
 #cve.url-1.2.modified=http://nvd.nist.gov/download/nvdcve-modified.xml
 #the original URL and modified URL should be the same; this is used to detect if we are using an internal NVD CVE copy
-cve.url-2.0.original=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
-cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
+cve.url-2.0.original=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-modified.xml.gz
+cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-modified.xml.gz
 #cve.url-2.0.modified=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-modified.xml
 cve.url-1.2.base=https://nvd.nist.gov/download/nvdcve-%d.xml.gz
 #cve.url-1.2.base=http://nvd.nist.gov/download/nvdcve-%d.xml
-cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml.gz
+cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 #cve.url-2.0.base=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml
 cve.cpe.startswith.filter=cpe:/a:
 

--- a/core/src/test/resources/dependencycheck.properties
+++ b/core/src/test/resources/dependencycheck.properties
@@ -52,12 +52,12 @@ cve.startyear=2014
 cve.url-1.2.modified=https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
 #cve.url-1.2.modified=http://nvd.nist.gov/download/nvdcve-modified.xml
 #the original URL and modified URL should be the same; this is used to detect if we are using an internal NVD CVE copy
-cve.url-2.0.original=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
-cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
+cve.url-2.0.original=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-modified.xml.gz
+cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-modified.xml.gz
 #cve.url-2.0.modified=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-modified.xml
 cve.url-1.2.base=https://nvd.nist.gov/download/nvdcve-%d.xml.gz
 #cve.url-1.2.base=http://nvd.nist.gov/download/nvdcve-%d.xml
-cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml.gz
+cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 #cve.url-2.0.base=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml
 cve.cpe.startswith.filter=cpe:/a:
 

--- a/utils/src/test/resources/dependencycheck.properties
+++ b/utils/src/test/resources/dependencycheck.properties
@@ -51,11 +51,11 @@ cve.url.modified.validfordays=7
 cve.startyear=2014
 cve.url-1.2.modified=https://nvd.nist.gov/download/nvdcve-Modified.xml.gz
 #cve.url-1.2.modified=http://nvd.nist.gov/download/nvdcve-modified.xml
-cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-Modified.xml.gz
+cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-modified.xml.gz
 #cve.url-2.0.modified=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-modified.xml
 cve.url-1.2.base=https://nvd.nist.gov/download/nvdcve-%d.xml.gz
 #cve.url-1.2.base=http://nvd.nist.gov/download/nvdcve-%d.xml
-cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml.gz
+cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 #cve.url-2.0.base=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml
 
 # the URL for searching Nexus for SHA-1 hashes and whether it's enabled


### PR DESCRIPTION
URLs retrieved from https://nvd.nist.gov/vuln/data-feeds

## Description of Change

In response to changes to the URL format of NVD's database at https://nvd.nist.gov/vuln/data-feeds, we've updated the URLs in the properties files.

## Have test cases been added to cover the new functionality?

*no* - the existing test cases fail without these changes, these updates fix the existing test cases.