### PR TITLE
Reduce dependency on central

### DIFF
--- a/maven/src/main/resources/mojo.properties
+++ b/maven/src/main/resources/mojo.properties
@@ -1,2 +1,3 @@
 # the path to the data directory
 data.directory=[JAR]/../../dependency-check-data/3.0
+analyzer.central.enabled=false


### PR DESCRIPTION
## Fixes Issue - too many to reference...

- If a Java dependency already has analyzed a pom.xml the Central Analyzer will be skipped
- The Maven plugin no longer uses the central analyzer

## Have test cases been added to cover the new functionality?

existing