### PR TITLE
Correct release date for 3.2.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 Please see the [dependency-check google group](https://groups.google.com/forum/#!forum/dependency-check) for the release notes on versions not listed below.
 
-## [Version 3.2.1](https://github.com/jeremylong/DependencyCheck/releases/tag/v3.2.1) (2018-05-21)
+## [Version 3.2.1](https://github.com/jeremylong/DependencyCheck/releases/tag/v3.2.1) (2018-05-28)
 
 ### Bug Fixes
 


### PR DESCRIPTION


## Fixes Issue #

## Description of Change
Previously, the release date for version 3.2.1 was listed as 2018-05-21 in
the release notes, but the actual release date was 2018-05-28.  2018-05-21
was the date of the previous release, so it looks like a simple copy/paste
error.

This commit updates the listed release date to match the actual date of
the release.

## Have test cases been added to cover the new functionality?

*no* - no functionality added, just documentation updates.