### PR TITLE
Fix of issue #1439 

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
@@ -35,6 +35,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.text.MessageFormat;
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 import org.owasp.dependencycheck.dependency.EvidenceType;
@@ -258,11 +259,16 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
                             }
                             //CSON: NestedTryDepth
                         } while (!success && retryCount++ < maxAttempts);
-                        PomUtils.analyzePOM(dependency, pomFile);
+                        if (success) {
+                            PomUtils.analyzePOM(dependency, pomFile);
+                        } else {
+                            LOGGER.warn("Unable to download pom.xml for {} from Central; "
+                                    + "this could result in undetected CPE/CVEs.", dependency.getFileName());
+                        }
 
-                    } catch (DownloadFailedException ex) {
-                        LOGGER.warn("Unable to download pom.xml for {} from Central; "
-                                + "this could result in undetected CPE/CVEs.", dependency.getFileName());
+                    } catch (AnalysisException ex) {
+                        LOGGER.warn(MessageFormat.format("Unable to analyze pom.xml for {0} from Central; "
+                                + "this could result in undetected CPE/CVEs.", dependency.getFileName()), ex);
 
                     } finally {
                         if (pomFile != null && pomFile.exists() && !FileUtils.deleteQuietly(pomFile)) {

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -702,7 +702,7 @@ public final class Settings {
      * @param value the value for the property
      */
     public void setArrayIfNotEmpty(String key, List<String> value) {
-        if (null != value && value.size() > 0) {
+        if (null != value && !value.isEmpty()) {
             setString(key, new Gson().toJson(value));
         }
     }


### PR DESCRIPTION
Error org.owasp.dependencycheck.xml.pom.PomParseException during analysis of not existed pom in Maven Central

## Fixes Issue #
#1439 
## Description of Change

*Added check that after all attempts to download we received needed file.
And added AnalysisException to catch cases when pom file cannot be parsed*

## Have test cases been added to cover the new functionality?

*no*