### PR TITLE
Apply MS SQL suppressions to official artifactId (fixes #1017)

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -1766,7 +1766,7 @@
         FP per issue #947 - instead of suppressing the whole thing, we will just
             suppress specific CVE that are for the server
         ]]></notes>
-        <gav regex="true">^com\.microsoft\.sqlserver:sqljdbc4:.*$</gav>
+        <gav regex="true">^com\.microsoft\.sqlserver:(sqljdbc4|mssql-jdbc):.*$</gav>
         <cve>CVE-2000-1081</cve>
         <cve>CVE-2004-1560</cve>
         <cve>CVE-2000-1083</cve>


### PR DESCRIPTION
## Fixes Issue #

Fixes #1017 (at least the initial reported part of it, the rest of that issue should probably moved to a new issue)

## Description of Change

See #1017, the official GA of the MS SQL JDBC driver is `com.microsoft.sqlserver:mssql-jdbc` - I left `com.microsoft.sqlserver:sqljdbc4` intact since that seems to be a common GA used before the driver was OpenSource...