### PR TITLE
Filter doctype from pom.xml

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -238,8 +238,20 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <groupId>com.h3xstream.retirejs</groupId>
             <artifactId>retirejs-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- The following dependencies are only used during testing 
              and must not be converted to a properties based version number -->
+        <dependency>
+            <groupId>org.jslipc</groupId>
+            <artifactId>jslipc</artifactId>
+            <version>0.2.0</version>
+            <scope>test</scope>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-cvsexe</artifactId>
@@ -369,12 +381,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <scope>test</scope>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.19.0</version>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
     <profiles>
         <profile>

--- a/core/src/main/java/org/owasp/dependencycheck/xml/pom/PomParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/pom/PomParser.java
@@ -84,7 +84,7 @@ public class PomParser {
             final XMLReader xmlReader = saxParser.getXMLReader();
             xmlReader.setContentHandler(handler);
 
-            final BOMInputStream bomStream = new BOMInputStream(new XmlInputStream(inputStream));
+            final BOMInputStream bomStream = new BOMInputStream(new XmlInputStream(new PomProjectInputStream(inputStream)));
             final ByteOrderMark bom = bomStream.getBOM();
             final String defaultEncoding = "UTF-8";
             final String charsetName = bom == null ? defaultEncoding : bom.getCharsetName();

--- a/core/src/main/java/org/owasp/dependencycheck/xml/pom/PomProjectInputStream.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/pom/PomProjectInputStream.java
@@ -1,0 +1,114 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2018 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.xml.pom;
+
+import java.io.BufferedInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Filters everything in an input stream prior to the &lt;project&gt; element.
+ * This is useful to filter out the DOCTYPE declarations that can cause parsing
+ * issues.
+ *
+ * @author Jeremy Long
+ */
+public class PomProjectInputStream extends FilterInputStream {
+
+    /**
+     * The project tag for a pom.xml.
+     */
+    private static final byte[] PROJECT = "<project".getBytes();
+    /**
+     * The size of the buffer used to scan the input stream.
+     */
+    protected static final int BUFFER_SIZE = 1024;
+
+    public PomProjectInputStream(InputStream in) throws IOException {
+        super(new BufferedInputStream(in));
+        skipToProject();
+    }
+
+    /**
+     * Skips bytes from the input stream until it finds the &lt;project&gt;
+     * element.
+     *
+     * @throws IOException thrown if an I/O error occurs
+     */
+    private void skipToProject() throws IOException {
+        boolean found = false;
+        byte[] buffer = new byte[BUFFER_SIZE];
+        super.mark(BUFFER_SIZE);
+        int count = super.read(buffer, 0, BUFFER_SIZE);
+        int adjustment = 0;
+        while (count > 0 && !found) {
+            int pos = findSequence(PROJECT, buffer);
+            if (pos >= 0) {
+                super.reset();
+                super.skip(pos - adjustment);
+                return;
+            }
+            super.reset();
+            super.skip(PROJECT.length);
+            super.mark(BUFFER_SIZE);
+            for (int i = 0; i < PROJECT.length; i++) {
+                buffer[i] = buffer[BUFFER_SIZE - PROJECT.length + i];
+            }
+            adjustment = PROJECT.length;
+            count = super.read(buffer, PROJECT.length, BUFFER_SIZE - PROJECT.length);
+        }
+    }
+
+    /**
+     * Tests the buffer to see if it contains the given sequence[1]..[n]. It is assumed
+     * that sequence[0] is checked prior to calling this method and that buffer[pos]
+     * equals sequence[0].
+     *
+     * @param sequence the prefix to scan against
+     * @return <code>true</code>if the next set of bytes from the input stream
+     * match the contents of the prefix.
+     */
+    private static boolean testRemaining(byte[] sequence, byte[] buffer, int pos) {
+        boolean match = true;
+        for (int i = 1; i < sequence.length; i++) {
+            if (buffer[pos + i] != sequence[i]) {
+                match = false;
+                break;
+            }
+        }
+        return match;
+    }
+
+    /**
+     * Finds the start of the given sequence in the buffer. If not found, -1 is returned.
+     * @param sequence the sequence to locate
+     * @param buffer the buffer to search
+     * @return the starting position of the sequence in the buffer if found; otherwise -1
+     */
+    protected static int findSequence(byte[] sequence, byte[] buffer) {
+        int pos = -1;
+        for (int i = 0; i < buffer.length - sequence.length + 1; i++) {
+            if (buffer[i] == sequence[0] && testRemaining(sequence, buffer, i)) {
+                pos = i;
+                break;
+            }
+        }
+        return pos;
+    }
+}

--- a/core/src/test/java/org/owasp/dependencycheck/xml/pom/PomProjectInputStreamTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/pom/PomProjectInputStreamTest.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2018 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.xml.pom;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author Jeremy Long
+ */
+public class PomProjectInputStreamTest {
+
+    private String POM = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n"
+            + "<!DOCTYPE xml [<!ENTITY quot \"&#34;\">\n"
+            + "               <!ENTITY euro \"&#x20ac;\">\n"
+            + "               <!ENTITY reg \"&#174;\">\n"
+            + "               <!ENTITY nbsp \"&#160;\">\n"
+            + "               <!ENTITY Auml \"&#196;\">\n"
+            + "               <!ENTITY Uuml \"&#220;\">\n"
+            + "               <!ENTITY Ouml \"&#214;\">\n"
+            + "               <!ENTITY auml \"&#228;\">\n"
+            + "               <!ENTITY uuml \"&#252;\">\n"
+            + "               <!ENTITY ouml \"&#246;\">\n"
+            + "               <!ENTITY raquo \"&#187;\">\n"
+            + "               <!ENTITY szlig \"&#223;\">]>\n"
+            + "<project></project>";
+
+    private String INVALID = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n"
+            + "<!DOCTYPE xml [<!ENTITY quot \"&#34;\">\n"
+            + "               <!ENTITY euro \"&#x20ac;\">\n"
+            + "               <!ENTITY reg \"&#174;\">\n"
+            + "               <!ENTITY nbsp \"&#160;\">\n"
+            + "               <!ENTITY Auml \"&#196;\">\n"
+            + "               <!ENTITY Uuml \"&#220;\">\n"
+            + "               <!ENTITY Ouml \"&#214;\">\n"
+            + "               <!ENTITY auml \"&#228;\">\n"
+            + "               <!ENTITY uuml \"&#252;\">\n"
+            + "               <!ENTITY ouml \"&#246;\">\n"
+            + "               <!ENTITY raquo \"&#187;\">\n"
+            + "               <!ENTITY szlig \"&#223;\">]>\n"
+            + "<blue></blue>";
+
+    @Test
+    public void testFilter() throws UnsupportedEncodingException, IOException {
+        InputStream in = new ByteArrayInputStream(POM.getBytes("UTF-8"));
+        PomProjectInputStream instance = new PomProjectInputStream(in);
+        byte[] expected = "<project></project>".getBytes("UTF-8");
+        byte[] results = new byte[expected.length];
+        int count = instance.read(results, 0, results.length);
+        assertEquals(results.length, count);
+        assertArrayEquals(expected, results);
+        instance.close();
+
+        in = new ByteArrayInputStream(INVALID.getBytes("UTF-8"));
+        instance = new PomProjectInputStream(in);
+        results = new byte[100];
+        count = instance.read(results, 0, 100);
+        assertEquals(-1, count);
+        instance.close();
+
+    }
+
+    /**
+     * Test of findSequence method, of class PomProjectInputStream.
+     */
+    @Test
+    public void testFindSequence() throws IOException {
+
+        byte[] sequence = "project".getBytes("UTF-8");
+        byte[] buffer = "my big project".getBytes("UTF-8");
+
+        int expResult = 7;
+        int result = PomProjectInputStream.findSequence(sequence, buffer);
+        assertEquals(expResult, result);
+
+        sequence = "<project".getBytes("UTF-8");
+        buffer = "my big project".getBytes("UTF-8");
+
+        expResult = -1;
+        result = PomProjectInputStream.findSequence(sequence, buffer);
+        assertEquals(expResult, result);
+
+        sequence = "bigger sequence".getBytes("UTF-8");
+        buffer = "buffer".getBytes("UTF-8");
+
+        expResult = -1;
+        result = PomProjectInputStream.findSequence(sequence, buffer);
+        assertEquals(expResult, result);
+
+        sequence = "fff".getBytes("UTF-8");
+        buffer = "buffer".getBytes("UTF-8");
+
+        expResult = -1;
+        result = PomProjectInputStream.findSequence(sequence, buffer);
+        assertEquals(expResult, result);
+    }
+
+}

--- a/core/src/test/java/org/owasp/dependencycheck/xml/pom/PomProjectInputStreamTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/pom/PomProjectInputStreamTest.java
@@ -21,10 +21,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -34,7 +30,7 @@ import static org.junit.Assert.*;
  */
 public class PomProjectInputStreamTest {
 
-    private String POM = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n"
+    private final String POM = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n"
             + "<!DOCTYPE xml [<!ENTITY quot \"&#34;\">\n"
             + "               <!ENTITY euro \"&#x20ac;\">\n"
             + "               <!ENTITY reg \"&#174;\">\n"
@@ -49,7 +45,7 @@ public class PomProjectInputStreamTest {
             + "               <!ENTITY szlig \"&#223;\">]>\n"
             + "<project></project>";
 
-    private String INVALID = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n"
+    private final String INVALID = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n"
             + "<!DOCTYPE xml [<!ENTITY quot \"&#34;\">\n"
             + "               <!ENTITY euro \"&#x20ac;\">\n"
             + "               <!ENTITY reg \"&#174;\">\n"
@@ -118,5 +114,4 @@ public class PomProjectInputStreamTest {
         result = PomProjectInputStream.findSequence(sequence, buffer);
         assertEquals(expResult, result);
     }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@ Copyright (c) 2012 - Jeremy Long
         <junit.version>4.12</junit.version>
         <hamcrest-core.version>1.3</hamcrest-core.version>
         <org.jmockit.version>1.40</org.jmockit.version>
-
+        <mockito-core.version>2.19.0</mockito-core.version>
         <jsoup.version>1.11.3</jsoup.version>
         <commons-compress.version>1.17</commons-compress.version>
         <org.apache.maven.shared.file-management.version>3.0.0</org.apache.maven.shared.file-management.version>
@@ -999,6 +999,12 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.jmockit</groupId>
                 <artifactId>jmockit</artifactId>
                 <version>${org.jmockit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito-core.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Fixes Issue #1016 

Doctypes defined in the pom.xml would cause parsing the xml to fail as doctypes are disallowed. The resolution was to just strip everything from the pom.xml up to the `<project>` tag.

## Have test cases been added to cover the new functionality?

yes