### PR TITLE
Suppress CVE-2017-14798 in PostgreSQL JDBC client

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -1665,6 +1665,7 @@
             suppress specific CVE that are for the server
         ]]></notes>
         <gav regex="true">^(org\.)?postgresql:postgresql:.*$</gav>
+        <cve>CVE-2017-14798</cve>
         <cve>CVE-2017-8806</cve>
         <cve>CVE-2006-5540</cve>
         <cve>CVE-2006-5542</cve>


### PR DESCRIPTION
## Description of Change

New suppression for false positive in PostgreSQL JDBC driver:

CVE-2017-14798  

> A race condition in the postgresql init script could be used by attackers able to access the postgresql account to escalate their privileges to root. 
