### PR TITLE
exclude bower_components from NPM analyzers

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java
@@ -83,19 +83,22 @@ public abstract class AbstractNpmAnalyzer extends AbstractFileTypeAnalyzer {
     }
 
     /**
-     * Determines if the path contains "/node_modules/" (i.e. it is a child
-     * module. This analyzer does not scan child modules.
+     * Determines if the path contains "/node_modules/" or "/bower_components/"
+     * (i.e. it is a child module). This analyzer does not scan child modules.
      *
      * @param pathname the path to test
      * @return <code>true</code> if the path does not contain "/node_modules/"
+     * or "/bower_components/"
      * @throws AnalysisException thrown if the canonical path cannot be obtained
      * from the given file
      */
     protected boolean shouldProcess(File pathname) throws AnalysisException {
         try {
-            // Do not scan the node_modules directory
-            if (pathname.getCanonicalPath().contains(File.separator + "node_modules" + File.separator)) {
-                LOGGER.debug("Skipping analysis of node module: " + pathname.getCanonicalPath());
+            // Do not scan the node_modules (or bower_components) directory
+            String canonicalPath = pathname.getCanonicalPath();
+            if (canonicalPath.contains(File.separator + "node_modules" + File.separator)
+                    || canonicalPath.contains(File.separator + "bower_components" + File.separator)) {
+                LOGGER.debug("Skipping analysis of node/bower module: {}", canonicalPath);
                 return false;
             }
         } catch (IOException ex) {


### PR DESCRIPTION
## Fixes Issue #

The _Node Audit_ analyzer correctly ignores ``package-lock.json`` files found under a ``node_modules`` directory (same for ``npm-shrinkwrap.json`` files). This is a common behavior for analyzers based on ``AbstractNpmAnalyzer``, which is documented and implemented here:
https://github.com/jeremylong/DependencyCheck/blob/v4.0.0/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java#L97

I think the same exclusion logic should be applied to modules found under a ``bower_components`` directory, for the same reasons (ie., avoiding scan of child modules).

## Description of Change

Auto-exclude files with path matching ``.../bower_components/...``, just like ``.../node_modules/...`` is already excluded.

## Have test cases been added to cover the new functionality?

*no*

Manual testing was done on a project which was still using Bower though.  And the code is simple enough...
