### PR TITLE
Only match '-' version to all versions if no other versions named

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -959,7 +959,7 @@ public final class CveDB implements AutoCloseable {
         String majorVersionMatch = null;
         for (Entry<String, Boolean> entry : vulnerableSoftware.entrySet()) {
             final DependencyVersion v = parseDependencyVersion(entry.getKey());
-            if (v == null || "-".equals(v.toString())) { //all versions
+            if (v == null || ("-".equals(v.toString()) && vulnerableSoftware.size() == 1)) { //all versions
                 return entry;
             }
             if (entry.getValue()) {

--- a/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/CveDBIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/CveDBIT.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.junit.Before;
@@ -116,7 +117,7 @@ public class CveDBIT extends BaseDBTestCase {
         assertTrue("Expected " + expected + ", but was not identified", found);
 
         found = false;
-        expected = "CVE-2012-5370";
+        expected = "CVE-2012-5370"; // Affects all versions
         for (Vulnerability v : results) {
             if (expected.equals(v.getName())) {
                 found = true;
@@ -124,6 +125,16 @@ public class CveDBIT extends BaseDBTestCase {
             }
         }
         assertTrue("Expected " + expected + ", but was not identified", found);
+
+        found = false;
+        expected = "CVE-2010-1330"; // Affects all versions before 1.4.1
+        for (Vulnerability v : results) {
+            if (expected.equals(v.getName())) {
+                found = true;
+                break;
+            }
+        }
+        assertFalse("Did not expect " + expected + ", but it was identified", found);
     }
 
     /**
@@ -174,9 +185,18 @@ public class CveDBIT extends BaseDBTestCase {
 
         versions.clear();
 
-        versions.put("cpe:/a:jruby:jruby:-", Boolean.FALSE);
+        versions.put("cpe:/a:jruby:jruby:-", Boolean.FALSE); // Matches all versions
         identifiedVersion = new DependencyVersion("1.6.3");
         results = instance.getMatchingSoftware(versions, "springsource", "spring_framework", identifiedVersion);
         assertNotNull(results);
+
+        versions.put("cpe:/a:jruby:jruby:1.0.0", Boolean.TRUE); // Adding another version means that the hyphen only denotes the initial version
+        results = instance.getMatchingSoftware(versions, "springsource", "spring_framework", identifiedVersion);
+        assertNull(results);
+
+        versions.put("cpe:/a:jruby:jruby:1.6.5", Boolean.TRUE);
+        results = instance.getMatchingSoftware(versions, "springsource", "spring_framework", identifiedVersion);
+        assertNotNull(results);
+
     }
 }


### PR DESCRIPTION
## Fixes Issue #

For instance, https://nvd.nist.gov/vuln/detail/CVE-2018-8012 is currently assumed by dependency-check to affect **all** versions of Apache ZooKeeper, even though the list of vulnerable versions (<3.4.10, >=3.5.0, <= 3.5.3) does not include e.g. 3.4.11. This due to the first item in the list of vulnerable versions before 3.4.10 being `cpe:/a:apache:zookeeper:-` (`cpe:2.3:a:apache:zookeeper:-:*:*:*:*:*:*:*`)

Similar things happen with e.g. https://nvd.nist.gov/vuln/detail/CVE-2016-5017, https://nvd.nist.gov/vuln/detail/CVE-2018-0124 and https://nvd.nist.gov/vuln/detail/CVE-2018-0101.

The CPE 2.2 definition (https://cpe.mitre.org/files/cpe-specification_2.2.pdf), pp. 9-10 mentions that "
**The '-' term might also be used to describing an initial release** (bolding mine) if a platform does identify with a given component but no term is commonly used to describe it.  An example of this might be the initial release of an application before any updates have been released. [...]
It is important to note that when a CPE Name is being created for a specific platform type (i.e. a 
specific release of an application) then the hyphen should be used at all times (when a vendor 
term is not available) instead of a blank component.  The blank component is to be used only 
when a more general platform type is being enumerated.  (i.e. any version of an application)"

The CPE 2.3 naming specification (https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7695.pdf) P. 16 (printed page number is 10): "The logical value NA SHOULD be assigned when there is no legal or meaningful value for that attribute, or when that attribute is not used as part of the description. This includes the situation in which an attribute has an obtainable value that is null."
P. 24/18: "The logical values ANY and NA are defined as possible attribute values in WFNs. The logical value ANY SHALL bind to what [CPE22] calls a “blank” (i.e., an empty component, indicated by two 
sequential colons) in the URI. **The logical value NA SHALL bind to a single hyphen.** (bolding mine)"

The CPE dictionary (https://nvd.nist.gov/Products/CPE), marks initial versions with a hyphen and replaces it with the version number in subsequent versions. The CVE DB uses the same dictionary for listing affected versions. It does not always use the hyphen in the list of configurations e.g. in CVE 2018 `{
          "vulnerable" : true,
          "cpe22Uri" : "cpe:/a:apache:zookeeper",
          "cpe23Uri" : "cpe:2.3:a:apache:zookeeper:*:*:*:*:*:*:*:*",
          "versionEndExcluding" : "3.4.10"
        }`


So blank version numbers should match every version, and so do '-' versions *but only if there are no other named versions*.

## Description of Change

When finding matching software versions for a CVE in CVE DB, only assume that the special case (hyphen) matches all versions if there are no other version numbers listed.

## Have test cases been added to cover the new functionality?

Yes