### PR TITLE
add option to verify <dependencyManagement/> section in POM

### DIFF
--- a/maven/src/it/1551-verify-dependency-management/invoker.properties
+++ b/maven/src/it/1551-verify-dependency-management/invoker.properties
@@ -1,0 +1,19 @@
+#
+# This file is part of dependency-check-maven.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+#
+
+invoker.goals = install -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -Dformat=ALL -DskipDependencyManagement=false

--- a/maven/src/it/1551-verify-dependency-management/pom.xml
+++ b/maven/src/it/1551-verify-dependency-management/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2017 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.owasp.test</groupId>
+    <artifactId>verify-dependency-management</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+              <groupId>com.fasterxml.jackson.dataformat</groupId>
+              <artifactId>jackson-dataformat-xml</artifactId>
+              <version>2.6.3</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/maven/src/it/1551-verify-dependency-management/postbuild.groovy
+++ b/maven/src/it/1551-verify-dependency-management/postbuild.groovy
@@ -1,0 +1,32 @@
+/*
+ * This file is part of dependency-check-maven.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import java.nio.charset.Charset;
+
+
+// Check to see if jackson-dataformat-xml-2.4.5.jar was identified.
+//TODO change this to xpath and check for CVE-2016-3720
+String log = FileUtils.readFileToString(new File(basedir, "target/dependency-check-report.xml"), Charset.defaultCharset().name());
+int count = StringUtils.countMatches(log, "<name>CVE-2017-15095</name>");
+if (count == 0){
+    System.out.println(String.format("jackson-dataformat-xml was not identified", count));
+    return false;
+}
+return true;

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -565,7 +565,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     private boolean skipSystemScope = false;
 
     /**
-     * Skip Analysis for System Scope Dependencies.
+     * Skip Analysis for dependencyManagement section.
      */
     @SuppressWarnings("CanBeFinal")
     @Parameter(property = "skipDependencyManagement", defaultValue = "true", required = false)

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -789,15 +789,6 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     }
 
     /**
-     * Returns if the mojo should skip dependencyManagement section.
-     *
-     * @return whether or not the mojo should skip dependencyManagement section
-     */
-    public boolean isSkipDependencyManagement() {
-        return skipDependencyManagement;
-    }
-
-    /**
      * Generates the Dependency-Check Site Report.
      *
      * @param sink the sink to write the report to

--- a/maven/src/site/markdown/configuration.md
+++ b/maven/src/site/markdown/configuration.md
@@ -28,6 +28,7 @@ skipProvidedScope           | Skip analysis for artifacts with Provided Scope.  
 skipRuntimeScope            | Skip analysis for artifacts with Runtime Scope.            | false
 skipSystemScope             | Skip analysis for artifacts with System Scope.             | false
 skipTestScope               | Skip analysis for artifacts with Test Scope.               | true
+skipDependencyManagement    | Skip analysis for dependencyManagement sections.           | true
 skipArtifactType            | A regular expression used to filter/skip artifact types.   | &nbsp;
 suppressionFiles            | The file paths to the XML suppression files \- used to suppress [false positives](../general/suppression.html). | &nbsp;
 hintsFile                   | The file path to the XML hints file \- used to resolve [false negatives](../general/hints.html).       | &nbsp;
@@ -129,4 +130,3 @@ are configured in the Maven settings file you must tell dependency-check which p
 Property             | Description                                                                          | Default Value
 ---------------------|--------------------------------------------------------------------------------------|------------------
 mavenSettingsProxyId | The id for the proxy, configured via settings.xml, that dependency-check should use. | &nbsp;
-


### PR DESCRIPTION
## Fixes Issue #1551

## Description of Change

This PR adds the option to also scan the dependencyManagement section of POM's for vulnerablilities

## Have test cases been added to cover the new functionality?

Yes

## Note
consider this a rough draft or proof-of-concept, i'm not very familiar with the codebase, just putting this out there for review and commenting