### PR TITLE
Artifactory analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ _site/**
 /cov-int/
 /dependency-check-core/nbproject/
 cov-scan.bat
+/core/data/dc.h2.db

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -365,6 +365,12 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <scope>test</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.19.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java
@@ -117,6 +117,7 @@ public abstract class AbstractNpmAnalyzer extends AbstractFileTypeAnalyzer {
         nodeModule.setEcosystem(NPM_DEPENDENCY_ECOSYSTEM);
         //this is virtual - the sha1 is purely for the hyperlink in the final html report
         nodeModule.setSha1sum(Checksum.getSHA1Checksum(String.format("%s:%s", name, version)));
+        nodeModule.setSha256sum(Checksum.getSHA256Checksum(String.format("%s:%s", name, version)));
         nodeModule.setMd5sum(Checksum.getMD5Checksum(String.format("%s:%s", name, version)));
         nodeModule.addEvidence(EvidenceType.PRODUCT, "package.json", "name", name, Confidence.HIGHEST);
         nodeModule.addEvidence(EvidenceType.VENDOR, "package.json", "name", name, Confidence.HIGH);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
@@ -311,8 +311,10 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
             //store the archives sha1 and change it so that the engine doesn't think the zip and jar file are the same
             // and add it is a related dependency.
             final String archiveSha1 = dependency.getSha1sum();
+            final String archiveSha256 = dependency.getSha256sum();
             try {
                 dependency.setSha1sum("");
+                dependency.setSha256sum("");
                 org.apache.commons.io.FileUtils.copyFile(dependency.getActualFile(), tmpLoc);
                 final List<Dependency> dependencySet = findMoreDependencies(engine, tmpLoc);
                 if (dependencySet != null && !dependencySet.isEmpty()) {
@@ -335,6 +337,7 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
                 LOGGER.debug("Unable to perform deep copy on '{}'", dependency.getActualFile().getPath(), ex);
             } finally {
                 dependency.setSha1sum(archiveSha1);
+                dependency.setSha256sum(archiveSha256);
             }
         }
     }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ArtifactoryAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ArtifactoryAnalyzer.java
@@ -1,0 +1,239 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.analyzer;
+
+import org.apache.commons.io.FileUtils;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.data.artifactory.ArtifactorySearch;
+import org.owasp.dependencycheck.data.nexus.MavenArtifact;
+import org.owasp.dependencycheck.dependency.Confidence;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.Evidence;
+import org.owasp.dependencycheck.dependency.EvidenceType;
+import org.owasp.dependencycheck.utils.DownloadFailedException;
+import org.owasp.dependencycheck.utils.Downloader;
+import org.owasp.dependencycheck.utils.FileFilterBuilder;
+import org.owasp.dependencycheck.utils.InvalidSettingException;
+import org.owasp.dependencycheck.utils.Settings;
+import org.owasp.dependencycheck.xml.pom.PomUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.List;
+
+/**
+ * Analyzer which will attempt to locate a dependency, and the GAV information,
+ * by querying Artifactory for the dependency's hashes digest.
+ *
+ * @author nhenneaux
+ */
+@ThreadSafe
+public class ArtifactoryAnalyzer extends AbstractFileTypeAnalyzer {
+
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactoryAnalyzer.class);
+
+
+    /**
+     * The name of the analyzer.
+     */
+    private static final String ANALYZER_NAME = "Artifactory Analyzer";
+
+    /**
+     * The phase in which this analyzer runs.
+     */
+    private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.INFORMATION_COLLECTION;
+
+    /**
+     * The types of files on which this will work.
+     */
+    private static final String SUPPORTED_EXTENSIONS = "jar";
+
+    /**
+     * The file filter used to determine which files this analyzer supports.
+     */
+    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addExtensions(SUPPORTED_EXTENSIONS).build();
+
+
+    /**
+     * The searcher itself.
+     */
+    private ArtifactorySearch searcher;
+
+    /**
+     * Initializes the analyzer with the configured settings.
+     *
+     * @param settings the configured settings to use
+     */
+    @Override
+    public synchronized void initialize(Settings settings) {
+        super.initialize(settings);
+        setEnabled(checkEnabled());
+    }
+
+    /**
+     * Whether the analyzer is configured to support parallel processing.
+     *
+     * @return true if configured to support parallel processing; otherwise
+     * false
+     */
+    @Override
+    public boolean supportsParallelProcessing() {
+        try {
+            return getSettings().getBoolean(Settings.KEYS.ANALYZER_ARTIFACTORY_PARALLEL_ANALYSIS, true);
+        } catch (InvalidSettingException ex) {
+            LOGGER.debug("Invalid setting for analyzer.artifactory.parallel.analysis; using true.");
+        }
+        return true;
+    }
+
+    /**
+     * Determines if this analyzer is enabled.
+     *
+     * @return <code>true</code> if the analyzer is enabled; otherwise
+     * <code>false</code>
+     */
+    private boolean checkEnabled() {
+        try {
+            return getSettings().getBoolean(Settings.KEYS.ANALYZER_ARTIFACTORY_ENABLED);
+        } catch (InvalidSettingException ise) {
+            LOGGER.warn("Invalid setting. Disabling the Artifactory analyzer");
+        }
+        return false;
+    }
+
+    /**
+     * Initializes the analyzer once before any analysis is performed.
+     *
+     * @param engine a reference to the dependency-check engine
+     */
+    @Override
+    public void prepareFileTypeAnalyzer(Engine engine) {
+        LOGGER.debug("Initializing Artifactory analyzer");
+        final boolean enabled = isEnabled();
+        LOGGER.debug("Artifactory analyzer enabled: {}", enabled);
+        if (enabled) {
+            searcher = new ArtifactorySearch(getSettings());
+        }
+    }
+
+    /**
+     * Returns the analyzer's name.
+     *
+     * @return the name of the analyzer
+     */
+    @Override
+    public String getName() {
+        return ANALYZER_NAME;
+    }
+
+    /**
+     * Returns the key used in the properties file to to reference the
+     * analyzer's enabled property.
+     *
+     * @return the analyzer's enabled property setting key.
+     */
+    @Override
+    protected String getAnalyzerEnabledSettingKey() {
+        return Settings.KEYS.ANALYZER_ARTIFACTORY_ENABLED;
+    }
+
+    /**
+     * Returns the analysis phase under which the analyzer runs.
+     *
+     * @return the phase under which the analyzer runs
+     */
+    @Override
+    public AnalysisPhase getAnalysisPhase() {
+        return ANALYSIS_PHASE;
+    }
+
+    @Override
+    protected FileFilter getFileFilter() {
+        return FILTER;
+    }
+
+    /**
+     * Performs the analysis.
+     *
+     * @param dependency the dependency to analyze
+     * @param engine     the engine
+     * @throws AnalysisException when there's an exception during analysis
+     */
+    @Override
+    public void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
+        for (Evidence e : dependency.getEvidence(EvidenceType.VENDOR)) {
+            if ("pom".equals(e.getSource())) {
+                return;
+            }
+        }
+        try {
+            final List<MavenArtifact> mas = searcher.search(dependency);
+            final Confidence confidence = mas.size() > 1 ? Confidence.HIGH : Confidence.HIGHEST;
+            for (MavenArtifact ma : mas) {
+                LOGGER.debug("Artifactory analyzer found artifact ({}) for dependency ({})", ma, dependency.getFileName());
+                dependency.addAsEvidence("artifactory", ma, confidence);
+
+                if (ma.getPomUrl() != null) {
+                    processPom(dependency, ma);
+                }
+            }
+        } catch (IllegalArgumentException iae) {
+            LOGGER.info("invalid sha1-hash on {}", dependency.getFileName());
+        } catch (FileNotFoundException fnfe) {
+            LOGGER.debug("Artifact not found in repository: '{}", dependency.getFileName());
+        } catch (IOException ioe) {
+            final String message = "Could not connect to Artifactory search. Analysis failed.";
+            LOGGER.error(message, ioe);
+            throw new AnalysisException(message, ioe);
+        }
+    }
+
+    private void processPom(Dependency dependency, MavenArtifact ma) throws IOException, AnalysisException {
+        File pomFile = null;
+        try {
+            final File baseDir = getSettings().getTempDirectory();
+            pomFile = File.createTempFile("pom", ".xml", baseDir);
+            Files.delete(pomFile.toPath());
+            LOGGER.debug("Downloading {}", ma.getPomUrl());
+            final Downloader downloader = new Downloader(getSettings());
+            downloader.fetchFile(new URL(ma.getPomUrl()), pomFile);
+            PomUtils.analyzePOM(dependency, pomFile);
+
+        } catch (DownloadFailedException ex) {
+            LOGGER.warn("Unable to download pom.xml for {} from Artifactory; "
+                    + "this could result in undetected CPE/CVEs.", dependency.getFileName());
+        } finally {
+            if (pomFile != null && pomFile.exists() && !FileUtils.deleteQuietly(pomFile)) {
+                LOGGER.debug("Failed to delete temporary pom file {}", pomFile);
+                pomFile.deleteOnExit();
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ArtifactoryAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ArtifactoryAnalyzer.java
@@ -26,6 +26,7 @@ import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
 import org.owasp.dependencycheck.dependency.EvidenceType;
+import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.DownloadFailedException;
 import org.owasp.dependencycheck.utils.Downloader;
 import org.owasp.dependencycheck.utils.FileFilterBuilder;
@@ -133,12 +134,17 @@ public class ArtifactoryAnalyzer extends AbstractFileTypeAnalyzer {
      * @param engine a reference to the dependency-check engine
      */
     @Override
-    public void prepareFileTypeAnalyzer(Engine engine) {
+    public void prepareFileTypeAnalyzer(Engine engine) throws InitializationException {
         LOGGER.debug("Initializing Artifactory analyzer");
         final boolean enabled = isEnabled();
         LOGGER.debug("Artifactory analyzer enabled: {}", enabled);
         if (enabled) {
             searcher = new ArtifactorySearch(getSettings());
+            final boolean preflightRequest = searcher.preflightRequest();
+            if (!preflightRequest) {
+                setEnabled(false);
+                throw new InitializationException("There was an issue connecting to Artifactory . Disabling analyzer.");
+            }
         }
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ArtifactoryAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ArtifactoryAnalyzer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ * Copyright (c) 2018 Nicolas Henneaux. All Rights Reserved.
  */
 package org.owasp.dependencycheck.analyzer;
 

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -208,6 +208,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
                 currentDep.setFilePath(filePath);
 
                 currentDep.setSha1sum(Checksum.getSHA1Checksum(filePath));
+                currentDep.setSha256sum(Checksum.getSHA256Checksum(filePath));
                 currentDep.setMd5sum(Checksum.getMD5Checksum(filePath));
                 engine.addDependency(currentDep);
             }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
@@ -116,6 +116,7 @@ public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
                 d.setEcosystem(DEPENDENCY_ECOSYSTEM);
                 d.setFilePath(filePath);
                 d.setSha1sum(Checksum.getSHA1Checksum(filePath));
+                d.setSha256sum(Checksum.getSHA256Checksum(filePath));
                 d.setMd5sum(Checksum.getMD5Checksum(filePath));
                 d.addEvidence(EvidenceType.VENDOR, COMPOSER_LOCK, "vendor", dep.getGroup(), Confidence.HIGHEST);
                 d.addEvidence(EvidenceType.PRODUCT, COMPOSER_LOCK, "product", dep.getProject(), Confidence.HIGHEST);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
@@ -246,6 +246,7 @@ public class NodePackageAnalyzer extends AbstractNpmAnalyzer {
                     child = new Dependency(rootFile, true);
                     //TOOD - we should use the integrity value instead of calculating the SHA1/MD5
                     child.setSha1sum(Checksum.getSHA1Checksum(String.format("%s:%s", name, version)));
+                    child.setSha256sum(Checksum.getSHA256Checksum(String.format("%s:%s", name, version)));
                     child.setMd5sum(Checksum.getMD5Checksum(String.format("%s:%s", name, version)));
                     child.addEvidence(EvidenceType.VENDOR, rootFile.getName(), "name", name, Confidence.HIGHEST);
                     child.addEvidence(EvidenceType.PRODUCT, rootFile.getName(), "name", name, Confidence.HIGHEST);

--- a/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearch.java
@@ -1,0 +1,188 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.artifactory;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import org.owasp.dependencycheck.data.nexus.MavenArtifact;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.utils.InvalidSettingException;
+import org.owasp.dependencycheck.utils.Settings;
+import org.owasp.dependencycheck.utils.URLConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Class of methods to search Artifactory for hashes and determine Maven GAV from there.
+ *
+ * @author nhenneaux
+ */
+@ThreadSafe
+public class ArtifactorySearch {
+
+    /**
+     * Used for logging.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactorySearch.class);
+
+    private static final Pattern PATH_PATTERN = Pattern.compile("^/(?<groupId>.+)/(?<artifactId>[^/]+)/(?<version>[^/]+)/[^/]+$");
+    private static final String WHILE_ACTUAL_IS = " while actual is ";
+    /**
+     * The URL for the Central service.
+     */
+    private final String rootURL;
+
+    /**
+     * Whether to use the Proxy when making requests.
+     */
+    private final boolean useProxy;
+
+    /**
+     * The configured settings.
+     */
+    private final Settings settings;
+
+    /**
+     * Creates a NexusSearch for the given repository URL.
+     *
+     * @param settings the configured settings
+     */
+    public ArtifactorySearch(Settings settings) {
+        this.settings = settings;
+
+        final String searchUrl = settings.getString(Settings.KEYS.ANALYZER_ARTIFACTORY_URL);
+
+        this.rootURL = searchUrl;
+        LOGGER.debug("Artifactory Search URL {}", searchUrl);
+
+        if (null != settings.getString(Settings.KEYS.PROXY_SERVER)) {
+            boolean useProxySettings = false;
+            try {
+                useProxySettings = settings.getBoolean(Settings.KEYS.ANALYZER_ARTIFACTORY_USES_PROXY);
+            } catch (InvalidSettingException e) {
+                LOGGER.error("Settings {} is invalid, only, true/false is valid", Settings.KEYS.ANALYZER_ARTIFACTORY_USES_PROXY, e);
+            }
+            this.useProxy = useProxySettings;
+            LOGGER.debug("Using proxy? {}", useProxy);
+        } else {
+            useProxy = false;
+            LOGGER.debug("Not using proxy");
+        }
+    }
+
+    /**
+     * Searches the configured Central URL for the given hash (MD5, SHA1 and SHA256). If the
+     * artifact is found, a <code>MavenArtifact</code> is populated with the
+     * GAV.
+     *
+     * @param dependency the dependency for which to search (search is based on hashes)
+     * @return the populated Maven GAV.
+     * @throws FileNotFoundException if the specified artifact is not found
+     * @throws IOException           if it's unable to connect to the specified repository
+     */
+    public List<MavenArtifact> search(Dependency dependency) throws IOException {
+
+        final URL url = new URL(rootURL + "/api/search/checksum?sha1=" + dependency.getSha1sum());
+        LOGGER.debug("Searching Artifactory url {}", url);
+
+        // Determine if we need to use a proxy. The rules:
+        // 1) If the proxy is set, AND the setting is set to true, use the proxy
+        // 2) Otherwise, don't use the proxy (either the proxy isn't configured,
+        // or proxy is specifically set to false)
+        final URLConnectionFactory factory = new URLConnectionFactory(settings);
+        final HttpURLConnection conn = factory.createHttpURLConnection(url, useProxy);
+        conn.setDoOutput(true);
+        conn.addRequestProperty("X-Result-Detail", "info");
+        // TODO what is the best way to retrieve credentials to connect to Artifactory?
+        conn.addRequestProperty("Authorization", "Bearer " + System.getenv("artifactory.authentication.bearer.token"));
+        conn.connect();
+        final int responseCode = conn.getResponseCode();
+        if (responseCode == 200) {
+            return processResponse(dependency, conn);
+        }
+        throw new IOException("Could not connect to Artifactory " + url + " (" + responseCode + "): " + conn.getResponseMessage());
+
+    }
+
+
+    List<MavenArtifact> processResponse(Dependency dependency, HttpURLConnection conn) throws IOException {
+        final JsonObject asJsonObject = new JsonParser().parse(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8)).getAsJsonObject();
+        final JsonArray results = asJsonObject.getAsJsonArray("results");
+        final int numFound = results.size();
+        if (numFound == 0) {
+            throw new FileNotFoundException("Artifact " + dependency + " not found in Artifactory");
+        }
+
+
+        final String sha1sum = dependency.getSha1sum();
+        final String sha256sum = dependency.getSha256sum();
+        final String md5sum = dependency.getMd5sum();
+
+        final List<MavenArtifact> result = new ArrayList<>(numFound);
+        for (JsonElement jsonElement : results) {
+
+            final JsonObject checksumList = jsonElement.getAsJsonObject().getAsJsonObject("checksums");
+            final String sha1 = checksumList.getAsJsonPrimitive("sha1").getAsString();
+            final JsonPrimitive sha256Primitive = checksumList.getAsJsonPrimitive("sha256");
+            final String sha256 = sha256Primitive == null ? null : sha256Primitive.getAsString();
+            final String md5 = checksumList.getAsJsonPrimitive("md5").getAsString();
+
+            if (!md5.equals(md5sum)) {
+                throw new FileNotFoundException("Artifact found by API is not matching the md5 of the artifact (repository hash is " + md5 + WHILE_ACTUAL_IS + md5sum + ") !");
+            }
+            if (!sha1.equals(sha1sum)) {
+                throw new FileNotFoundException("Artifact found by API is not matching the SHA1 of the artifact (repository hash is " + sha1 + WHILE_ACTUAL_IS + sha1sum + ") !");
+            }
+            if (sha256 != null && !sha256.equals(sha256sum)) {
+                throw new FileNotFoundException("Artifact found by API is not matching the SHA-256 of the artifact (repository hash is " + sha256 + WHILE_ACTUAL_IS + sha256sum + ") !");
+            }
+
+            final String downloadUri = jsonElement.getAsJsonObject().getAsJsonPrimitive("downloadUri").getAsString();
+
+            final String path = jsonElement.getAsJsonObject().getAsJsonPrimitive("path").getAsString();
+
+            final Matcher pathMatcher = PATH_PATTERN.matcher(path);
+            if (!pathMatcher.matches()) {
+                throw new IllegalStateException("Cannot extract the Maven information from the apth retrieved in Artifactory " + path);
+            }
+            final String groupId = pathMatcher.group("groupId").replace('/', '.');
+            final String artifactId = pathMatcher.group("artifactId");
+            final String version = pathMatcher.group("version");
+
+            result.add(new MavenArtifact(groupId, artifactId, version, downloadUri));
+        }
+
+        return result;
+    }
+
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearch.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ * Copyright (c) 2018 Nicolas Henneaux. All Rights Reserved.
  */
 package org.owasp.dependencycheck.data.artifactory;
 
@@ -56,7 +56,13 @@ public class ArtifactorySearch {
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactorySearch.class);
 
+    /**
+     * Pattern to match the path returned by the Artifactory AQL API.
+     */
     private static final Pattern PATH_PATTERN = Pattern.compile("^/(?<groupId>.+)/(?<artifactId>[^/]+)/(?<version>[^/]+)/[^/]+$");
+    /**
+     * Extracted duplicateArtifactorySearchIT.java  comment.
+     */
     private static final String WHILE_ACTUAL_IS = " while actual is ";
     /**
      * The URL for the Central service.

--- a/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearch.java
@@ -152,7 +152,10 @@ public class ArtifactorySearch {
 
 
     protected List<MavenArtifact> processResponse(Dependency dependency, HttpURLConnection conn) throws IOException {
-        final JsonObject asJsonObject = new JsonParser().parse(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8)).getAsJsonObject();
+        final JsonObject asJsonObject;
+        try (final InputStreamReader streamReader = new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8)) {
+            asJsonObject = new JsonParser().parse(streamReader).getAsJsonObject();
+        }
         final JsonArray results = asJsonObject.getAsJsonArray("results");
         final int numFound = results.size();
         if (numFound == 0) {

--- a/core/src/main/java/org/owasp/dependencycheck/data/artifactory/package-info.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/artifactory/package-info.java
@@ -1,0 +1,7 @@
+/**
+ *
+ * Contains classes related to searching Artifactory Maven repository.<br><br>
+ *
+ * These are used to abstractArtifactory searching away from OWASP Dependency Check so they can be reused elsewhere.
+ */
+package org.owasp.dependencycheck.data.artifactory;

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/MavenArtifact.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/MavenArtifact.java
@@ -120,20 +120,22 @@ public class MavenArtifact {
     /**
      * Creates a MavenArtifact with the given attributes.
      *
-     * @param groupId      the groupId
-     * @param artifactId   the artifactId
-     * @param version      the version
-     * @param artifactUrl  the artifactLink url
-     * @param pomAvailable if the pom file is available in the same URL as the artifact
+     * @param groupId     the groupId
+     * @param artifactId  the artifactId
+     * @param version     the version
+     * @param artifactUrl the artifactLink url
+     * @param pomUrl      the pomUrl
      */
-    public MavenArtifact(String groupId, String artifactId, String version, String artifactUrl, boolean pomAvailable) {
+    public MavenArtifact(String groupId, String artifactId, String version, String artifactUrl, String pomUrl) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;
         this.artifactUrl = artifactUrl;
-        if (pomAvailable) {
-            this.pomUrl = artifactUrl.substring(0, artifactUrl.lastIndexOf('/')) + '/' + artifactId + '-' + version + ".pom";
-        }
+        this.pomUrl = derivePomUrl(artifactId, version, artifactUrl);
+    }
+
+    public static String derivePomUrl(String artifactId, String version, String artifactUrl) {
+        return artifactUrl.substring(0, artifactUrl.lastIndexOf('/')) + '/' + artifactId + '-' + version + ".pom";
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/MavenArtifact.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/MavenArtifact.java
@@ -115,7 +115,25 @@ public class MavenArtifact {
         this.artifactId = artifactId;
         this.version = version;
         this.artifactUrl = url;
-        this.pomUrl = url.substring(0, url.lastIndexOf('/')) + '/' + artifactId + '-' + version + ".pom";
+    }
+
+    /**
+     * Creates a MavenArtifact with the given attributes.
+     *
+     * @param groupId      the groupId
+     * @param artifactId   the artifactId
+     * @param version      the version
+     * @param artifactUrl  the artifactLink url
+     * @param pomAvailable if the pom file is available in the same URL as the artifact
+     */
+    public MavenArtifact(String groupId, String artifactId, String version, String artifactUrl, boolean pomAvailable) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+        this.artifactUrl = artifactUrl;
+        if (pomAvailable) {
+            this.pomUrl = artifactUrl.substring(0, artifactUrl.lastIndexOf('/')) + '/' + artifactId + '-' + version + ".pom";
+        }
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/MavenArtifact.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/MavenArtifact.java
@@ -131,7 +131,7 @@ public class MavenArtifact {
         this.artifactId = artifactId;
         this.version = version;
         this.artifactUrl = artifactUrl;
-        this.pomUrl = derivePomUrl(artifactId, version, artifactUrl);
+        this.pomUrl = pomUrl;
     }
 
     public static String derivePomUrl(String artifactId, String version, String artifactUrl) {

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/MavenArtifact.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/MavenArtifact.java
@@ -23,6 +23,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * Simple bean representing a Maven Artifact.
  *
  * @author colezlaw
+ * @author nhenneaux
  */
 @ThreadSafe
 public class MavenArtifact {
@@ -66,9 +67,9 @@ public class MavenArtifact {
     /**
      * Creates a MavenArtifact with the given attributes.
      *
-     * @param groupId the groupId
+     * @param groupId    the groupId
      * @param artifactId the artifactId
-     * @param version the version
+     * @param version    the version
      */
     public MavenArtifact(String groupId, String artifactId, String version) {
         this.groupId = groupId;
@@ -79,9 +80,9 @@ public class MavenArtifact {
     /**
      * Creates a MavenArtifact with the given attributes.
      *
-     * @param groupId the groupId
-     * @param artifactId the artifactId
-     * @param version the version
+     * @param groupId      the groupId
+     * @param artifactId   the artifactId
+     * @param version      the version
      * @param jarAvailable if the jar file is available from central
      * @param pomAvailable if the pom file is available from central
      */
@@ -104,16 +105,17 @@ public class MavenArtifact {
     /**
      * Creates a MavenArtifact with the given attributes.
      *
-     * @param groupId the groupId
+     * @param groupId    the groupId
      * @param artifactId the artifactId
-     * @param version the version
-     * @param url the artifactLink url
+     * @param version    the version
+     * @param url        the artifactLink url
      */
     public MavenArtifact(String groupId, String artifactId, String version, String url) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;
         this.artifactUrl = url;
+        this.pomUrl = url.substring(0, url.lastIndexOf('/')) + '/' + artifactId + '-' + version + ".pom";
     }
 
     /**
@@ -127,15 +129,6 @@ public class MavenArtifact {
     }
 
     /**
-     * Sets the groupId.
-     *
-     * @param groupId the groupId
-     */
-    public void setGroupId(String groupId) {
-        this.groupId = groupId;
-    }
-
-    /**
      * Gets the groupId.
      *
      * @return the groupId
@@ -145,12 +138,12 @@ public class MavenArtifact {
     }
 
     /**
-     * Sets the artifactId.
+     * Sets the groupId.
      *
-     * @param artifactId the artifactId
+     * @param groupId the groupId
      */
-    public void setArtifactId(String artifactId) {
-        this.artifactId = artifactId;
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
     }
 
     /**
@@ -163,12 +156,12 @@ public class MavenArtifact {
     }
 
     /**
-     * Sets the version.
+     * Sets the artifactId.
      *
-     * @param version the version
+     * @param artifactId the artifactId
      */
-    public void setVersion(String version) {
-        this.version = version;
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
     }
 
     /**
@@ -181,12 +174,12 @@ public class MavenArtifact {
     }
 
     /**
-     * Sets the artifactUrl.
+     * Sets the version.
      *
-     * @param artifactUrl the artifactUrl
+     * @param version the version
      */
-    public void setArtifactUrl(String artifactUrl) {
-        this.artifactUrl = artifactUrl;
+    public void setVersion(String version) {
+        this.version = version;
     }
 
     /**
@@ -196,6 +189,15 @@ public class MavenArtifact {
      */
     public String getArtifactUrl() {
         return artifactUrl;
+    }
+
+    /**
+     * Sets the artifactUrl.
+     *
+     * @param artifactUrl the artifactUrl
+     */
+    public void setArtifactUrl(String artifactUrl) {
+        this.artifactUrl = artifactUrl;
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -17,6 +17,14 @@
  */
 package org.owasp.dependencycheck.dependency;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.owasp.dependencycheck.data.nexus.MavenArtifact;
+import org.owasp.dependencycheck.utils.Checksum;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -27,14 +35,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import javax.annotation.concurrent.ThreadSafe;
-
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.owasp.dependencycheck.data.nexus.MavenArtifact;
-import org.owasp.dependencycheck.utils.Checksum;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A program dependency. This object is one of the core components within
@@ -55,6 +55,34 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * The logger.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(Dependency.class);
+    /**
+     * A list of Identifiers.
+     */
+    private final Set<Identifier> identifiers = new TreeSet<>();
+    /**
+     * A set of identifiers that have been suppressed.
+     */
+    private final Set<Identifier> suppressedIdentifiers = new TreeSet<>();
+    /**
+     * A set of vulnerabilities that have been suppressed.
+     */
+    private final Set<Vulnerability> suppressedVulnerabilities = new HashSet<>();
+    /**
+     * A list of vulnerabilities for this dependency.
+     */
+    private final Set<Vulnerability> vulnerabilities = new HashSet<>();
+    /**
+     * A collection of related dependencies.
+     */
+    private final Set<Dependency> relatedDependencies = new HashSet<>();
+    /**
+     * A list of projects that reference this dependency.
+     */
+    private final Set<String> projectReferences = new HashSet<>();
+    /**
+     * A list of available versions.
+     */
+    private final List<String> availableVersions = new ArrayList<>();
     /**
      * The actual file path of the dependency on disk.
      */
@@ -80,21 +108,13 @@ public class Dependency extends EvidenceCollection implements Serializable {
      */
     private String sha1sum;
     /**
-     * A list of Identifiers.
+     * The SHA256 hash of the dependency.
      */
-    private final Set<Identifier> identifiers = new TreeSet<>();
+    private String sha256sum;
     /**
      * The file name to display in reports.
      */
     private String displayName = null;
-    /**
-     * A set of identifiers that have been suppressed.
-     */
-    private final Set<Identifier> suppressedIdentifiers = new TreeSet<>();
-    /**
-     * A set of vulnerabilities that have been suppressed.
-     */
-    private final Set<Vulnerability> suppressedVulnerabilities = new HashSet<>();
     /**
      * The description of the JAR file.
      */
@@ -103,23 +123,6 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * The license that this dependency uses.
      */
     private String license;
-    /**
-     * A list of vulnerabilities for this dependency.
-     */
-    private final Set<Vulnerability> vulnerabilities = new HashSet<>();
-    /**
-     * A collection of related dependencies.
-     */
-    private final Set<Dependency> relatedDependencies = new HashSet<>();
-    /**
-     * A list of projects that reference this dependency.
-     */
-    private final Set<String> projectReferences = new HashSet<>();
-    /**
-     * A list of available versions.
-     */
-    private final List<String> availableVersions = new ArrayList<>();
-
     /**
      * Defines an actual or virtual dependency.
      */
@@ -142,24 +145,6 @@ public class Dependency extends EvidenceCollection implements Serializable {
     private String ecosystem;
 
     /**
-     * Returns the package path.
-     *
-     * @return the package path
-     */
-    public String getPackagePath() {
-        return packagePath;
-    }
-
-    /**
-     * Sets the package path.
-     *
-     * @param packagePath the package path
-     */
-    public void setPackagePath(String packagePath) {
-        this.packagePath = packagePath;
-    }
-
-    /**
      * Constructs a new Dependency object.
      */
     public Dependency() {
@@ -178,9 +163,9 @@ public class Dependency extends EvidenceCollection implements Serializable {
     /**
      * Constructs a new Dependency object.
      *
-     * @param file the File to create the dependency object from.
+     * @param file      the File to create the dependency object from.
      * @param isVirtual specifies if the dependency is virtual indicating the
-     * file doesn't actually exist.
+     *                  file doesn't actually exist.
      */
     public Dependency(File file, boolean isVirtual) {
         this();
@@ -196,11 +181,29 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * Constructs a new Dependency object.
      *
      * @param isVirtual specifies if the dependency is virtual indicating the
-     * file doesn't actually exist.
+     *                  file doesn't actually exist.
      */
     public Dependency(boolean isVirtual) {
         this();
         this.isVirtual = isVirtual;
+    }
+
+    /**
+     * Returns the package path.
+     *
+     * @return the package path
+     */
+    public String getPackagePath() {
+        return packagePath;
+    }
+
+    /**
+     * Sets the package path.
+     *
+     * @param packagePath the package path
+     */
+    public void setPackagePath(String packagePath) {
+        this.packagePath = packagePath;
     }
 
     /**
@@ -222,6 +225,15 @@ public class Dependency extends EvidenceCollection implements Serializable {
     }
 
     /**
+     * Gets the file path of the dependency.
+     *
+     * @return the file path of the dependency
+     */
+    public String getActualFilePath() {
+        return this.actualFilePath;
+    }
+
+    /**
      * Sets the actual file path of the dependency on disk.
      *
      * @param actualFilePath the file path of the dependency
@@ -235,42 +247,12 @@ public class Dependency extends EvidenceCollection implements Serializable {
     }
 
     /**
-     * Gets the file path of the dependency.
-     *
-     * @return the file path of the dependency
-     */
-    public String getActualFilePath() {
-        return this.actualFilePath;
-    }
-
-    /**
      * Gets a reference to the File object.
      *
      * @return the File object
      */
     public File getActualFile() {
         return new File(this.actualFilePath);
-    }
-
-    /**
-     * Sets the file path of the dependency.
-     *
-     * @param filePath the file path of the dependency
-     */
-    public void setFilePath(String filePath) {
-        if (this.packagePath == null || this.packagePath.equals(this.filePath)) {
-            this.packagePath = filePath;
-        }
-        this.filePath = filePath;
-    }
-
-    /**
-     * Sets the file name to display in reports.
-     *
-     * @param displayName the name to display
-     */
-    public void setDisplayFileName(String displayName) {
-        this.displayName = displayName;
     }
 
     /**
@@ -294,6 +276,15 @@ public class Dependency extends EvidenceCollection implements Serializable {
     }
 
     /**
+     * Sets the file name to display in reports.
+     *
+     * @param displayName the name to display
+     */
+    public void setDisplayFileName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
      * <p>
      * Gets the file path of the dependency.</p>
      * <p>
@@ -305,6 +296,18 @@ public class Dependency extends EvidenceCollection implements Serializable {
      */
     public String getFilePath() {
         return this.filePath;
+    }
+
+    /**
+     * Sets the file path of the dependency.
+     *
+     * @param filePath the file path of the dependency
+     */
+    public void setFilePath(String filePath) {
+        if (this.packagePath == null || this.packagePath.equals(this.filePath)) {
+            this.packagePath = filePath;
+        }
+        this.filePath = filePath;
     }
 
     /**
@@ -343,6 +346,14 @@ public class Dependency extends EvidenceCollection implements Serializable {
         this.sha1sum = sha1sum;
     }
 
+    public String getSha256sum() {
+        return sha256sum;
+    }
+
+    public void setSha256sum(String sha256sum) {
+        this.sha256sum = sha256sum;
+    }
+
     /**
      * Returns an unmodifiable List of Identifiers.
      *
@@ -366,9 +377,9 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * Adds an entry to the list of detected Identifiers for the dependency
      * file.
      *
-     * @param type the type of identifier (such as CPE)
+     * @param type  the type of identifier (such as CPE)
      * @param value the value of the identifier
-     * @param url the URL of the identifier
+     * @param url   the URL of the identifier
      */
     public synchronized void addIdentifier(String type, String value, String url) {
         final Identifier i = new Identifier(type, value, url);
@@ -379,9 +390,9 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * Adds an entry to the list of detected Identifiers for the dependency
      * file.
      *
-     * @param type the type of identifier (such as CPE)
-     * @param value the value of the identifier
-     * @param url the URL of the identifier
+     * @param type       the type of identifier (such as CPE)
+     * @param value      the value of the identifier
+     * @param url        the URL of the identifier
      * @param confidence the confidence in the Identifier being accurate
      */
     public synchronized void addIdentifier(String type, String value, String url, Confidence confidence) {
@@ -402,9 +413,9 @@ public class Dependency extends EvidenceCollection implements Serializable {
     /**
      * Adds the maven artifact as evidence.
      *
-     * @param source The source of the evidence
+     * @param source        The source of the evidence
      * @param mavenArtifact The maven artifact
-     * @param confidence The confidence level of this evidence
+     * @param confidence    The confidence level of this evidence
      */
     public void addAsEvidence(String source, MavenArtifact mavenArtifact, Confidence confidence) {
         if (mavenArtifact.getGroupId() != null && !mavenArtifact.getGroupId().isEmpty()) {
@@ -581,14 +592,13 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * @param file the file to create checksums for
      */
     private void determineHashes(File file) {
-        String md5 = null;
-        String sha1 = null;
         if (isVirtual) {
             return;
         }
         try {
-            md5 = Checksum.getMD5Checksum(file);
-            sha1 = Checksum.getSHA1Checksum(file);
+            this.setMd5sum(Checksum.getMD5Checksum(file));
+            this.setSha1sum(Checksum.getSHA1Checksum(file));
+            this.setSha256sum(Checksum.getSHA256Checksum(file));
         } catch (IOException ex) {
             LOGGER.warn("Unable to read '{}' to determine hashes.", file.getName());
             LOGGER.debug("", ex);
@@ -596,8 +606,6 @@ public class Dependency extends EvidenceCollection implements Serializable {
             LOGGER.warn("Unable to use MD5 or SHA1 checksums.");
             LOGGER.debug("", ex);
         }
-        this.setMd5sum(md5);
-        this.setSha1sum(sha1);
     }
 
     /**
@@ -825,4 +833,6 @@ public class Dependency extends EvidenceCollection implements Serializable {
     public void setEcosystem(String ecosystem) {
         this.ecosystem = ecosystem;
     }
+
+
 }

--- a/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
+++ b/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
@@ -10,6 +10,7 @@ org.owasp.dependencycheck.analyzer.NvdCveAnalyzer
 org.owasp.dependencycheck.analyzer.VulnerabilitySuppressionAnalyzer
 org.owasp.dependencycheck.analyzer.CentralAnalyzer
 org.owasp.dependencycheck.analyzer.NexusAnalyzer
+org.owasp.dependencycheck.analyzer.ArtifactoryAnalyzer
 org.owasp.dependencycheck.analyzer.NuspecAnalyzer
 org.owasp.dependencycheck.analyzer.AssemblyAnalyzer
 org.owasp.dependencycheck.analyzer.PythonDistributionAnalyzer

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchIT.java
@@ -1,0 +1,93 @@
+package org.owasp.dependencycheck.data.artifactory;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.owasp.dependencycheck.data.nexus.MavenArtifact;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.utils.Settings;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@Ignore
+public class ArtifactorySearchIT {
+
+
+    @Test
+    public void testWithRealInstanceUsingBearerToken() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
+        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
+        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
+
+        final Settings settings = new Settings();
+        settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_URL, "https://artifactory.techno.ingenico.com/artifactory");
+
+        // See org.owasp.dependencycheck.utils.Settings.KEYS.ANALYZER_ARTIFACTORY_BEARER_TOKEN .for how to generate a bearer token using the API
+        settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_BEARER_TOKEN, "yourBearerToken");
+        final ArtifactorySearch artifactorySearch = new ArtifactorySearch(settings);
+        // When
+        final List<MavenArtifact> mavenArtifacts = artifactorySearch.search(dependency);
+
+        // Then
+
+        assertEquals(1, mavenArtifacts.size());
+        final MavenArtifact artifact = mavenArtifacts.get(0);
+        assertEquals("com.google.code.gson", artifact.getGroupId());
+        assertEquals("gson", artifact.getArtifactId());
+        assertEquals("2.8.5", artifact.getVersion());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar", artifact.getArtifactUrl());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5.pom", artifact.getPomUrl());
+    }
+
+    @Test
+    public void testWithRealInstanceAnonymous() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
+
+        final Settings settings = new Settings();
+        settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_URL, "https://artifactory.techno.ingenico.com/artifactory");
+        final ArtifactorySearch artifactorySearch = new ArtifactorySearch(settings);
+        // When
+        try {
+            artifactorySearch.search(dependency);
+            fail("No Match found, should throw an exception!");
+        } catch (FileNotFoundException e) {
+            // Then
+            assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testWithRealInstanceWithUserToken() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("0695b63d702f505b9b916e02272e3b6381bade7f");
+        dependency.setMd5sum("cde1963375c651f769d40c8023ab5876");
+
+        final Settings settings = new Settings();
+        settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_URL, "https://artifactory.techno.ingenico.com/artifactory");
+        settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_API_USERNAME, "yourUserName");
+        settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_API_TOKEN, "yourSecretApiToken");
+        final ArtifactorySearch artifactorySearch = new ArtifactorySearch(settings);
+        // When
+        final List<MavenArtifact> mavenArtifacts = artifactorySearch.search(dependency);
+
+        // Then
+        assertEquals(1, mavenArtifacts.size());
+        final MavenArtifact artifact = mavenArtifacts.get(0);
+        assertEquals("com.google.code.gson", artifact.getGroupId());
+        assertEquals("gson", artifact.getArtifactId());
+        assertEquals("2.4", artifact.getVersion());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/com/google/code/gson/gson/2.4/gson-2.4.jar", artifact.getArtifactUrl());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/com/google/code/gson/gson/2.4/gson-2.4.pom", artifact.getPomUrl());
+    }
+
+
+}

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchIT.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2018 Nicolas Henneaux. All Rights Reserved.
+ */
 package org.owasp.dependencycheck.data.artifactory;
 
 import org.junit.Ignore;

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
@@ -1,7 +1,6 @@
 package org.owasp.dependencycheck.data.artifactory;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
@@ -17,7 +16,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,42 +31,6 @@ public class ArtifactorySearchTest extends BaseTest {
     }
 
 
-    // This test does generate network traffic and communicates with a host
-    // you may not be able to reach. Remove the @Ignore annotation if you want to
-    // test it anyway
-    @Test
-    @Ignore
-    public void testValidSha1() throws Exception {
-        final Dependency dependency = new Dependency();
-        dependency.setSha1sum("9977a8d04e75609cf01badc4eb6a9c7198c4c5ea");
-        List<MavenArtifact> ma = searcher.search(dependency);
-        assertEquals("Incorrect group", "org.apache.maven.plugins", ma.get(0).getGroupId());
-        assertEquals("Incorrect artifact", "maven-compiler-plugin", ma.get(0).getArtifactId());
-        assertEquals("Incorrect version", "3.1", ma.get(0).getVersion());
-    }
-
-    // This test does generate network traffic and communicates with a host
-    // you may not be able to reach. Remove the @Ignore annotation if you want to
-    // test it anyway
-    @Test(expected = IOException.class)
-    @Ignore
-    public void testMissingSha1() throws Exception {
-
-        final Dependency dependency = new Dependency();
-        dependency.setSha1sum("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-        searcher.search(dependency);
-    }
-
-    // This test should give us multiple results back from Central
-    @Test
-    @Ignore
-    public void testMultipleReturns() throws Exception {
-        final Dependency dependency = new Dependency();
-        dependency.setSha1sum("94a9ce681a42d0352b3ad22659f67835e560d107");
-        List<MavenArtifact> ma = searcher.search(dependency);
-        assertTrue(ma.size() > 1);
-    }
-
     @Test
     public void shouldFailWhenHostUnknown() throws IOException {
         // Given
@@ -81,39 +43,14 @@ public class ArtifactorySearchTest extends BaseTest {
         settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_URL, "https://artifactory.techno.ingenico.com.non-existing/artifactory");
         final ArtifactorySearch artifactorySearch = new ArtifactorySearch(settings);
         // When
-        try{
+        try {
             artifactorySearch.search(dependency);
             fail();
-        }catch (UnknownHostException exception){
+        } catch (UnknownHostException exception) {
             // Then
             assertEquals("artifactory.techno.ingenico.com.non-existing", exception.getMessage());
         }
 
-    }
-    @Test
-    @Ignore
-    public void testWithRealInstance() throws IOException {
-        // Given
-        Dependency dependency = new Dependency();
-        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
-        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
-        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
-
-        final Settings settings = getSettings();
-        settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_URL, "https://artifactory.techno.ingenico.com/artifactory");
-        final ArtifactorySearch artifactorySearch = new ArtifactorySearch(settings);
-        // When
-        final List<MavenArtifact> mavenArtifacts = artifactorySearch.search(dependency);
-
-        // Then
-
-        assertEquals(1, mavenArtifacts.size());
-        final MavenArtifact artifact = mavenArtifacts.get(0);
-        assertEquals("com.google.code.gson", artifact.getGroupId());
-        assertEquals("gson", artifact.getArtifactId());
-        assertEquals("2.8.5", artifact.getVersion());
-        assertEquals("https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar", artifact.getArtifactUrl());
-        assertEquals("https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5.pom", artifact.getPomUrl());
     }
 
 

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
@@ -1,0 +1,410 @@
+package org.owasp.dependencycheck.data.artifactory;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.data.nexus.MavenArtifact;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.utils.Settings;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ArtifactorySearchTest extends BaseTest {
+    private ArtifactorySearch searcher;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        searcher = new ArtifactorySearch(getSettings());
+    }
+
+
+    // This test does generate network traffic and communicates with a host
+    // you may not be able to reach. Remove the @Ignore annotation if you want to
+    // test it anyway
+    @Test
+    @Ignore
+    public void testValidSha1() throws Exception {
+        final Dependency dependency = new Dependency();
+        dependency.setSha1sum("9977a8d04e75609cf01badc4eb6a9c7198c4c5ea");
+        List<MavenArtifact> ma = searcher.search(dependency);
+        assertEquals("Incorrect group", "org.apache.maven.plugins", ma.get(0).getGroupId());
+        assertEquals("Incorrect artifact", "maven-compiler-plugin", ma.get(0).getArtifactId());
+        assertEquals("Incorrect version", "3.1", ma.get(0).getVersion());
+    }
+
+    // This test does generate network traffic and communicates with a host
+    // you may not be able to reach. Remove the @Ignore annotation if you want to
+    // test it anyway
+    @Test(expected = IOException.class)
+    @Ignore
+    public void testMissingSha1() throws Exception {
+
+        final Dependency dependency = new Dependency();
+        dependency.setSha1sum("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        searcher.search(dependency);
+    }
+
+    // This test should give us multiple results back from Central
+    @Test
+    @Ignore
+    public void testMultipleReturns() throws Exception {
+        final Dependency dependency = new Dependency();
+        dependency.setSha1sum("94a9ce681a42d0352b3ad22659f67835e560d107");
+        List<MavenArtifact> ma = searcher.search(dependency);
+        assertTrue(ma.size() > 1);
+    }
+
+    @Test
+    public void shouldFailWhenHostUnknown() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
+        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
+        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
+
+        final Settings settings = getSettings();
+        settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_URL, "https://artifactory.techno.ingenico.com.non-existing/artifactory");
+        final ArtifactorySearch artifactorySearch = new ArtifactorySearch(settings);
+        // When
+        try{
+            artifactorySearch.search(dependency);
+            fail();
+        }catch (UnknownHostException exception){
+            // Then
+            assertEquals("artifactory.techno.ingenico.com.non-existing", exception.getMessage());
+        }
+
+    }
+    @Test
+    @Ignore
+    public void testWithRealInstance() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
+        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
+        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
+
+        final Settings settings = getSettings();
+        settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_URL, "https://artifactory.techno.ingenico.com/artifactory");
+        final ArtifactorySearch artifactorySearch = new ArtifactorySearch(settings);
+        // When
+        final List<MavenArtifact> mavenArtifacts = artifactorySearch.search(dependency);
+
+        // Then
+
+        assertEquals(1, mavenArtifacts.size());
+        final MavenArtifact artifact = mavenArtifacts.get(0);
+        assertEquals("com.google.code.gson", artifact.getGroupId());
+        assertEquals("gson", artifact.getArtifactId());
+        assertEquals("2.8.5", artifact.getVersion());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar", artifact.getArtifactUrl());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5.pom", artifact.getPomUrl());
+    }
+
+
+    @Test
+    public void shouldProcessCorrectlyArtifactoryAnswerWithoutSha256() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("2e66da15851f9f5b5079228f856c2f090ba98c38");
+        dependency.setMd5sum("3dbee72667f107b4f76f2d5aa33c5687");
+        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
+        final byte[] payload = ("{\n" +
+                "  \"results\" : [ {\n" +
+                "    \"repo\" : \"jcenter-cache\",\n" +
+                "    \"path\" : \"/com/google/code/gson/gson/2.1/gson-2.1.jar\",\n" +
+                "    \"created\" : \"2017-06-14T16:15:37.936+02:00\",\n" +
+                "    \"createdBy\" : \"anonymous\",\n" +
+                "    \"lastModified\" : \"2012-12-12T22:20:22.000+01:00\",\n" +
+                "    \"modifiedBy\" : \"anonymous\",\n" +
+                "    \"lastUpdated\" : \"2017-06-14T16:15:37.939+02:00\",\n" +
+                "    \"properties\" : {\n" +
+                "      \"artifactory.internal.etag\" : [ \"2e66da15851f9f5b5079228f856c2f090ba98c38\" ]\n" +
+                "    },\n" +
+                "    \"downloadUri\" : \"https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar\",\n" +
+                "    \"remoteUrl\" : \"http://jcenter.bintray.com/com/google/code/gson/gson/2.1/gson-2.1.jar\",\n" +
+                "    \"mimeType\" : \"application/java-archive\",\n" +
+                "    \"size\" : \"180110\",\n" +
+                "    \"checksums\" : {\n" +
+                "      \"sha1\" : \"2e66da15851f9f5b5079228f856c2f090ba98c38\",\n" +
+                "      \"md5\" : \"3dbee72667f107b4f76f2d5aa33c5687\"\n" +
+                "    },\n" +
+                "    \"originalChecksums\" : {\n" +
+                "      \"sha1\" : \"2e66da15851f9f5b5079228f856c2f090ba98c38\"\n" +
+                "    },\n" +
+                "    \"uri\" : \"https://artifactory.techno.ingenico.com/artifactory/api/storage/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar\"\n" +
+                "  } ]\n" +
+                "}").getBytes(StandardCharsets.UTF_8);
+        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        final List<MavenArtifact> mavenArtifacts = searcher.processResponse(dependency, urlConnection);
+
+        // Then
+
+        assertEquals(1, mavenArtifacts.size());
+        final MavenArtifact artifact = mavenArtifacts.get(0);
+        assertEquals("com.google.code.gson", artifact.getGroupId());
+        assertEquals("gson", artifact.getArtifactId());
+        assertEquals("2.1", artifact.getVersion());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar", artifact.getArtifactUrl());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.pom", artifact.getPomUrl());
+    }
+
+    @Test
+    public void shouldProcessCorrectlyArtifactoryAnswerWithMultipleMatches() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("94a9ce681a42d0352b3ad22659f67835e560d107");
+        dependency.setMd5sum("03dcfdd88502505cc5a805a128bfdd8d");
+        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
+        final byte[] payload = multipleMatchesPayload();
+        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        final List<MavenArtifact> mavenArtifacts = searcher.processResponse(dependency, urlConnection);
+
+        // Then
+
+        assertEquals(2, mavenArtifacts.size());
+        final MavenArtifact artifact1 = mavenArtifacts.get(0);
+        assertEquals("axis", artifact1.getGroupId());
+        assertEquals("axis", artifact1.getArtifactId());
+        assertEquals("1.4", artifact1.getVersion());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/axis/axis/1.4/axis-1.4.jar", artifact1.getArtifactUrl());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/axis/axis/1.4/axis-1.4.pom", artifact1.getPomUrl());
+        final MavenArtifact artifact2 = mavenArtifacts.get(1);
+        assertEquals("org.apache.axis", artifact2.getGroupId());
+        assertEquals("axis", artifact2.getArtifactId());
+        assertEquals("1.4", artifact2.getVersion());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/org/apache/axis/axis/1.4/axis-1.4.jar", artifact2.getArtifactUrl());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/org/apache/axis/axis/1.4/axis-1.4.pom", artifact2.getPomUrl());
+    }
+
+    @Test
+    public void shouldHandleNoMatches() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("94a9ce681a42d0352b3ad22659f67835e560d108");
+        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
+        final byte[] payload = ("{\n" +
+                "  \"results\" : [ ]}").getBytes(StandardCharsets.UTF_8);
+        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        try {
+            searcher.processResponse(dependency, urlConnection);
+            fail("No Match found, should throw an exception!");
+        } catch (FileNotFoundException e) {
+            // Then
+            assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory", e.getMessage());
+        }
+    }
+
+    private byte[] multipleMatchesPayload() {
+        return ("{\n" +
+                "  \"results\" : [ {\n" +
+                "    \"repo\" : \"gradle-libs-cache\",\n" +
+                "    \"path\" : \"/axis/axis/1.4/axis-1.4.jar\",\n" +
+                "    \"created\" : \"2015-07-17T08:58:28.039+02:00\",\n" +
+                "    \"createdBy\" : \"loic\",\n" +
+                "    \"lastModified\" : \"2006-04-23T06:32:12.000+02:00\",\n" +
+                "    \"modifiedBy\" : \"loic\",\n" +
+                "    \"lastUpdated\" : \"2015-07-17T08:58:28.049+02:00\",\n" +
+                "    \"properties\" : {\n" +
+                "    },\n" +
+                "    \"downloadUri\" : \"https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/axis/axis/1.4/axis-1.4.jar\",\n" +
+                "    \"remoteUrl\" : \"http://gradle.artifactoryonline.com/gradle/libs/axis/axis/1.4/axis-1.4.jar\",\n" +
+                "    \"mimeType\" : \"application/java-archive\",\n" +
+                "    \"size\" : \"1599570\",\n" +
+                "    \"checksums\" : {\n" +
+                "      \"sha1\" : \"94a9ce681a42d0352b3ad22659f67835e560d107\",\n" +
+                "      \"md5\" : \"03dcfdd88502505cc5a805a128bfdd8d\"\n" +
+                "    },\n" +
+                "    \"originalChecksums\" : {\n" +
+                "      \"sha1\" : \"94a9ce681a42d0352b3ad22659f67835e560d107\",\n" +
+                "      \"md5\" : \"03dcfdd88502505cc5a805a128bfdd8d\"\n" +
+                "    },\n" +
+                "    \"uri\" : \"https://artifactory.techno.ingenico.com/artifactory/api/storage/gradle-libs-cache/axis/axis/1.4/axis-1.4.jar\"\n" +
+                "  }, {\n" +
+                "    \"repo\" : \"gradle-libs-cache\",\n" +
+                "    \"path\" : \"/org/apache/axis/axis/1.4/axis-1.4.jar\",\n" +
+                "    \"created\" : \"2015-07-09T10:09:43.074+02:00\",\n" +
+                "    \"createdBy\" : \"fabrizio\",\n" +
+                "    \"lastModified\" : \"2006-04-23T07:16:56.000+02:00\",\n" +
+                "    \"modifiedBy\" : \"fabrizio\",\n" +
+                "    \"lastUpdated\" : \"2015-07-09T10:09:43.082+02:00\",\n" +
+                "    \"properties\" : {\n" +
+                "    },\n" +
+                "    \"downloadUri\" : \"https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/org/apache/axis/axis/1.4/axis-1.4.jar\",\n" +
+                "    \"remoteUrl\" : \"http://gradle.artifactoryonline.com/gradle/libs/org/apache/axis/axis/1.4/axis-1.4.jar\",\n" +
+                "    \"mimeType\" : \"application/java-archive\",\n" +
+                "    \"size\" : \"1599570\",\n" +
+                "    \"checksums\" : {\n" +
+                "      \"sha1\" : \"94a9ce681a42d0352b3ad22659f67835e560d107\",\n" +
+                "      \"md5\" : \"03dcfdd88502505cc5a805a128bfdd8d\"\n" +
+                "    },\n" +
+                "    \"originalChecksums\" : {\n" +
+                "      \"sha1\" : \"94a9ce681a42d0352b3ad22659f67835e560d107\",\n" +
+                "      \"md5\" : \"03dcfdd88502505cc5a805a128bfdd8d\"\n" +
+                "    },\n" +
+                "    \"uri\" : \"https://artifactory.techno.ingenico.com/artifactory/api/storage/gradle-libs-cache/org/apache/axis/axis/1.4/axis-1.4.jar\"\n" +
+                "  } ]}").getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void shouldProcessCorrectlyArtifactoryAnswer() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
+        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
+        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
+        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
+        final byte[] payload = payloadWithSha256().getBytes(StandardCharsets.UTF_8);
+        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        final List<MavenArtifact> mavenArtifacts = searcher.processResponse(dependency, urlConnection);
+
+        // Then
+
+        assertEquals(1, mavenArtifacts.size());
+        final MavenArtifact artifact = mavenArtifacts.get(0);
+        assertEquals("com.google.code.gson", artifact.getGroupId());
+        assertEquals("gson", artifact.getArtifactId());
+        assertEquals("2.8.5", artifact.getVersion());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar", artifact.getArtifactUrl());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5.pom", artifact.getPomUrl());
+    }
+
+    private String payloadWithSha256() {
+        return "{\n" +
+                "  \"results\" : [ {\n" +
+                "    \"repo\" : \"repo1-cache\",\n" +
+                "    \"path\" : \"/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\",\n" +
+                "    \"created\" : \"2018-06-20T12:05:23.295+02:00\",\n" +
+                "    \"createdBy\" : \"nhenneaux\",\n" +
+                "    \"lastModified\" : \"2018-05-22T05:09:01.000+02:00\",\n" +
+                "    \"modifiedBy\" : \"nhenneaux\",\n" +
+                "    \"lastUpdated\" : \"2018-06-20T12:05:23.302+02:00\",\n" +
+                "    \"properties\" : {\n" +
+                "      \"artifactory.internal.etag\" : [ \"\\\"2d1dd0fc21ee96bccfab4353d5379649\\\"\" ]\n" +
+                "    },\n" +
+                "    \"downloadUri\" : \"https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\",\n" +
+                "    \"remoteUrl\" : \"http://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\",\n" +
+                "    \"mimeType\" : \"application/java-archive\",\n" +
+                "    \"size\" : \"156280\",\n" +
+                "    \"checksums\" : {\n" +
+                "      \"sha1\" : \"c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f\",\n" +
+                "      \"md5\" : \"2d1dd0fc21ee96bccfab4353d5379649\",\n" +
+                "      \"sha256\" : \"512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e\"\n" +
+                "    },\n" +
+                "    \"originalChecksums\" : {\n" +
+                "      \"sha1\" : \"c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f\",\n" +
+                "      \"md5\" : \"2d1dd0fc21ee96bccfab4353d5379649\",\n" +
+                "      \"sha256\" : \"512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e\"\n" +
+                "    },\n" +
+                "    \"uri\" : \"https://artifactory.techno.ingenico.com/artifactory/api/storage/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\"\n" +
+                "  } ]\n" +
+                "}";
+    }
+
+    @Test
+    public void shouldProcessCorrectlyArtifactoryAnswerMisMatchMd5() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
+        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
+        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379640");
+        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
+        final byte[] payload = payloadWithSha256().getBytes(StandardCharsets.UTF_8);
+        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        try {
+            searcher.processResponse(dependency, urlConnection);
+            fail("MD5 mismatching should throw an exception!");
+        } catch (FileNotFoundException e) {
+            // Then
+            assertEquals("Artifact found by API is not matching the md5 of the artifact (repository hash is 2d1dd0fc21ee96bccfab4353d5379649 while actual is 2d1dd0fc21ee96bccfab4353d5379640) !", e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldProcessCorrectlyArtifactoryAnswerMisMatchSha1() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0e");
+        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
+        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
+        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
+        final byte[] payload = payloadWithSha256().getBytes(StandardCharsets.UTF_8);
+        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        try {
+            searcher.processResponse(dependency, urlConnection);
+            fail("SHA1 mismatching should throw an exception!");
+        } catch (FileNotFoundException e) {
+            // Then
+            assertEquals("Artifact found by API is not matching the SHA1 of the artifact (repository hash is c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f while actual is c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0e) !", e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldProcessCorrectlyArtifactoryAnswerMisMatchSha256() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
+        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068f");
+        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
+        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
+        final byte[] payload = payloadWithSha256().getBytes(StandardCharsets.UTF_8);
+        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        try {
+            searcher.processResponse(dependency, urlConnection);
+            fail("SHA256 mismatching should throw an exception!");
+        } catch (FileNotFoundException e) {
+            // Then
+            assertEquals("Artifact found by API is not matching the SHA-256 of the artifact (repository hash is 512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e while actual is 512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068f) !", e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenPatternCannotBeParsed() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
+        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
+        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
+        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
+        final byte[] payload = payloadWithSha256().replace("/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar", "/2.8.5/gson-2.8.5-sources.jar").getBytes(StandardCharsets.UTF_8);
+        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        try {
+            searcher.processResponse(dependency, urlConnection);
+            fail("SHA256 mismatching should throw an exception!");
+        } catch (IllegalStateException e) {
+            // Then
+            assertEquals("Cannot extract the Maven information from the apth retrieved in Artifactory /2.8.5/gson-2.8.5-sources.jar", e.getMessage());
+        }
+    }
+}

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2018 Nicolas Henneaux. All Rights Reserved.
+ */
 package org.owasp.dependencycheck.data.artifactory;
 
 import org.junit.Before;

--- a/core/src/test/java/org/owasp/dependencycheck/data/central/CentralSearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/central/CentralSearchTest.java
@@ -4,15 +4,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
-import org.owasp.dependencycheck.utils.Settings;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by colezlaw on 10/13/14.
@@ -28,7 +25,9 @@ public class CentralSearchTest extends BaseTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testNullSha1() throws Exception { searcher.searchSha1(null); }
+    public void testNullSha1() throws Exception {
+        searcher.searchSha1(null);
+    }
 
     @Test(expected = IllegalArgumentException.class)
     public void testMalformedSha1() throws Exception {

--- a/core/src/test/java/org/owasp/dependencycheck/data/central/CentralSearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/central/CentralSearchTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.*;
  * Created by colezlaw on 10/13/14.
  */
 public class CentralSearchTest extends BaseTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CentralSearchTest.class);
     private CentralSearch searcher;
 
     @Before

--- a/core/src/test/java/org/owasp/dependencycheck/data/nexus/MavenArtifactTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nexus/MavenArtifactTest.java
@@ -1,0 +1,33 @@
+package org.owasp.dependencycheck.data.nexus;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MavenArtifactTest {
+
+    @Test
+    public void getPomUrl() {
+        // Given
+        final MavenArtifact mavenArtifact = new MavenArtifact("com.google.code.gson", "gson", "2.1",
+                "https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar");
+        // When
+        final String pomUrl = mavenArtifact.getPomUrl();
+        // Then
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.pom", pomUrl);
+
+    }
+
+
+    @Test
+    public void getPomUrlWithQualifier() {
+        // Given
+        final MavenArtifact mavenArtifact = new MavenArtifact("com.google.code.gson", "gson", "2.8.5",
+                "https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar");
+        // When
+        final String pomUrl = mavenArtifact.getPomUrl();
+        // Then
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5.pom", pomUrl);
+
+    }
+}

--- a/core/src/test/java/org/owasp/dependencycheck/data/nexus/MavenArtifactTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nexus/MavenArtifactTest.java
@@ -10,7 +10,7 @@ public class MavenArtifactTest {
     public void getPomUrl() {
         // Given
         final MavenArtifact mavenArtifact = new MavenArtifact("com.google.code.gson", "gson", "2.1",
-                "https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar");
+                "https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar", true);
         // When
         final String pomUrl = mavenArtifact.getPomUrl();
         // Then
@@ -23,7 +23,7 @@ public class MavenArtifactTest {
     public void getPomUrlWithQualifier() {
         // Given
         final MavenArtifact mavenArtifact = new MavenArtifact("com.google.code.gson", "gson", "2.8.5",
-                "https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar");
+                "https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar", true);
         // When
         final String pomUrl = mavenArtifact.getPomUrl();
         // Then

--- a/core/src/test/java/org/owasp/dependencycheck/data/nexus/MavenArtifactTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nexus/MavenArtifactTest.java
@@ -10,7 +10,8 @@ public class MavenArtifactTest {
     public void getPomUrl() {
         // Given
         final MavenArtifact mavenArtifact = new MavenArtifact("com.google.code.gson", "gson", "2.1",
-                "https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar", true);
+                "https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar", MavenArtifact.derivePomUrl("gson", "2.1",
+                "https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar"));
         // When
         final String pomUrl = mavenArtifact.getPomUrl();
         // Then
@@ -23,7 +24,8 @@ public class MavenArtifactTest {
     public void getPomUrlWithQualifier() {
         // Given
         final MavenArtifact mavenArtifact = new MavenArtifact("com.google.code.gson", "gson", "2.8.5",
-                "https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar", true);
+                "https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar", MavenArtifact.derivePomUrl("gson", "2.8.5",
+                "https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar"));
         // When
         final String pomUrl = mavenArtifact.getPomUrl();
         // Then

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
@@ -154,7 +154,7 @@ public class DependencyTest extends BaseTest {
     public void testGetSha256sum() {
         File file = BaseTest.getResourceAsFile(this, "struts2-core-2.1.2.jar");
         Dependency instance = new Dependency(file);
-        String expResult = "89ce9e36aa9a9e03f1450936d2f4f8dd0f961f8b";
+        String expResult = "5c1847a10800027254fcd0073385cceb46b1dacee061f3cd465e314bec592e81";
         String result = instance.getSha256sum();
         assertEquals(expResult, result);
     }

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
@@ -17,6 +17,10 @@
  */
 package org.owasp.dependencycheck.dependency;
 
+import org.junit.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.data.nexus.MavenArtifact;
+
 import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
@@ -26,12 +30,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
-import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.data.nexus.MavenArtifact;
-
 /**
- *
  * @author Jeremy Long
  */
 public class DependencyTest extends BaseTest {
@@ -149,6 +148,18 @@ public class DependencyTest extends BaseTest {
     }
 
     /**
+     * Test of getSha1sum method, of class Dependency.
+     */
+    @Test
+    public void testGetSha256sum() {
+        File file = BaseTest.getResourceAsFile(this, "struts2-core-2.1.2.jar");
+        Dependency instance = new Dependency(file);
+        String expResult = "89ce9e36aa9a9e03f1450936d2f4f8dd0f961f8b";
+        String result = instance.getSha256sum();
+        assertEquals(expResult, result);
+    }
+
+    /**
      * Test of setSha1sum method, of class Dependency.
      */
     @Test
@@ -157,6 +168,17 @@ public class DependencyTest extends BaseTest {
         Dependency instance = new Dependency();
         instance.setSha1sum(sha1sum);
         assertEquals(sha1sum, instance.getSha1sum());
+    }
+
+    /**
+     * Test of setSha1sum method, of class Dependency.
+     */
+    @Test
+    public void testSetSha256um() {
+        String sha256sum = "test";
+        Dependency instance = new Dependency();
+        instance.setSha256sum(sha256sum);
+        assertEquals(sha256sum, instance.getSha256sum());
     }
 
     /**

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -20,6 +20,9 @@
     <logger name="org.owasp.dependencycheck.data.central.CentralSearchTest" additivity="false" level="WARN">
         <appender-ref ref="console"/>
     </logger>
+    <logger name="org.owasp.dependencycheck.data.central.ArtifactorySearchTest" additivity="false" level="WARN">
+        <appender-ref ref="console"/>
+    </logger>
     <logger name="org.owasp.dependencycheck.data.nexus.NexusSearchTest" additivity="false" level="WARN">
         <appender-ref ref="console"/>
     </logger>

--- a/maven/src/it/artifactory-analyzer/invoker.properties
+++ b/maven/src/it/artifactory-analyzer/invoker.properties
@@ -1,0 +1,18 @@
+#
+# This file is part of dependency-check-core.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright (c) 2017 The OWASP Foundation. All Rights Reserved.
+#
+invoker.goals = install -X -Danalyzer.central.enabled=false -Danalyzer.artifactory.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check

--- a/maven/src/it/artifactory-analyzer/pom.xml
+++ b/maven/src/it/artifactory-analyzer/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-core.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2017 The OWASP Foundation. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.owasp.test</groupId>
+    <artifactId>artifactory-analyzer-it</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <configuration>
+                    <artifactoryAnalyzerEnabled>true</artifactoryAnalyzerEnabled>
+                    <artifactoryAnalyzerUrl>https://artifactory.techno.ingenico.com/artifactory</artifactoryAnalyzerUrl>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven/src/it/artifactory-analyzer/postbuild.groovy
+++ b/maven/src/it/artifactory-analyzer/postbuild.groovy
@@ -1,0 +1,28 @@
+/*
+ * This file is part of dependency-check-maven.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2018 Nicolas Henneaux. All Rights Reserved.
+ */
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import java.nio.charset.Charset;
+
+String log = FileUtils.readFileToString(new File(basedir, "build.log"), Charset.defaultCharset().name());
+int count = StringUtils.countMatches(log, "There was an issue connecting to Artifactory . Disabling analyzer.");
+if (count > 0){
+    System.out.println(String.format("There was an issue connecting to Artifactory . Disabling analyzer."));
+    return false;
+}

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1309,11 +1309,11 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_NEXUS_URL, nexusUrl);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_NEXUS_USES_PROXY, nexusUsesProxy);
 
-        if (artifactoryAnalyzerEnabled && artifactoryAnalyzerServerId != null) {
+        if (Boolean.TRUE.equals(artifactoryAnalyzerEnabled) && artifactoryAnalyzerServerId != null) {
             final Server server = settingsXml.getServer(artifactoryAnalyzerServerId);
             if (server != null) {
-                settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_API_USERNAME, server.getUsername());
-                settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_API_TOKEN, server.getPassword());
+                settings.setStringIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_API_USERNAME, server.getUsername());
+                settings.setStringIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_API_TOKEN, server.getPassword());
             }
         }
 

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -17,13 +17,6 @@
  */
 package org.owasp.dependencycheck.maven;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -70,8 +63,15 @@ import org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
 /**
- *
  * @author Jeremy Long
  */
 public abstract class BaseDependencyCheckMojo extends AbstractMojo implements MavenReport {
@@ -358,6 +358,12 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     @Parameter(property = "artifactoryAnalyzerEnabled")
     private Boolean artifactoryAnalyzerEnabled;
     /**
+     * The serverId inside the settings.xml containing the username and token to access artifactory
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "artifactoryAnalyzerServerId", defaultValue = "artifactory")
+    private String artifactoryAnalyzerServerId;
+    /**
      * Whether or not the Nexus Analyzer is enabled.
      */
     @SuppressWarnings("CanBeFinal")
@@ -583,12 +589,40 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
 
     // </editor-fold>
     //<editor-fold defaultstate="collapsed" desc="Base Maven implementation">
+
+    /**
+     * Determines if the groupId, artifactId, and version of the Maven
+     * dependency and artifact match.
+     *
+     * @param d the Maven dependency
+     * @param a the Maven artifact
+     * @return true if the groupId, artifactId, and version match
+     */
+    private static boolean artifactsMatch(org.apache.maven.model.Dependency d, Artifact a) {
+        return (isEqualOrNull(a.getArtifactId(), d.getArtifactId()))
+                && (isEqualOrNull(a.getGroupId(), d.getGroupId()))
+                && (isEqualOrNull(a.getVersion(), d.getVersion()));
+    }
+
+    /**
+     * Compares two strings for equality; if both strings are null they are
+     * considered equal.
+     *
+     * @param left  the first string to compare
+     * @param right the second string to compare
+     * @return true if the strings are equal or if they are both null; otherwise
+     * false.
+     */
+    private static boolean isEqualOrNull(String left, String right) {
+        return (left != null && left.equals(right)) || (left == null && right == null);
+    }
+
     /**
      * Executes dependency-check.
      *
      * @throws MojoExecutionException thrown if there is an exception executing
-     * the mojo
-     * @throws MojoFailureException thrown if dependency-check failed the build
+     *                                the mojo
+     * @throws MojoFailureException   thrown if dependency-check failed the build
      */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -621,7 +655,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     /**
      * Generates the Dependency-Check Site Report.
      *
-     * @param sink the sink to write the report to
+     * @param sink   the sink to write the report to
      * @param locale the locale to use when generating the report
      * @throws MavenReportException if a maven report exception occurs
      * @deprecated use
@@ -664,7 +698,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     /**
      * Generates the Dependency-Check Site Report.
      *
-     * @param sink the sink to write the report to
+     * @param sink   the sink to write the report to
      * @param locale the locale to use when generating the report
      * @throws MavenReportException if a maven report exception occurs
      */
@@ -697,7 +731,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      *
      * @return the directory to write the report(s)
      * @throws MojoExecutionException thrown if there is an error loading the
-     * file path
+     *                                file path
      */
     protected File getCorrectOutputDirectory() throws MojoExecutionException {
         return getCorrectOutputDirectory(this.project);
@@ -727,7 +761,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * list.
      *
      * @param project the project to scan the dependencies of
-     * @param engine the engine to use to scan the dependencies
+     * @param engine  the engine to use to scan the dependencies
      * @return a collection of exceptions that may have occurred while resolving
      * and scanning the dependencies
      */
@@ -739,8 +773,8 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * Scans the project's artifacts and adds them to the engine's dependency
      * list.
      *
-     * @param project the project to scan the dependencies of
-     * @param engine the engine to use to scan the dependencies
+     * @param project   the project to scan the dependencies of
+     * @param engine    the engine to use to scan the dependencies
      * @param aggregate whether the scan is part of an aggregate build
      * @return a collection of exceptions that may have occurred while resolving
      * and scanning the dependencies
@@ -762,17 +796,17 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * Resolves the projects artifacts using Aether and scans the resulting
      * dependencies.
      *
-     * @param engine the core dependency-check engine
-     * @param project the project being scanned
-     * @param nodes the list of dependency nodes, generally obtained via the
-     * DependencyGraphBuilder
+     * @param engine          the core dependency-check engine
+     * @param project         the project being scanned
+     * @param nodes           the list of dependency nodes, generally obtained via the
+     *                        DependencyGraphBuilder
      * @param buildingRequest the Maven project building request
-     * @param aggregate whether the scan is part of an aggregate build
+     * @param aggregate       whether the scan is part of an aggregate build
      * @return a collection of exceptions that may have occurred while resolving
      * and scanning the dependencies
      */
     private ExceptionCollection collectDependencies(Engine engine, MavenProject project,
-            List<DependencyNode> nodes, ProjectBuildingRequest buildingRequest, boolean aggregate) {
+                                                    List<DependencyNode> nodes, ProjectBuildingRequest buildingRequest, boolean aggregate) {
         ExceptionCollection exCol = null;
         for (DependencyNode dependencyNode : nodes) {
             if (artifactScopeExcluded.passes(dependencyNode.getArtifact().getScope())
@@ -921,7 +955,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * have not yet been built. If true a virtual dependency is created based on
      * the evidence in the project.
      *
-     * @param engine a reference to the engine being used to scan
+     * @param engine   a reference to the engine being used to scan
      * @param artifact the artifact being analyzed in the mojo
      * @return <code>true</code> if the artifact is in the reactor; otherwise
      * <code>false</code>
@@ -1001,33 +1035,6 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     }
 
     /**
-     * Determines if the groupId, artifactId, and version of the Maven
-     * dependency and artifact match.
-     *
-     * @param d the Maven dependency
-     * @param a the Maven artifact
-     * @return true if the groupId, artifactId, and version match
-     */
-    private static boolean artifactsMatch(org.apache.maven.model.Dependency d, Artifact a) {
-        return (isEqualOrNull(a.getArtifactId(), d.getArtifactId()))
-                && (isEqualOrNull(a.getGroupId(), d.getGroupId()))
-                && (isEqualOrNull(a.getVersion(), d.getVersion()));
-    }
-
-    /**
-     * Compares two strings for equality; if both strings are null they are
-     * considered equal.
-     *
-     * @param left the first string to compare
-     * @param right the second string to compare
-     * @return true if the strings are equal or if they are both null; otherwise
-     * false.
-     */
-    private static boolean isEqualOrNull(String left, String right) {
-        return (left != null && left.equals(right)) || (left == null && right == null);
-    }
-
-    /**
      * @return Returns a new ProjectBuildingRequest populated from the current
      * session and the current project remote repositories, used to resolve
      * artifacts.
@@ -1042,9 +1049,9 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * Executes the dependency-check scan and generates the necessary report.
      *
      * @throws MojoExecutionException thrown if there is an exception running
-     * the scan
-     * @throws MojoFailureException thrown if dependency-check is configured to
-     * fail the build
+     *                                the scan
+     * @throws MojoFailureException   thrown if dependency-check is configured to
+     *                                fail the build
      */
     protected void runCheck() throws MojoExecutionException, MojoFailureException {
         try (Engine engine = initializeEngine()) {
@@ -1102,10 +1109,10 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * MojoExecutionException
      *
      * @param currentEx the primary exception collection
-     * @param newEx the new exception collection to add
+     * @param newEx     the new exception collection to add
      * @return the combined exception collection
      * @throws MojoExecutionException thrown if dependency-check is configured
-     * to fail on errors
+     *                                to fail on errors
      */
     private ExceptionCollection handleAnalysisExceptions(ExceptionCollection currentEx, ExceptionCollection newEx) throws MojoExecutionException {
         ExceptionCollection returnEx = currentEx;
@@ -1145,16 +1152,6 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     protected abstract ExceptionCollection scanDependencies(final Engine engine) throws MojoExecutionException;
 
     /**
-     * Sets the Reporting output directory.
-     *
-     * @param directory the output directory
-     */
-    @Override
-    public void setReportOutputDirectory(File directory) {
-        reportOutputDirectory = directory;
-    }
-
-    /**
      * Returns the report output directory.
      *
      * @return the report output directory
@@ -1162,6 +1159,16 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     @Override
     public File getReportOutputDirectory() {
         return reportOutputDirectory;
+    }
+
+    /**
+     * Sets the Reporting output directory.
+     *
+     * @param directory the output directory
+     */
+    @Override
+    public void setReportOutputDirectory(File directory) {
+        reportOutputDirectory = directory;
     }
 
     /**
@@ -1292,7 +1299,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_JAR_ENABLED, jarAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_NUSPEC_ENABLED, nuspecAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, centralAnalyzerEnabled);
-        settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_ENABLED, nexusAnalyzerEnabled);
+        settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_ENABLED, artifactoryAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_NEXUS_ENABLED, nexusAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_ASSEMBLY_ENABLED, assemblyAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARCHIVE_ENABLED, archiveAnalyzerEnabled);
@@ -1301,6 +1308,14 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
 
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_NEXUS_URL, nexusUrl);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_NEXUS_USES_PROXY, nexusUsesProxy);
+
+        if (artifactoryAnalyzerEnabled && artifactoryAnalyzerServerId != null) {
+            final Server server = settingsXml.getServer(artifactoryAnalyzerServerId);
+            if (server != null) {
+                settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_API_USERNAME, server.getUsername());
+                settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_API_TOKEN, server.getPassword());
+            }
+        }
 
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_PYTHON_DISTRIBUTION_ENABLED, pyDistributionAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_PYTHON_PACKAGE_ENABLED, pyPackageAnalyzerEnabled);
@@ -1474,13 +1489,14 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     }
 
     //<editor-fold defaultstate="collapsed" desc="Methods to fail build or show summary">
+
     /**
      * Checks to see if a vulnerability has been identified with a CVSS score
      * that is above the threshold set in the configuration.
      *
      * @param dependencies the list of dependency objects
      * @throws MojoFailureException thrown if a CVSS score is found that is
-     * higher then the threshold set
+     *                              higher then the threshold set
      */
     protected void checkForFailure(Dependency[] dependencies) throws MojoFailureException {
         final StringBuilder ids = new StringBuilder();
@@ -1521,7 +1537,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * Generates a warning message listing a summary of dependencies and their
      * associated CPE and CVE entries.
      *
-     * @param mp the Maven project for which the summary is shown
+     * @param mp           the Maven project for which the summary is shown
      * @param dependencies a list of dependency objects
      */
     protected void showSummary(MavenProject mp, Dependency[] dependencies) {
@@ -1562,6 +1578,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
 
     //</editor-fold>
     //<editor-fold defaultstate="collapsed" desc="Methods to read/write the serialized data file">
+
     /**
      * Returns the key used to store the path to the data file that is saved by
      * <code>writeDataFile()</code>. This key is used in the

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -379,7 +379,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * The bearer token to connect to Artifactory instance
      */
     @SuppressWarnings("CanBeFinal")
-    @Parameter(property = "artifactoryAnalyzerBearerToken", defaultValue = "artifactory")
+    @Parameter(property = "artifactoryAnalyzerBearerToken")
     private String artifactoryAnalyzerBearerToken;
     /**
      * The Artifactory URL for the Artifactory analyzer.

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -364,6 +364,24 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     @Parameter(property = "artifactoryAnalyzerServerId", defaultValue = "artifactory")
     private String artifactoryAnalyzerServerId;
     /**
+     * The username (only used with API token) to connect to Artifactory instance
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "artifactoryAnalyzerUsername", defaultValue = "artifactory")
+    private String artifactoryAnalyzerUsername;
+    /**
+     * The API token to connect to Artifactory instance
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "artifactoryAnalyzerApiToken", defaultValue = "artifactory")
+    private String artifactoryAnalyzerApiToken;
+    /**
+     * The bearer token to connect to Artifactory instance
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "artifactoryAnalyzerBearerToken", defaultValue = "artifactory")
+    private String artifactoryAnalyzerBearerToken;
+    /**
      * The Artifactory URL for the Artifactory analyzer.
      */
     @SuppressWarnings("CanBeFinal")
@@ -1331,12 +1349,19 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_USES_PROXY, artifactoryAnalyzerUseProxy);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_PARALLEL_ANALYSIS, artifactoryAnalyzerParallelAnalysis);
 
-        if (Boolean.TRUE.equals(artifactoryAnalyzerEnabled) && artifactoryAnalyzerServerId != null) {
-            final Server server = settingsXml.getServer(artifactoryAnalyzerServerId);
-            if (server != null) {
-                settings.setStringIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_API_USERNAME, server.getUsername());
-                settings.setStringIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_API_TOKEN, server.getPassword());
+
+        if (Boolean.TRUE.equals(artifactoryAnalyzerEnabled)) {
+            if (artifactoryAnalyzerServerId != null) {
+                final Server server = settingsXml.getServer(artifactoryAnalyzerServerId);
+                if (server != null) {
+                    settings.setStringIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_API_USERNAME, server.getUsername());
+                    settings.setStringIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_API_TOKEN, server.getPassword());
+                }
+            } else {
+                settings.setStringIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_API_USERNAME, artifactoryAnalyzerUsername);
+                settings.setStringIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_API_TOKEN, artifactoryAnalyzerApiToken);
             }
+            settings.setStringIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_BEARER_TOKEN, artifactoryAnalyzerBearerToken);
         }
 
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_PYTHON_DISTRIBUTION_ENABLED, pyDistributionAnalyzerEnabled);

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -950,6 +950,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 }
                 final String key = String.format("%s:%s:%s", artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
                 d.setSha1sum(Checksum.getSHA1Checksum(key));
+                d.setSha256sum(Checksum.getSHA256Checksum(key));
                 d.setMd5sum(Checksum.getMD5Checksum(key));
 
                 d.setDisplayFileName(displayName);

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -352,6 +352,12 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     private Boolean centralAnalyzerEnabled;
 
     /**
+     * Whether or not the Artifactory Analyzer is enabled.
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "artifactoryAnalyzerEnabled")
+    private Boolean artifactoryAnalyzerEnabled;
+    /**
      * Whether or not the Nexus Analyzer is enabled.
      */
     @SuppressWarnings("CanBeFinal")
@@ -1286,13 +1292,15 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_JAR_ENABLED, jarAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_NUSPEC_ENABLED, nuspecAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, centralAnalyzerEnabled);
+        settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_ENABLED, nexusAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_NEXUS_ENABLED, nexusAnalyzerEnabled);
-        settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_NEXUS_URL, nexusUrl);
-        settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_NEXUS_USES_PROXY, nexusUsesProxy);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_ASSEMBLY_ENABLED, assemblyAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARCHIVE_ENABLED, archiveAnalyzerEnabled);
         settings.setStringIfNotEmpty(Settings.KEYS.ADDITIONAL_ZIP_EXTENSIONS, zipExtensions);
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_ASSEMBLY_MONO_PATH, pathToMono);
+
+        settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_NEXUS_URL, nexusUrl);
+        settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_NEXUS_USES_PROXY, nexusUsesProxy);
 
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_PYTHON_DISTRIBUTION_ENABLED, pyDistributionAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_PYTHON_PACKAGE_ENABLED, pyPackageAnalyzerEnabled);

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -364,6 +364,24 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     @Parameter(property = "artifactoryAnalyzerServerId", defaultValue = "artifactory")
     private String artifactoryAnalyzerServerId;
     /**
+     * The Artifactory URL for the Artifactory analyzer.
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "artifactoryAnalyzerUrl")
+    private String artifactoryAnalyzerUrl;
+    /**
+     * Whether Artifactory should be accessed through a proxy or not
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "artifactoryAnalyzerUseProxy", defaultValue = "artifactory")
+    private Boolean artifactoryAnalyzerUseProxy;
+    /**
+     * Whether the Artifactory analyzer should be run in parallel or not.
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "artifactoryAnalyzerParallelAnalysis", defaultValue = "true")
+    private Boolean artifactoryAnalyzerParallelAnalysis;
+    /**
      * Whether or not the Nexus Analyzer is enabled.
      */
     @SuppressWarnings("CanBeFinal")
@@ -1308,6 +1326,10 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
 
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_NEXUS_URL, nexusUrl);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_NEXUS_USES_PROXY, nexusUsesProxy);
+
+        settings.setStringIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_URL, artifactoryAnalyzerUrl);
+        settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_USES_PROXY, artifactoryAnalyzerUseProxy);
+        settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_PARALLEL_ANALYSIS, artifactoryAnalyzerParallelAnalysis);
 
         if (Boolean.TRUE.equals(artifactoryAnalyzerEnabled) && artifactoryAnalyzerServerId != null) {
             final Server server = settingsXml.getServer(artifactoryAnalyzerServerId);

--- a/maven/src/site/markdown/configuration.md
+++ b/maven/src/site/markdown/configuration.md
@@ -56,7 +56,10 @@ artifactoryAnalyzerEnabled    | Sets whether Artifactory analyzer will be used |
 artifactoryAnalyzerUrl        | The Artifactory server URL. | &nbsp;
 artifactoryAnalyzerUseProxy   | Whether Artifactory should be accessed through a proxy or not. | false
 artifactoryAnalyzerParallelAnalysis | Whether the Artifactory analyzer should be run in parallel or not | true
-artifactoryAnalyzerServerId   | The id of a server defined in the settings.xml to retrieve the credentials to connect to Artifactory instance | artifactory
+artifactoryAnalyzerServerId   | The id of a server defined in the settings.xml to retrieve the credentials (username and API token) to connect to Artifactory instance. It is used in priority to artifactoryAnalyzerUsername and artifactoryAnalyzerApiToken | artifactory
+artifactoryAnalyzerUsername   | The user name (only used with API token) to connect to Artifactory instance | &nbsp;
+artifactoryAnalyzerApiToken   | The API token to connect to Artifactory instance, only used if the username or the API key are not defined by artifactoryAnalyzerServerId,artifactoryAnalyzerUsername or artifactoryAnalyzerApiToken | &nbsp;
+artifactoryAnalyzerBearerToken   | The bearer token to connect to Artifactory instance | &nbsp;
 pyDistributionAnalyzerEnabled | Sets whether the [experimental](../analyzers/index.html) Python Distribution Analyzer will be used.               | true
 pyPackageAnalyzerEnabled      | Sets whether the [experimental](../analyzers/index.html) Python Package Analyzer will be used.                    | true
 rubygemsAnalyzerEnabled       | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used.                      | true

--- a/maven/src/site/markdown/configuration.md
+++ b/maven/src/site/markdown/configuration.md
@@ -52,6 +52,11 @@ centralAnalyzerEnabled        | Sets whether Central Analyzer will be used. If t
 nexusAnalyzerEnabled          | Sets whether Nexus Analyzer will be used (requires Nexus Pro). This analyzer is superceded by the Central Analyzer; however, you can configure this to run against a Nexus Pro installation. | true
 nexusUrl                      | Defines the Nexus Server's web service end point (example http://domain.enterprise/service/local/). If not set the Nexus Analyzer will be disabled. | &nbsp;
 nexusUsesProxy                | Whether or not the defined proxy should be used when connecting to Nexus. | true
+artifactoryAnalyzerEnabled    | Sets whether Artifactory analyzer will be used | false
+artifactoryAnalyzerUrl        | The Artifactory server URL. | &nbsp;
+artifactoryAnalyzerUseProxy   | Whether Artifactory should be accessed through a proxy or not. | false
+artifactoryAnalyzerParallelAnalysis | Whether the Artifactory analyzer should be run in parallel or not | true
+artifactoryAnalyzerServerId   | The id of a server defined in the settings.xml to retrieve the credentials to connect to Artifactory instance | artifactory
 pyDistributionAnalyzerEnabled | Sets whether the [experimental](../analyzers/index.html) Python Distribution Analyzer will be used.               | true
 pyPackageAnalyzerEnabled      | Sets whether the [experimental](../analyzers/index.html) Python Package Analyzer will be used.                    | true
 rubygemsAnalyzerEnabled       | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used.                      | true

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Checksum.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Checksum.java
@@ -108,6 +108,18 @@ public final class Checksum {
         final byte[] b = getChecksum("SHA1", file);
         return getHex(b);
     }
+    /**
+     * Calculates the SH256 checksum of a specified file.
+     *
+     * @param file the file to generate the MD5 checksum
+     * @return the hex representation of the SHA1 hash
+     * @throws IOException when the file passed in does not exist
+     * @throws NoSuchAlgorithmException when the SHA1 algorithm is not available
+     */
+    public static String getSHA256Checksum(File file) throws IOException, NoSuchAlgorithmException {
+        final byte[] b = getChecksum("SHA256", file);
+        return getHex(b);
+    }
 
     /**
      * Calculates the MD5 checksum of a specified bytes.
@@ -143,6 +155,16 @@ public final class Checksum {
     public static String getSHA1Checksum(String text) {
         final byte[] data = stringToBytes(text);
         return getChecksum("SHA1", data);
+    }
+    /**
+     * Calculates the SHA1 checksum of the specified text.
+     *
+     * @param text the text to generate the SHA1 checksum
+     * @return the hex representation of the SHA1
+     */
+    public static String getSHA256Checksum(String text) {
+        final byte[] data = stringToBytes(text);
+        return getChecksum("SHA256", data);
     }
 
     /**

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Checksum.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Checksum.java
@@ -46,6 +46,7 @@ public final class Checksum {
      * The logger.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(Checksum.class);
+    private  static final String SHA_256 = "SHA-256";
 
     /**
      * Private constructor for a utility class.
@@ -117,7 +118,7 @@ public final class Checksum {
      * @throws NoSuchAlgorithmException when the SHA1 algorithm is not available
      */
     public static String getSHA256Checksum(File file) throws IOException, NoSuchAlgorithmException {
-        final byte[] b = getChecksum("SHA256", file);
+        final byte[] b = getChecksum(SHA_256, file);
         return getHex(b);
     }
 
@@ -164,7 +165,7 @@ public final class Checksum {
      */
     public static String getSHA256Checksum(String text) {
         final byte[] data = stringToBytes(text);
-        return getChecksum("SHA256", data);
+        return getChecksum(SHA_256, data);
     }
 
     /**

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -336,6 +336,19 @@ public final class Settings {
          */
         public static final String ANALYZER_ARTIFACTORY_URL = "analyzer.artifactory.url";
         /**
+         * The properties key for the Artifactory username.
+         */
+        public static final String ANALYZER_ARTIFACTORY_API_USERNAME = "analyzer.artifactory.api.username";
+        /**
+         * The properties key for the Artifactory API token.
+         */
+        public static final String ANALYZER_ARTIFACTORY_API_TOKEN = "analyzer.artifactory.api.token";
+        /**
+         * The properties key for the Artifactory bearer token (https://www.jfrog.com/confluence/display/RTF/Access+Tokens).
+         * It can be generated using <code>curl -u yourUserName -X POST "https://artifactory.techno.ingenico.com/artifactory/api/security/token" -d "username=yourUserName"</code>.
+         */
+        public static final String ANALYZER_ARTIFACTORY_BEARER_TOKEN = "analyzer.artifactory.bearer.token";
+        /**
          * The properties key for using the proxy to reach Artifactory.
          */
         public static final String ANALYZER_ARTIFACTORY_USES_PROXY = "analyzer.artifactory.proxy";

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -328,6 +328,23 @@ public final class Settings {
          */
         public static final String ANALYZER_NEXUS_USES_PROXY = "analyzer.nexus.proxy";
         /**
+         * The properties key for whether the Artifactory analyzer is enabled.
+         */
+        public static final String ANALYZER_ARTIFACTORY_ENABLED = "analyzer.artifactory.enabled";
+        /**
+         * The properties key for the Artifactory search URL.
+         */
+        public static final String ANALYZER_ARTIFACTORY_URL = "analyzer.artifactory.url";
+        /**
+         * The properties key for using the proxy to reach Artifactory.
+         */
+        public static final String ANALYZER_ARTIFACTORY_USES_PROXY = "analyzer.artifactory.proxy";
+        /**
+         * The properties key for whether the Artifactory analyzer should use
+         * parallel processing.
+         */
+        public static final String ANALYZER_ARTIFACTORY_PARALLEL_ANALYSIS = "analyzer.artifactory.parallel.analysis";
+        /**
          * The properties key for whether the Central analyzer is enabled.
          */
         public static final String ANALYZER_CENTRAL_ENABLED = "analyzer.central.enabled";


### PR DESCRIPTION
## Fixes Issue #
https://github.com/jeremylong/DependencyCheck/issues/60 Add Artifactory Analyzer
## Description of Change
Use Artifactory AQL API to find a artifacts by their hashes (SHA1 for the moment because SHA256 search API seems not working).
MD5, SHA1 and SHA256 (if present) are checked in the results retrieved from Artifactory.
Authentication could be configured with bearer or API token.

## Have test cases been added to cover the new functionality?

*yes included in the PR*