### PR TITLE
Fixing the test case failure behind proxy.

### DIFF
--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
@@ -61,8 +61,12 @@ public class ArtifactorySearchTest extends BaseTest {
 
     @AfterClass
     public static void restoreProxies() {
-        System.setProperty("https.proxyHost", httpsProxyHostOrig);
-        System.setProperty("https.proxyPort", httpsPortOrig);
+        if (httpsProxyHostOrig != null) {
+            System.setProperty("https.proxyHost", httpsProxyHostOrig);
+        }
+        if (httpsPortOrig != null) {
+            System.setProperty("https.proxyPort", httpsPortOrig);
+        }
     }
 
     @Before

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
@@ -17,7 +17,9 @@
  */
 package org.owasp.dependencycheck.data.artifactory;
 
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
@@ -40,6 +42,28 @@ import static org.mockito.Mockito.when;
 
 public class ArtifactorySearchTest extends BaseTest {
     private ArtifactorySearch searcher;
+    private static String httpsProxyHostOrig;
+    private static String httpsPortOrig;
+
+    @BeforeClass
+    public static void tinkerProxies() {
+        httpsProxyHostOrig = System.getProperty("https.proxyHost");
+        if (httpsProxyHostOrig == null) {
+            httpsProxyHostOrig = System.getenv("https.proxyHost");
+        }
+        httpsPortOrig = System.getProperty("https.proxyPort");
+        if(httpsPortOrig == null) {
+            httpsPortOrig = System.getenv("https.proxyPort");
+        }
+        System.setProperty("https.proxyHost", "");
+        System.setProperty("https.proxyPort", "");
+    }
+
+    @AfterClass
+    public static void restoreProxies() {
+        System.setProperty("https.proxyHost", httpsProxyHostOrig);
+        System.setProperty("https.proxyPort", httpsPortOrig);
+    }
 
     @Before
     @Override


### PR DESCRIPTION
## Fixes Issue #1493 

## Description of Change

Though probably I could have changed that artifactory host URI protocol to `http` instead of `https` but I was not sure if you had any reason to choose that. Hence I just made sure, that particular test case runs in non proxy environment. Hence the change.

## Have test cases been added to cover the new functionality?

Not Applicable.