### PR TITLE
Updates to support gradle android builds

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
@@ -177,12 +177,15 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
             dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
             dependency.setName(name);
             dependency.setVersion(version);
-            dependency.setPackagePath(String.format("%s:%s", name, version));
-            dependency.setSha1sum(Checksum.getSHA1Checksum(String.format("%s:%s", name, version)));
-            dependency.setSha256sum(Checksum.getSHA256Checksum(String.format("%s:%s", name, version)));
-            dependency.setMd5sum(Checksum.getMD5Checksum(String.format("%s:%s", name, version)));
-            dependency.addEvidence(EvidenceType.PRODUCT, dependency.getFilePath(), "name", name, Confidence.HIGHEST);
-            dependency.addEvidence(EvidenceType.PRODUCT, dependency.getFilePath(), "version", version, Confidence.HIGHEST);
+            final String packagePath = String.format("%s:%s", name, version);
+            dependency.setPackagePath(packagePath);
+            dependency.setDisplayFileName(packagePath);
+            dependency.setSha1sum(Checksum.getSHA1Checksum(packagePath));
+            dependency.setSha256sum(Checksum.getSHA256Checksum(packagePath));
+            dependency.setMd5sum(Checksum.getMD5Checksum(packagePath));
+            dependency.addEvidence(EvidenceType.VENDOR, PODFILE_LOCK, "name", name, Confidence.HIGHEST);
+            dependency.addEvidence(EvidenceType.PRODUCT, PODFILE_LOCK, "name", name, Confidence.HIGHEST);
+            dependency.addEvidence(EvidenceType.VERSION, PODFILE_LOCK, "version", version, Confidence.HIGHEST);
             engine.addDependency(dependency);
         }
     }
@@ -239,7 +242,11 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
                 dependency.setVersion(version);
             }
         }
-
+        if (dependency.getVersion() != null && !dependency.getVersion().isEmpty()) {
+            dependency.setDisplayFileName(String.format("%s:%s", dependency.getName(), dependency.getVersion()));
+        } else {
+            dependency.setDisplayFileName(dependency.getName());
+        }
         setPackagePath(dependency);
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -412,7 +412,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
                         newDependency.setName(String.format("%s:%s", groupId, pom.getArtifactId()));
                         newDependency.setPackagePath(String.format("%s:%s:%s", groupId, pom.getArtifactId(), version));
                     }
-                    newDependency.setDisplayFileName(String.format("%s (%s)", dependency.getDisplayFileName(), newDependency.getPackagePath()));
+                    newDependency.setDisplayFileName(String.format("%s (shaded: %s)", dependency.getDisplayFileName(), newDependency.getPackagePath()));
                     newDependency.setVersion(version);
                     setPomEvidence(newDependency, pom, null);
                     if (dependency.getProjectReferences().size() > 0) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NuspecAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NuspecAnalyzer.java
@@ -153,8 +153,14 @@ public class NuspecAnalyzer extends AbstractFileTypeAnalyzer {
             dependency.addEvidence(EvidenceType.VENDOR, "nuspec", "authors", np.getAuthors(), Confidence.HIGH);
             dependency.addEvidence(EvidenceType.VERSION, "nuspec", "version", np.getVersion(), Confidence.HIGHEST);
             dependency.addEvidence(EvidenceType.PRODUCT, "nuspec", "id", np.getId(), Confidence.HIGHEST);
-            dependency.setVersion(np.getVersion());
             dependency.setName(np.getId());
+            dependency.setVersion(np.getVersion());
+            final String packagePath = String.format("%s:%s",np.getId(), np.getVersion());
+            dependency.setPackagePath(packagePath);
+            dependency.setDisplayFileName(packagePath);
+            if (np.getLicenseUrl() != null && !np.getLicenseUrl().isEmpty()) {
+                dependency.setLicense(np.getLicenseUrl());
+            }
             if (np.getTitle() != null) {
                 dependency.addEvidence(EvidenceType.PRODUCT, "nuspec", "title", np.getTitle(), Confidence.MEDIUM);
             }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
@@ -289,8 +289,14 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
         addPropertyToEvidence(dependency, EvidenceType.VERSION, Confidence.HIGHEST, headers, "Version");
         addPropertyToEvidence(dependency, EvidenceType.PRODUCT, Confidence.HIGHEST, headers, "Name");
         addPropertyToEvidence(dependency, EvidenceType.PRODUCT, Confidence.MEDIUM, headers, "Name");
-        dependency.setName(headers.getHeader("Name", null));
-        dependency.setVersion(headers.getHeader("Version", null));
+        
+        final String name = headers.getHeader("Name", null);
+        final String version = headers.getHeader("Version", null);
+        final String packagePath = String.format("%s:%s", name, version);
+        dependency.setName(name);
+        dependency.setVersion(version);
+        dependency.setPackagePath(packagePath);
+        dependency.setDisplayFileName(packagePath);
         final String url = headers.getHeader("Home-page", null);
         if (StringUtils.isNotBlank(url)) {
             if (UrlStringUtils.isUrl(url)) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
@@ -320,7 +320,10 @@ public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
         if (found) {
             dependency.addEvidence(type, source, name, matcher.group(4), confidence);
             if (type == EvidenceType.VERSION) {
+                //TODO - this seems broken as we are cycling over py files and could be grabbing versions from multiple?
                 dependency.setVersion(matcher.group(4));
+                final String dispName = String.format("%s:%s", dependency.getName(), dependency.getVersion());
+                dependency.setDisplayFileName(dispName);
             }
         }
         return found;

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzer.java
@@ -153,20 +153,30 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
                 dependency.addEvidence(EvidenceType.VENDOR, GEMSPEC, "name_project", name + "_project", Confidence.LOW);
                 dependency.setName(name);
             }
-            addStringEvidence(dependency, EvidenceType.PRODUCT, contents, blockVariable, "summary", "summary", Confidence.LOW);
-
+            final String description = addStringEvidence(dependency, EvidenceType.PRODUCT, contents, blockVariable, "summary", "summary", Confidence.LOW);
+            if (description != null && !description.isEmpty()) {
+                dependency.setDescription(description);
+            }
             addStringEvidence(dependency, EvidenceType.VENDOR, contents, blockVariable, "author", "authors?", Confidence.HIGHEST);
             addStringEvidence(dependency, EvidenceType.VENDOR, contents, blockVariable, "email", "emails?", Confidence.MEDIUM);
             addStringEvidence(dependency, EvidenceType.VENDOR, contents, blockVariable, "homepage", "homepage", Confidence.HIGHEST);
-            addStringEvidence(dependency, EvidenceType.VENDOR, contents, blockVariable, "license", "licen[cs]es?", Confidence.HIGHEST);
-
+            final String license = addStringEvidence(dependency, EvidenceType.VENDOR, contents, blockVariable, "license", "licen[cs]es?", Confidence.HIGHEST);
+            if (license != null && !license.isEmpty()) {
+                dependency.setLicense(license);
+            }
             final String value = addStringEvidence(dependency, EvidenceType.VERSION, contents,
                     blockVariable, "version", "version", Confidence.HIGHEST);
             if (value.length() < 1) {
-                addEvidenceFromVersionFile(dependency, EvidenceType.VERSION, dependency.getActualFile());
+                final String version = addEvidenceFromVersionFile(dependency, EvidenceType.VERSION, dependency.getActualFile());
+                if (version != null) {
+                    dependency.setVersion(version);
+                }
             } else {
                 dependency.setVersion(value);
             }
+        }
+        if (dependency.getName()!=null && dependency.getVersion()!=null) {
+            dependency.setDisplayFileName(String.format("%s:%s", dependency.getName(), dependency.getVersion()));
         }
         setPackagePath(dependency);
     }
@@ -213,9 +223,12 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
      * @param dependency the dependency being analyzed
      * @param type the type of evidence to add
      * @param dependencyFile the dependency being analyzed
+     * @return the version number added
      */
-    private void addEvidenceFromVersionFile(Dependency dependency, EvidenceType type, File dependencyFile) {
+    private String addEvidenceFromVersionFile(Dependency dependency, EvidenceType type, File dependencyFile) {
         final File parentDir = dependencyFile.getParentFile();
+        String version = null;
+        int versionCount = 0;
         if (parentDir != null) {
             final File[] matchingFiles = parentDir.listFiles(new FilenameFilter() {
                 @Override
@@ -224,13 +237,18 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
                 }
             });
             if (matchingFiles == null) {
-                return;
+                return null;
             }
             for (File f : matchingFiles) {
                 try {
                     final List<String> lines = FileUtils.readLines(f, Charset.defaultCharset());
                     if (lines.size() == 1) { //TODO other checking?
                         final String value = lines.get(0).trim();
+                        if (version == null || !version.equals(value)) {
+                            version = value;
+                            versionCount++;
+                        }
+
                         dependency.addEvidence(type, GEMSPEC, "version", value, Confidence.HIGH);
                     }
                 } catch (IOException e) {
@@ -238,6 +256,10 @@ public class RubyGemspecAnalyzer extends AbstractFileTypeAnalyzer {
                 }
             }
         }
+        if (versionCount == 1) {
+            return version;
+        }
+        return null;
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageManagerAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageManagerAnalyzer.java
@@ -156,6 +156,11 @@ public class SwiftPackageManagerAnalyzer extends AbstractFileTypeAnalyzer {
                 // the parent folder containing the package.swift file.
                 dependency.setName(dependency.getActualFile().getParentFile().getName());
             }
+            if (dependency.getVersion() != null && !dependency.getVersion().isEmpty()) {
+                dependency.setDisplayFileName(String.format("%s:%s", dependency.getName(), dependency.getVersion()));
+            } else {
+                dependency.setDisplayFileName(dependency.getName());
+            }
         }
         setPackagePath(dependency);
     }

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -313,6 +313,9 @@ public class Dependency extends EvidenceCollection implements Serializable {
         if (displayName != null) {
             return displayName;
         }
+        if (!isVirtual) {
+            return fileName;
+        }
         if (name == null) {
             return fileName;
         }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
@@ -91,25 +91,6 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
     }
 
     /**
-     * Test of basic additions to the dependency list by parsing the
-     * composer.lock file
-     *
-     * @throws AnalysisException is thrown when an exception occurs.
-     */
-    @Test
-    public void testRemoveRedundantParent() throws Exception {
-        try (Engine engine = new Engine(getSettings())) {
-            final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "composer.lock"));
-            //test that we don't remove the parent if it's not redundant by name
-            result.setDisplayFileName("NotComposer.Lock");
-            engine.addDependency(result);
-            analyzer.analyze(result, engine);
-            //make sure the composer.lock is not removed
-            assertTrue(ArrayUtils.contains(engine.getDependencies(), result));
-        }
-    }
-
-    /**
      * Test of inspect method, of class PythonDistributionAnalyzer.
      *
      * @throws AnalysisException is thrown when an exception occurs.


### PR DESCRIPTION
To better support android builds in the gradle plugin the default behavior of the `Dependency.getDisplayFileName()` was changed.

Additionally, the `DependencyMergingAnalyzer` was updated to merge related android dependencies (aar and the embedded classes.jar).

Other changes made were to the other file type analyzers to maintain correct behavior with the changes to the `getDisplayFileName()`.  Other cleanup was performed on some of the analyzers as part of this PR.