### PR TITLE
Analyze dependencies from CocoaPods Podfile.lock

### DIFF
--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
@@ -4,6 +4,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 
@@ -87,6 +88,7 @@ public class SwiftAnalyzersTest extends BaseTest {
     @Test
     public void testPodsSupportsFiles() {
         assertThat(podsAnalyzer.accept(new File("test.podspec")), is(true));
+        assertThat(podsAnalyzer.accept(new File("Podfile.lock")), is(true));
     }
 
     /**
@@ -103,7 +105,35 @@ public class SwiftAnalyzersTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testCocoaPodsAnalyzer() throws AnalysisException {
+    public void testCocoaPodsPodfileAnalyzer() throws AnalysisException {
+        final Engine engine = new Engine(getSettings());
+        final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
+                "swift/cocoapods/Podfile.lock"));
+        podsAnalyzer.analyze(result, engine);
+
+        assertThat(engine.getDependencies().length, equalTo(9));
+        assertThat(engine.getDependencies()[0].getName(), equalTo("Bolts"));
+        assertThat(engine.getDependencies()[0].getVersion(), equalTo("1.9.0"));
+        assertThat(engine.getDependencies()[1].getName(), equalTo("Bolts/AppLinks"));
+        assertThat(engine.getDependencies()[1].getVersion(), equalTo("1.9.0"));
+        assertThat(engine.getDependencies()[2].getName(), equalTo("Bolts/Tasks"));
+        assertThat(engine.getDependencies()[2].getVersion(), equalTo("1.9.0"));
+        assertThat(engine.getDependencies()[3].getName(), equalTo("FBSDKCoreKit"));
+        assertThat(engine.getDependencies()[3].getVersion(), equalTo("4.33.0"));
+        assertThat(engine.getDependencies()[4].getName(), equalTo("FBSDKLoginKit"));
+        assertThat(engine.getDependencies()[4].getVersion(), equalTo("4.33.0"));
+        assertThat(engine.getDependencies()[5].getName(), equalTo("FirebaseCore"));
+        assertThat(engine.getDependencies()[5].getVersion(), equalTo("5.0.1"));
+        assertThat(engine.getDependencies()[6].getName(), equalTo("GoogleToolboxForMac/Defines"));
+        assertThat(engine.getDependencies()[6].getVersion(), equalTo("2.1.4"));
+        assertThat(engine.getDependencies()[7].getName(), equalTo("GoogleToolboxForMac/NSData+zlib"));
+        assertThat(engine.getDependencies()[7].getVersion(), equalTo("2.1.4"));
+        assertThat(engine.getDependencies()[8].getName(), equalTo("OCMock"));
+        assertThat(engine.getDependencies()[8].getVersion(), equalTo("3.4.1"));
+    }
+
+    @Test
+    public void testCocoaPodsPodspecAnalyzer() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "swift/cocoapods/EasyPeasy.podspec"));
         podsAnalyzer.analyze(result, null);

--- a/core/src/test/resources/swift/cocoapods/Podfile
+++ b/core/src/test/resources/swift/cocoapods/Podfile
@@ -1,0 +1,18 @@
+platform :ios, '9.0'
+inhibit_all_warnings!
+
+target 'MyApp' do
+  pod 'FBSDKLoginKit', '4.33.0'
+  pod 'FirebaseCore'
+
+  target "MyAppTests" do
+    inherit! :search_paths
+    pod 'OCMock', '~> 3.4'
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    puts "#{target.name}"
+  end
+end

--- a/core/src/test/resources/swift/cocoapods/Podfile.lock
+++ b/core/src/test/resources/swift/cocoapods/Podfile.lock
@@ -1,0 +1,43 @@
+PODS:
+  - Bolts (1.9.0):
+    - Bolts/AppLinks (= 1.9.0)
+    - Bolts/Tasks (= 1.9.0)
+  - Bolts/AppLinks (1.9.0):
+    - Bolts/Tasks
+  - Bolts/Tasks (1.9.0)
+  - FBSDKCoreKit (4.33.0):
+    - Bolts (~> 1.7)
+  - FBSDKLoginKit (4.33.0):
+    - FBSDKCoreKit
+  - FirebaseCore (5.0.1):
+    - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
+  - GoogleToolboxForMac/Defines (2.1.4)
+  - "GoogleToolboxForMac/NSData+zlib (2.1.4)":
+    - GoogleToolboxForMac/Defines (= 2.1.4)
+  - OCMock (3.4.1)
+
+DEPENDENCIES:
+  - FBSDKLoginKit (= 4.33.0)
+  - FirebaseCore
+  - OCMock (~> 3.4)
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Bolts
+    - FBSDKCoreKit
+    - FBSDKLoginKit
+    - FirebaseCore
+    - GoogleToolboxForMac
+    - OCMock
+
+SPEC CHECKSUMS:
+  Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
+  FBSDKCoreKit: 572b047a7e029bc44542bcf8a59414e7ff2b543e
+  FBSDKLoginKit: 88cb456349cfb3b554427ce4f8b43729d85dfb40
+  FirebaseCore: cafc814b2d84fc8733f09e653041cc2165332ad7
+  GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
+  OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
+
+PODFILE CHECKSUM: d0ec79889aef3bb4726fd6450afda314a35bfc0c
+
+COCOAPODS: 1.5.2


### PR DESCRIPTION
## Fixes Issue #1187 

## Description of Change

Adds analyze of `Podfile.lock` files which are generated based on `Podfile` dependencies. The resulting dependency tree is added as dependencies to the engine.

## Have test cases been added to cover the new functionality?

*yes*