### PR TITLE
Ignore packages.config files in File Analyzer

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzer.java
@@ -55,6 +55,7 @@ public class FileNameAnalyzer extends AbstractAnalyzer {
         "METADATA",
         "PKG-INFO",
         "package.json",
+        "packages.config",
         "Package.swift",
         "classes.jar",
         "build.gradle"}, IOCase.INSENSITIVE);


### PR DESCRIPTION
## Fixes Issue #

As a side effect of introducing the new Nugetconf Analyzer that scans packages.config for dependencies, the old File Analyzer started picking up all analyzed packages.config files as dependencies and adding them to the dependencies list. This behavior creates a lot of noise and doesn't carry any valuable information.

## Description of Change

Added "packages.config" to the ignore list of the File Analyzer.

## Have test cases been added to cover the new functionality?

no