### PR TITLE
Migrate from deprecated commons-lang3 to supported commons-text

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -188,6 +188,10 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
         </dependency>

--- a/core/src/main/java/org/owasp/dependencycheck/reporting/EscapeTool.java
+++ b/core/src/main/java/org/owasp/dependencycheck/reporting/EscapeTool.java
@@ -21,7 +21,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Set;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.owasp.dependencycheck.dependency.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
+++ b/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
@@ -35,7 +35,7 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.concurrent.NotThreadSafe;
-import org.apache.commons.lang3.text.WordUtils;
+import org.apache.commons.text.WordUtils;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.context.Context;

--- a/core/src/main/java/org/owasp/dependencycheck/xml/pom/Model.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/pom/Model.java
@@ -22,8 +22,8 @@ import java.util.List;
 import java.util.Properties;
 import javax.annotation.concurrent.NotThreadSafe;
 
-import org.apache.commons.lang3.text.StrLookup;
-import org.apache.commons.lang3.text.StrSubstitutor;
+import org.apache.commons.text.StringSubstitutor;
+import org.apache.commons.text.lookup.StringLookup;
 
 /**
  * A simple pojo to hold data related to a Maven POM file.
@@ -354,15 +354,15 @@ public class Model {
         if (null == text || null == properties) {
             return text;
         }
-        final StrSubstitutor substitutor = new StrSubstitutor(new PropertyLookup(properties));
+        final StringSubstitutor substitutor = new StringSubstitutor(new PropertyLookup(properties));
         return substitutor.replace(text);
     }
 
     /**
      * Utility class that can provide values from a Properties object to a
-     * StrSubstitutor.
+     * StringSubstitutor.
      */
-    private static class PropertyLookup extends StrLookup<String> {
+    private static class PropertyLookup implements StringLookup {
 
         /**
          * Reference to the properties to lookup.

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@ Copyright (c) 2012 - Jeremy Long
 
         <!--upgrading beyond lang3 3.4 may cause issues with the Jenkins plugin-->
         <commons-lang3.version>3.7</commons-lang3.version>
+        <commons-text.version>1.3</commons-text.version>
         <com.sun.mail.mailapi.version>1.6.1</com.sun.mail.mailapi.version>
         <junit.version>4.12</junit.version>
         <hamcrest-core.version>1.3</hamcrest-core.version>
@@ -848,6 +849,11 @@ Copyright (c) 2012 - Jeremy Long
                 <artifactId>commons-lang3</artifactId>
                 <!--upgrading beyond this may cause issues with the Jenkins plugin-->
                 <version>${commons-lang3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${commons-text.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.mail</groupId>


### PR DESCRIPTION
## Fixes Issue #1251 

## Description of Change
Adapted the code to use the supported functions of the Apache Commons Text project in favor of the corresponding deprecated functions of Apache Commons Lang v3

## Have test cases been added to cover the new functionality?
no, it is assumed that the modified code is already covered by existing tests