### PR TITLE
Fix aggregate scan set

### DIFF
--- a/maven/src/it/740-aggregate/pom.xml
+++ b/maven/src/it/740-aggregate/pom.xml
@@ -25,7 +25,7 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
     <modules>
         <module>first</module>
         <module>second</module>
-		<module>third</module>
+        <module>third</module>
     </modules>
     <build>
         <plugins>
@@ -37,6 +37,12 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
                 <configuration>
                     <format>ALL</format>
                     <centralAnalyzerEnabled>false</centralAnalyzerEnabled>
+                    <enableExperimental>true</enableExperimental>
+                    <scanSet>
+                        <fileSet>
+                            <directory>src/test</directory>
+                        </fileSet>
+                    </scanSet>
                 </configuration>
                 <executions>
                     <execution>

--- a/maven/src/it/740-aggregate/postbuild.groovy
+++ b/maven/src/it/740-aggregate/postbuild.groovy
@@ -28,7 +28,13 @@ if (count == 0) {
 }
 count = StringUtils.countMatches(report, "org.apache.james:apache-mime4j-core:0.7.2");
 if (count == 0) {
-    System.out.println(String.format("org.apache.james:apache-mime4j-core:0.7.2 was not identified and is a dependency of fourth-1.0.0-SNAPSHOT"));
+    System.out.println("org.apache.james:apache-mime4j-core:0.7.2 was not identified and is a dependency of fourth-1.0.0-SNAPSHOT");
     return false;
 }
+count = StringUtils.countMatches(report, "HelloWorld.js");
+if (count == 0) {
+    System.out.println("HelloWorld.js was not included via ScanSet and is found in `second/srt/test`");
+    return false;
+}
+
 return true;

--- a/maven/src/it/740-aggregate/second/src/test/HelloWorld.js
+++ b/maven/src/it/740-aggregate/second/src/test/HelloWorld.js
@@ -1,0 +1,4 @@
+/*
+Copyright (c) 2018 The OWAS Foundation. All Rights Reserved.
+*/
+alert('hello world');

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1026,7 +1026,6 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
             projectScan = new FileSet[]{resourcesSet, filtersSet, webappSet};
 
         } else if (aggregate) {
-            //TODO build the correct scan set for the child project?
             projectScan = new FileSet[scanSet.length];
             for (int x = 0; x < scanSet.length; x++) {
                 //deep copy of the FileSet - modifying the directory if it is not absolute.

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1007,7 +1007,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         ExceptionCollection exCol = null;
         exCol = collectMavenDependencies(engine, project, nodes, buildingRequest, aggregate);
 
-        FileSet[] projectScan = scanSet;
+        final FileSet[] projectScan;
         if (scanSet == null || scanSet.length == 0) {
             // Define the default FileSets
             final FileSet resourcesSet = new FileSet();

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1007,7 +1007,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         ExceptionCollection exCol = null;
         exCol = collectMavenDependencies(engine, project, nodes, buildingRequest, aggregate);
 
-        final FileSet[] projectScan;
+        FileSet[] projectScan = null;
         if (scanSet == null || scanSet.length == 0) {
             // Define the default FileSets
             final FileSet resourcesSet = new FileSet();

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -371,13 +371,15 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     @Parameter(property = "artifactoryAnalyzerEnabled")
     private Boolean artifactoryAnalyzerEnabled;
     /**
-     * The serverId inside the settings.xml containing the username and token to access artifactory
+     * The serverId inside the settings.xml containing the username and token to
+     * access artifactory
      */
     @SuppressWarnings("CanBeFinal")
     @Parameter(property = "artifactoryAnalyzerServerId", defaultValue = "artifactory")
     private String artifactoryAnalyzerServerId;
     /**
-     * The username (only used with API token) to connect to Artifactory instance
+     * The username (only used with API token) to connect to Artifactory
+     * instance
      */
     @SuppressWarnings("CanBeFinal")
     @Parameter(property = "artifactoryAnalyzerUsername", defaultValue = "artifactory")
@@ -657,7 +659,6 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
 
     // </editor-fold>
     //<editor-fold defaultstate="collapsed" desc="Base Maven implementation">
-
     /**
      * Determines if the groupId, artifactId, and version of the Maven
      * dependency and artifact match.
@@ -676,7 +677,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * Compares two strings for equality; if both strings are null they are
      * considered equal.
      *
-     * @param left  the first string to compare
+     * @param left the first string to compare
      * @param right the second string to compare
      * @return true if the strings are equal or if they are both null; otherwise
      * false.
@@ -689,8 +690,8 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * Executes dependency-check.
      *
      * @throws MojoExecutionException thrown if there is an exception executing
-     *                                the mojo
-     * @throws MojoFailureException   thrown if dependency-check failed the build
+     * the mojo
+     * @throws MojoFailureException thrown if dependency-check failed the build
      */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -723,7 +724,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     /**
      * Generates the Dependency-Check Site Report.
      *
-     * @param sink   the sink to write the report to
+     * @param sink the sink to write the report to
      * @param locale the locale to use when generating the report
      * @throws MavenReportException if a maven report exception occurs
      * @deprecated use
@@ -766,7 +767,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     /**
      * Generates the Dependency-Check Site Report.
      *
-     * @param sink   the sink to write the report to
+     * @param sink the sink to write the report to
      * @param locale the locale to use when generating the report
      * @throws MavenReportException if a maven report exception occurs
      */
@@ -799,7 +800,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      *
      * @return the directory to write the report(s)
      * @throws MojoExecutionException thrown if there is an error loading the
-     *                                file path
+     * file path
      */
     protected File getCorrectOutputDirectory() throws MojoExecutionException {
         return getCorrectOutputDirectory(this.project);
@@ -829,7 +830,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * list.
      *
      * @param project the project to scan the dependencies of
-     * @param engine  the engine to use to scan the dependencies
+     * @param engine the engine to use to scan the dependencies
      * @return a collection of exceptions that may have occurred while resolving
      * and scanning the dependencies
      */
@@ -841,8 +842,8 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * Scans the project's artifacts and adds them to the engine's dependency
      * list.
      *
-     * @param project   the project to scan the dependencies of
-     * @param engine    the engine to use to scan the dependencies
+     * @param project the project to scan the dependencies of
+     * @param engine the engine to use to scan the dependencies
      * @param aggregate whether the scan is part of an aggregate build
      * @return a collection of exceptions that may have occurred while resolving
      * and scanning the dependencies
@@ -864,17 +865,17 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * Resolves the projects artifacts using Aether and scans the resulting
      * dependencies.
      *
-     * @param engine          the core dependency-check engine
-     * @param project         the project being scanned
-     * @param nodes           the list of dependency nodes, generally obtained via the
-     *                        DependencyGraphBuilder
+     * @param engine the core dependency-check engine
+     * @param project the project being scanned
+     * @param nodes the list of dependency nodes, generally obtained via the
+     * DependencyGraphBuilder
      * @param buildingRequest the Maven project building request
-     * @param aggregate       whether the scan is part of an aggregate build
+     * @param aggregate whether the scan is part of an aggregate build
      * @return a collection of exceptions that may have occurred while resolving
      * and scanning the dependencies
      */
     private ExceptionCollection collectDependencies(Engine engine, MavenProject project,
-                                                    List<DependencyNode> nodes, ProjectBuildingRequest buildingRequest, boolean aggregate) {
+            List<DependencyNode> nodes, ProjectBuildingRequest buildingRequest, boolean aggregate) {
         ExceptionCollection exCol = null;
         for (DependencyNode dependencyNode : nodes) {
             if (artifactScopeExcluded.passes(dependencyNode.getArtifact().getScope())
@@ -984,9 +985,9 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 }
             }
         }
-
-        // Define the default FileSets
+        FileSet[] projectScan = scanSet;
         if (scanSet == null || scanSet.length == 0) {
+            // Define the default FileSets
             final FileSet resourcesSet = new FileSet();
             final FileSet filtersSet = new FileSet();
             final FileSet webappSet = new FileSet();
@@ -1000,11 +1001,15 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 }
                 exCol.addException(ex);
             }
-            scanSet = new FileSet[]{resourcesSet, filtersSet, webappSet};
+            projectScan = new FileSet[]{resourcesSet, filtersSet, webappSet};
+
+        } else if (aggregate) {
+            //TODO build the correct scan set for the child project?
         }
+
         // Iterate through FileSets and scan included files
         final FileSetManager fileSetManager = new FileSetManager();
-        for (FileSet fileSet : scanSet) {
+        for (FileSet fileSet : projectScan) {
             final String[] includedFiles = fileSetManager.getIncludedFiles(fileSet);
             for (String include : includedFiles) {
                 final File includeFile = new File(fileSet.getDirectory(), include).getAbsoluteFile();
@@ -1023,7 +1028,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * have not yet been built. If true a virtual dependency is created based on
      * the evidence in the project.
      *
-     * @param engine   a reference to the engine being used to scan
+     * @param engine a reference to the engine being used to scan
      * @param artifact the artifact being analyzed in the mojo
      * @return <code>true</code> if the artifact is in the reactor; otherwise
      * <code>false</code>
@@ -1117,9 +1122,9 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * Executes the dependency-check scan and generates the necessary report.
      *
      * @throws MojoExecutionException thrown if there is an exception running
-     *                                the scan
-     * @throws MojoFailureException   thrown if dependency-check is configured to
-     *                                fail the build
+     * the scan
+     * @throws MojoFailureException thrown if dependency-check is configured to
+     * fail the build
      */
     protected void runCheck() throws MojoExecutionException, MojoFailureException {
         try (Engine engine = initializeEngine()) {
@@ -1177,10 +1182,10 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * MojoExecutionException
      *
      * @param currentEx the primary exception collection
-     * @param newEx     the new exception collection to add
+     * @param newEx the new exception collection to add
      * @return the combined exception collection
      * @throws MojoExecutionException thrown if dependency-check is configured
-     *                                to fail on errors
+     * to fail on errors
      */
     private ExceptionCollection handleAnalysisExceptions(ExceptionCollection currentEx, ExceptionCollection newEx) throws MojoExecutionException {
         ExceptionCollection returnEx = currentEx;
@@ -1382,7 +1387,6 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_USES_PROXY, artifactoryAnalyzerUseProxy);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARTIFACTORY_PARALLEL_ANALYSIS, artifactoryAnalyzerParallelAnalysis);
 
-
         if (Boolean.TRUE.equals(artifactoryAnalyzerEnabled)) {
             if (artifactoryAnalyzerServerId != null) {
                 final Server server = settingsXml.getServer(artifactoryAnalyzerServerId);
@@ -1575,14 +1579,13 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     }
 
     //<editor-fold defaultstate="collapsed" desc="Methods to fail build or show summary">
-
     /**
      * Checks to see if a vulnerability has been identified with a CVSS score
      * that is above the threshold set in the configuration.
      *
      * @param dependencies the list of dependency objects
      * @throws MojoFailureException thrown if a CVSS score is found that is
-     *                              higher then the threshold set
+     * higher then the threshold set
      */
     protected void checkForFailure(Dependency[] dependencies) throws MojoFailureException {
         final StringBuilder ids = new StringBuilder();
@@ -1623,7 +1626,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * Generates a warning message listing a summary of dependencies and their
      * associated CPE and CVE entries.
      *
-     * @param mp           the Maven project for which the summary is shown
+     * @param mp the Maven project for which the summary is shown
      * @param dependencies a list of dependency objects
      */
     protected void showSummary(MavenProject mp, Dependency[] dependencies) {
@@ -1664,7 +1667,6 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
 
     //</editor-fold>
     //<editor-fold defaultstate="collapsed" desc="Methods to read/write the serialized data file">
-
     /**
      * Returns the key used to store the path to the data file that is saved by
      * <code>writeDataFile()</code>. This key is used in the


### PR DESCRIPTION
## Fixes Issue #1421 

The ScanSet implementation for the Maven plugin did not work for aggregate goals. This PR enables the standard Maven layout to be scanned (or alternatively one configured in the build).

## Have test cases been added to cover the new functionality?

Yes