### PR TITLE
Fix testcase 740-aggregate: give it unique GAV coordinates

### DIFF
--- a/maven/src/it/740-aggregate/first/pom.xml
+++ b/maven/src/it/740-aggregate/first/pom.xml
@@ -19,7 +19,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.owasp.test</groupId>
+        <groupId>org.owasp.test.aggregate</groupId>
         <artifactId>aggregate-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>

--- a/maven/src/it/740-aggregate/pom.xml
+++ b/maven/src/it/740-aggregate/pom.xml
@@ -18,7 +18,7 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.owasp.test</groupId>
+    <groupId>org.owasp.test.aggregate</groupId>
     <artifactId>aggregate-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>

--- a/maven/src/it/740-aggregate/second/pom.xml
+++ b/maven/src/it/740-aggregate/second/pom.xml
@@ -19,7 +19,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.owasp.test</groupId>
+        <groupId>org.owasp.test.aggregate</groupId>
         <artifactId>aggregate-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
@@ -27,7 +27,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
-            <groupId>org.owasp.test</groupId>
+            <groupId>org.owasp.test.aggregate</groupId>
             <artifactId>fourth</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>

--- a/maven/src/it/740-aggregate/third/fourth/pom.xml
+++ b/maven/src/it/740-aggregate/third/fourth/pom.xml
@@ -19,7 +19,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.owasp.test</groupId>
+        <groupId>org.owasp.test.aggregate</groupId>
         <artifactId>third</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>

--- a/maven/src/it/740-aggregate/third/pom.xml
+++ b/maven/src/it/740-aggregate/third/pom.xml
@@ -19,7 +19,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.owasp.test</groupId>
+        <groupId>org.owasp.test.aggregate</groupId>
         <artifactId>aggregate-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>


### PR DESCRIPTION
## Description of Change
As referenced in #1165 comments a PR to update to 740-aggregate test so that it is guaranteed to fail regardless of the sequence in which the integrationtests are run.
The testcase will fail until #740 has been fixed.