### PR TITLE
Fix help text output

### DIFF
--- a/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
@@ -58,6 +58,8 @@ public final class CliParser {
      */
     private final Settings settings;
 
+    private static final String SUPPORTED_FORMATS = "HTML, XML, CSV, JSON, VULN, or ALL";
+
     /**
      * Constructs a new CLI Parser object with the configured settings.
      *
@@ -133,7 +135,7 @@ public final class CliParser {
                     Format.valueOf(format);
                 } catch (IllegalArgumentException ex) {
                     final String msg = String.format("An invalid 'format' of '%s' was specified. "
-                            + "Supported output formats are HTML, XML, CSV, JSON, VULN, or ALL", format);
+                            + "Supported output formats are " + SUPPORTED_FORMATS, format);
                     throw new ParseException(msg);
                 }
             }
@@ -273,7 +275,7 @@ public final class CliParser {
                 .build();
 
         final Option outputFormat = Option.builder(ARGUMENT.OUTPUT_FORMAT_SHORT).argName("format").hasArg().longOpt(ARGUMENT.OUTPUT_FORMAT)
-                .desc("The output format to write to (XML, JSON, HTML, VULN, ALL). The default is HTML.")
+                .desc("The output format to write to (" + SUPPORTED_FORMATS + "). The default is HTML.")
                 .build();
 
         final Option verboseLog = Option.builder(ARGUMENT.VERBOSE_LOG_SHORT).argName("file").hasArg().longOpt(ARGUMENT.VERBOSE_LOG)


### PR DESCRIPTION
## Description of Change

The 'format' argument's help output was missing one of the valid formats,
'CSV,' even though it is listed in both the documentation and the error
message for invalid formats.

This commit syncs the text of that error message and the format argument's
help output so that they stay the same going forward.

**Before**
```
$ ./cli/target/release/bin/dependency-check.bat -h
usage: Dependency-Check Core [--advancedHelp] [--cveValidForHours <hours>]
       [--enableExperimental] [--enableRetired] [--exclude <pattern>] [-f
       <format>] [--failOnCVSS <score>] [-h] [--hints <file>] [-l <file>]
       [-n] [-o <path>] [-P <file>] [--project <name>] [-s <path>]
       [--suppression <file>] [--symLink <depth>] [-v]

Dependency-Check Core can be used to identify if there are any known CVE
vulnerabilities in libraries utilized by an application. Dependency-Check
Core will automatically update required data from the Internet, such as
the CVE and CPE data files from nvd.nist.gov.

    --advancedHelp               Print the advanced help message.
    --cveValidForHours <hours>   The number of hours to wait before
                                 checking for new updates from the NVD.
    --enableExperimental         Enables the experimental analyzers.
    --enableRetired              Enables the retired analyzers.
    --exclude <pattern>          Specify an exclusion pattern. This option
                                 can be specified multiple times and it
                                 accepts Ant style exclusions.
 -f,--format <format>            The output format to write to (XML, JSON,
                                 HTML, VULN, ALL). The default is HTML.
```

**After**
```
$ ./cli/target/release/bin/dependency-check.bat -h
usage: Dependency-Check Core [--advancedHelp] [--cveValidForHours <hours>]
       [--enableExperimental] [--enableRetired] [--exclude <pattern>] [-f
       <format>] [--failOnCVSS <score>] [-h] [--hints <file>] [-l <file>]
       [-n] [-o <path>] [-P <file>] [--project <name>] [-s <path>]
       [--suppression <file>] [--symLink <depth>] [-v]

Dependency-Check Core can be used to identify if there are any known CVE
vulnerabilities in libraries utilized by an application. Dependency-Check
Core will automatically update required data from the Internet, such as
the CVE and CPE data files from nvd.nist.gov.

    --advancedHelp               Print the advanced help message.
    --cveValidForHours <hours>   The number of hours to wait before
                                 checking for new updates from the NVD.
    --enableExperimental         Enables the experimental analyzers.
    --enableRetired              Enables the retired analyzers.
    --exclude <pattern>          Specify an exclusion pattern. This option
                                 can be specified multiple times and it
                                 accepts Ant style exclusions.
 -f,--format <format>            The output format to write to (HTML, XML,
                                 CSV, JSON, VULN, or ALL). The default is
                                 HTML.
```



## Have test cases been added to cover the new functionality?

No