### PR TITLE
Fix a typo in maven task configuration site

### DIFF
--- a/maven/src/site/markdown/configuration.md
+++ b/maven/src/site/markdown/configuration.md
@@ -102,7 +102,7 @@ filterNonVulnerable | A boolean controlling whether or not the Retire JS Analyze
 Advanced Configuration
 ====================
 The following properties can be configured in the plugin. However, they are less frequently changed. One exception
-may be the cvedUrl properties, which can be used to host a mirror of the NVD within an enterprise environment.
+may be the cveUrl properties, which can be used to host a mirror of the NVD within an enterprise environment.
 
 Property             | Description                                                                                 | Default Value
 ---------------------|---------------------------------------------------------------------------------------------|------------------


### PR DESCRIPTION
## Fixes Issue #
A typo
## Description of Change
Removes a confusing 'd'

## Have test cases been added to cover the new functionality?

No.