### PR TITLE
Retire JS Initialization Bug

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/RetireJSDataSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/RetireJSDataSource.java
@@ -162,7 +162,7 @@ public class RetireJSDataSource implements CachedWebDataSource {
                     IOUtils.copy(inputStream, outputStream);
                 }
                 //using move fails if target and destination are on different disks which does happen (see #1394 and #1404)
-                Files.copy(tmpFile.toPath(), repoFile.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+                Files.copy(tmpFile.toPath(), repoFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
                 if (!tmpFile.delete()) {
                     tmpFile.deleteOnExit();
                 }

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/RetireJSDataSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/RetireJSDataSource.java
@@ -163,20 +163,13 @@ public class RetireJSDataSource implements CachedWebDataSource {
                         FileOutputStream outputStream = new FileOutputStream(tmpFile)) {
                     IOUtils.copy(inputStream, outputStream);
                 }
-                Files.move(tmpFile.toPath(), repoFile.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-            }
-        } catch (IOException e) {
-            if (e.getMessage().contains("The system cannot move the file to a different disk drive")) {
-                try {
-                    LOGGER.debug("Failed to move the file; attempting copy: " + e.getMessage());
-                    Files.copy(tmpFile.toPath(), repoFile.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-                    if (!tmpFile.delete()) {
-                        tmpFile.deleteOnExit();
-                    }
-                } catch (IOException ex) {
-                    throw new UpdateException("Failed to initialize the RetireJS repo", ex);
+                //using move fails if target and destination are on different disks which does happen (see #1394 and #1404)
+                Files.copy(tmpFile.toPath(), repoFile.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+                if (!tmpFile.delete()) {
+                    tmpFile.deleteOnExit();
                 }
             }
+        } catch (IOException e) {
             throw new UpdateException("Failed to initialize the RetireJS repo", e);
         }
     }

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/RetireJSDataSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/RetireJSDataSource.java
@@ -142,8 +142,6 @@ public class RetireJSDataSource implements CachedWebDataSource {
      * initialization
      */
     private void initializeRetireJsRepo(Settings settings, URL repoUrl) throws UpdateException {
-        File tmpFile = null;
-        File repoFile = null;
         try {
             final File dataDir = settings.getDataDirectory();
             final File tmpDir = settings.getTempDirectory();
@@ -157,8 +155,8 @@ public class RetireJSDataSource implements CachedWebDataSource {
             final HttpURLConnection conn = factory.createHttpURLConnection(repoUrl, useProxy);
             final String filename = repoUrl.getFile().substring(repoUrl.getFile().lastIndexOf("/") + 1, repoUrl.getFile().length());
             if (conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
-                tmpFile = new File(tmpDir, filename);
-                repoFile = new File(dataDir, filename);
+                final File tmpFile = new File(tmpDir, filename);
+                final File repoFile = new File(dataDir, filename);
                 try (InputStream inputStream = conn.getInputStream();
                         FileOutputStream outputStream = new FileOutputStream(tmpFile)) {
                     IOUtils.copy(inputStream, outputStream);


### PR DESCRIPTION
## Fixes Issue #1394 and #1404 

Instead of using move to copy the retire js database the code has been updated to perform a copy and delete.