### PR TITLE
Bug fixes

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
@@ -310,9 +310,11 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
             final File tmpLoc = new File(tempDir, fileName.substring(0, fileName.length() - 3) + "jar");
             //store the archives sha1 and change it so that the engine doesn't think the zip and jar file are the same
             // and add it is a related dependency.
+            final String archiveMd5 = dependency.getMd5sum();
             final String archiveSha1 = dependency.getSha1sum();
             final String archiveSha256 = dependency.getSha256sum();
             try {
+                dependency.setMd5sum("");
                 dependency.setSha1sum("");
                 dependency.setSha256sum("");
                 org.apache.commons.io.FileUtils.copyFile(dependency.getActualFile(), tmpLoc);
@@ -336,6 +338,7 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
             } catch (IOException ex) {
                 LOGGER.debug("Unable to perform deep copy on '{}'", dependency.getActualFile().getPath(), ex);
             } finally {
+                dependency.setMd5sum(archiveMd5);
                 dependency.setSha1sum(archiveSha1);
                 dependency.setSha256sum(archiveSha256);
             }

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -181,9 +181,9 @@ public class Dependency extends EvidenceCollection implements Serializable {
     /**
      * Constructs a new Dependency object.
      *
-     * @param file      the File to create the dependency object from.
+     * @param file the File to create the dependency object from.
      * @param isVirtual specifies if the dependency is virtual indicating the
-     *                  file doesn't actually exist.
+     * file doesn't actually exist.
      */
     public Dependency(File file, boolean isVirtual) {
         this();
@@ -192,13 +192,31 @@ public class Dependency extends EvidenceCollection implements Serializable {
         this.filePath = this.actualFilePath;
         this.fileName = file.getName();
         this.packagePath = filePath;
+        if (!isVirtual && file.isFile()) {
+            calculateChecksums(file);
+        }
+    }
+
+    /**
+     * Calculates the checksums for the given file.
+     *
+     * @param file the file used to calculate the checksums
+     */
+    private void calculateChecksums(File file) {
+        try {
+            this.md5sum = Checksum.getMD5Checksum(file);
+            this.sha1sum = Checksum.getSHA1Checksum(file);
+            this.sha256sum = Checksum.getSHA256Checksum(file);
+        } catch (NoSuchAlgorithmException | IOException ex) {
+            LOGGER.debug(String.format("Unable to calculate checksums on %s", file), ex);
+        }
     }
 
     /**
      * Constructs a new Dependency object.
      *
      * @param isVirtual specifies if the dependency is virtual indicating the
-     *                  file doesn't actually exist.
+     * file doesn't actually exist.
      */
     public Dependency(boolean isVirtual) {
         this();
@@ -260,6 +278,10 @@ public class Dependency extends EvidenceCollection implements Serializable {
         this.sha1sum = null;
         this.sha256sum = null;
         this.md5sum = null;
+        final File file = getActualFile();
+        if (file.isFile()) {
+            calculateChecksums(this.getActualFile());
+        }
     }
 
     /**
@@ -403,9 +425,9 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * Adds an entry to the list of detected Identifiers for the dependency
      * file.
      *
-     * @param type  the type of identifier (such as CPE)
+     * @param type the type of identifier (such as CPE)
      * @param value the value of the identifier
-     * @param url   the URL of the identifier
+     * @param url the URL of the identifier
      */
     public synchronized void addIdentifier(String type, String value, String url) {
         final Identifier i = new Identifier(type, value, url);
@@ -416,9 +438,9 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * Adds an entry to the list of detected Identifiers for the dependency
      * file.
      *
-     * @param type       the type of identifier (such as CPE)
-     * @param value      the value of the identifier
-     * @param url        the URL of the identifier
+     * @param type the type of identifier (such as CPE)
+     * @param value the value of the identifier
+     * @param url the URL of the identifier
      * @param confidence the confidence in the Identifier being accurate
      */
     public synchronized void addIdentifier(String type, String value, String url, Confidence confidence) {
@@ -439,9 +461,9 @@ public class Dependency extends EvidenceCollection implements Serializable {
     /**
      * Adds the maven artifact as evidence.
      *
-     * @param source        The source of the evidence
+     * @param source The source of the evidence
      * @param mavenArtifact The maven artifact
-     * @param confidence    The confidence level of this evidence
+     * @param confidence The confidence level of this evidence
      */
     public void addAsEvidence(String source, MavenArtifact mavenArtifact, Confidence confidence) {
         if (mavenArtifact.getGroupId() != null && !mavenArtifact.getGroupId().isEmpty()) {
@@ -772,6 +794,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
                 .append(this.packagePath, other.packagePath)
                 .append(this.md5sum, other.md5sum)
                 .append(this.sha1sum, other.sha1sum)
+                .append(this.sha256sum, other.sha256sum)
                 .append(this.identifiers, other.identifiers)
                 .append(this.description, other.description)
                 .append(this.license, other.license)
@@ -798,6 +821,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
                 .append(packagePath)
                 .append(md5sum)
                 .append(sha1sum)
+                .append(sha256sum)
                 .append(identifiers)
                 .append(description)
                 .append(license)
@@ -862,6 +886,5 @@ public class Dependency extends EvidenceCollection implements Serializable {
 
         String hash(File file) throws IOException, NoSuchAlgorithmException;
     }
-
 
 }

--- a/core/src/main/java/org/owasp/dependencycheck/xml/pom/PomUtils.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/pom/PomUtils.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 import javax.annotation.concurrent.ThreadSafe;
+import org.apache.commons.io.FileUtils;
 import org.owasp.dependencycheck.analyzer.JarAnalyzer;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
@@ -66,6 +67,16 @@ public final class PomUtils {
             throw ex;
         } catch (PomParseException ex) {
             LOGGER.warn("Unable to parse pom '{}'", file.getPath());
+            //todo remove test code for intermittent error.
+            try {
+                File target = new File("~/Projects/DependencyCheck/core/target/");
+                if (target.isDirectory()) {
+                    FileUtils.copyFile(file, target);
+                    LOGGER.info("Unparsable pom was copied to {}",target.toString());
+                }
+            } catch (IOException ex1) {
+                throw new RuntimeException(ex1);
+            }
             LOGGER.debug("", ex);
             throw new AnalysisException(ex);
         } catch (Throwable ex) {


### PR DESCRIPTION
Fixes two bugs:

1) In some cases the Md5 checksum was not being calculated correctly and caused an error message when the report was generated
2) added the retry count to the Central Analyzer for purposes of downloading the pom.xml if it had not already been analyzed.