### PR TITLE
Added new Nuget packages.config analyzer (Nugetconf)

### DIFF
--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -209,7 +209,7 @@ public class Check extends Update {
      */
     private Boolean nuspecAnalyzerEnabled;
     /**
-     * Whether or not the .NET Nuget config file Analyzer is enabled.
+     * Whether or not the .NET Nuget packages.config file Analyzer is enabled.
      */
     private Boolean nugetconfAnalyzerEnabled;
     /**

--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -684,7 +684,7 @@ public class Check extends Update {
     /**
      * Sets whether or not the analyzer is enabled.
      *
-     * @param nuspecAnalyzerEnabled the value of the new setting
+     * @param nugetconfAnalyzerEnabled the value of the new setting
      */
     public void setNugetconfAnalyzerEnabled(Boolean nugetconfAnalyzerEnabled) {
         this.nugetconfAnalyzerEnabled = nugetconfAnalyzerEnabled;

--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -209,6 +209,10 @@ public class Check extends Update {
      */
     private Boolean nuspecAnalyzerEnabled;
     /**
+     * Whether or not the .NET Nuget config file Analyzer is enabled.
+     */
+    private Boolean nugetconfAnalyzerEnabled;
+    /**
      * Whether or not the PHP Composer Analyzer is enabled.
      */
     private Boolean composerAnalyzerEnabled;
@@ -659,12 +663,31 @@ public class Check extends Update {
     }
 
     /**
+     * Returns whether or not the analyzer is enabled.
+     *
+     * @return true if the analyzer is enabled
+     */
+    public Boolean isNugetconfAnalyzerEnabled() {
+        return nugetconfAnalyzerEnabled;
+    }
+
+    
+    /**
      * Sets whether or not the analyzer is enabled.
      *
      * @param nuspecAnalyzerEnabled the value of the new setting
      */
     public void setNuspecAnalyzerEnabled(Boolean nuspecAnalyzerEnabled) {
         this.nuspecAnalyzerEnabled = nuspecAnalyzerEnabled;
+    }
+
+    /**
+     * Sets whether or not the analyzer is enabled.
+     *
+     * @param nuspecAnalyzerEnabled the value of the new setting
+     */
+    public void setNugetconfAnalyzerEnabled(Boolean nugetconfAnalyzerEnabled) {
+        this.nugetconfAnalyzerEnabled = nugetconfAnalyzerEnabled;
     }
 
     /**
@@ -1337,6 +1360,7 @@ public class Check extends Update {
         getSettings().setArrayIfNotEmpty(Settings.KEYS.ANALYZER_RETIREJS_FILTERS, retirejsFilters);
 
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_NUSPEC_ENABLED, nuspecAnalyzerEnabled);
+        getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_NUGETCONF_ENABLED, nugetconfAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, centralAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_NEXUS_ENABLED, nexusAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARCHIVE_ENABLED, archiveAnalyzerEnabled);

--- a/ant/src/site/markdown/configuration.md
+++ b/ant/src/site/markdown/configuration.md
@@ -92,7 +92,7 @@ retireJsAnalyzerEnabled             | Sets whether the [experimental](../analyze
 retirejsFilterNonVulnerable         | Configures the RetireJS Analyzer to remove non-vulnerable JS dependencies from the report.                 | false
 retirejsFilter                      | A nested configuration that can be specified multple times; The regex defined is used to filter JS files based on content. | &nbsp;
 nuspecAnalyzerEnabled               | Sets whether the .NET Nuget Nuspec Analyzer will be used.                                                  | true
-nugetconfAnalyzerEnabled               | Sets whether the .NET Nuget packages.config Analyzer will be used.                                                  | true
+nugetconfAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used.                                                                                                           | true
 cocoapodsAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used.                | true
 bundleAuditAnalyzerEnabled          | Sets whether the [experimental](../analyzers/index.html) Bundle Audit Analyzer should be used.             | true
 bundleAuditPath                     | Sets the path to the bundle audit executable; only used if bundle audit analyzer is enabled and experimental analyzers are enabled.  | &nbsp;

--- a/ant/src/site/markdown/configuration.md
+++ b/ant/src/site/markdown/configuration.md
@@ -92,6 +92,7 @@ retireJsAnalyzerEnabled             | Sets whether the [experimental](../analyze
 retirejsFilterNonVulnerable         | Configures the RetireJS Analyzer to remove non-vulnerable JS dependencies from the report.                 | false
 retirejsFilter                      | A nested configuration that can be specified multple times; The regex defined is used to filter JS files based on content. | &nbsp;
 nuspecAnalyzerEnabled               | Sets whether the .NET Nuget Nuspec Analyzer will be used.                                                  | true
+nugetconfAnalyzerEnabled               | Sets whether the .NET Nuget packages.config Analyzer will be used.                                                  | true
 cocoapodsAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used.                | true
 bundleAuditAnalyzerEnabled          | Sets whether the [experimental](../analyzers/index.html) Bundle Audit Analyzer should be used.             | true
 bundleAuditPath                     | Sets the path to the bundle audit executable; only used if bundle audit analyzer is enabled and experimental analyzers are enabled.  | &nbsp;

--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -461,6 +461,7 @@ public class App {
         settings.setBoolean(Settings.KEYS.ANALYZER_AUTOCONF_ENABLED, !cli.isAutoconfDisabled());
         settings.setBoolean(Settings.KEYS.ANALYZER_CMAKE_ENABLED, !cli.isCmakeDisabled());
         settings.setBoolean(Settings.KEYS.ANALYZER_NUSPEC_ENABLED, !cli.isNuspecDisabled());
+        settings.setBoolean(Settings.KEYS.ANALYZER_NUGETCONF_ENABLED, !cli.isNugetconfDisabled());
         settings.setBoolean(Settings.KEYS.ANALYZER_ASSEMBLY_ENABLED, !cli.isAssemblyDisabled());
         settings.setBoolean(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_ENABLED, !cli.isBundleAuditDisabled());
         settings.setBoolean(Settings.KEYS.ANALYZER_OPENSSL_ENABLED, !cli.isOpenSSLDisabled());

--- a/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
@@ -400,6 +400,8 @@ public final class CliParser {
                 .desc("Disable the Archive Analyzer.").build();
         final Option disableNuspecAnalyzer = Option.builder().longOpt(ARGUMENT.DISABLE_NUSPEC)
                 .desc("Disable the Nuspec Analyzer.").build();
+        final Option disableNugetconfAnalyzer = Option.builder().longOpt(ARGUMENT.DISABLE_NUGETCONF)
+        .desc("Disable the Nuget Config Analyzer.").build();
         final Option disableAssemblyAnalyzer = Option.builder().longOpt(ARGUMENT.DISABLE_ASSEMBLY)
                 .desc("Disable the .NET Assembly Analyzer.").build();
         final Option disablePythonDistributionAnalyzer = Option.builder().longOpt(ARGUMENT.DISABLE_PY_DIST)
@@ -460,6 +462,7 @@ public final class CliParser {
                 .addOption(disableComposerAnalyzer)
                 .addOption(disableOpenSSLAnalyzer)
                 .addOption(disableNuspecAnalyzer)
+                .addOption(disableNugetconfAnalyzer)
                 .addOption(disableCentralAnalyzer)
                 .addOption(disableNexusAnalyzer)
                 .addOption(cocoapodsAnalyzerEnabled)
@@ -621,6 +624,17 @@ public final class CliParser {
     public boolean isNuspecDisabled() {
         return hasDisableOption(ARGUMENT.DISABLE_NUSPEC, Settings.KEYS.ANALYZER_NUSPEC_ENABLED);
     }
+
+    /**
+     * Returns true if the disableNugetconf command line argument was specified.
+     *
+     * @return true if the disableNugetconf command line argument was specified;
+     * otherwise false
+     */
+    public boolean isNugetconfDisabled() {
+        return hasDisableOption(ARGUMENT.DISABLE_NUGETCONF, Settings.KEYS.ANALYZER_NUGETCONF_ENABLED);
+    }
+
 
     /**
      * Returns true if the disableAssembly command line argument was specified.
@@ -1515,6 +1529,10 @@ public final class CliParser {
          * Disables the Nuspec Analyzer.
          */
         public static final String DISABLE_NUSPEC = "disableNuspec";
+        /**
+         * Disables the Nuget Config Analyzer.
+         */
+        public static final String DISABLE_NUGETCONF = "disableNugetconf";
         /**
          * Disables the Central Analyzer.
          */

--- a/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
@@ -401,7 +401,7 @@ public final class CliParser {
         final Option disableNuspecAnalyzer = Option.builder().longOpt(ARGUMENT.DISABLE_NUSPEC)
                 .desc("Disable the Nuspec Analyzer.").build();
         final Option disableNugetconfAnalyzer = Option.builder().longOpt(ARGUMENT.DISABLE_NUGETCONF)
-        .desc("Disable the Nuget Config Analyzer.").build();
+        .desc("Disable the Nuget packages.config Analyzer.").build();
         final Option disableAssemblyAnalyzer = Option.builder().longOpt(ARGUMENT.DISABLE_ASSEMBLY)
                 .desc("Disable the .NET Assembly Analyzer.").build();
         final Option disablePythonDistributionAnalyzer = Option.builder().longOpt(ARGUMENT.DISABLE_PY_DIST)
@@ -1530,7 +1530,7 @@ public final class CliParser {
          */
         public static final String DISABLE_NUSPEC = "disableNuspec";
         /**
-         * Disables the Nuget Config Analyzer.
+         * Disables the Nuget packages.config Analyzer.
          */
         public static final String DISABLE_NUGETCONF = "disableNugetconf";
         /**

--- a/cli/src/site/markdown/arguments.md
+++ b/cli/src/site/markdown/arguments.md
@@ -62,7 +62,7 @@ Short  | Argument&nbsp;Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Paramete
        | \-\-nexus              | \<url\>         | The url to the Nexus Server's web service end point (example: http://domain.enterprise/nexus/service/local/). If not set the Nexus Analyzer will be disabled. | &nbsp;
        | \-\-nexusUsesProxy     | \<true\|false\> | Whether or not the defined proxy should be used when connecting to Nexus.        | true
        | \-\-disableNuspec      |                 | Sets whether or not the .NET Nuget Nuspec Analyzer will be used.                 | false
-       | \-\-disableNugetconf   |                 | Sets whether or not the .NET Nuget packages.config Analyzer will be used.        | false
+       | \-\-disableNugetconf   |                 | Sets whether or not the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used.        | false
        | \-\-disableAssembly    |                 | Sets whether or not the .NET Assembly Analyzer should be used.                   | false
        | \-\-mono               | \<path\>        | The path to Mono for .NET Assembly analysis on non-windows systems.              | &nbsp;
        | \-\-bundleAudit        |                 | The path to the bundle-audit executable. | &nbsp;

--- a/cli/src/site/markdown/arguments.md
+++ b/cli/src/site/markdown/arguments.md
@@ -62,6 +62,7 @@ Short  | Argument&nbsp;Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Paramete
        | \-\-nexus              | \<url\>         | The url to the Nexus Server's web service end point (example: http://domain.enterprise/nexus/service/local/). If not set the Nexus Analyzer will be disabled. | &nbsp;
        | \-\-nexusUsesProxy     | \<true\|false\> | Whether or not the defined proxy should be used when connecting to Nexus.        | true
        | \-\-disableNuspec      |                 | Sets whether or not the .NET Nuget Nuspec Analyzer will be used.                 | false
+       | \-\-disableNugetconf   |                 | Sets whether or not the .NET Nuget packages.config Analyzer will be used.        | false
        | \-\-disableAssembly    |                 | Sets whether or not the .NET Assembly Analyzer should be used.                   | false
        | \-\-mono               | \<path\>        | The path to Mono for .NET Assembly analysis on non-windows systems.              | &nbsp;
        | \-\-bundleAudit        |                 | The path to the bundle-audit executable. | &nbsp;

--- a/cli/src/test/resources/sample.properties
+++ b/cli/src/test/resources/sample.properties
@@ -12,6 +12,7 @@ analyzer.autoconf.enabled=true
 analyzer.cmake.enabled=true
 analyzer.assembly.enabled=true
 analyzer.nuspec.enabled=true
+analyzer.nugetconf.enabled=true
 analyzer.openssl.enabled=true
 analyzer.central.enabled=true
 analyzer.nexus.enabled=false

--- a/cli/src/test/resources/sample2.properties
+++ b/cli/src/test/resources/sample2.properties
@@ -12,6 +12,7 @@ analyzer.autoconf.enabled=false
 analyzer.cmake.enabled=false
 analyzer.assembly.enabled=false
 analyzer.nuspec.enabled=false
+analyzer.nugetconf.enabled=false
 analyzer.openssl.enabled=false
 analyzer.central.enabled=false
 analyzer.nexus.enabled=true

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzer.java
@@ -41,10 +41,12 @@ import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.exception.InitializationException;
 
 /**
- * Analyzer which will parse a Nuget packages.config file to gather module information.
+ * Analyzer which parses a Nuget packages.config file to gather module information.
  *
  * @author igoand
  */
+
+@Experimental
 @ThreadSafe
 public class NugetconfAnalyzer extends AbstractFileTypeAnalyzer {
 

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzer.java
@@ -1,0 +1,171 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.analyzer;
+
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.data.nuget.NugetPackage;
+import org.owasp.dependencycheck.data.nuget.NugetconfParseException;
+import org.owasp.dependencycheck.data.nuget.NugetconfParser;
+import org.owasp.dependencycheck.data.nuget.XPathNugetconfParser;
+import org.owasp.dependencycheck.dependency.Confidence;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.utils.FileFilterBuilder;
+import org.owasp.dependencycheck.utils.Settings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import javax.annotation.concurrent.ThreadSafe;
+import org.owasp.dependencycheck.dependency.EvidenceType;
+import org.owasp.dependencycheck.exception.InitializationException;
+
+/**
+ * Analyzer which will parse a Nuget packages config file to gather module information.
+ *
+ * @author colezlaw
+ */
+@ThreadSafe
+public class NugetconfAnalyzer extends AbstractFileTypeAnalyzer {
+
+    /**
+     * A descriptor for the type of dependencies processed or added by this
+     * analyzer.
+     */
+    public static final String DEPENDENCY_ECOSYSTEM = "NuGet";
+
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(NugetconfAnalyzer.class);
+
+    /**
+     * The name of the analyzer.
+     */
+    private static final String ANALYZER_NAME = "Nugetconf Analyzer";
+
+    /**
+     * The phase in which the analyzer runs.
+     */
+    private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.INFORMATION_COLLECTION;
+
+    /**
+     * The types of files on which this will work.
+     */
+    private static final String SUPPORTED_EXTENSIONS = "config";
+    /**
+     * The file filter used to determine which files this analyzer supports.
+     */
+    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addExtensions(SUPPORTED_EXTENSIONS).build();
+
+    /**
+     * Initializes the analyzer once before any analysis is performed.
+     *
+     * @param engine a reference to the dependency-check engine
+     * @throws InitializationException if there's an error during initialization
+     */
+    @Override
+    public void prepareFileTypeAnalyzer(Engine engine) throws InitializationException {
+        //nothing to initialize
+    }
+
+    /**
+     * Returns the analyzer's name.
+     *
+     * @return the name of the analyzer
+     */
+    @Override
+    public String getName() {
+        return ANALYZER_NAME;
+    }
+
+    /**
+     * Returns the key used in the properties file to reference the analyzer's
+     * enabled property.
+     *
+     * @return the analyzer's enabled property setting key
+     */
+    @Override
+    protected String getAnalyzerEnabledSettingKey() {
+        return Settings.KEYS.ANALYZER_NUGETCONF_ENABLED;
+    }
+
+    /**
+     * Returns the analysis phase under which the analyzer runs.
+     *
+     * @return the phase under which this analyzer runs
+     */
+    @Override
+    public AnalysisPhase getAnalysisPhase() {
+        return ANALYSIS_PHASE;
+    }
+
+    /**
+     * Returns the FileFilter
+     *
+     * @return the FileFilter
+     */
+    @Override
+    protected FileFilter getFileFilter() {
+        return FILTER;
+    }
+
+    /**
+     * Performs the analysis.
+     *
+     * @param dependency the dependency to analyze
+     * @param engine the engine
+     * @throws AnalysisException when there's an exception during analysis
+     */
+    @Override
+    public void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
+        LOGGER.debug("Checking Nugetconf file {}", dependency);
+        try {
+            final NugetconfParser parser = new XPathNugetconfParser();
+            NugetPackage np = null;
+            try (FileInputStream fis = new FileInputStream(dependency.getActualFilePath())) {
+                np = parser.parse(fis);
+            } catch (NugetconfParseException | FileNotFoundException ex) {
+                throw new AnalysisException(ex);
+            }
+
+            dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
+            if (np.getOwners() != null) {
+                dependency.addEvidence(EvidenceType.VENDOR, "packages.config", "owners", np.getOwners(), Confidence.HIGHEST);
+            }
+            dependency.addEvidence(EvidenceType.VENDOR, "packages.config", "authors", np.getAuthors(), Confidence.HIGH);
+            dependency.addEvidence(EvidenceType.VERSION, "packages.config", "version", np.getVersion(), Confidence.HIGHEST);
+            dependency.addEvidence(EvidenceType.PRODUCT, "packages.config", "id", np.getId(), Confidence.HIGHEST);
+            dependency.setName(np.getId());
+            dependency.setVersion(np.getVersion());
+            final String packagePath = String.format("%s:%s", np.getId(), np.getVersion());
+            dependency.setPackagePath(packagePath);
+            dependency.setDisplayFileName(packagePath);
+            if (np.getLicenseUrl() != null && !np.getLicenseUrl().isEmpty()) {
+                dependency.setLicense(np.getLicenseUrl());
+            }
+            if (np.getTitle() != null) {
+                dependency.addEvidence(EvidenceType.PRODUCT, "packages.config", "title", np.getTitle(), Confidence.MEDIUM);
+            }
+        } catch (Throwable e) {
+            throw new AnalysisException(e);
+        }
+    }
+}

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzer.java
@@ -41,7 +41,7 @@ import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.exception.InitializationException;
 
 /**
- * Analyzer which will parse a Nuget packages config file to gather module information.
+ * Analyzer which will parse a Nuget packages.config file to gather module information.
  *
  * @author igoand
  */
@@ -140,7 +140,7 @@ public class NugetconfAnalyzer extends AbstractFileTypeAnalyzer {
      */
     @Override
     public void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
-        LOGGER.debug("Checking Nugetconf file {}", dependency);
+        LOGGER.debug("Checking packages.config file {}", dependency);
         try {
             final NugetconfParser parser = new XPathNugetconfParser();
             List<NugetPackageReference> packages = null;

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzer.java
@@ -43,7 +43,7 @@ import org.owasp.dependencycheck.exception.InitializationException;
 /**
  * Analyzer which parses a Nuget packages.config file to gather module information.
  *
- * @author igoand
+ * @author doshyt
  */
 
 @Experimental

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzer.java
@@ -19,7 +19,6 @@ package org.owasp.dependencycheck.analyzer;
 
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
-import org.owasp.dependencycheck.data.nuget.NugetPackage;
 import org.owasp.dependencycheck.data.nuget.NugetPackageReference;
 import org.owasp.dependencycheck.data.nuget.NugetconfParseException;
 import org.owasp.dependencycheck.data.nuget.NugetconfParser;
@@ -44,7 +43,7 @@ import org.owasp.dependencycheck.exception.InitializationException;
 /**
  * Analyzer which will parse a Nuget packages config file to gather module information.
  *
- * @author colezlaw
+ * @author igoand
  */
 @ThreadSafe
 public class NugetconfAnalyzer extends AbstractFileTypeAnalyzer {
@@ -71,13 +70,14 @@ public class NugetconfAnalyzer extends AbstractFileTypeAnalyzer {
     private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.INFORMATION_COLLECTION;
 
     /**
-     * The types of files on which this will work.
+     * The file filter used to determine which files this analyzer supports.
      */
-    private static final String SUPPORTED_EXTENSIONS = "config";
+    public static final String FILE_NAME = "packages.config";
+
     /**
      * The file filter used to determine which files this analyzer supports.
      */
-    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addExtensions(SUPPORTED_EXTENSIONS).build();
+    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addFilenames(FILE_NAME).build();
 
     /**
      * Initializes the analyzer once before any analysis is performed.
@@ -166,6 +166,7 @@ public class NugetconfAnalyzer extends AbstractFileTypeAnalyzer {
                 child.addEvidence(EvidenceType.VERSION, "packages.config", "version", np.getVersion(), Confidence.HIGHEST);
                 child.addEvidence(EvidenceType.PRODUCT, "packages.config", "id", np.getId(), Confidence.HIGHEST);
 
+                // handle package names the same way as the MSBuild analyzer
                 if (id.indexOf(".") > 0) {
                     final String[] parts = id.split("\\.");
 

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetconfParseException.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetconfParseException.java
@@ -20,9 +20,9 @@ package org.owasp.dependencycheck.data.nuget;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * Exception during the parsing of a Nugetconf file.
+ * Exception during the parsing of a packages.config file.
  *
- * @author colezlaw
+ * @author igoand
  */
 @ThreadSafe
 public class NugetconfParseException extends Exception {

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetconfParseException.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetconfParseException.java
@@ -22,7 +22,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * Exception during the parsing of a packages.config file.
  *
- * @author igoand
+ * @author doshyt
  */
 @ThreadSafe
 public class NugetconfParseException extends Exception {

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetconfParseException.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetconfParseException.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.nuget;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Exception during the parsing of a Nugetconf file.
+ *
+ * @author colezlaw
+ */
+@ThreadSafe
+public class NugetconfParseException extends Exception {
+
+    /**
+     * The serialVersionUID
+     */
+    private static final long serialVersionUID = 1;
+
+    /**
+     * Constructs a new exception with <code>null</code> as its detail message.
+     *
+     * The cause is not initialized, and may subsequently be initialized by a
+     * call to {@link java.lang.Throwable#initCause(java.lang.Throwable)}.
+     */
+    public NugetconfParseException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause
+     * is not initialized, and may subsequently be initialized by a call to
+     * {@link java.lang.Throwable#initCause(java.lang.Throwable)}.
+     *
+     * @param message the detail message. The detail message is saved for later
+     * retrieval by the {@link java.lang.Throwable#getMessage()} method.
+     */
+    public NugetconfParseException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * Note that the detail message associated with <code>cause</code> is
+     * <em>not</em>
+     * automatically incorporated in this exception's detail message.
+     *
+     * @param message the detail message (which is saved for later retrieval by
+     * the {@link java.lang.Throwable#getMessage()} method.
+     * @param cause the cause (which is saved for later retrieval by the
+     * {@link java.lang.Throwable#getCause()} method). (A <code>null</code>
+     * value is permitted, and indicates that the cause is nonexistent or
+     * unknown).
+     */
+    public NugetconfParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetconfParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetconfParser.java
@@ -23,7 +23,7 @@ import java.util.List;
 /**
  * Interface defining methods for parsing a packages.config file.
  *
- * @author igoand
+ * @author doshyt
  *
  */
 public interface NugetconfParser {

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetconfParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetconfParser.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.nuget;
+
+import java.io.InputStream;
+
+/**
+ * Interface defining methods for parsing a Nugetconf file.
+ *
+ * @author colezlaw
+ *
+ */
+public interface NugetconfParser {
+
+    /**
+     * Parse an input stream and return the resulting {@link NugetPackage}.
+     *
+     * @param stream the input stream to parse
+     * @return the populated bean
+     * @throws NugetconfParseException when an exception occurs
+     */
+    NugetPackage parse(InputStream stream) throws NugetconfParseException;
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetconfParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetconfParser.java
@@ -21,9 +21,9 @@ import java.io.InputStream;
 import java.util.List;
 
 /**
- * Interface defining methods for parsing a Nugetconf file.
+ * Interface defining methods for parsing a packages.config file.
  *
- * @author colezlaw
+ * @author igoand
  *
  */
 public interface NugetconfParser {

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetconfParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetconfParser.java
@@ -18,6 +18,7 @@
 package org.owasp.dependencycheck.data.nuget;
 
 import java.io.InputStream;
+import java.util.List;
 
 /**
  * Interface defining methods for parsing a Nugetconf file.
@@ -34,5 +35,5 @@ public interface NugetconfParser {
      * @return the populated bean
      * @throws NugetconfParseException when an exception occurs
      */
-    NugetPackage parse(InputStream stream) throws NugetconfParseException;
+    List<NugetPackageReference> parse(InputStream stream) throws NugetconfParseException;
 }

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/XPathNugetconfParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/XPathNugetconfParser.java
@@ -37,7 +37,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 /**
- * Parse a Nugetconf file using XPath.
+ * Parse a packages.config file using XPath.
  *
  * @author doshyt
  */
@@ -50,6 +50,7 @@ public class XPathNugetconfParser implements NugetconfParser {
      * @return the populated bean
      * @throws NugetconfParseException when an exception occurs
      */
+
     @Override
     public List<NugetPackageReference> parse(InputStream stream) throws NugetconfParseException {
         try {
@@ -59,16 +60,15 @@ public class XPathNugetconfParser implements NugetconfParser {
             final XPath xpath = XPathFactory.newInstance().newXPath();
             final List<NugetPackageReference> packages = new ArrayList<>();
 
-            final NodeList nodeList = (NodeList) xpath.evaluate("//packages", d, XPathConstants.NODESET);
+            final NodeList nodeList = (NodeList) xpath.evaluate("/packages/package", d, XPathConstants.NODESET);
 
             if (nodeList == null) {
-                throw new NugetconfParseException("Unable to parse pacakcges.config project file");
+                throw new NugetconfParseException("Unable to parse packages.config file");
             }
 
             for (int i = 0; i < nodeList.getLength(); i++) {
                 final Node node = nodeList.item(i);
                 final NamedNodeMap attrs = node.getAttributes();
-
                 final Node id = attrs.getNamedItem("id");
                 final Node version = attrs.getNamedItem("version");
 
@@ -84,7 +84,7 @@ public class XPathNugetconfParser implements NugetconfParser {
 
             return packages;
         } catch (ParserConfigurationException | SAXException | IOException | XPathExpressionException | NugetconfParseException e) {
-            throw new NugetconfParseException("Unable to parse packages.config project file", e);
+            throw new NugetconfParseException("Unable to parse packages.config file", e);
         }
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/XPathNugetconfParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/XPathNugetconfParser.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.nuget;
+
+import java.io.IOException;
+import java.io.InputStream;
+import javax.annotation.concurrent.ThreadSafe;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.owasp.dependencycheck.utils.XmlUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+/**
+ * Parse a Nugetconf file using XPath.
+ *
+ * @author colezlaw
+ */
+@ThreadSafe
+public class XPathNugetconfParser implements NugetconfParser {
+
+    /**
+     * Gets the string value of a node or null if it's not present
+     *
+     * @param n the node to test
+     * @return the string content of the node, or null if the node itself is
+     * null
+     */
+    private String getOrNull(Node n) {
+        if (n != null) {
+            return n.getTextContent();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Parse an input stream and return the resulting {@link NugetPackage}.
+     *
+     * @param stream the input stream to parse
+     * @return the populated bean
+     * @throws NugetconfParseException when an exception occurs
+     */
+    @Override
+    public NugetPackage parse(InputStream stream) throws NugetconfParseException {
+        try {
+            final DocumentBuilder db = XmlUtils.buildSecureDocumentBuilder();
+            final Document d = db.parse(stream);
+
+            final XPath xpath = XPathFactory.newInstance().newXPath();
+            final NugetPackage nugetconf = new NugetPackage();
+
+            if (xpath.evaluate("/package/metadata/id", d, XPathConstants.NODE) == null
+                    || xpath.evaluate("/package/metadata/version", d, XPathConstants.NODE) == null
+                    || xpath.evaluate("/package/metadata/authors", d, XPathConstants.NODE) == null
+                    || xpath.evaluate("/package/metadata/description", d, XPathConstants.NODE) == null) {
+                throw new NugetconfParseException("Invalid packages.config format");
+            }
+
+            nugetconf.setId(xpath.evaluate("/package/metadata/id", d));
+            nugetconf.setVersion(xpath.evaluate("/package/metadata/version", d));
+            nugetconf.setAuthors(xpath.evaluate("/package/metadata/authors", d));
+            nugetconf.setOwners(getOrNull((Node) xpath.evaluate("/package/metadata/owners", d, XPathConstants.NODE)));
+            nugetconf.setLicenseUrl(getOrNull((Node) xpath.evaluate("/package/metadata/licenseUrl", d, XPathConstants.NODE)));
+            nugetconf.setTitle(getOrNull((Node) xpath.evaluate("/package/metadata/title", d, XPathConstants.NODE)));
+            return nugetconf;
+        } catch (ParserConfigurationException | SAXException | IOException | XPathExpressionException | NugetconfParseException e) {
+            throw new NugetconfParseException("Unable to parse packages.config", e);
+        }
+    }
+}

--- a/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
+++ b/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
@@ -12,6 +12,7 @@ org.owasp.dependencycheck.analyzer.CentralAnalyzer
 org.owasp.dependencycheck.analyzer.NexusAnalyzer
 org.owasp.dependencycheck.analyzer.ArtifactoryAnalyzer
 org.owasp.dependencycheck.analyzer.NuspecAnalyzer
+org.owasp.dependencycheck.analyzer.NugetconfAnalyzer
 org.owasp.dependencycheck.analyzer.MSBuildProjectAnalyzer
 org.owasp.dependencycheck.analyzer.AssemblyAnalyzer
 org.owasp.dependencycheck.analyzer.PythonDistributionAnalyzer

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -75,7 +75,7 @@
             19. amazon_aws_project is a drupal utility (#1290)
             20. google android should not be flagged for the base library
         ]]></notes>
-        <filePath regex="true">.*(\.(dll|jar|ear|war|pom|nupkg|nuspec|aar)|pom\.xml|package.json)$</filePath>
+        <filePath regex="true">.*(\.(dll|jar|ear|war|pom|nupkg|nuspec|aar)|pom\.xml|package.json|packages.config)$</filePath>
         <cpe>cpe:/a:sandbox:sandbox</cpe>
         <cpe>cpe:/a:openmedia:openmedia</cpe>        
         <cpe>cpe:/a:file_project:file</cpe>

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -118,6 +118,7 @@ analyzer.autoconf.enabled=true
 analyzer.cmake.enabled=true
 analyzer.assembly.enabled=true
 analyzer.nuspec.enabled=true
+analyzer.nugetconf.enabled=true
 analyzer.msbuildproject.enabled=true
 analyzer.openssl.enabled=true
 analyzer.central.enabled=true

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzerTest.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2018 Paul Irwin. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.analyzer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.EvidenceType;
+
+import java.io.File;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.owasp.dependencycheck.analyzer.NuspecAnalyzer.DEPENDENCY_ECOSYSTEM;
+
+public class NugetconfAnalyzerTest extends BaseTest {
+
+    private NugetconfAnalyzer instance;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        instance = new NugetconfAnalyzer();
+        instance.initialize(getSettings());
+        instance.prepare(null);
+        instance.setEnabled(true);
+    }
+
+    @Test
+    public void testGetAnalyzerName() {
+        assertEquals("Nugetconf Analyzer", instance.getName());
+    }
+
+    @Test
+    public void testSupportedFileNames() {
+        assertTrue(instance.accept(new File("packages.config")));
+        assertFalse(instance.accept(new File("packages.json")));
+    }
+
+    @Test
+    public void testNugetconfAnalysis() throws Exception {
+
+        try (Engine engine = new Engine(getSettings())) {
+            File file = BaseTest.getResourceAsFile(this, "nugetconf/packages.config");
+            Dependency toScan = new Dependency(file);
+            NugetconfAnalyzer analyzer = new NugetconfAnalyzer();
+            analyzer.setFilesMatched(true);
+            analyzer.initialize(getSettings());
+            analyzer.prepare(engine);
+            analyzer.setEnabled(true);
+            analyzer.analyze(toScan, engine);
+
+            int foundCount = 0;
+
+            for (Dependency result : engine.getDependencies()) {
+                assertEquals(DEPENDENCY_ECOSYSTEM, result.getEcosystem());
+                assertTrue(result.isVirtual());
+
+                switch(result.getName()) {
+                    case "Autofac":
+                        foundCount++;
+                        assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("Autofac"));
+                        assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains("4.6.2"));
+                        break;
+
+                    case "Microsoft.AspNet.WebApi.Core":
+                        foundCount++;
+                        assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("Microsoft.AspNet.WebApi.Core"));
+                        assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains("5.2.4"));
+                        break;
+
+                    case "Microsoft.Owin":
+                        foundCount++;
+                        assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("Microsoft.Owin"));
+                        assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains("3.1.0"));
+                        break;
+
+                    case "Newtonsoft.Json":
+                        foundCount++;
+                        assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("Newtonsoft.Json"));
+                        assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains("10.0.3"));
+                        break;
+                    }
+                }
+            assertEquals("4 dependencies should be found", 4, foundCount);
+        }
+    }
+}

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzerTest.java
@@ -99,6 +99,9 @@ public class NugetconfAnalyzerTest extends BaseTest {
                         assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("Newtonsoft.Json"));
                         assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains("10.0.3"));
                         break;
+                    
+                    default :
+                        break;
                     }
                 }
             assertEquals("4 dependencies should be found", 4, foundCount);

--- a/core/src/test/resources/dependencycheck.properties
+++ b/core/src/test/resources/dependencycheck.properties
@@ -111,6 +111,7 @@ analyzer.autoconf.enabled=true
 analyzer.cmake.enabled=true
 analyzer.assembly.enabled=true
 analyzer.nuspec.enabled=true
+analyzer.nugetconf.enabled=true
 analyzer.msbuildproject.enabled=true
 analyzer.openssl.enabled=true
 analyzer.central.enabled=true

--- a/core/target/test-classes/nugetconf/packages.config
+++ b/core/target/test-classes/nugetconf/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Autofac" version="4.6.2" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.4" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="3.1.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+</packages>

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -351,6 +351,13 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     private Boolean nuspecAnalyzerEnabled;
 
     /**
+     * Whether or not the .NET packages.config Analyzer is enabled.
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "nugetconfAnalyzerEnabled", required = false)
+    private Boolean nugetconfAnalyzerEnabled;
+
+    /**
      * Whether or not the Central Analyzer is enabled.
      */
     @SuppressWarnings("CanBeFinal")
@@ -1359,6 +1366,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         //File Type Analyzer Settings
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_JAR_ENABLED, jarAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_NUSPEC_ENABLED, nuspecAnalyzerEnabled);
+        settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_NUGETCONF_ENABLED, nugetconfAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, centralAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_ENABLED, artifactoryAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_NEXUS_ENABLED, nexusAnalyzerEnabled);

--- a/maven/src/site/markdown/configuration.md
+++ b/maven/src/site/markdown/configuration.md
@@ -71,6 +71,7 @@ nodeAnalyzerEnabled           | Sets whether the [retired](../analyzers/index.ht
 nspAnalyzerEnabled            | Sets whether the NSP Analyzer should be used.                                                              | true
 retireJsAnalyzerEnabled       | Sets whether the [experimental](../analyzers/index.html) RetireJS Analyzer should be used.                                                         | true
 nuspecAnalyzerEnabled         | Sets whether the .NET Nuget Nuspec Analyzer will be used.                                                  | true
+nugetconfAnalyzerEnabled      | Sets whether the .NET Nuget packages.config Analyzer will be used.                                         | true
 cocoapodsAnalyzerEnabled      | Sets whether the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used.                | true
 bundleAuditAnalyzerEnabled    | Sets whether the [experimental](../analyzers/index.html) Bundle Audit Analyzer should be used.             | true
 bundleAuditPath               | Sets the path to the bundle audit executable; only used if bundle audit analyzer is enabled and experimental analyzers are enabled.  | &nbsp;

--- a/maven/src/site/markdown/configuration.md
+++ b/maven/src/site/markdown/configuration.md
@@ -71,7 +71,7 @@ nodeAnalyzerEnabled           | Sets whether the [retired](../analyzers/index.ht
 nspAnalyzerEnabled            | Sets whether the NSP Analyzer should be used.                                                              | true
 retireJsAnalyzerEnabled       | Sets whether the [experimental](../analyzers/index.html) RetireJS Analyzer should be used.                                                         | true
 nuspecAnalyzerEnabled         | Sets whether the .NET Nuget Nuspec Analyzer will be used.                                                  | true
-nugetconfAnalyzerEnabled      | Sets whether the .NET Nuget packages.config Analyzer will be used.                                         | true
+nugetconfAnalyzerEnabled      | Sets whether the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used.                                         | true
 cocoapodsAnalyzerEnabled      | Sets whether the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used.                | true
 bundleAuditAnalyzerEnabled    | Sets whether the [experimental](../analyzers/index.html) Bundle Audit Analyzer should be used.             | true
 bundleAuditPath               | Sets the path to the bundle audit executable; only used if bundle audit analyzer is enabled and experimental analyzers are enabled.  | &nbsp;

--- a/src/site/markdown/analyzers/index.md
+++ b/src/site/markdown/analyzers/index.md
@@ -12,7 +12,6 @@ to extract identification information from the files analyzed.
 | [Node.js](./nodejs.html) | NPM package specification files (package.json) | Parses the package.json to gather a bill-of-materials for a Node JS project. |
 | [NSP](./nsp-analyzer.html) | [Node Security Project](https://nodesecurity.io) is used to analyze Node.js' `package.json` files for known vulnerable packages.|
 | [Nuspec](./nuspec-analyzer.html) | Nuget package specification file (\*.nuspec) | Uses XPath to parse specification XML. |
-| [Nugetconf](./nugetconf-analyzer.html) | Nuget packages.config file | Uses XPath to parse specification XML. |
 | [OpenSSL](./openssl.html) | OpenSSL Version Source Header File (opensslv.h) | Regex parse of the OPENSSL_VERSION_NUMBER macro definition. |
 | [Ruby bundler&#8209;audit](./bundle-audit.html) | Ruby `Gemfile.lock` files | Executes bundle-audit and incorporates the results into the dependency-check report. |
 
@@ -30,6 +29,7 @@ several teams have found them useful in their current state.
 | [CMake](./cmake.html) | CMake project files (CMakeLists.txt) and scripts (\*.cmake) | Regex scan for project initialization and version setting commands. |
 | [CocoaPods](./cocoapods.html) | CocoaPods `.podspec` files | Extracts dependency information from specification file. |
 | [Composer Lock](./composer-lock.html) | PHP [Composer](http://getcomposer.org) Lock files (composer.lock) | Parses PHP [Composer](http://getcomposer.org) lock files for exact versions of dependencies. | 
+| [Nugetconf](./nugetconf-analyzer.html) | Nuget packages.config file | Uses XPath to parse specification XML. |
 | [Python](./python.html) | Python source files (\*.py); Package metadata files (PKG-INFO, METADATA); Package Distribution Files (\*.whl, \*.egg, \*.zip) | Regex scan of Python source files for setuptools metadata; Parse RFC822 header format for metadata in all other artifacts. |
 | [Ruby Gemspec](./ruby-gemspec.html) | Ruby makefiles (Rakefile); Ruby Gemspec files (\*.gemspec) | Regex scan Gemspec initialization blocks for metadata. |
 | [RetireJS](./retirejs-analyzer.html) | JavaScript files | Analyzes JavaScript files using the [RetireJS](https://github.com/RetireJS/retire.js) database. |

--- a/src/site/markdown/analyzers/index.md
+++ b/src/site/markdown/analyzers/index.md
@@ -12,6 +12,7 @@ to extract identification information from the files analyzed.
 | [Node.js](./nodejs.html) | NPM package specification files (package.json) | Parses the package.json to gather a bill-of-materials for a Node JS project. |
 | [NSP](./nsp-analyzer.html) | [Node Security Project](https://nodesecurity.io) is used to analyze Node.js' `package.json` files for known vulnerable packages.|
 | [Nuspec](./nuspec-analyzer.html) | Nuget package specification file (\*.nuspec) | Uses XPath to parse specification XML. |
+| [Nugetconf](./nugetconf-analyzer.html) | Nuget packages.config file | Uses XPath to parse specification XML. |
 | [OpenSSL](./openssl.html) | OpenSSL Version Source Header File (opensslv.h) | Regex parse of the OPENSSL_VERSION_NUMBER macro definition. |
 | [Ruby bundler&#8209;audit](./bundle-audit.html) | Ruby `Gemfile.lock` files | Executes bundle-audit and incorporates the results into the dependency-check report. |
 

--- a/src/site/markdown/analyzers/nugetconf-analyzer.md
+++ b/src/site/markdown/analyzers/nugetconf-analyzer.md
@@ -1,0 +1,9 @@
+Nugetconf Analyzer
+==============
+
+OWASP dependency-check includes an analyzer that will scan NuGet's packages.config files to
+collect information about the component being used. The evidence collected
+is used by other analyzers to determine if there are any known vulnerabilities
+associated with the component.
+
+Files Scanned: packages.config

--- a/src/site/markdown/analyzers/nugetconf-analyzer.md
+++ b/src/site/markdown/analyzers/nugetconf-analyzer.md
@@ -1,6 +1,10 @@
 Nugetconf Analyzer
 ==============
 
+*Experimental*: This analyzer is considered experimental. While this analyzer may 
+be useful and provide valid results more testing must be completed to ensure that
+the false negative/false positive rates are acceptable. 
+
 OWASP dependency-check includes an analyzer that will scan NuGet's packages.config files to
 collect information about the component being used. The evidence collected
 is used by other analyzers to determine if there are any known vulnerabilities

--- a/src/site/markdown/dependency-check-gradle/configuration-aggregate.md
+++ b/src/site/markdown/dependency-check-gradle/configuration-aggregate.md
@@ -119,6 +119,7 @@ analyzers    | pyPackageEnabled      | Sets whether the [experimental](../analyz
 analyzers    | rubygemsEnabled       | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used.                      | true
 analyzers    | opensslEnabled        | Sets whether or not the openssl Analyzer should be used.                                                          | true
 analyzers    | nuspecEnabled         | Sets whether or not the .NET Nuget Nuspec Analyzer will be used.                                                  | true
+analyzers    | nugetconfEnabled      | Sets whether or not the .NET Nuget packages.config Analyzer will be used.                                         | true
 analyzers    | assemblyEnabled       | Sets whether or not the .NET Assembly Analyzer should be used.                                                    | true
 analyzers    | pathToMono            | The path to Mono for .NET assembly analysis on non-windows systems.                                               | &nbsp;
 analyzers    | cmakeEnabled          | Sets whether or not the [experimental](../analyzers/index.html) CMake Analyzer should be used.                    | true

--- a/src/site/markdown/dependency-check-gradle/configuration-aggregate.md
+++ b/src/site/markdown/dependency-check-gradle/configuration-aggregate.md
@@ -119,7 +119,7 @@ analyzers    | pyPackageEnabled      | Sets whether the [experimental](../analyz
 analyzers    | rubygemsEnabled       | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used.                      | true
 analyzers    | opensslEnabled        | Sets whether or not the openssl Analyzer should be used.                                                          | true
 analyzers    | nuspecEnabled         | Sets whether or not the .NET Nuget Nuspec Analyzer will be used.                                                  | true
-analyzers    | nugetconfEnabled      | Sets whether or not the .NET Nuget packages.config Analyzer will be used.                                         | true
+analyzers    | nugetconfEnabled      | Sets whether or not the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used.                                         | true
 analyzers    | assemblyEnabled       | Sets whether or not the .NET Assembly Analyzer should be used.                                                    | true
 analyzers    | pathToMono            | The path to Mono for .NET assembly analysis on non-windows systems.                                               | &nbsp;
 analyzers    | cmakeEnabled          | Sets whether or not the [experimental](../analyzers/index.html) CMake Analyzer should be used.                    | true

--- a/src/site/markdown/dependency-check-gradle/configuration.md
+++ b/src/site/markdown/dependency-check-gradle/configuration.md
@@ -119,6 +119,7 @@ analyzers    | pyPackageEnabled      | Sets whether the [experimental](../analyz
 analyzers    | rubygemsEnabled       | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used.                      | true
 analyzers    | opensslEnabled        | Sets whether or not the openssl Analyzer should be used.                                                          | true
 analyzers    | nuspecEnabled         | Sets whether or not the .NET Nuget Nuspec Analyzer will be used.                                                  | true
+analyzers    | nugetconfEnabled      | Sets whether or not the .NET Nuget packages.config Analyzer will be used.                                         | true
 analyzers    | assemblyEnabled       | Sets whether or not the .NET Assembly Analyzer should be used.                                                    | true
 analyzers    | pathToMono            | The path to Mono for .NET assembly analysis on non-windows systems.                                               | &nbsp;
 analyzers    | cmakeEnabled          | Sets whether or not the [experimental](../analyzers/index.html) CMake Analyzer should be used.                    | true

--- a/src/site/markdown/dependency-check-gradle/configuration.md
+++ b/src/site/markdown/dependency-check-gradle/configuration.md
@@ -119,7 +119,7 @@ analyzers    | pyPackageEnabled      | Sets whether the [experimental](../analyz
 analyzers    | rubygemsEnabled       | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used.                      | true
 analyzers    | opensslEnabled        | Sets whether or not the openssl Analyzer should be used.                                                          | true
 analyzers    | nuspecEnabled         | Sets whether or not the .NET Nuget Nuspec Analyzer will be used.                                                  | true
-analyzers    | nugetconfEnabled      | Sets whether or not the .NET Nuget packages.config Analyzer will be used.                                         | true
+analyzers    | nugetconfEnabled      | Sets whether or not the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used.                                         | true
 analyzers    | assemblyEnabled       | Sets whether or not the .NET Assembly Analyzer should be used.                                                    | true
 analyzers    | pathToMono            | The path to Mono for .NET assembly analysis on non-windows systems.                                               | &nbsp;
 analyzers    | cmakeEnabled          | Sets whether or not the [experimental](../analyzers/index.html) CMake Analyzer should be used.                    | true

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -351,7 +351,7 @@ public final class Settings {
          */
         public static final String ANALYZER_NUSPEC_ENABLED = "analyzer.nuspec.enabled";
         /**
-         * The properties key for whether the .NET Nuget packages config analyzer is enabled.
+         * The properties key for whether the .NET Nuget packages.config analyzer is enabled.
          */
         public static final String ANALYZER_NUGETCONF_ENABLED = "analyzer.nugetconf.enabled";
         /**

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -351,6 +351,10 @@ public final class Settings {
          */
         public static final String ANALYZER_NUSPEC_ENABLED = "analyzer.nuspec.enabled";
         /**
+         * The properties key for whether the .NET Nuget packages config analyzer is enabled.
+         */
+        public static final String ANALYZER_NUGETCONF_ENABLED = "analyzer.nugetconf.enabled";
+        /**
          * The properties key for whether the .NET MSBuild Project analyzer is
          * enabled.
          */

--- a/utils/src/test/resources/dependencycheck.properties
+++ b/utils/src/test/resources/dependencycheck.properties
@@ -111,6 +111,7 @@ analyzer.autoconf.enabled=true
 analyzer.cmake.enabled=true
 analyzer.assembly.enabled=true
 analyzer.nuspec.enabled=true
+analyzer.nugetconf.enabled=true
 analyzer.openssl.enabled=true
 analyzer.central.enabled=true
 analyzer.nexus.enabled=false


### PR DESCRIPTION
## Fixes Issue #
Adds support of .NET [packages.config](https://docs.microsoft.com/en-us/nuget/reference/packages-config) dependency format. This format is a popular way to declare dependencies for MSBuild projects without including them into *.csproj files or using *.nuspec files.

## Description of Change
Created a new analyzer "Nugetconf" using the existing Nuspec and MSBuild analyzers as inspirations; marked it as *experimental*. Updated settings, CLI options, various documentation files and added test cases.

## Have test cases been added to cover the new functionality?
Yes