### PR TITLE
Multiple proxy settings in maven settings breaks the plugin function.

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1572,27 +1572,10 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                         }
                     }
                 } else {
-                    Proxy httpsProxy = null;
-                    Proxy httpProxy = null;
-
                     for (Proxy aProxy: proxies) {
-                        if (aProxy.getProtocol().equalsIgnoreCase("https") && aProxy.isActive() && httpsProxy == null) {
-                            httpsProxy = aProxy;
+                        if (aProxy.isActive()) {
+                            return aProxy;
                         }
-
-                        if (aProxy.getProtocol().equalsIgnoreCase("http") && aProxy.isActive() && httpProxy == null) {
-                            httpProxy = aProxy;
-                        }
-
-                        if (httpProxy != null && httpsProxy != null) {
-                            break;
-                        }
-                    }
-
-                    if (httpsProxy != null) {
-                        return httpsProxy;
-                    } else if (httpProxy != null) {
-                        return httpProxy;
                     }
                 }
             }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1571,8 +1571,6 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                             return proxy;
                         }
                     }
-                } else if (proxies.size() == 1) {
-                    return proxies.get(0);
                 } else {
                     Proxy httpsProxy = null;
                     Proxy httpProxy = null;
@@ -1595,10 +1593,6 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                         return httpsProxy;
                     } else if (httpProxy != null) {
                         return httpProxy;
-                    } else {
-                        getLog().warn("Multiple proxy definitions exist in the Maven settings. In the dependency-check "
-                                + "configuration set the mavenSettingsProxyId so that the correct proxy will be used.");
-                        throw new IllegalStateException("Ambiguous proxy definition");
                     }
                 }
             }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1572,14 +1572,27 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                         }
                     }
                 } else {
+                    Proxy httpsProxy = null;
+                    Proxy httpProxy = null;
+
                     for (Proxy aProxy: proxies) {
-                        if (aProxy.getProtocol().equalsIgnoreCase("https") && aProxy.isActive()) {
-                            return aProxy;
+                        if (aProxy.getProtocol().equalsIgnoreCase("https") && aProxy.isActive() && httpsProxy == null) {
+                            httpsProxy = aProxy;
                         }
 
-                        if (aProxy.getProtocol().equalsIgnoreCase("http") && aProxy.isActive()) {
-                            return aProxy;
+                        if (aProxy.getProtocol().equalsIgnoreCase("http") && aProxy.isActive() && httpProxy == null) {
+                            httpProxy = aProxy;
                         }
+
+                        if (httpProxy != null && httpsProxy != null) {
+                            break;
+                        }
+                    }
+
+                    if (httpsProxy != null) {
+                        return httpsProxy;
+                    } else if (httpProxy != null) {
+                        return httpProxy;
                     }
                 }
             }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1574,9 +1574,32 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 } else if (proxies.size() == 1) {
                     return proxies.get(0);
                 } else {
-                    getLog().warn("Multiple proxy definitions exist in the Maven settings. In the dependency-check "
-                            + "configuration set the mavenSettingsProxyId so that the correct proxy will be used.");
-                    throw new IllegalStateException("Ambiguous proxy definition");
+                    Proxy httpsProxy = null;
+                    Proxy httpProxy = null;
+
+                    for (Proxy aProxy: proxies) {
+                        if (aProxy.getProtocol().equalsIgnoreCase("https") && aProxy.isActive() && httpsProxy == null) {
+                            httpsProxy = aProxy;
+                        }
+
+                        if (aProxy.getProtocol().equalsIgnoreCase("http") && aProxy.isActive() && httpProxy == null) {
+                            httpProxy = aProxy;
+                        }
+
+                        if (httpProxy != null && httpsProxy != null) {
+                            break;
+                        }
+                    }
+
+                    if (httpsProxy != null) {
+                        return httpsProxy;
+                    } else if (httpProxy != null) {
+                        return httpProxy;
+                    } else {
+                        getLog().warn("Multiple proxy definitions exist in the Maven settings. In the dependency-check "
+                                + "configuration set the mavenSettingsProxyId so that the correct proxy will be used.");
+                        throw new IllegalStateException("Ambiguous proxy definition");
+                    }
                 }
             }
         }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1572,27 +1572,14 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                         }
                     }
                 } else {
-                    Proxy httpsProxy = null;
-                    Proxy httpProxy = null;
-
                     for (Proxy aProxy: proxies) {
-                        if (aProxy.getProtocol().equalsIgnoreCase("https") && aProxy.isActive() && httpsProxy == null) {
-                            httpsProxy = aProxy;
+                        if (aProxy.getProtocol().equalsIgnoreCase("https") && aProxy.isActive()) {
+                            return aProxy;
                         }
 
-                        if (aProxy.getProtocol().equalsIgnoreCase("http") && aProxy.isActive() && httpProxy == null) {
-                            httpProxy = aProxy;
+                        if (aProxy.getProtocol().equalsIgnoreCase("http") && aProxy.isActive()) {
+                            return aProxy;
                         }
-
-                        if (httpProxy != null && httpsProxy != null) {
-                            break;
-                        }
-                    }
-
-                    if (httpsProxy != null) {
-                        return httpsProxy;
-                    } else if (httpProxy != null) {
-                        return httpProxy;
                     }
                 }
             }


### PR DESCRIPTION
## Fixes Issue #831 

## Description of Change

In case we find multiple settings for proxy in maven settings, pick the first active one. Also, it might be very much possible that proxy definition is specified in maven settings file but they are not active. Hence throwing IllegalStateException is not really correct?! Hence letting null return in case none of the proxy settings are active.

## Have test cases been added to cover the new functionality?

I would love to. But not able to figure out where are the relevant test cases for this at the moment. Hence I going ahead and raising this PR. Let us see if any test case fails for this.