### PR TITLE
Fix NPM and NSP Analysis

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NspAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NspAnalyzer.java
@@ -44,6 +44,8 @@ import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonReader;
 import org.owasp.dependencycheck.analyzer.exception.SearchException;
+import org.owasp.dependencycheck.dependency.Confidence;
+import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.URLConnectionFailureException;
@@ -157,7 +159,9 @@ public class NspAnalyzer extends AbstractNpmAnalyzer {
 
     @Override
     protected void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
-        engine.removeDependency(dependency);
+        if (dependency.getDisplayFileName().equals(dependency.getFileName()))  {
+            engine.removeDependency(dependency);
+        }
         final File file = dependency.getActualFile();
         if (!file.isFile() || file.length() == 0 || !shouldProcess(file)) {
             return;

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NspAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NspAnalyzer.java
@@ -44,8 +44,6 @@ import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonReader;
 import org.owasp.dependencycheck.analyzer.exception.SearchException;
-import org.owasp.dependencycheck.dependency.Confidence;
-import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.URLConnectionFailureException;

--- a/src/site/markdown/analyzers/index.md
+++ b/src/site/markdown/analyzers/index.md
@@ -9,6 +9,7 @@ to extract identification information from the files analyzed.
 | [Assembly](./assembly-analyzer.html) | .NET Assemblies (\*.exe, \*.dll) | Uses [GrokAssembly.exe](https://github.com/colezlaw/GrokAssembly), which requires .NET Framework or Mono runtime to be installed. |
 | [CMake](./cmake.html) | CMake project files (CMakeLists.txt) and scripts (\*.cmake) | Regex scan for project initialization and version setting commands. |
 | [Jar](./jar-analyzer.html) | Java archive files (\*.jar); Web application archive (\*.war) | Examines archive manifest metadata, and Maven Project Object Model files (pom.xml). |
+| [Node.js](./nodejs.html) | NPM package specification files (package.json) | Parses the package.json to gather a bill-of-materials for a Node JS project. |
 | [NSP](./nsp-analyzer.html) | [Node Security Project](https://nodesecurity.io) is used to analyze Node.js' `package.json` files for known vulnerable packages.|
 | [Nuspec](./nuspec-analyzer.html) | Nuget package specification file (\*.nuspec) | Uses XPath to parse specification XML. |
 | [OpenSSL](./openssl.html) | OpenSSL Version Source Header File (opensslv.h) | Regex parse of the OPENSSL_VERSION_NUMBER macro definition. |
@@ -28,7 +29,6 @@ several teams have found them useful in their current state.
 | [CMake](./cmake.html) | CMake project files (CMakeLists.txt) and scripts (\*.cmake) | Regex scan for project initialization and version setting commands. |
 | [CocoaPods](./cocoapods.html) | CocoaPods `.podspec` files | Extracts dependency information from specification file. |
 | [Composer Lock](./composer-lock.html) | PHP [Composer](http://getcomposer.org) Lock files (composer.lock) | Parses PHP [Composer](http://getcomposer.org) lock files for exact versions of dependencies. | 
-| [Node.js](./nodejs.html) | NPM package specification files (package.json) | Parse JSON format for metadata. |
 | [Python](./python.html) | Python source files (\*.py); Package metadata files (PKG-INFO, METADATA); Package Distribution Files (\*.whl, \*.egg, \*.zip) | Regex scan of Python source files for setuptools metadata; Parse RFC822 header format for metadata in all other artifacts. |
 | [Ruby Gemspec](./ruby-gemspec.html) | Ruby makefiles (Rakefile); Ruby Gemspec files (\*.gemspec) | Regex scan Gemspec initialization blocks for metadata. |
 | [RetireJS](./retirejs-analyzer.html) | JavaScript files | Analyzes JavaScript files using the [RetireJS](https://github.com/RetireJS/retire.js) database. |

--- a/src/site/markdown/analyzers/nodejs.md
+++ b/src/site/markdown/analyzers/nodejs.md
@@ -1,14 +1,8 @@
 Node.js Analyzer
 ================
 
-*Retired*: This analyzer has been retired due to an extremely high false positive
-rate. 
-
 OWASP dependency-check includes an analyzer that will scan [Node Package Manager](https://www.npmjs.com/)
-package specification files. The analyzer will collect as much information as
-it can about the package. The information collected is internally referred to
-as evidence and is grouped into vendor, product, and version buckets. Other
-analyzers later use this evidence to identify any Common Platform Enumeration
-(CPE) identifiers that apply.
+package specification files that works in conjunction with the [NSP-Analyzer](./nsp-analyzer.html) to
+create a bill-of-materials for a Node.js project.
 
-Files Types Scanned: [package.json](https://docs.npmjs.com/files/package.json)
+Files Types Scanned: [package.json](https://docs.npmjs.com/files/package.json), package-lock.json, npm-shrinkwrap.json


### PR DESCRIPTION
## Fixes Issue #1355

The NSP and NPM Analyzers had a conflict in that they would remove the necessary files the other analyzer needed or generated.  This PR resolves the issue.