### PR TITLE
removed tlsv1

### DIFF
--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -93,7 +93,7 @@ archive.scan.depth=3
 
 # use HEAD (default) or GET as HTTP request method for query timestamp
 downloader.quick.query.timestamp=true
-downloader.tls.protocols=TLSv1,TLSv1.1,TLSv1.2,TLSv1.3
+downloader.tls.protocols=TLSv1.1,TLSv1.2,TLSv1.3
 
 # defines if the experimental and retired analyzers can be enabled
 analyzer.experimental.enabled=false

--- a/core/src/test/resources/dependencycheck.properties
+++ b/core/src/test/resources/dependencycheck.properties
@@ -89,7 +89,7 @@ archive.scan.depth=3
 
 # use HEAD (default) or GET as HTTP request method for query timestamp
 downloader.quick.query.timestamp=true
-downloader.tls.protocols=TLSv1,TLSv1.1,TLSv1.2,TLSv1.3
+downloader.tls.protocols=TLSv1.1,TLSv1.2,TLSv1.3
 
 # defines if the experimental and retired analyzers can be enabled
 analyzer.experimental.enabled=false

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/SSLSocketFactoryEx.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/SSLSocketFactoryEx.java
@@ -46,6 +46,11 @@ public class SSLSocketFactoryEx extends SSLSocketFactory {
      * The configured settings.
      */
     private final Settings settings;
+    
+    /**
+     * Simple boolean flag to prevent logging the protocols repeatedly.
+     */
+    private static boolean protocolsLogged = false;
 
     /**
      * Constructs a new SSLSocketFactory.
@@ -267,7 +272,7 @@ public class SSLSocketFactoryEx extends SSLSocketFactory {
         String[] availableProtocols = null;
         final String[] preferredProtocols = settings.getString(
                 Settings.KEYS.DOWNLOADER_TLS_PROTOCOL_LIST,
-                "TLSv1,TLSv1.1,TLSv1.2,TLSv1.3")
+                "TLSv1.1,TLSv1.2,TLSv1.3")
                 .split(",");
         try {
             final SSLSocketFactory factory = sslCtxt.getSocketFactory();
@@ -275,15 +280,16 @@ public class SSLSocketFactoryEx extends SSLSocketFactory {
 
             availableProtocols = socket.getSupportedProtocols();
             Arrays.sort(availableProtocols);
-            if (LOGGER.isDebugEnabled()) {
+            if (LOGGER.isDebugEnabled() && !protocolsLogged) {
+                protocolsLogged = true;
                 LOGGER.debug("Available Protocols:");
                 for (String p : availableProtocols) {
                     LOGGER.debug(p);
                 }
             }
         } catch (Exception ex) {
-            LOGGER.debug("Error getting protocol list, using TLSv1", ex);
-            return new String[]{"TLSv1"};
+            LOGGER.debug("Error getting protocol list, using TLSv1.1-1.3", ex);
+            return new String[]{"TLSv1.1", "TLSv1.2", "TLSv1.3"};
         } finally {
             if (socket != null) {
                 try {

--- a/utils/src/test/resources/dependencycheck.properties
+++ b/utils/src/test/resources/dependencycheck.properties
@@ -3,7 +3,7 @@ application.version=${pom.version}
 autoupdate=true
 
 # the url to obtain the current engine version from
-engine.version.url=http://jeremylong.github.io/DependencyCheck/current.txt
+engine.version.url=https://jeremylong.github.io/DependencyCheck/current.txt
 
 #temp.directory defaults to System.getProperty("java.io.tmpdir")
 #temp.directory=[path to temp directory]
@@ -15,10 +15,10 @@ engine.version.url=http://jeremylong.github.io/DependencyCheck/current.txt
 # will not be used. The data.directory will be resolved and if the connection string
 # below contains a %s then the data.directory will replace the %s.
 data.directory=[JAR]/data
+#if the filename has a %s it will be replaced with the current expected version
 data.file_name=dc.h2.db
 data.version=3.0
 data.connection_string=jdbc:h2:file:%s;MV_STORE=FALSE;AUTOCOMMIT=ON;LOG=0;CACHE_SIZE=65536;
-#data.connection_string=jdbc:h2:file:%s;AUTO_SERVER=TRUE;AUTOCOMMIT=ON;
 #data.connection_string=jdbc:mysql://localhost:3306/dependencycheck
 
 # user name and password for the database connection. The inherent case is to use H2.
@@ -36,27 +36,34 @@ data.password=DC-Pass1337!
 data.driver_name=org.h2.Driver
 data.driver_path=
 
-proxy.disableSchemas=true
-# the path to the cpe xml file
-cpe.url=http://static.nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.2.xml.gz
-# the path to the cpe meta data file.
-cpe.meta.url=http://static.nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.2.meta
+# the class name of the H2 database shutdown hook
+data.h2.shutdownhook=org.owasp.dependencycheck.utils.H2DBCleanupHook
 
+proxy.disableSchemas=true
 # the number of days that the modified nvd cve data holds data for. We don't need
 # to update the other files if we are within this timespan. Per NIST this file
 # holds 8 days of updates, we are using 7 just to be safe.
 cve.url.modified.validfordays=7
-
-# the path to the modified nvd cve xml file.
+# the number of hours to wait before checking if updates are available from the NVD.
+cve.check.validforhours=0
+#first year to pull data from the URLs below
 cve.startyear=2014
+# the path to the modified nvd cve xml file.
 cve.url-1.2.modified=https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-modified.xml.gz
 #cve.url-1.2.modified=http://nvd.nist.gov/download/nvdcve-modified.xml
+#the original URL and modified URL should be the same; this is used to detect if we are using an internal NVD CVE copy
+cve.url-2.0.original=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
 cve.url-2.0.modified=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-Modified.xml.gz
 #cve.url-2.0.modified=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-modified.xml
 cve.url-1.2.base=https://nvd.nist.gov/feeds/xml/cve/1.2/nvdcve-%d.xml.gz
 #cve.url-1.2.base=http://nvd.nist.gov/download/nvdcve-%d.xml
 cve.url-2.0.base=https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%d.xml.gz
 #cve.url-2.0.base=http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%d.xml
+cve.cpe.startswith.filter=cpe:/a:
+
+cpe.validfordays=30
+cpe.url=https://static.nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz
+
 
 # the URL for searching Nexus for SHA-1 hashes and whether it's enabled
 analyzer.nexus.enabled=true
@@ -65,6 +72,63 @@ analyzer.nexus.url=https://repository.sonatype.org/service/local/
 # are configured
 analyzer.nexus.proxy=true
 
+# the URL for searching search.maven.org for SHA-1 and whether it's enabled
+analyzer.central.enabled=true
+analyzer.central.url=https://search.maven.org/solrsearch/select
+# Note - the central query is used in a String.format(query, url, sha1)).
+# As such, it must have two %s and any other % must be escapped by doubling it
+analyzer.central.query=%s?q=1:%s&wt=xml
+analyzer.central.retry.count=7
+analyzer.central.parallel.analysis=true
+
+# the URL for searching api.nodesecurity.io
+analyzer.nsp.url=https://api.nodesecurity.io/check
+
+# the number of nested archives that will be searched.
+archive.scan.depth=3
+
 # use HEAD (default) or GET as HTTP request method for query timestamp
 downloader.quick.query.timestamp=true
-downloader.tls.protocols=TLSv1,TLSv1.1,TLSv1.2,TLSv1.3
+downloader.tls.protocols=TLSv1.1,TLSv1.2,TLSv1.3
+
+# defines if the experimental and retired analyzers can be enabled
+analyzer.experimental.enabled=false
+analyzer.retired.enabled=false
+
+analyzer.jar.enabled=true
+analyzer.archive.enabled=true
+analyzer.node.package.enabled=true
+analyzer.nsp.package.enabled=true
+analyzer.composer.lock.enabled=true
+analyzer.python.distribution.enabled=true
+analyzer.python.package.enabled=true
+analyzer.ruby.gemspec.enabled=true
+analyzer.autoconf.enabled=true
+analyzer.cmake.enabled=true
+analyzer.assembly.enabled=true
+analyzer.nuspec.enabled=true
+analyzer.openssl.enabled=true
+analyzer.central.enabled=true
+analyzer.nexus.enabled=false
+analyzer.cocoapods.enabled=true
+analyzer.swift.package.manager.enabled=true
+#whether the nexus analyzer uses the proxy
+analyzer.nexus.proxy=true
+
+#Use your own bundle-audit install directory.
+analyzer.bundle.audit.path=/usr/local/bin/bundle-audit
+analyzer.cpe.enabled=true
+analyzer.cpesuppression.enabled=true
+analyzer.dependencybundling.enabled=true
+analyzer.dependencymerging.enabled=true
+analyzer.falsepositive.enabled=true
+analyzer.filename.enabled=true
+analyzer.hint.enabled=true
+analyzer.nvdcve.enabled=true
+analyzer.vulnerabilitysuppression.enabled=true
+updater.nvdcve.enabled=true
+updater.versioncheck.enabled=true
+
+ecosystem.skip.cpeanalyzer=npm
+database.batchinsert.enabled=true
+database.batchinsert.maxsize=1000


### PR DESCRIPTION
## Fixes Issue #1070

It appears having TLSv1 in the list of available protocols is causing issues in some environments. As such, as this should not be used anymore we are removing it from the default list.

See comments on #1070 and https://github.com/spotbugs/spotbugs-maven-plugin/pull/41.

## Have test cases been added to cover the new functionality?

Existing test cases cover the change.