### PR TITLE
StackOverflowException exception if two related dependencies reference each other

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzer.java
@@ -335,7 +335,7 @@ public class DependencyBundlingAnalyzer extends AbstractDependencyComparingAnaly
         }
         //new code
         for (Dependency child : dependency2.getRelatedDependencies()) {
-            if (hasSameBasePath(dependency1, child)) {
+            if (hasSameBasePath(child, dependency1)) {
                 return true;
             }
         }


### PR DESCRIPTION


## Fixes Issue #
fixes a stackoverflow exception if two related dependencies have each other in the <relatedDependencies> list. This caused a ping pong in checking the path again and again on the same files resulting in a StackOverflowException.fix stackoverflow exception.

## Description of Change
The change simply switches the arguments of hasSameBasePath to avoid the ping pong. So dependency1 is checked against each child of dependency2.

## Have test cases been added to cover the new functionality?
no