### PR TITLE
Fix dependency resolution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ after_success:
     fi;
 
 after_failure:
+    - cat /home/travis/build/jeremylong/DependencyCheck/maven/target/it/740-aggregate/build.log
     - cat /home/travis/build/jeremylong/DependencyCheck/maven/target/it/617-hierarchical-cross-deps/build.log
     - cat /home/travis/build/jeremylong/DependencyCheck/maven/target/it/618-aggregator-purge/build.log
     - cat /home/travis/build/jeremylong/DependencyCheck/maven/target/it/618-aggregator-update-only/build.log

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzer.java
@@ -403,7 +403,7 @@ public class DependencyBundlingAnalyzer extends AbstractDependencyComparingAnaly
      * @return true if on of the dependencies is a pom.xml and the identifiers
      * between the two collections match; otherwise false
      */
-    private boolean isShadedJar(Dependency dependency, Dependency nextDependency) {
+    protected boolean isShadedJar(Dependency dependency, Dependency nextDependency) {
         if (dependency == null || dependency.getFileName() == null
                 || nextDependency == null || nextDependency.getFileName() == null
                 || dependency.getIdentifiers().isEmpty() 

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzer.java
@@ -405,7 +405,9 @@ public class DependencyBundlingAnalyzer extends AbstractDependencyComparingAnaly
      */
     private boolean isShadedJar(Dependency dependency, Dependency nextDependency) {
         if (dependency == null || dependency.getFileName() == null
-                || nextDependency == null || nextDependency.getFileName() == null) {
+                || nextDependency == null || nextDependency.getFileName() == null
+                || dependency.getIdentifiers().isEmpty() 
+                || nextDependency.getIdentifiers().isEmpty()) {
             return false;
         }
         final String mainName = dependency.getFileName().toLowerCase();

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -193,6 +193,17 @@ public class Dependency extends EvidenceCollection implements Serializable {
     }
 
     /**
+     * Constructs a new Dependency object.
+     *
+     * @param isVirtual specifies if the dependency is virtual indicating the
+     * file doesn't actually exist.
+     */
+    public Dependency(boolean isVirtual) {
+        this();
+        this.isVirtual = isVirtual;
+    }
+
+    /**
      * Returns the file name of the dependency.
      *
      * @return the file name of the dependency

--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -731,8 +731,8 @@ Getting Help: <a href="https://groups.google.com/forum/#!forum/dependency-check"
                             #end
                         #end
                             <b>File&nbsp;Path:</b>&nbsp;$enc.html($dependency.FilePath)<br/>
-                            <b>MD5:</b>&nbsp;$enc.html($dependency.Md5sum)<br/>
-                            <b>SHA1:</b>&nbsp;$enc.html($dependency.Sha1sum)
+                            <b>MD5:</b>&nbsp;#if($dependency.Md5sum)$enc.html($dependency.Md5sum)#end<br/>
+                            <b>SHA1:</b>&nbsp;#if($dependency.Sha1sum)$enc.html($dependency.Sha1sum)#end
                             #if ($dependency.projectReferences.size()==1)
                                 <br/><b>Referenced In Project/Scope:</b>
                                 #foreach($ref in $dependency.projectReferences)
@@ -940,8 +940,8 @@ Getting Help: <a href="https://groups.google.com/forum/#!forum/dependency-check"
                                     #end
                                 #end
                                     <b>File&nbsp;Path:</b>&nbsp;$enc.html($dependency.FilePath)<br/>
-                                    <b>MD5:</b>&nbsp;$enc.html($dependency.Md5sum)<br/>
-                                    <b>SHA1:</b>&nbsp;$enc.html($dependency.Sha1sum)
+                                    <b>MD5:</b>&nbsp;#if($dependency.Md5sum)$enc.html($dependency.Md5sum)#end<br/>
+                                    <b>SHA1:</b>&nbsp;#if($dependency.Sha1sum)$enc.html($dependency.Sha1sum)#end
                                 </p>
                                 #set($cnt=$cnt+1)
                                 <h4 id="header$cnt" class="subsectionheader expandable expandablesubsection white">Evidence</h4>

--- a/core/src/main/resources/templates/jsonReport.vsl
+++ b/core/src/main/resources/templates/jsonReport.vsl
@@ -27,8 +27,8 @@
             "isVirtual": #if($dependency.isVirtual)true#{else}false#end,
             "fileName": "$enc.json($dependency.DisplayFileName)",
             "filePath": "$enc.json($dependency.FilePath)",
-            "md5": "$enc.json($dependency.Md5sum)",
-            "sha1": "$enc.json($dependency.Sha1sum)"
+            "md5": "#if($dependency.Md5sum)$enc.json($dependency.Md5sum)#end",
+            "sha1": "#if($dependency.Sha1sum)$enc.json($dependency.Sha1sum)#end"
             #if($dependency.description),"description": "$enc.json($dependency.description)"#end
             #if($dependency.license),"license": "$enc.json($dependency.license)"#end
             #if ($dependency.projectReferences.size()>0)

--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -117,7 +117,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <identifiers>
 #foreach($id in $dependency.getIdentifiers())
                 <identifier type="$enc.xml($id.type)" #if($id.confidence)confidence="$id.confidence"#end>
-                    <name>($id.value)</name>
+                    <name>$enc.xml($id.value)</name>
 #if( $id.url )
                     <url>$enc.xml($id.url)</url>
 #end

--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -48,8 +48,8 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <dependency isVirtual="#if($dependency.isVirtual)true#{else}false#end">
             <fileName>$enc.xml($dependency.DisplayFileName)</fileName>
             <filePath>$enc.xml($dependency.FilePath)</filePath>
-            <md5>$enc.xml($dependency.Md5sum)</md5>
-            <sha1>$enc.xml($dependency.Sha1sum)</sha1>
+            <md5>#if($dependency.Md5sum)$enc.xml($dependency.Md5sum)#end</md5>
+            <sha1>#if($dependency.Sha1sum)$enc.xml($dependency.Sha1sum)#end</sha1>
 #if ($dependency.description)
             <description>$enc.xml($dependency.description)</description>
 #end

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzerTest.java
@@ -17,6 +17,7 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
+import java.io.File;
 import mockit.Mocked;
 import mockit.Verifications;
 import org.junit.Test;
@@ -59,8 +60,8 @@ public class DependencyBundlingAnalyzerTest extends BaseTest {
     }
 
     /**
-     * Test of analyze method, of class DependencyBundlingAnalyzer.
-     * The actually passed dependency does not matter. The analyzer only runs once.
+     * Test of analyze method, of class DependencyBundlingAnalyzer. The actually
+     * passed dependency does not matter. The analyzer only runs once.
      */
     @Test
     public void testAnalyze() throws Exception {
@@ -77,10 +78,12 @@ public class DependencyBundlingAnalyzerTest extends BaseTest {
         instance.analyze(null, engineMock);
         assertTrue(instance.getAnalyzed());
 
-        new Verifications() {{
-            engineMock.getDependencies();
-            times = 1;
-        }};
+        new Verifications() {
+            {
+                engineMock.getDependencies();
+                times = 1;
+            }
+        };
     }
 
     /**
@@ -138,6 +141,74 @@ public class DependencyBundlingAnalyzerTest extends BaseTest {
         right = "./a/b/c.jar";
         expResult = true;
         result = instance.firstPathIsShortest(left, right);
+        assertEquals(expResult, result);
+    }
+
+    @Test
+    public void testIsShaded() {
+        DependencyBundlingAnalyzer instance = new DependencyBundlingAnalyzer();
+
+        Dependency left = null;
+        Dependency right = null;
+
+        boolean expResult = false;
+        boolean result = instance.isShadedJar(left, right);
+        assertEquals(expResult, result);
+
+        left = new Dependency();
+        expResult = false;
+        result = instance.isShadedJar(left, right);
+        assertEquals(expResult, result);
+
+        left = new Dependency(new File("/path/jar.jar"), true);
+        expResult = false;
+        result = instance.isShadedJar(left, right);
+        assertEquals(expResult, result);
+
+        right = new Dependency();
+        expResult = false;
+        result = instance.isShadedJar(left, right);
+        assertEquals(expResult, result);
+
+        right = new Dependency(new File("/path/pom.xml"), true);
+        expResult = false;
+        result = instance.isShadedJar(left, right);
+        assertEquals(expResult, result);
+
+        left.addIdentifier("test", "test", "http://example.com/test");
+        expResult = false;
+        result = instance.isShadedJar(left, right);
+        assertEquals(expResult, result);
+
+        right.addIdentifier("next", "next", "http://example.com/next");
+        expResult = false;
+        result = instance.isShadedJar(left, right);
+        assertEquals(expResult, result);
+
+        left.addIdentifier("next", "next", "http://example.com/next");
+        expResult = true;
+        result = instance.isShadedJar(left, right);
+        assertEquals(expResult, result);
+
+        left = new Dependency(new File("/path/pom.xml"), true);
+        left.addIdentifier("test", "test", "http://example.com/test");
+        right = new Dependency(new File("/path/jar.jar"), true);
+        right.addIdentifier("next", "next", "http://example.com/next");
+        expResult = false;
+        result = instance.isShadedJar(left, right);
+        assertEquals(expResult, result);
+        
+        right.addIdentifier("test", "test", "http://example.com/test");
+        expResult = true;
+        result = instance.isShadedJar(left, right);
+        assertEquals(expResult, result);
+        
+        left = new Dependency(new File("/path/other.jar"), true);
+        left.addIdentifier("test", "test", "http://example.com/test");
+        right = new Dependency(new File("/path/jar.jar"), true);
+        right.addIdentifier("next", "next", "http://example.com/next");
+        expResult = false;
+        result = instance.isShadedJar(left, right);
         assertEquals(expResult, result);
     }
 }

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -136,6 +136,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-tree</artifactId>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>
@@ -195,6 +196,9 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                             </setupIncludes-->
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
                             <localRepositoryPath>target/local-repo</localRepositoryPath>
+                            <properties>
+                                <odc.version>${project.version}</odc.version>
+                            </properties>
                         </configuration>
                         <executions>
                             <execution>

--- a/maven/src/it/617-hierarchical-cross-deps/invoker.properties
+++ b/maven/src/it/617-hierarchical-cross-deps/invoker.properties
@@ -16,4 +16,4 @@
 # Copyright (c) 2014 Jeremy Long. All Rights Reserved.
 #
 
-invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -X
+invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check

--- a/maven/src/it/618-aggregator-purge/invoker.properties
+++ b/maven/src/it/618-aggregator-purge/invoker.properties
@@ -16,5 +16,5 @@
 # Copyright (c) 2014 Jeremy Long. All Rights Reserved.
 #
 
-invoker.goals.1 = ${project.groupId}:${project.artifactId}:${project.version}:update-only -DdataDirectory=./data -Dcve.startyear=2017 -X
-invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:purge -DdataDirectory=./data -X
+invoker.goals.1 = ${project.groupId}:${project.artifactId}:${project.version}:update-only -DdataDirectory=./data -Dcve.startyear=2018
+invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:purge -DdataDirectory=./data

--- a/maven/src/it/618-aggregator-update-only/invoker.properties
+++ b/maven/src/it/618-aggregator-update-only/invoker.properties
@@ -16,4 +16,4 @@
 # Copyright (c) 2014 Jeremy Long. All Rights Reserved.
 #
 
-invoker.goals = -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:update-only -X
+invoker.goals = -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:update-only

--- a/maven/src/it/629-jackson-dataformat/invoker.properties
+++ b/maven/src/it/629-jackson-dataformat/invoker.properties
@@ -16,4 +16,4 @@
 # Copyright (c) 2014 Jeremy Long. All Rights Reserved.
 #
 
-invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -X -Dformat=ALL
+invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -Dformat=ALL

--- a/maven/src/it/690-threadsafety/invoker.properties
+++ b/maven/src/it/690-threadsafety/invoker.properties
@@ -16,4 +16,4 @@
 # Copyright (c) 2014 Jeremy Long. All Rights Reserved.
 #
 
-invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -X -T 10
+invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -T 10

--- a/maven/src/it/710-pom-parse-error/invoker.properties
+++ b/maven/src/it/710-pom-parse-error/invoker.properties
@@ -16,4 +16,4 @@
 # Copyright (c) 2014 Jeremy Long. All Rights Reserved.
 #
 
-invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -X -Dformat=ALL
+invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -Dformat=ALL

--- a/maven/src/it/729-system-scope-resolved/invoker.properties
+++ b/maven/src/it/729-system-scope-resolved/invoker.properties
@@ -16,4 +16,4 @@
 # Copyright (c) 2017 Jeremy Long. All Rights Reserved.
 #
 
-invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -X -Dformat=JSON
+invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -Dformat=JSON

--- a/maven/src/it/729-system-scope-skipped/invoker.properties
+++ b/maven/src/it/729-system-scope-skipped/invoker.properties
@@ -16,4 +16,4 @@
 # Copyright (c) 2014 Jeremy Long. All Rights Reserved.
 #
 
-invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -DskipSystemScope=true -Dformat=JSON -X
+invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -DskipSystemScope=true -Dformat=JSON

--- a/maven/src/it/730-multiple-suppression-files-configs/invoker.properties
+++ b/maven/src/it/730-multiple-suppression-files-configs/invoker.properties
@@ -15,4 +15,4 @@
 #
 # Copyright (c) 2017 The OWASP Foundation. All Rights Reserved.
 #
-invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -X
+invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check

--- a/maven/src/it/730-multiple-suppression-files/invoker.properties
+++ b/maven/src/it/730-multiple-suppression-files/invoker.properties
@@ -15,4 +15,4 @@
 #
 # Copyright (c) 2017 The OWASP Foundation. All Rights Reserved.
 #
-invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -X
+invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check

--- a/maven/src/it/740-aggregate/first/pom.xml
+++ b/maven/src/it/740-aggregate/first/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.owasp.test</groupId>
+        <artifactId>threaded-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>first</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.1</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/src/it/740-aggregate/first/pom.xml
+++ b/maven/src/it/740-aggregate/first/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.owasp.test</groupId>
-        <artifactId>threaded-parent</artifactId>
+        <artifactId>aggregate-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>first</artifactId>

--- a/maven/src/it/740-aggregate/first/pom.xml
+++ b/maven/src/it/740-aggregate/first/pom.xml
@@ -19,7 +19,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.owasp.test</groupId>
+        <groupId>org.owasp.test.aggregate</groupId>
         <artifactId>aggregate-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>

--- a/maven/src/it/740-aggregate/invoker.properties
+++ b/maven/src/it/740-aggregate/invoker.properties
@@ -16,4 +16,4 @@
 # Copyright (c) 2014 Jeremy Long. All Rights Reserved.
 #
 
-invoker.goals = install ${project.groupId}:${project.artifactId}:${project.version}:check -X -T 10
+invoker.goals = install -X

--- a/maven/src/it/740-aggregate/invoker.properties
+++ b/maven/src/it/740-aggregate/invoker.properties
@@ -16,4 +16,4 @@
 # Copyright (c) 2014 Jeremy Long. All Rights Reserved.
 #
 
-invoker.goals = install -X
+invoker.goals = verify -X

--- a/maven/src/it/740-aggregate/invoker.properties
+++ b/maven/src/it/740-aggregate/invoker.properties
@@ -16,4 +16,4 @@
 # Copyright (c) 2014 Jeremy Long. All Rights Reserved.
 #
 
-invoker.goals = install ${project.groupId}:${project.artifactId}:${project.version}:check -X -T 10
+invoker.goals = verify -X

--- a/maven/src/it/740-aggregate/invoker.properties
+++ b/maven/src/it/740-aggregate/invoker.properties
@@ -1,0 +1,19 @@
+#
+# This file is part of dependency-check-maven.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+#
+
+invoker.goals = install ${project.groupId}:${project.artifactId}:${project.version}:check -X -T 10

--- a/maven/src/it/740-aggregate/pom.xml
+++ b/maven/src/it/740-aggregate/pom.xml
@@ -18,7 +18,7 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.owasp.test</groupId>
+    <groupId>org.owasp.test.aggregate</groupId>
     <artifactId>aggregate-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>

--- a/maven/src/it/740-aggregate/pom.xml
+++ b/maven/src/it/740-aggregate/pom.xml
@@ -35,6 +35,7 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
                 <version>${odc.version}</version>
                 <inherited>false</inherited>
                 <configuration>
+                    <format>XML</format>
                     <centralAnalyzerEnabled>false</centralAnalyzerEnabled>
                 </configuration>
                 <executions>

--- a/maven/src/it/740-aggregate/pom.xml
+++ b/maven/src/it/740-aggregate/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2018 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.owasp.test</groupId>
+    <artifactId>threaded-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>first</module>
+        <module>second</module>
+		<module>third</module>
+    </modules>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>${odc.version}</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <centralAnalyzerEnabled>false</centralAnalyzerEnabled>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven/src/it/740-aggregate/pom.xml
+++ b/maven/src/it/740-aggregate/pom.xml
@@ -19,7 +19,7 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.owasp.test</groupId>
-    <artifactId>threaded-parent</artifactId>
+    <artifactId>aggregate-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>

--- a/maven/src/it/740-aggregate/postbuild.groovy
+++ b/maven/src/it/740-aggregate/postbuild.groovy
@@ -1,0 +1,29 @@
+/*
+ * This file is part of dependency-check-maven.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+
+import java.nio.charset.Charset;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+ 
+String log = FileUtils.readFileToString(new File(basedir, "build.log"), Charset.defaultCharset().name());
+int count = StringUtils.countMatches(log, "Download Started for NVD CVE - 2002");
+if (count > 1){
+    System.out.println(String.format("NVD CVE was downloaded %s times, should be 0 or 1 times", count));
+    return false;
+}
+return true;

--- a/maven/src/it/740-aggregate/postbuild.groovy
+++ b/maven/src/it/740-aggregate/postbuild.groovy
@@ -24,7 +24,6 @@ String report = FileUtils.readFileToString(new File(basedir, "target/dependency-
 int count = StringUtils.countMatches(report, "org.owasp.test.aggregate:fourth:1.0.0-SNAPSHOT");
 if (count == 0) {
     System.out.println(String.format("fourth-1.0.0-SNAPSHOT was not identified"));
-    System.out.println(report
 );
     return false;
 }

--- a/maven/src/it/740-aggregate/postbuild.groovy
+++ b/maven/src/it/740-aggregate/postbuild.groovy
@@ -20,14 +20,15 @@ import java.nio.charset.Charset;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 
-String log = FileUtils.readFileToString(new File(basedir, "target/dependency-check-report.xml"), Charset.defaultCharset().name());
-int count = StringUtils.countMatches(log, "fourth-1.0.0-SNAPSHOT");
+String report = FileUtils.readFileToString(new File(basedir, "target/dependency-check-report.xml"), Charset.defaultCharset().name());
+int count = StringUtils.countMatches(report, "org.owasp.test.aggregate:fourth:1.0.0-SNAPSHOT");
 if (count == 0) {
     System.out.println(String.format("fourth-1.0.0-SNAPSHOT was not identified"));
-    System.out.println(log);
+    System.out.println(report
+);
     return false;
 }
-count = StringUtils.countMatches(log, "org.apache.james:apache-mime4j-core:0.7.2");
+count = StringUtils.countMatches(report, "org.apache.james:apache-mime4j-core:0.7.2");
 if (count == 0) {
     System.out.println(String.format("org.apache.james:apache-mime4j-core:0.7.2 was not identified and is a dependency of fourth-1.0.0-SNAPSHOT"));
     return false;

--- a/maven/src/it/740-aggregate/postbuild.groovy
+++ b/maven/src/it/740-aggregate/postbuild.groovy
@@ -24,7 +24,6 @@ String report = FileUtils.readFileToString(new File(basedir, "target/dependency-
 int count = StringUtils.countMatches(report, "org.owasp.test.aggregate:fourth:1.0.0-SNAPSHOT");
 if (count == 0) {
     System.out.println(String.format("fourth-1.0.0-SNAPSHOT was not identified"));
-);
     return false;
 }
 count = StringUtils.countMatches(report, "org.apache.james:apache-mime4j-core:0.7.2");

--- a/maven/src/it/740-aggregate/postbuild.groovy
+++ b/maven/src/it/740-aggregate/postbuild.groovy
@@ -19,11 +19,16 @@
 import java.nio.charset.Charset;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
- 
-String log = FileUtils.readFileToString(new File(basedir, "build.log"), Charset.defaultCharset().name());
-int count = StringUtils.countMatches(log, "Download Started for NVD CVE - 2002");
-if (count > 1){
-    System.out.println(String.format("NVD CVE was downloaded %s times, should be 0 or 1 times", count));
+
+String log = FileUtils.readFileToString(new File(basedir, "target/dependency-check-report.xml"), Charset.defaultCharset().name());
+int count = StringUtils.countMatches(log, "fourth-1.0.0-SNAPSHOT");
+if (count == 0) {
+    System.out.println(String.format("fourth-1.0.0-SNAPSHOT was not identified"));
+    return false;
+}
+count = StringUtils.countMatches(log, "org.apache.james:apache-mime4j-core:0.7.2");
+if (count == 0) {
+    System.out.println(String.format("org.apache.james:apache-mime4j-core:0.7.2 was not identified and is a dependency of fourth-1.0.0-SNAPSHOT"));
     return false;
 }
 return true;

--- a/maven/src/it/740-aggregate/postbuild.groovy
+++ b/maven/src/it/740-aggregate/postbuild.groovy
@@ -24,6 +24,7 @@ String log = FileUtils.readFileToString(new File(basedir, "target/dependency-che
 int count = StringUtils.countMatches(log, "fourth-1.0.0-SNAPSHOT");
 if (count == 0) {
     System.out.println(String.format("fourth-1.0.0-SNAPSHOT was not identified"));
+    System.out.println(log);
     return false;
 }
 count = StringUtils.countMatches(log, "org.apache.james:apache-mime4j-core:0.7.2");

--- a/maven/src/it/740-aggregate/second/pom.xml
+++ b/maven/src/it/740-aggregate/second/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.owasp.test</groupId>
-        <artifactId>threaded-parent</artifactId>
+        <artifactId>aggregate-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>second</artifactId>

--- a/maven/src/it/740-aggregate/second/pom.xml
+++ b/maven/src/it/740-aggregate/second/pom.xml
@@ -27,7 +27,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
-            <groupId>org.owasp.test</groupId>
+            <groupId>org.owasp.test.aggregate</groupId>
             <artifactId>fourth</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>

--- a/maven/src/it/740-aggregate/second/pom.xml
+++ b/maven/src/it/740-aggregate/second/pom.xml
@@ -19,7 +19,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.owasp.test</groupId>
+        <groupId>org.owasp.test.aggregate</groupId>
         <artifactId>aggregate-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>

--- a/maven/src/it/740-aggregate/second/pom.xml
+++ b/maven/src/it/740-aggregate/second/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.owasp.test</groupId>
+        <artifactId>threaded-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>second</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.owasp.test</groupId>
+            <artifactId>fourth</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/src/it/740-aggregate/second/src/main/webapp/WEB-INF/web.xml
+++ b/maven/src/it/740-aggregate/second/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+-->
+<web-app id="WebApp_ID" version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+    <display-name>test-app</display-name>
+    <welcome-file-list>
+        <welcome-file>index.html</welcome-file>
+    </welcome-file-list>
+</web-app>
+

--- a/maven/src/it/740-aggregate/third/fourth/pom.xml
+++ b/maven/src/it/740-aggregate/third/fourth/pom.xml
@@ -19,7 +19,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.owasp.test</groupId>
+        <groupId>org.owasp.test.aggregate</groupId>
         <artifactId>third</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>

--- a/maven/src/it/740-aggregate/third/fourth/pom.xml
+++ b/maven/src/it/740-aggregate/third/fourth/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.owasp.test</groupId>
+        <artifactId>third</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>fourth</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-mime4j-dom</artifactId>
+            <version>0.7.2</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/src/it/740-aggregate/third/fourth/src/main/webapp/WEB-INF/web.xml
+++ b/maven/src/it/740-aggregate/third/fourth/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+-->
+<web-app id="WebApp_ID" version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+    <display-name>test-app</display-name>
+    <welcome-file-list>
+        <welcome-file>index.html</welcome-file>
+    </welcome-file-list>
+</web-app>
+

--- a/maven/src/it/740-aggregate/third/pom.xml
+++ b/maven/src/it/740-aggregate/third/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.owasp.test</groupId>
+        <artifactId>threaded-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>third</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>fourth</module>
+    </modules>
+</project>

--- a/maven/src/it/740-aggregate/third/pom.xml
+++ b/maven/src/it/740-aggregate/third/pom.xml
@@ -19,7 +19,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.owasp.test</groupId>
+        <groupId>org.owasp.test.aggregate</groupId>
         <artifactId>aggregate-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>

--- a/maven/src/it/740-aggregate/third/pom.xml
+++ b/maven/src/it/740-aggregate/third/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.owasp.test</groupId>
-        <artifactId>threaded-parent</artifactId>
+        <artifactId>aggregate-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>third</artifactId>

--- a/maven/src/it/815-broken-suppression-aggregate/invoker.properties
+++ b/maven/src/it/815-broken-suppression-aggregate/invoker.properties
@@ -16,4 +16,4 @@
 # Copyright (c) 2017 The OWASP Foundation. All Rights Reserved.
 #
 invoker.buildResult = failure
-invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:aggregate -X
+invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:aggregate

--- a/maven/src/it/846-site-plugin/invoker.properties
+++ b/maven/src/it/846-site-plugin/invoker.properties
@@ -15,4 +15,4 @@
 #
 # Copyright (c) 2017 The OWASP Foundation. All Rights Reserved.
 #
-invoker.goals = site -Danalyzer.central.enabled=false -Dodcversion=${project.version} -X
+invoker.goals = site -Danalyzer.central.enabled=false -Dodcversion=${project.version}

--- a/maven/src/it/false-positives/invoker.properties
+++ b/maven/src/it/false-positives/invoker.properties
@@ -16,4 +16,4 @@
 # Copyright (c) 2014 Jeremy Long. All Rights Reserved.
 #
 
-invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -X -Dformat=ALL
+invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -Dformat=ALL

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/AggregateMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/AggregateMojo.java
@@ -64,9 +64,9 @@ public class AggregateMojo extends BaseDependencyCheckMojo {
      */
     @Override
     protected ExceptionCollection scanDependencies(final Engine engine) throws MojoExecutionException {
-        ExceptionCollection exCol = scanArtifacts(getProject(), engine);
+        ExceptionCollection exCol = scanArtifacts(getProject(), engine, true);
         for (MavenProject childProject : getDescendants(this.getProject())) {
-            final ExceptionCollection ex = scanArtifacts(childProject, engine);
+            final ExceptionCollection ex = scanArtifacts(childProject, engine, true);
             if (ex != null) {
                 if (exCol == null) {
                     exCol = ex;

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -917,7 +917,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
 
         for (MavenProject prj : reactorProjects) {
 
-            getLog().debug(String.format("Comparing %s:%s%s to %s:%s:%s",
+            getLog().debug(String.format("Comparing %s:%s:%s to %s:%s:%s",
                     artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(),
                     prj.getGroupId(), prj.getArtifactId(), prj.getVersion()));
 
@@ -964,7 +964,9 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                         d.setLicense(String.format("%s%n%s", d.getLicense(), license.toString()));
                     }
                 }
+                System.out.println(String.format("Dependency Count Before: %d", engine.getDependencies().length));
                 engine.addDependency(d);
+                System.out.println(String.format("Dependency Count after: %d", engine.getDependencies().length));
                 return true;
             }
         }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -905,15 +905,20 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * <code>false</code>
      */
     private boolean addReactorDependency(Engine engine, Artifact artifact) {
-        for (MavenProject project : reactorProjects) {
-            if (project.getArtifactId().equals(artifact.getArtifactId())
-                    && project.getGroupId().equals(artifact.getGroupId())
-                    && project.getVersion().equals(artifact.getVersion())) {
+        for (MavenProject prj : reactorProjects) {
+
+            getLog().debug(String.format("Comparing %s:%s%s to %s:%s:%s",
+                    artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(),
+                    prj.getGroupId(), prj.getArtifactId(), prj.getVersion()));
+
+            if (prj.getArtifactId().equals(artifact.getArtifactId())
+                    && prj.getGroupId().equals(artifact.getGroupId())
+                    && prj.getVersion().equals(artifact.getVersion())) {
 
                 final String displayName = String.format("%s:%s:%s",
-                        project.getGroupId(), project.getArtifactId(), project.getVersion());
+                        prj.getGroupId(), prj.getArtifactId(), prj.getVersion());
                 getLog().info(String.format("Unable to resolve %s as it has not been built yet - creating a virtual dependency instead.", displayName));
-                File pom = new File(project.getBasedir(), "pom.xml");
+                File pom = new File(prj.getBasedir(), "pom.xml");
                 Dependency d;
                 if (pom.isFile()) {
                     d = new Dependency(pom, true);
@@ -922,18 +927,18 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 }
                 d.setDisplayFileName(displayName);
 
-                d.addEvidence(EvidenceType.PRODUCT, "project", "artifactid", project.getArtifactId(), Confidence.HIGHEST);
-                d.addEvidence(EvidenceType.VENDOR, "project", "artifactid", project.getArtifactId(), Confidence.LOW);
+                d.addEvidence(EvidenceType.PRODUCT, "project", "artifactid", prj.getArtifactId(), Confidence.HIGHEST);
+                d.addEvidence(EvidenceType.VENDOR, "project", "artifactid", prj.getArtifactId(), Confidence.LOW);
 
-                d.addEvidence(EvidenceType.VENDOR, "project", "groupid", project.getGroupId(), Confidence.HIGHEST);
-                d.addEvidence(EvidenceType.PRODUCT, "project", "groupid", project.getGroupId(), Confidence.LOW);
+                d.addEvidence(EvidenceType.VENDOR, "project", "groupid", prj.getGroupId(), Confidence.HIGHEST);
+                d.addEvidence(EvidenceType.PRODUCT, "project", "groupid", prj.getGroupId(), Confidence.LOW);
                 d.setEcosystem(JarAnalyzer.DEPENDENCY_ECOSYSTEM);
                 //TODO unify the setName/version and package path - they are equivelent ideas submitted by two seperate committers
-                d.setName(String.format("%s:%s", project.getGroupId(), project.getArtifactId()));
-                d.setVersion(project.getVersion());
+                d.setName(String.format("%s:%s", prj.getGroupId(), prj.getArtifactId()));
+                d.setVersion(prj.getVersion());
                 d.setPackagePath(displayName);
-                JarAnalyzer.addDescription(d, project.getDescription(), "project", "description");
-                for (License l : project.getLicenses()) {
+                JarAnalyzer.addDescription(d, prj.getDescription(), "project", "description");
+                for (License l : prj.getLicenses()) {
                     StringBuilder license = new StringBuilder();
                     if (l.getName() != null) {
                         license.append(l.getName());
@@ -953,7 +958,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         }
         return false;
     }
-    
+
     /**
      * Determines if the groupId, artifactId, and version of the Maven
      * dependency and artifact match.
@@ -1537,5 +1542,4 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     }
 
     //</editor-fold>
-    
 }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -905,6 +905,11 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * <code>false</code>
      */
     private boolean addReactorDependency(Engine engine, Artifact artifact) {
+
+        getLog().debug(String.format("Checking the reactor projects (%d) for %s:%s:%s",
+                reactorProjects.size(),
+                artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion()));
+
         for (MavenProject prj : reactorProjects) {
 
             getLog().debug(String.format("Comparing %s:%s%s to %s:%s:%s",

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -806,12 +806,16 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                     result = artifactResolver.resolveArtifact(buildingRequest, coordinate).getArtifact();
                 } catch (ArtifactResolverException ex) {
                     getLog().debug(String.format("Aggregate : %s", aggregate));
+                    boolean addException = true;
                     if (!aggregate || addReactorDependency(engine, dependencyNode.getArtifact())) {
+                        addException = false;
+                    }
+                    if (addException) {
                         if (exCol == null) {
                             exCol = new ExceptionCollection();
                         }
+                        exCol.addException(ex);
                     }
-                    exCol.addException(ex);
                     continue;
                 }
                 isResolved = result.isResolved();

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -805,6 +805,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 try {
                     result = artifactResolver.resolveArtifact(buildingRequest, coordinate).getArtifact();
                 } catch (ArtifactResolverException ex) {
+                    getLog().debug(String.format("Aggregate : %s", aggregate));
                     if (!aggregate || addReactorDependency(engine, dependencyNode.getArtifact())) {
                         if (exCol == null) {
                             exCol = new ExceptionCollection();

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -931,6 +931,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 File pom = new File(prj.getBasedir(), "pom.xml");
                 Dependency d;
                 if (pom.isFile()) {
+                    getLog().debug("Adding virtual dependency from pom.xml");
                     d = new Dependency(pom, true);
                 } else {
                     d = new Dependency(true);
@@ -964,9 +965,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                         d.setLicense(String.format("%s%n%s", d.getLicense(), license.toString()));
                     }
                 }
-                System.out.println(String.format("Dependency Count Before: %d", engine.getDependencies().length));
                 engine.addDependency(d);
-                System.out.println(String.format("Dependency Count after: %d", engine.getDependencies().length));
                 return true;
             }
         }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -720,8 +720,8 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      */
     protected ExceptionCollection scanArtifacts(MavenProject project, Engine engine) {
         try {
-            final DependencyNode dn = dependencyGraphBuilder.buildDependencyGraph(project, null, reactorProjects);
             final ProjectBuildingRequest buildingRequest = newResolveArtifactProjectBuildingRequest();
+            final DependencyNode dn = dependencyGraphBuilder.buildDependencyGraph(buildingRequest, null, reactorProjects);
             return collectDependencies(engine, project, dn.getChildren(), buildingRequest);
         } catch (DependencyGraphBuilderException ex) {
             final String msg = String.format("Unable to build dependency graph on project %s", project.getName());

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -947,7 +947,9 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 d.setName(String.format("%s:%s", prj.getGroupId(), prj.getArtifactId()));
                 d.setVersion(prj.getVersion());
                 d.setPackagePath(displayName);
-                JarAnalyzer.addDescription(d, prj.getDescription(), "project", "description");
+                if (prj.getDescription() != null) {
+                    JarAnalyzer.addDescription(d, prj.getDescription(), "project", "description");
+                }
                 for (License l : prj.getLicenses()) {
                     StringBuilder license = new StringBuilder();
                     if (l.getName() != null) {

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -721,6 +721,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     protected ExceptionCollection scanArtifacts(MavenProject project, Engine engine) {
         try {
             final ProjectBuildingRequest buildingRequest = newResolveArtifactProjectBuildingRequest();
+            buildingRequest.setProject(project);
             final DependencyNode dn = dependencyGraphBuilder.buildDependencyGraph(buildingRequest, null, reactorProjects);
             return collectDependencies(engine, project, dn.getChildren(), buildingRequest);
         } catch (DependencyGraphBuilderException ex) {

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -944,6 +944,11 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 d.addEvidence(EvidenceType.VENDOR, "project", "groupid", prj.getGroupId(), Confidence.HIGHEST);
                 d.addEvidence(EvidenceType.PRODUCT, "project", "groupid", prj.getGroupId(), Confidence.LOW);
                 d.setEcosystem(JarAnalyzer.DEPENDENCY_ECOSYSTEM);
+                Identifier id = new Identifier();
+                id.setType("maven");
+                id.setConfidence(Confidence.HIGHEST);
+                id.setValue(displayName);
+                d.addIdentifier(id);
                 //TODO unify the setName/version and package path - they are equivelent ideas submitted by two seperate committers
                 d.setName(String.format("%s:%s", prj.getGroupId(), prj.getArtifactId()));
                 d.setVersion(prj.getVersion());

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -29,6 +29,7 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.License;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -51,10 +52,12 @@ import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.apache.maven.shared.model.fileset.FileSet;
 import org.apache.maven.shared.model.fileset.util.FileSetManager;
 import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.JarAnalyzer;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.dependency.Identifier;
 import org.owasp.dependencycheck.dependency.Vulnerability;
 import org.owasp.dependencycheck.exception.DependencyNotFoundException;
@@ -152,9 +155,9 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     @Parameter(defaultValue = "${project.build.directory}", required = true)
     private File outputDirectory;
     /**
-     * This is a reference to the &gt;reporting&lt; sections <code>outputDirectory</code>.
-     * This cannot be configured in the dependency-check mojo directly.
-     * This generally maps to "target/site".
+     * This is a reference to the &gt;reporting&lt; sections
+     * <code>outputDirectory</code>. This cannot be configured in the
+     * dependency-check mojo directly. This generally maps to "target/site".
      */
     @Parameter(property = "project.reporting.outputDirectory", readonly = true)
     private File reportOutputDirectory;
@@ -228,7 +231,8 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     @Parameter(property = "connectionTimeout", defaultValue = "", required = false)
     private String connectionTimeout;
     /**
-     * Sets whether dependency-check should check if there is a new version available.
+     * Sets whether dependency-check should check if there is a new version
+     * available.
      */
     @SuppressWarnings("CanBeFinal")
     @Parameter(property = "versionCheckEnabled", defaultValue = "true", required = false)
@@ -719,11 +723,25 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * and scanning the dependencies
      */
     protected ExceptionCollection scanArtifacts(MavenProject project, Engine engine) {
+        return scanArtifacts(project, engine, false);
+    }
+
+    /**
+     * Scans the project's artifacts and adds them to the engine's dependency
+     * list.
+     *
+     * @param project the project to scan the dependencies of
+     * @param engine the engine to use to scan the dependencies
+     * @param aggregate whether the scan is part of an aggregate build
+     * @return a collection of exceptions that may have occurred while resolving
+     * and scanning the dependencies
+     */
+    protected ExceptionCollection scanArtifacts(MavenProject project, Engine engine, boolean aggregate) {
         try {
             final ProjectBuildingRequest buildingRequest = newResolveArtifactProjectBuildingRequest();
             buildingRequest.setProject(project);
             final DependencyNode dn = dependencyGraphBuilder.buildDependencyGraph(buildingRequest, null, reactorProjects);
-            return collectDependencies(engine, project, dn.getChildren(), buildingRequest);
+            return collectDependencies(engine, project, dn.getChildren(), buildingRequest, aggregate);
         } catch (DependencyGraphBuilderException ex) {
             final String msg = String.format("Unable to build dependency graph on project %s", project.getName());
             getLog().debug(msg, ex);
@@ -740,101 +758,106 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * @param nodes the list of dependency nodes, generally obtained via the
      * DependencyGraphBuilder
      * @param buildingRequest the Maven project building request
+     * @param aggregate whether the scan is part of an aggregate build
      * @return a collection of exceptions that may have occurred while resolving
      * and scanning the dependencies
      */
     private ExceptionCollection collectDependencies(Engine engine, MavenProject project,
-            List<DependencyNode> nodes, ProjectBuildingRequest buildingRequest) {
+            List<DependencyNode> nodes, ProjectBuildingRequest buildingRequest, boolean aggregate) {
         ExceptionCollection exCol = null;
         for (DependencyNode dependencyNode : nodes) {
             if (artifactScopeExcluded.passes(dependencyNode.getArtifact().getScope())
                     || artifactTypeExcluded.passes(dependencyNode.getArtifact().getType())) {
                 continue;
             }
-            exCol = collectDependencies(engine, project, dependencyNode.getChildren(), buildingRequest);
-            try {
-                boolean isResolved = false;
-                File artifactFile = null;
-                String artifactId = null;
-                String groupId = null;
-                String version = null;
-                List<ArtifactVersion> availableVersions = null;
-                if (org.apache.maven.artifact.Artifact.SCOPE_SYSTEM.equals(dependencyNode.getArtifact().getScope())) {
-                    for (org.apache.maven.model.Dependency d : project.getDependencies()) {
-                        final Artifact a = dependencyNode.getArtifact();
-                        if (d.getSystemPath() != null && artifactsMatch(d, a)) {
+            exCol = collectDependencies(engine, project, dependencyNode.getChildren(), buildingRequest, aggregate);
+            boolean isResolved = false;
+            File artifactFile = null;
+            String artifactId = null;
+            String groupId = null;
+            String version = null;
+            List<ArtifactVersion> availableVersions = null;
+            if (org.apache.maven.artifact.Artifact.SCOPE_SYSTEM.equals(dependencyNode.getArtifact().getScope())) {
+                for (org.apache.maven.model.Dependency d : project.getDependencies()) {
+                    final Artifact a = dependencyNode.getArtifact();
+                    if (d.getSystemPath() != null && artifactsMatch(d, a)) {
 
-                            artifactFile = new File(d.getSystemPath());
-                            isResolved = artifactFile.isFile();
-                            groupId = a.getGroupId();
-                            artifactId = a.getArtifactId();
-                            version = a.getVersion();
-                            availableVersions = a.getAvailableVersions();
-                            break;
-                        }
+                        artifactFile = new File(d.getSystemPath());
+                        isResolved = artifactFile.isFile();
+                        groupId = a.getGroupId();
+                        artifactId = a.getArtifactId();
+                        version = a.getVersion();
+                        availableVersions = a.getAvailableVersions();
+                        break;
                     }
-                    if (!isResolved) {
-                        getLog().error("Unable to resolve system scoped dependency: " + dependencyNode.toNodeString());
-                        if (exCol == null) {
-                            exCol = new ExceptionCollection();
-                        }
-                        exCol.addException(new DependencyNotFoundException("Unable to resolve system scoped dependency: "
-                                + dependencyNode.toNodeString()));
-                    }
-                } else {
-                    final ArtifactCoordinate coordinate = TransferUtils.toArtifactCoordinate(dependencyNode.getArtifact());
-                    final Artifact result = artifactResolver.resolveArtifact(buildingRequest, coordinate).getArtifact();
-                    isResolved = result.isResolved();
-                    artifactFile = result.getFile();
-                    groupId = result.getGroupId();
-                    artifactId = result.getArtifactId();
-                    version = result.getVersion();
-                    availableVersions = result.getAvailableVersions();
                 }
-                if (isResolved && artifactFile != null) {
-                    final List<Dependency> deps = engine.scan(artifactFile.getAbsoluteFile(),
-                            project.getName() + ":" + dependencyNode.getArtifact().getScope());
-                    if (deps != null) {
-                        if (deps.size() == 1) {
-                            final Dependency d = deps.get(0);
-                            if (d != null) {
-                                final MavenArtifact ma = new MavenArtifact(groupId, artifactId, version);
-                                d.addAsEvidence("pom", ma, Confidence.HIGHEST);
-                                if (availableVersions != null) {
-                                    for (ArtifactVersion av : availableVersions) {
-                                        d.addAvailableVersion(av.toString());
-                                    }
-                                }
-                                getLog().debug(String.format("Adding project reference %s on dependency %s",
-                                        project.getName(), d.getDisplayFileName()));
-                            }
-                        } else if (getLog().isDebugEnabled()) {
-                            final String msg = String.format("More than 1 dependency was identified in first pass scan of '%s' in project %s",
-                                    dependencyNode.getArtifact().getId(), project.getName());
-                            getLog().debug(msg);
-                        }
-                    } else if ("import".equals(dependencyNode.getArtifact().getScope())) {
-                        final String msg = String.format("Skipping '%s:%s' in project %s as it uses an `import` scope",
-                                dependencyNode.getArtifact().getId(), dependencyNode.getArtifact().getScope(), project.getName());
-                        getLog().debug(msg);
-                    } else {
-                        final String msg = String.format("No analyzer could be found for '%s:%s' in project %s",
-                                dependencyNode.getArtifact().getId(), dependencyNode.getArtifact().getScope(), project.getName());
-                        getLog().warn(msg);
-                    }
-                } else {
-                    final String msg = String.format("Unable to resolve '%s' in project %s",
-                            dependencyNode.getArtifact().getId(), project.getName());
-                    getLog().debug(msg);
+                if (!isResolved) {
+                    getLog().error("Unable to resolve system scoped dependency: " + dependencyNode.toNodeString());
                     if (exCol == null) {
                         exCol = new ExceptionCollection();
                     }
+                    exCol.addException(new DependencyNotFoundException("Unable to resolve system scoped dependency: "
+                            + dependencyNode.toNodeString()));
                 }
-            } catch (ArtifactResolverException ex) {
+            } else {
+                final ArtifactCoordinate coordinate = TransferUtils.toArtifactCoordinate(dependencyNode.getArtifact());
+                final Artifact result;
+                try {
+                    result = artifactResolver.resolveArtifact(buildingRequest, coordinate).getArtifact();
+                } catch (ArtifactResolverException ex) {
+                    if (!aggregate || addReactorDependency(engine, dependencyNode.getArtifact())) {
+                        if (exCol == null) {
+                            exCol = new ExceptionCollection();
+                        }
+                    }
+                    exCol.addException(ex);
+                    continue;
+                }
+                isResolved = result.isResolved();
+                artifactFile = result.getFile();
+                groupId = result.getGroupId();
+                artifactId = result.getArtifactId();
+                version = result.getVersion();
+                availableVersions = result.getAvailableVersions();
+            }
+            if (isResolved && artifactFile != null) {
+                final List<Dependency> deps = engine.scan(artifactFile.getAbsoluteFile(),
+                        project.getName() + ":" + dependencyNode.getArtifact().getScope());
+                if (deps != null) {
+                    if (deps.size() == 1) {
+                        final Dependency d = deps.get(0);
+                        if (d != null) {
+                            final MavenArtifact ma = new MavenArtifact(groupId, artifactId, version);
+                            d.addAsEvidence("pom", ma, Confidence.HIGHEST);
+                            if (availableVersions != null) {
+                                for (ArtifactVersion av : availableVersions) {
+                                    d.addAvailableVersion(av.toString());
+                                }
+                            }
+                            getLog().debug(String.format("Adding project reference %s on dependency %s",
+                                    project.getName(), d.getDisplayFileName()));
+                        }
+                    } else if (getLog().isDebugEnabled()) {
+                        final String msg = String.format("More than 1 dependency was identified in first pass scan of '%s' in project %s",
+                                dependencyNode.getArtifact().getId(), project.getName());
+                        getLog().debug(msg);
+                    }
+                } else if ("import".equals(dependencyNode.getArtifact().getScope())) {
+                    final String msg = String.format("Skipping '%s:%s' in project %s as it uses an `import` scope",
+                            dependencyNode.getArtifact().getId(), dependencyNode.getArtifact().getScope(), project.getName());
+                    getLog().debug(msg);
+                } else {
+                    final String msg = String.format("No analyzer could be found for '%s:%s' in project %s",
+                            dependencyNode.getArtifact().getId(), dependencyNode.getArtifact().getScope(), project.getName());
+                    getLog().warn(msg);
+                }
+            } else {
+                final String msg = String.format("Unable to resolve '%s' in project %s",
+                        dependencyNode.getArtifact().getId(), project.getName());
+                getLog().debug(msg);
                 if (exCol == null) {
                     exCol = new ExceptionCollection();
                 }
-                exCol.addException(ex);
             }
         }
 
@@ -871,6 +894,66 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         return exCol;
     }
 
+    /**
+     * Checks if the current artifact is actually in the reactor projects that
+     * have not yet been built. If true a virtual dependency is created based on
+     * the evidence in the project.
+     *
+     * @param engine a reference to the engine being used to scan
+     * @param artifact the artifact being analyzed in the mojo
+     * @return <code>true</code> if the artifact is in the reactor; otherwise
+     * <code>false</code>
+     */
+    private boolean addReactorDependency(Engine engine, Artifact artifact) {
+        for (MavenProject project : reactorProjects) {
+            if (project.getArtifactId().equals(artifact.getArtifactId())
+                    && project.getGroupId().equals(artifact.getGroupId())
+                    && project.getVersion().equals(artifact.getVersion())) {
+
+                final String displayName = String.format("%s:%s:%s",
+                        project.getGroupId(), project.getArtifactId(), project.getVersion());
+                getLog().info(String.format("Unable to resolve %s as it has not been built yet - creating a virtual dependency instead.", displayName));
+                File pom = new File(project.getBasedir(), "pom.xml");
+                Dependency d;
+                if (pom.isFile()) {
+                    d = new Dependency(pom, true);
+                } else {
+                    d = new Dependency(true);
+                }
+                d.setDisplayFileName(displayName);
+
+                d.addEvidence(EvidenceType.PRODUCT, "project", "artifactid", project.getArtifactId(), Confidence.HIGHEST);
+                d.addEvidence(EvidenceType.VENDOR, "project", "artifactid", project.getArtifactId(), Confidence.LOW);
+
+                d.addEvidence(EvidenceType.VENDOR, "project", "groupid", project.getGroupId(), Confidence.HIGHEST);
+                d.addEvidence(EvidenceType.PRODUCT, "project", "groupid", project.getGroupId(), Confidence.LOW);
+                d.setEcosystem(JarAnalyzer.DEPENDENCY_ECOSYSTEM);
+                //TODO unify the setName/version and package path - they are equivelent ideas submitted by two seperate committers
+                d.setName(String.format("%s:%s", project.getGroupId(), project.getArtifactId()));
+                d.setVersion(project.getVersion());
+                d.setPackagePath(displayName);
+                JarAnalyzer.addDescription(d, project.getDescription(), "project", "description");
+                for (License l : project.getLicenses()) {
+                    StringBuilder license = new StringBuilder();
+                    if (l.getName() != null) {
+                        license.append(l.getName());
+                    }
+                    if (l.getUrl() != null) {
+                        license.append(" ").append(l.getUrl());
+                    }
+                    if (d.getLicense() == null) {
+                        d.setLicense(license.toString());
+                    } else if (!d.getLicense().contains(license)) {
+                        d.setLicense(String.format("%s%n%s", d.getLicense(), license.toString()));
+                    }
+                }
+                engine.addDependency(d);
+                return true;
+            }
+        }
+        return false;
+    }
+    
     /**
      * Determines if the groupId, artifactId, and version of the Maven
      * dependency and artifact match.
@@ -975,7 +1058,8 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * @param currentEx the primary exception collection
      * @param newEx the new exception collection to add
      * @return the combined exception collection
-     * @throws MojoExecutionException thrown if dependency-check is configured to fail on errors
+     * @throws MojoExecutionException thrown if dependency-check is configured
+     * to fail on errors
      */
     private ExceptionCollection handleAnalysisExceptions(ExceptionCollection currentEx, ExceptionCollection newEx) throws MojoExecutionException {
         ExceptionCollection returnEx = currentEx;
@@ -1453,4 +1537,5 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     }
 
     //</editor-fold>
+    
 }

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@ Copyright (c) 2012 - Jeremy Long
         <plexus-sec-dispatcher.version>1.4</plexus-sec-dispatcher.version>
 
         <!-- upgrading beyond 2.2 requires reworking the dependency resolution -->
-        <maven-dependency-tree.version>2.2</maven-dependency-tree.version>
+        <maven-dependency-tree.version>3.0.1</maven-dependency-tree.version>
 
         <org.glassfish.javax.json.version>1.0.4</org.glassfish.javax.json.version>
         <maven-artifact-transfer.version>0.9.1</maven-artifact-transfer.version>


### PR DESCRIPTION
## Fixes Issue #740

* Upgrades maven-dependency-tree (this PR supersedes #1165)
* When analyzing an aggregate build (in Maven) if a child module has not been built and as such, the JAR file does not exist, a warning will be printed and a dependency will be added that contains the evidence from the build - but does not point back to a specific file.
* Fixed bug that would cause pom.xml dependencies without an identifier to be incorrectly merged with any other JAR.

## Have test cases been added to cover the new functionality?

yes