### PR TITLE
support ZIP CVE files too

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
@@ -165,6 +165,13 @@ public class DownloadTask implements Callable<Future<ProcessTask>> {
                 ExtractionUtil.extractGzip(second);
             }
 
+            if (url1.toExternalForm().endsWith(".xml.zip") && !isXml(first)) {
+                ExtractionUtil.extractZip(first);
+            }
+            if (url2.toExternalForm().endsWith(".xml.zip") && !isXml(second)) {
+                ExtractionUtil.extractZip(second);
+            }
+
             LOGGER.info("Download Complete for NVD CVE - {}  ({} ms)", nvdCveInfo.getId(),
                     System.currentTimeMillis() - startDownload);
             if (this.processorService == null) {

--- a/core/src/main/java/org/owasp/dependencycheck/utils/ExtractionUtil.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/ExtractionUtil.java
@@ -296,4 +296,36 @@ public final class ExtractionUtil {
             }
         }
     }
+
+    /**
+     * Extracts the file contained in a Zip archive. The extracted file is
+     * placed in the exact same path as the file specified.
+     *
+     * @param file the archive file
+     * @throws FileNotFoundException thrown if the file does not exist
+     * @throws IOException thrown if there is an error extracting the file.
+     */
+    public static void extractZip(File file) throws FileNotFoundException, IOException {
+        final String originalPath = file.getPath();
+        final File zip = new File(originalPath + ".zip");
+        if (zip.isFile() && !zip.delete()) {
+            LOGGER.debug("Failed to delete initial temporary file when extracting 'zip' {}", zip.toString());
+            zip.deleteOnExit();
+        }
+        if (!file.renameTo(zip)) {
+            throw new IOException("Unable to rename '" + file.getPath() + "'");
+        }
+        final File newFile = new File(originalPath);
+        try (FileInputStream fis = new FileInputStream(zip);
+             ZipInputStream cin = new ZipInputStream(fis);
+             FileOutputStream out = new FileOutputStream(newFile)) {
+            cin.getNextEntry();
+            IOUtils.copy(cin, out);
+        } finally {
+            if (zip.isFile() && !org.apache.commons.io.FileUtils.deleteQuietly(zip)) {
+                LOGGER.debug("Failed to delete temporary file when extracting 'zip' {}", zip.toString());
+                zip.deleteOnExit();
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description of Change

In some environments it's not allowed to download .gz files. nvd.nist.gov also supports zip Feed's. You can configure to use them via the following properties:

- cveUrl12Modified
- cveUrl20Modified
- cveUrl12Base
- cveUrl20Base

## Have test cases been added to cover the new functionality?

*no*