### PR TITLE
Increase Timeout

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -758,7 +758,7 @@ public class Engine implements FileFilter, AutoCloseable {
         final ExecutorService executorService = getExecutorService(analyzer);
 
         try {
-            final int timeout = settings.getInt(Settings.KEYS.TEMP_DIRECTORY, 20);
+            final int timeout = settings.getInt(Settings.KEYS.ANALYSIS_TIMEOUT, 20);
             final List<Future<Void>> results = executorService.invokeAll(analysisTasks, timeout, TimeUnit.MINUTES);
 
             // ensure there was no exception during execution

--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -758,7 +758,8 @@ public class Engine implements FileFilter, AutoCloseable {
         final ExecutorService executorService = getExecutorService(analyzer);
 
         try {
-            final List<Future<Void>> results = executorService.invokeAll(analysisTasks, 10, TimeUnit.MINUTES);
+            final int timeout = settings.getInt(Settings.KEYS.TEMP_DIRECTORY, 20);
+            final List<Future<Void>> results = executorService.invokeAll(analysisTasks, timeout, TimeUnit.MINUTES);
 
             // ensure there was no exception during execution
             for (Future<Void> result : results) {

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -23,6 +23,9 @@ data.file_name=dc.h2.db
 ### the gradle PurgeDataExtension.
 data.version=3.0
 
+#The analysis timeout in minutes
+odc.analysis.timeout=20
+
 data.connection_string=jdbc:h2:file:%s;MV_STORE=FALSE;AUTOCOMMIT=ON;LOG=0;CACHE_SIZE=65536;
 #data.connection_string=jdbc:mysql://localhost:3306/dependencycheck
 

--- a/core/src/test/resources/dependencycheck.properties
+++ b/core/src/test/resources/dependencycheck.properties
@@ -18,6 +18,10 @@ data.directory=[JAR]/data
 #if the filename has a %s it will be replaced with the current expected version
 data.file_name=dc.h2.db
 data.version=3.0
+
+#The analysis timeout in minutes
+odc.analysis.timeout=20
+
 data.connection_string=jdbc:h2:file:%s;MV_STORE=FALSE;AUTOCOMMIT=ON;LOG=0;CACHE_SIZE=65536;
 #data.connection_string=jdbc:mysql://localhost:3306/dependencycheck
 

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -238,6 +238,10 @@ public final class Settings {
          */
         public static final String MAX_DOWNLOAD_THREAD_POOL_SIZE = "max.download.threads";
         /**
+         * The properties key for the analysis timeout.
+         */
+        public static final String ANALYSIS_TIMEOUT = "odc.analysis.timeout";
+        /**
          * The key for the suppression file.
          */
         public static final String SUPPRESSION_FILE = "suppression.file";

--- a/utils/src/test/resources/dependencycheck.properties
+++ b/utils/src/test/resources/dependencycheck.properties
@@ -18,6 +18,10 @@ data.directory=[JAR]/data
 #if the filename has a %s it will be replaced with the current expected version
 data.file_name=dc.h2.db
 data.version=3.0
+
+#The analysis timeout in minutes
+odc.analysis.timeout=20
+
 data.connection_string=jdbc:h2:file:%s;MV_STORE=FALSE;AUTOCOMMIT=ON;LOG=0;CACHE_SIZE=65536;
 #data.connection_string=jdbc:mysql://localhost:3306/dependencycheck
 


### PR DESCRIPTION
## Fixes Issue #936

Increases the default analysis timeout from 10 minutes to 20 minutes. In addition, the analysis timeout was made configurable by setting the system property odc.analysis.timeout` (note, the timeout is set in minutes).
