### PR TITLE
Changes to resolve FP increase

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -176,7 +176,7 @@ public class CPEAnalyzer extends AbstractAnalyzer {
             skipEcosystems = Arrays.asList(tmp);
         }
 
-        minLuceneScore = engine.getSettings().getFloat(Settings.KEYS.ECOSYSTEM_SKIP_CPEANALYZER, 30);
+        minLuceneScore = engine.getSettings().getFloat(Settings.KEYS.LUCENE_MIN_SCORE_FILTER, 30);
 
         suppression = new CpeSuppressionAnalyzer();
         suppression.initialize(engine.getSettings());

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -127,6 +127,8 @@ public class CPEAnalyzer extends AbstractAnalyzer {
      */
     private CpeSuppressionAnalyzer suppression;
 
+    private float minLuceneScore = 30;
+
     /**
      * Returns the name of this analyzer.
      *
@@ -173,6 +175,8 @@ public class CPEAnalyzer extends AbstractAnalyzer {
             LOGGER.info("Skipping CPE Analysis for {}", StringUtils.join(tmp, ","));
             skipEcosystems = Arrays.asList(tmp);
         }
+
+        minLuceneScore = engine.getSettings().getFloat(Settings.KEYS.ECOSYSTEM_SKIP_CPEANALYZER, 30);
 
         suppression = new CpeSuppressionAnalyzer();
         suppression.initialize(engine.getSettings());
@@ -322,8 +326,9 @@ public class CPEAnalyzer extends AbstractAnalyzer {
         try {
             final TopDocs docs = cpe.search(searchString, MAX_QUERY_RESULTS);
             for (ScoreDoc d : docs.scoreDocs) {
-                if (d.score >= 0.08) {
-                    final Document doc = cpe.getDocument(d.doc);
+                final Document doc = cpe.getDocument(d.doc);
+                if (d.score >= minLuceneScore) {// 0.08) {
+                    //final Document doc = cpe.getDocument(d.doc);
                     final IndexEntry entry = new IndexEntry();
                     entry.setVendor(doc.get(Fields.VENDOR));
                     entry.setProduct(doc.get(Fields.PRODUCT));

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -98,6 +98,9 @@ archive.scan.depth=3
 downloader.quick.query.timestamp=true
 downloader.tls.protocols=TLSv1.1,TLSv1.2,TLSv1.3
 
+# the minimum score for documents from a lucene search
+dependency.check.lucene.min.score=30
+
 # defines if the experimental and retired analyzers can be enabled
 analyzer.experimental.enabled=false
 analyzer.retired.enabled=false

--- a/core/src/test/resources/dependencycheck.properties
+++ b/core/src/test/resources/dependencycheck.properties
@@ -95,6 +95,9 @@ archive.scan.depth=3
 downloader.quick.query.timestamp=true
 downloader.tls.protocols=TLSv1.1,TLSv1.2,TLSv1.3
 
+# the minimum score for documents from a lucene search
+dependency.check.lucene.min.score=30
+
 # defines if the experimental and retired analyzers can be enabled
 analyzer.experimental.enabled=false
 analyzer.retired.enabled=false

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -349,7 +349,8 @@ public final class Settings {
          */
         public static final String ANALYZER_NUSPEC_ENABLED = "analyzer.nuspec.enabled";
         /**
-         * The properties key for whether the .NET Nuget packages.config analyzer is enabled.
+         * The properties key for whether the .NET Nuget packages.config
+         * analyzer is enabled.
          */
         public static final String ANALYZER_NUGETCONF_ENABLED = "analyzer.nugetconf.enabled";
         /**
@@ -532,7 +533,10 @@ public final class Settings {
          * The key to determine which ecosystems should skip the CPE analysis.
          */
         public static final String ECOSYSTEM_SKIP_CPEANALYZER = "ecosystem.skip.cpeanalyzer";
-
+        /**
+         * The key to determine minimum score for Lucene search matches.
+         */
+        public static final String LUCENE_MIN_SCORE_FILTER = "dependency.check.lucene.min.score";
         /**
          *
          * Adds capabilities to batch insert. Tested on PostgreSQL and H2.
@@ -1042,6 +1046,28 @@ public final class Settings {
      */
     public boolean getBoolean(String key, boolean defaultValue) throws InvalidSettingException {
         return Boolean.parseBoolean(getString(key, Boolean.toString(defaultValue)));
+    }
+
+    /**
+     * Returns a float value from the properties file. If the value was
+     * specified as a system property or passed in via the
+     * <code>-Dprop=value</code> argument this method will return the value from
+     * the system properties before the values in the contained configuration
+     * file.
+     *
+     * @param key the key to lookup within the properties file
+     * @param defaultValue the default value to return if the setting does not
+     * exist
+     * @return the property from the properties file
+     */
+    public float getFloat(String key, float defaultValue) {
+        float retValue = defaultValue;
+        try {
+            Float.parseFloat(getString(key));
+        } catch (Throwable ignore) {
+            LOGGER.trace("ignore", ignore);
+        }
+        return retValue;
     }
 
     /**

--- a/utils/src/test/resources/dependencycheck.properties
+++ b/utils/src/test/resources/dependencycheck.properties
@@ -95,6 +95,9 @@ archive.scan.depth=3
 downloader.quick.query.timestamp=true
 downloader.tls.protocols=TLSv1.1,TLSv1.2,TLSv1.3
 
+# the minimum score for documents from a lucene search
+dependency.check.lucene.min.score=30
+
 # defines if the experimental and retired analyzers can be enabled
 analyzer.experimental.enabled=false
 analyzer.retired.enabled=false


### PR DESCRIPTION
## Fixes Issue #1580

## Description of Change

Externalized the minimum score for Lucene matches and increased the minimum score to 30 to resolve increase in FP after upgrading to Lucene 7.5.