### PR TITLE
Fix Vulnerable Dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,11 @@ addons:
 
 matrix:
   include:
-    - jdk: openjdk7
-      env:
-        - JDK="JDK7"
-      script:
-        - if [ ! -z "$TRAVIS_TAG" ]; then travis_wait 60 mvn install site site:stage -DreleaseTesting -Danalyzer.node.package.enabled=false -Danalyzer.node.audit.enabled=false; else travis_wait 60 mvn install -DreleaseTesting -Danalyzer.node.package.enabled=false -Danalyzer.node.audit.enabled=false; fi
     - jdk: oraclejdk8
       env:
         - JDK="JDK8"
       script:
-        - travis_wait 60 mvn install -DreleaseTesting
+        - if [ ! -z "$TRAVIS_TAG" ]; then travis_wait 60 mvn install site site:stage -DreleaseTesting -Danalyzer.node.package.enabled=false -Danalyzer.node.audit.enabled=false; else travis_wait 60 mvn install -DreleaseTesting -Danalyzer.node.package.enabled=false -Danalyzer.node.audit.enabled=false; fi
 
 #removed from after_success as the codacy integration keeps breaking the build
 #java -cp ~/codacy-coverage-reporter-assembly-latest.jar com.codacy.CodacyCoverageReporter -l Java -r build-reporting/target/coverage-reports/jacoco.xml;
@@ -73,7 +68,7 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
-      jdk: openjdk7
+      jdk: oraclejdk8
   - provider: pages
     skip_cleanup: true
     local_dir: target/staging
@@ -81,5 +76,5 @@ deploy:
     on:
       tags: true
       branch: master
-      jdk: openjdk7
+      jdk: oraclejdk8
  

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dependency-check-ant</artifactId>

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>4.0.0</version>
     </parent>
 
     <artifactId>dependency-check-ant</artifactId>

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -21,7 +21,7 @@ Copyright (c) 2017 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>4.0.0</version>
     </parent>
     <groupId>org.owasp</groupId>
     <artifactId>dependency-check-plugin</artifactId>

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -21,7 +21,7 @@ Copyright (c) 2017 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <groupId>org.owasp</groupId>
     <artifactId>dependency-check-plugin</artifactId>

--- a/build-reporting/pom.xml
+++ b/build-reporting/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2017 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <name>Dependency-Check Build-Reporting</name>
     <artifactId>build-reporting</artifactId>

--- a/build-reporting/pom.xml
+++ b/build-reporting/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2017 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>4.0.0</version>
     </parent>
     <name>Dependency-Check Build-Reporting</name>
     <artifactId>build-reporting</artifactId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>4.0.0</version>
     </parent>
 
     <artifactId>dependency-check-cli</artifactId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dependency-check-cli</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>4.0.0</version>
     </parent>
 
     <artifactId>dependency-check-core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dependency-check-core</artifactId>

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.CompareToBuilder;
-import org.apache.lucene.analysis.util.CharArraySet;
+import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.queryparser.classic.ParseException;

--- a/core/src/main/java/org/owasp/dependencycheck/data/lucene/SearchFieldAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/lucene/SearchFieldAnalyzer.java
@@ -25,8 +25,8 @@ import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.core.StopAnalyzer;
 import org.apache.lucene.analysis.core.StopFilter;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer;
-import org.apache.lucene.analysis.miscellaneous.WordDelimiterFilter;
-import org.apache.lucene.analysis.util.CharArraySet;
+import org.apache.lucene.analysis.miscellaneous.WordDelimiterGraphFilter;
+import org.apache.lucene.analysis.CharArraySet;
 
 /**
  * A Lucene field analyzer used to analyzer queries against the CPE data.
@@ -82,13 +82,13 @@ public class SearchFieldAnalyzer extends Analyzer {
 
         stream = new UrlTokenizingFilter(stream);
         stream = new AlphaNumericFilter(stream);
-        stream = new WordDelimiterFilter(stream,
-                WordDelimiterFilter.GENERATE_WORD_PARTS
-                | WordDelimiterFilter.GENERATE_NUMBER_PARTS
-                | WordDelimiterFilter.PRESERVE_ORIGINAL
-                | WordDelimiterFilter.SPLIT_ON_CASE_CHANGE
-                | WordDelimiterFilter.SPLIT_ON_NUMERICS
-                | WordDelimiterFilter.STEM_ENGLISH_POSSESSIVE, null);
+        stream = new WordDelimiterGraphFilter(stream,
+                WordDelimiterGraphFilter.GENERATE_WORD_PARTS
+                | WordDelimiterGraphFilter.GENERATE_NUMBER_PARTS
+                | WordDelimiterGraphFilter.PRESERVE_ORIGINAL
+                | WordDelimiterGraphFilter.SPLIT_ON_CASE_CHANGE
+                | WordDelimiterGraphFilter.SPLIT_ON_NUMERICS
+                | WordDelimiterGraphFilter.STEM_ENGLISH_POSSESSIVE, null);
 
         stream = new LowerCaseFilter(stream);
 

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -226,6 +226,15 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
+        Resolve FP that caused ant task IT to fail.
+        ]]></notes>
+        <gav regex="true">^jetty:org\.mortbay\.jetty:.*$</gav>
+        <cpe>cpe:/a:apache:http_server</cpe>
+        <cpe>cpe:/a:apache:apache_http_server</cpe>
+        <cpe>cpe:/a:free_java_web_server:free_java_web_server</cpe>
+     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
         False positives found while investigating https://github.com/jeremylong/dependency-check-gradle/issues/103
         ]]></notes>
         <gav regex="true">^com\.facebook\.android:facebook-android-sdk:.*$</gav>

--- a/core/src/test/java/org/owasp/dependencycheck/data/cpe/CpeMemoryIndexTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/cpe/CpeMemoryIndexTest.java
@@ -95,7 +95,7 @@ public class CpeMemoryIndexTest extends BaseDBTestCase {
     public void testParseQuery() throws Exception {
         String searchString = "product:(resteasy) AND vendor:(red hat)";
 
-        String expResult = "+product:resteasy +(vendor:red (vendor:redhat vendor:hat))";
+        String expResult = "+product:resteasy +(vendor:red vendor:redhat vendor:hat)";
         Query result = instance.parseQuery(searchString);
         assertEquals(expResult, result.toString());
         instance.close();

--- a/core/src/test/java/org/owasp/dependencycheck/data/lucene/SearchFieldAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/lucene/SearchFieldAnalyzerTest.java
@@ -17,7 +17,7 @@
  */
 package org.owasp.dependencycheck.data.lucene;
 
-import org.apache.lucene.analysis.util.CharArraySet;
+import org.apache.lucene.analysis.CharArraySet;
 import org.junit.Test;
 import static org.junit.Assert.*;
 

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>4.0.0</version>
     </parent>
     <artifactId>dependency-check-maven</artifactId>
     <packaging>maven-plugin</packaging>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>dependency-check-maven</artifactId>
     <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,8 @@ Copyright (c) 2012 - Jeremy Long
         <groovy-all.version>2.4.15</groovy-all.version>
         <!-- upgrading beyond 1.5 will cause the build to fail on Java 7 -->
         <gmavenplus-plugin.version>1.5</gmavenplus-plugin.version>
-        
+        <com.h3xstream.retirejs.core.version>3.0.2</com.h3xstream.retirejs.core.version>
+        <com.google.guava.version>27.0-jre</com.google.guava.version>
         <surefireArgLine/>
     </properties>
     <distributionManagement>
@@ -464,7 +465,7 @@ Copyright (c) 2012 - Jeremy Long
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>1.7.0</version>
+                                    <version>1.8.0</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
@@ -474,7 +475,7 @@ Copyright (c) 2012 - Jeremy Long
                         <configuration>
                             <rules>
                                 <byteCodeRule implementation="org.owasp.maven.enforcer.rule.ClassFileFormatRule">
-                                    <supportedClassFileFormat>51</supportedClassFileFormat>
+                                    <supportedClassFileFormat>52</supportedClassFileFormat>
                                 </byteCodeRule>
                             </rules>
                         </configuration>
@@ -917,9 +918,14 @@ Copyright (c) 2012 - Jeremy Long
                 <version>${apache.lucene.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${com.google.guava.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.h3xstream.retirejs</groupId>
                 <artifactId>retirejs-core</artifactId>
-                <version>3.0.1</version>
+                <version>${com.h3xstream.retirejs.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ Copyright (c) 2012 - Jeremy Long
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
-        <apache.lucene.version>5.5.5</apache.lucene.version>
+        <apache.lucene.version>7.5.0</apache.lucene.version>
         <apache.ant.version>1.9.9</apache.ant.version>
         <!--upgrading to the 1.8 requires Java 8 compatability  - we are maintaining 7 atm-->
         <slf4j.version>1.7.25</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 - Jeremy Long
 
     <groupId>org.owasp</groupId>
     <artifactId>dependency-check-parent</artifactId>
-    <version>3.3.4</version>
+    <version>3.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 - Jeremy Long
 
     <groupId>org.owasp</groupId>
     <artifactId>dependency-check-parent</artifactId>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -124,6 +124,7 @@ Copyright (c) 2012 - Jeremy Long
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
+        
         <apache.lucene.version>7.5.0</apache.lucene.version>
         <apache.ant.version>1.9.9</apache.ant.version>
         <!--upgrading to the 1.8 requires Java 8 compatability  - we are maintaining 7 atm-->
@@ -427,8 +428,8 @@ Copyright (c) 2012 - Jeremy Long
                 <configuration>
                     <compilerArgument>-Xlint</compilerArgument>
                     <showDeprecation>true</showDeprecation>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@ Copyright (c) 2012 - Jeremy Long
         <groovy-all.version>2.4.15</groovy-all.version>
         <!-- upgrading beyond 1.5 will cause the build to fail on Java 7 -->
         <gmavenplus-plugin.version>1.5</gmavenplus-plugin.version>
-        <com.h3xstream.retirejs.core.version>3.0.2</com.h3xstream.retirejs.core.version>
+        <com.h3xstream.retirejs.core.version>3.0.1</com.h3xstream.retirejs.core.version>
         <com.google.guava.version>27.0-jre</com.google.guava.version>
         <surefireArgLine/>
     </properties>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dependency-check-utils</artifactId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>4.0.0</version>
     </parent>
 
     <artifactId>dependency-check-utils</artifactId>


### PR DESCRIPTION
## Description of Change

Two vulnerable dependencies have been reported. This PR resolves the two vulnerable dependencies. However, to do so the project was upgrade to Java 8. Java 7 will no longer be supported; as such, the version number was moved to 4.0.0 even though this is not a major change.
