### PR TITLE
efficiency tweaks WIP

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -143,6 +143,10 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
     </build>
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.vdurmont</groupId>
             <artifactId>semver4j</artifactId>
         </dependency>

--- a/core/src/main/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgent.java
+++ b/core/src/main/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgent.java
@@ -17,10 +17,6 @@
  */
 package org.owasp.dependencycheck.agent;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import javax.annotation.concurrent.NotThreadSafe;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
 import org.owasp.dependencycheck.data.update.exception.UpdateException;
@@ -34,6 +30,12 @@ import org.owasp.dependencycheck.reporting.ReportGenerator;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * This class provides a way to easily conduct a scan solely based on existing
@@ -1032,7 +1034,7 @@ public class DependencyCheckScanAgent {
      * @throws org.owasp.dependencycheck.exception.ScanAgentException thrown if
      * there is an exception executing the scan.
      */
-    private void checkForFailure(Dependency[] dependencies) throws ScanAgentException {
+    private void checkForFailure(Collection<Dependency> dependencies) throws ScanAgentException {
         final StringBuilder ids = new StringBuilder();
         for (Dependency d : dependencies) {
             boolean addName = true;
@@ -1069,7 +1071,7 @@ public class DependencyCheckScanAgent {
      *
      * @param dependencies a list of dependency objects
      */
-    private void showSummary(Dependency[] dependencies) {
+    private void showSummary(Collection<Dependency> dependencies) {
         final StringBuilder summary = new StringBuilder();
         for (Dependency d : dependencies) {
             boolean firstEntry = true;

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractAnalyzer.java
@@ -23,9 +23,10 @@ import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
-import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Base class for analyzers to avoid code duplication of prepare and close as

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractDependencyComparingAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractDependencyComparingAnalyzer.java
@@ -17,14 +17,16 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.util.HashSet;
-import java.util.Set;
-import javax.annotation.concurrent.ThreadSafe;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * <p>
@@ -91,15 +93,15 @@ public abstract class AbstractDependencyComparingAnalyzer extends AbstractAnalyz
             analyzed = true;
             final Set<Dependency> dependenciesToRemove = new HashSet<>();
 
-            final Dependency[] dependencies = engine.getDependencies();
-            if (dependencies.length < 2) {
+            final List<Dependency> dependencies = engine.getDependencies();
+            if (dependencies.size() < 2) {
                 return;
             }
-            for (int x = 0; x < dependencies.length - 1; x++) {
-                final Dependency dependency = dependencies[x];
+            for (int x = 0; x < dependencies.size() - 1; x++) {
+                final Dependency dependency = dependencies.get(x);
                 if (!dependenciesToRemove.contains(dependency)) {
-                    for (int y = x + 1; y < dependencies.length; y++) {
-                        final Dependency nextDependency = dependencies[y];
+                    for (int y = x + 1; y < dependencies.size(); y++) {
+                        final Dependency nextDependency = dependencies.get(y);
                         if (evaluateDependencies(dependency, nextDependency, dependenciesToRemove)) {
                             break;
                         }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
@@ -17,20 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.concurrent.ThreadSafe;
-
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
@@ -43,7 +29,6 @@ import org.apache.commons.compress.compressors.bzip2.BZip2Utils;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipUtils;
 import org.apache.commons.compress.utils.IOUtils;
-
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.analyzer.exception.ArchiveExtractionException;
@@ -52,9 +37,22 @@ import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.owasp.dependencycheck.utils.FileUtils;
 import org.owasp.dependencycheck.utils.Settings;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * <p>
@@ -250,7 +248,7 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
         extractFiles(f, tmpDir, engine);
 
         //make a copy
-        final List<Dependency> dependencySet = findMoreDependencies(engine, tmpDir);
+        final Collection<Dependency> dependencySet = findMoreDependencies(engine, tmpDir);
 
         if (dependencySet != null && !dependencySet.isEmpty()) {
             for (Dependency d : dependencySet) {
@@ -318,7 +316,7 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
                 dependency.setSha1sum("");
                 dependency.setSha256sum("");
                 org.apache.commons.io.FileUtils.copyFile(dependency.getActualFile(), tmpLoc);
-                final List<Dependency> dependencySet = findMoreDependencies(engine, tmpLoc);
+                final Collection<Dependency> dependencySet = findMoreDependencies(engine, tmpLoc);
                 if (dependencySet != null && !dependencySet.isEmpty()) {
                     for (Dependency d : dependencySet) {
                         //fix the dependency's display name and path
@@ -352,7 +350,7 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
      * @param file target of scanning
      * @return any dependencies that weren't known to the engine before
      */
-    private static List<Dependency> findMoreDependencies(Engine engine, File file) {
+    private static Collection<Dependency> findMoreDependencies(Engine engine, File file) {
         return engine.scan(file);
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
@@ -17,19 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.FileFilter;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import javax.annotation.concurrent.ThreadSafe;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
@@ -41,6 +28,21 @@ import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.FileFilter;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * This analyzer attempts to remove some well known false positives -
@@ -483,7 +485,7 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
             String parentPath = dependency.getFilePath().toLowerCase();
             if (parentPath.contains(".jar")) {
                 parentPath = parentPath.substring(0, parentPath.indexOf(".jar") + 4);
-                final Dependency[] dependencies = engine.getDependencies();
+                final Collection<Dependency> dependencies = engine.getDependencies();
                 final Dependency parent = findDependency(parentPath, dependencies);
                 if (parent != null) {
                     boolean remove = false;
@@ -516,7 +518,7 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
      * @param dependencies the array of dependencies to search
      * @return the dependency object for the given path, otherwise null
      */
-    private Dependency findDependency(String dependencyPath, Dependency[] dependencies) {
+    private Dependency findDependency(String dependencyPath, Collection<Dependency> dependencies) {
         for (Dependency d : dependencies) {
             if (d.getFilePath().equalsIgnoreCase(dependencyPath)) {
                 return d;

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -17,35 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
-import java.util.StringTokenizer;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.jar.Attributes;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-import java.util.jar.Manifest;
-import java.util.regex.Pattern;
-import java.util.zip.ZipEntry;
-
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -64,6 +35,36 @@ import org.owasp.dependencycheck.xml.pom.Model;
 import org.owasp.dependencycheck.xml.pom.PomUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
 
 /**
  * Used to load a JAR file and collect information that can be used to determine
@@ -320,7 +321,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
      * @return whether or not the given dependencies contain a dependency with
      * the given filename
      */
-    private boolean hasDependencyWithFilename(final Dependency[] dependencies, final String fileName) {
+    private boolean hasDependencyWithFilename(final Collection<Dependency> dependencies, final String fileName) {
         for (final Dependency dependency : dependencies) {
             if (Paths.get(dependency.getActualFilePath()).getFileName().toString().equalsIgnoreCase(fileName)) {
                 return true;

--- a/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
+++ b/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
@@ -17,24 +17,9 @@
  */
 package org.owasp.dependencycheck.reporting;
 
-import java.util.List;
-
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
-import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
-import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.commons.text.WordUtils;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
@@ -52,6 +37,22 @@ import org.owasp.dependencycheck.utils.FileUtils;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * The ReportGenerator is used to, as the name implies, generate reports.
@@ -114,16 +115,15 @@ public class ReportGenerator {
 
     /**
      * Constructs a new ReportGenerator.
-     *
-     * @param applicationName the application name being analyzed
+     *  @param applicationName the application name being analyzed
      * @param dependencies the list of dependencies
      * @param analyzers the list of analyzers used
      * @param properties the database properties (containing timestamps of the
-     * NVD CVE data)
+* NVD CVE data)
      * @param settings a reference to the database settings
      */
-    public ReportGenerator(String applicationName, List<Dependency> dependencies, List<Analyzer> analyzers,
-            DatabaseProperties properties, Settings settings) {
+    public ReportGenerator(String applicationName, Collection<Dependency> dependencies, List<Analyzer> analyzers,
+                           DatabaseProperties properties, Settings settings) {
         this.settings = settings;
         velocityEngine = createVelocityEngine();
         velocityEngine.init();
@@ -132,20 +132,19 @@ public class ReportGenerator {
 
     /**
      * Constructs a new ReportGenerator.
-     *
-     * @param applicationName the application name being analyzed
+     *  @param applicationName the application name being analyzed
      * @param groupID the group id of the project being analyzed
      * @param artifactID the application id of the project being analyzed
      * @param version the application version of the project being analyzed
      * @param dependencies the list of dependencies
      * @param analyzers the list of analyzers used
      * @param properties the database properties (containing timestamps of the
-     * NVD CVE data)
+* NVD CVE data)
      * @param settings a reference to the database settings
      */
     //CSOFF: ParameterNumber
     public ReportGenerator(String applicationName, String groupID, String artifactID, String version,
-            List<Dependency> dependencies, List<Analyzer> analyzers, DatabaseProperties properties, Settings settings) {
+                           Collection<Dependency> dependencies, List<Analyzer> analyzers, DatabaseProperties properties, Settings settings) {
         this(applicationName, dependencies, analyzers, properties, settings);
         if (version != null) {
             context.put("applicationVersion", version);
@@ -182,8 +181,8 @@ public class ReportGenerator {
      * NVD CVE data)
      * @return the velocity context
      */
-    private VelocityContext createContext(String applicationName, List<Dependency> dependencies,
-            List<Analyzer> analyzers, DatabaseProperties properties) {
+    private VelocityContext createContext(String applicationName, Collection<Dependency> dependencies,
+                                          List<Analyzer> analyzers, DatabaseProperties properties) {
         final DateTime dt = new DateTime();
         final DateTimeFormatter dateFormat = DateTimeFormat.forPattern("MMM d, yyyy 'at' HH:mm:ss z");
         final DateTimeFormatter dateFormatXML = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");

--- a/core/src/test/java/org/owasp/dependencycheck/EngineIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/EngineIT.java
@@ -17,18 +17,19 @@
  */
 package org.owasp.dependencycheck;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
-
 import org.junit.Test;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
 import org.owasp.dependencycheck.exception.ExceptionCollection;
 import org.owasp.dependencycheck.exception.ReportException;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
-import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
 
 /**
  *
@@ -51,7 +52,7 @@ public class EngineIT extends BaseDBTestCase {
         getSettings().setBoolean(Settings.KEYS.AUTO_UPDATE, false);
         try (Engine instance = new Engine(getSettings())) {
             instance.scan(testClasses);
-            assertTrue(instance.getDependencies().length > 0);
+            assertTrue(instance.getDependencies().size() > 0);
             try {
                 instance.analyzeDependencies();
             } catch (ExceptionCollection ex) {

--- a/core/src/test/java/org/owasp/dependencycheck/EngineModeIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/EngineModeIT.java
@@ -1,29 +1,28 @@
 package org.owasp.dependencycheck;
 
-import org.junit.Before;
 import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 import org.owasp.dependencycheck.analyzer.AnalysisPhase;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.EvidenceType;
+import org.owasp.dependencycheck.utils.FileUtils;
 import org.owasp.dependencycheck.utils.Settings;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import org.junit.Assume;
-import org.owasp.dependencycheck.dependency.EvidenceType;
-import org.owasp.dependencycheck.utils.FileUtils;
+import static org.junit.Assert.*;
 
 /**
  * @author Mark Rekveld
@@ -65,7 +64,7 @@ public class EngineModeIT extends BaseTest {
 
     @Test
     public void testEvidenceCollectionAndEvidenceProcessingModes() throws Exception {
-        Dependency[] dependencies;
+        List<Dependency> dependencies;
         try (Engine engine = new Engine(Engine.Mode.EVIDENCE_COLLECTION, getSettings())) {
             engine.openDatabase(); //does nothing in the current mode
             assertDatabase(false);
@@ -79,8 +78,8 @@ public class EngineModeIT extends BaseTest {
             engine.scan(file);
             engine.analyzeDependencies();
             dependencies = engine.getDependencies();
-            assertThat(dependencies.length, is(1));
-            Dependency dependency = dependencies[0];
+            assertThat(dependencies.size(), is(1));
+            Dependency dependency = dependencies.get(0);
             assertTrue(dependency.getEvidence(EvidenceType.VENDOR).toString().toLowerCase().contains("apache"));
             assertTrue(dependency.getVendorWeightings().contains("apache"));
             assertTrue(dependency.getVulnerabilities().isEmpty());
@@ -95,9 +94,9 @@ public class EngineModeIT extends BaseTest {
             for (AnalysisPhase phase : Engine.Mode.EVIDENCE_COLLECTION.getPhases()) {
                 assertThat(engine.getAnalyzers(phase), is(nullValue()));
             }
-            engine.addDependency(dependencies[0]);
+            engine.addDependency(dependencies.get(0));
             engine.analyzeDependencies();
-            Dependency dependency = dependencies[0];
+            Dependency dependency = dependencies.get(0);
             assertFalse(dependency.getVulnerabilities().isEmpty());
         }
     }
@@ -113,9 +112,9 @@ public class EngineModeIT extends BaseTest {
             File file = BaseTest.getResourceAsFile(this, "struts2-core-2.1.2.jar");
             engine.scan(file);
             engine.analyzeDependencies();
-            Dependency[] dependencies = engine.getDependencies();
-            assertThat(dependencies.length, is(1));
-            Dependency dependency = dependencies[0];
+            List<Dependency> dependencies = engine.getDependencies();
+            assertThat(dependencies.size(), is(1));
+            Dependency dependency = dependencies.get(0);
             assertTrue(dependency.getEvidence(EvidenceType.VENDOR).toString().toLowerCase().contains("apache"));
             assertTrue(dependency.getVendorWeightings().contains("apache"));
             assertFalse(dependency.getVulnerabilities().isEmpty());

--- a/core/src/test/java/org/owasp/dependencycheck/EngineTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/EngineTest.java
@@ -60,12 +60,12 @@ public class EngineTest extends BaseDBTestCase {
             Dependency dwr = instance.scanFile(file);
             file = BaseTest.getResourceAsFile(this, "org.mortbay.jmx.jar");
             instance.scanFile(file);
-            assertEquals(2, instance.getDependencies().length);
+            assertEquals(2, instance.getDependencies().size());
 
             file = BaseTest.getResourceAsFile(this, "dwr.jar");
             Dependency secondDwr = instance.scanFile(file);
 
-            assertEquals(2, instance.getDependencies().length);
+            assertEquals(2, instance.getDependencies().size());
             assertEquals(dwr, secondDwr);
         }
     }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzerIT.java
@@ -17,17 +17,19 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.util.HashSet;
-import java.util.Set;
-import static org.junit.Assert.*;
 import org.junit.Test;
+import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
-import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.Settings;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
 
 /**
  *
@@ -137,10 +139,9 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
             File file = BaseTest.getResourceAsFile(this, "daytrader-ear-2.1.7.ear");
             Dependency dependency = new Dependency(file);
 
-            int initial_size = engine.getDependencies().length;
+            int initial_size = engine.getDependencies().size();
             instance.analyze(dependency, engine);
-            int ending_size = engine.getDependencies().length;
-            assertTrue(initial_size < ending_size);
+            assertTrue(initial_size < engine.getDependencies().size());
         } finally {
             instance.close();
         }
@@ -163,10 +164,9 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
             getSettings().setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
             getSettings().setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
             
-            int initial_size = engine.getDependencies().length;
+            int initial_size = engine.getDependencies().size();
             instance.analyze(dependency, engine);
-            int ending_size = engine.getDependencies().length;
-            assertTrue(initial_size < ending_size);
+            assertTrue(initial_size < engine.getDependencies().size());
 
         } finally {
             instance.close();
@@ -193,10 +193,9 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
             getSettings().setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
             getSettings().setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
             
-            int initial_size = engine.getDependencies().length;
+            int initial_size = engine.getDependencies().size();
             instance.analyze(dependency, engine);
-            int ending_size = engine.getDependencies().length;
-            assertTrue(initial_size < ending_size);
+            assertTrue(initial_size < engine.getDependencies().size());
         } finally {
             instance.close();
         }
@@ -220,12 +219,11 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
             getSettings().setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
             getSettings().setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
             
-            int initial_size = engine.getDependencies().length;
+            int initial_size = engine.getDependencies().size();
             //instance.analyze(dependency, engine);
             engine.scan(file);
             engine.analyzeDependencies();
-            int ending_size = engine.getDependencies().length;
-            assertTrue(initial_size < ending_size);
+            assertTrue(initial_size < engine.getDependencies().size());
 
         } finally {
             instance.close();
@@ -246,11 +244,10 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
             getSettings().setBoolean(Settings.KEYS.AUTO_UPDATE, false);
             getSettings().setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
             getSettings().setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
-            int initial_size = engine.getDependencies().length;
+            int initial_size = engine.getDependencies().size();
             engine.scan(file);
             engine.analyzeDependencies();
-            int ending_size = engine.getDependencies().length;
-            assertTrue(initial_size < ending_size);
+            assertTrue(initial_size < engine.getDependencies().size());
         } finally {
             instance.close();
         }
@@ -272,11 +269,10 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
             getSettings().setBoolean(Settings.KEYS.AUTO_UPDATE, false);
             getSettings().setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
             getSettings().setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
-            int initial_size = engine.getDependencies().length;
+            int initial_size = engine.getDependencies().size();
             engine.scan(file);
             engine.analyzeDependencies();
-            int ending_size = engine.getDependencies().length;
-            assertTrue(initial_size < ending_size);
+            assertTrue(initial_size < engine.getDependencies().size());
 
         } finally {
             instance.close();
@@ -297,11 +293,10 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
             getSettings().setBoolean(Settings.KEYS.AUTO_UPDATE, false);
             getSettings().setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
             getSettings().setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
-            int initial_size = engine.getDependencies().length;
+            int initial_size = engine.getDependencies().size();
             engine.scan(file);
             engine.analyzeDependencies();
-            int ending_size = engine.getDependencies().length;
-            assertTrue(initial_size < ending_size);
+            assertTrue(initial_size < engine.getDependencies().size());
         } finally {
             instance.close();
         }
@@ -323,7 +318,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
             getSettings().setBoolean(Settings.KEYS.AUTO_UPDATE, false);
             getSettings().setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
             getSettings().setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
-            int initial_size = engine.getDependencies().length;
+            int initial_size = engine.getDependencies().size();
 //            boolean failed = false;
 //            try {
             instance.analyze(dependency, engine);
@@ -331,8 +326,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
 //                failed = true;
 //            }
 //            assertTrue(failed);
-            int ending_size = engine.getDependencies().length;
-            assertEquals(initial_size, ending_size);
+            assertEquals(initial_size, engine.getDependencies().size());
         } finally {
             instance.close();
         }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzerTest.java
@@ -26,18 +26,15 @@ import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
 import org.owasp.dependencycheck.dependency.Dependency;
-
-import java.io.File;
-import java.util.regex.Pattern;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import org.owasp.dependencycheck.dependency.Evidence;
 import org.owasp.dependencycheck.dependency.EvidenceType;
+
+import java.io.File;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for CmakeAnalyzer.
@@ -173,9 +170,9 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
             assertVersionEvidence(result, "55.18.102");
             assertFalse("ALIASOF_ prefix shouldn't be present.",
                     Pattern.compile("\\bALIASOF_\\w+").matcher(result.getEvidence(EvidenceType.PRODUCT).toString()).find());
-            final Dependency[] dependencies = engine.getDependencies();
-            assertEquals("Number of additional dependencies should be 4.", 4, dependencies.length);
-            final Dependency last = dependencies[3];
+            final List<Dependency> dependencies = engine.getDependencies();
+            assertEquals("Number of additional dependencies should be 4.", 4, dependencies.size());
+            final Dependency last = dependencies.get(3);
             assertProductEvidence(last, "libavresample");
             assertVersionEvidence(last, "1.0.1");
         }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
@@ -27,13 +27,9 @@ import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 
 import java.io.File;
-import org.apache.commons.lang3.ArrayUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for NodePackageAnalyzer.
@@ -104,9 +100,9 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
             engine.addDependency(result);
             analyzer.analyze(result, engine);
             //make sure the redundant composer.lock is removed
-            assertFalse(ArrayUtils.contains(engine.getDependencies(), result));
-            assertEquals(30, engine.getDependencies().length);
-            Dependency d = engine.getDependencies()[0];
+            assertFalse(engine.getDependencies().contains(result));
+            assertEquals(30, engine.getDependencies().size());
+            Dependency d = engine.getDependencies().get(0);
             assertEquals("classpreloader", d.getName());
             assertEquals("2.0.0", d.getVersion());
             assertThat(d.getDisplayFileName(), equalTo("classpreloader:2.0.0"));

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzerTest.java
@@ -75,7 +75,7 @@ public class MSBuildProjectAnalyzerTest extends BaseTest {
             analyzer.setEnabled(true);
             analyzer.analyze(toScan, engine);
 
-            assertEquals("3 dependencies should be found", 3, engine.getDependencies().length);
+            assertEquals("3 dependencies should be found", 3, engine.getDependencies().size());
 
             int foundCount = 0;
 

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/NodeAuditAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/NodeAuditAnalyzerTest.java
@@ -1,18 +1,20 @@
 package org.owasp.dependencycheck.analyzer;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
-import java.io.File;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import org.junit.Assume;
-import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
+
+import java.io.File;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 public class NodeAuditAnalyzerTest extends BaseTest {
 
@@ -41,7 +43,7 @@ public class NodeAuditAnalyzerTest extends BaseTest {
             final Dependency toScan = new Dependency(BaseTest.getResourceAsFile(this, "nodeaudit/package-lock.json"));
             analyzer.analyze(toScan, engine);
             boolean found = false;
-            assertTrue("Mpre then 1 dependency should be identified", 1 < engine.getDependencies().length);
+            assertTrue("Mpre then 1 dependency should be identified", 1 < engine.getDependencies().size());
             for (Dependency result : engine.getDependencies()) {
                 if ("package-lock.json?uglify-js".equals(result.getFileName())) {
                     found = true;
@@ -83,7 +85,7 @@ public class NodeAuditAnalyzerTest extends BaseTest {
             final Dependency toScan = new Dependency(BaseTest.getResourceAsFile(this, "nodejs/node_modules/dns-sync/package.json"));
             engine.addDependency(toScan);
             analyzer.analyze(toScan, engine);
-            assertEquals("No dependencies should exist", 0, engine.getDependencies().length);
+            assertEquals("No dependencies should exist", 0, engine.getDependencies().size());
         }
     }
 

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzerTest.java
@@ -18,22 +18,22 @@
 package org.owasp.dependencycheck.analyzer;
 
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
-
-import java.io.File;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import org.junit.Assume;
-import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
+
+import java.io.File;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for NodePackageAnalyzer.
@@ -123,7 +123,7 @@ public class NodePackageAnalyzerTest extends BaseTest {
         engine.addDependency(toCombine);
         analyzer.analyze(toScan, engine);
         analyzer.analyze(toCombine, engine);
-        assertEquals("Expected 6 dependency", engine.getDependencies().length, 6);
+        assertEquals("Expected 6 dependency [" + engine.getDependencies().toString() +"]", engine.getDependencies().size(), 6);
         Dependency result = null;
         for (Dependency dep : engine.getDependencies()) {
             if ("dns-sync".equals(dep.getName())) {
@@ -156,12 +156,13 @@ public class NodePackageAnalyzerTest extends BaseTest {
                 "nodejs/npm-shrinkwrap.json"));
         engine.addDependency(packageJson);
         engine.addDependency(shrinkwrap);
-        assertEquals(2, engine.getDependencies().length);
+        List<Dependency> dependencies = engine.getDependencies();
+        assertEquals(2, dependencies.size());
         analyzer.analyze(packageJson, engine);
-        assertEquals(1, engine.getDependencies().length); //package-lock was removed without analysis
-        assertTrue(shrinkwrap.equals(engine.getDependencies()[0]));
+        assertEquals(1, dependencies.size()); //package-lock was removed without analysis
+        assertTrue(shrinkwrap.equals(dependencies.get(0)));
         analyzer.analyze(shrinkwrap, engine);
-        assertEquals(6, engine.getDependencies().length); //shrinkwrap was removed with analysis adding 6 dependency
-        assertFalse(shrinkwrap.equals(engine.getDependencies()[0]));
+        assertEquals(6, dependencies.size()); //shrinkwrap was removed with analysis adding 6 dependency
+        assertFalse(shrinkwrap.equals(dependencies.get(0)));
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzerFilters.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzerFilters.java
@@ -20,18 +20,16 @@ package org.owasp.dependencycheck.analyzer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
-import org.owasp.dependencycheck.dependency.Dependency;
-import org.owasp.dependencycheck.dependency.Evidence;
-import org.owasp.dependencycheck.dependency.EvidenceType;
-import org.owasp.dependencycheck.dependency.Vulnerability;
-import org.owasp.dependencycheck.utils.Settings;
-import java.io.File;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.data.update.RetireJSDataSource;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.utils.Settings;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
 
 public class RetireJsAnalyzerFilters extends BaseDBTestCase {
 
@@ -75,24 +73,24 @@ public class RetireJsAnalyzerFilters extends BaseDBTestCase {
         File file = BaseTest.getResourceAsFile(this, "javascript/jquery-1.6.2.js");
         Dependency dependency = new Dependency(file);
         engine.addDependency(dependency);
-        assertEquals(1, engine.getDependencies().length);
+        assertEquals(1, engine.getDependencies().size());
         analyzer.analyze(dependency, engine);
-        assertEquals(0, engine.getDependencies().length);
+        assertEquals(0, engine.getDependencies().size());
         
         //remove non-vulnerable
         file = BaseTest.getResourceAsFile(this, "javascript/custom.js");
         dependency = new Dependency(file);
         engine.addDependency(dependency);
-        assertEquals(1, engine.getDependencies().length);
+        assertEquals(1, engine.getDependencies().size());
         analyzer.analyze(dependency, engine);
-        assertEquals(0, engine.getDependencies().length);
+        assertEquals(0, engine.getDependencies().size());
         
         //kept because it is does not match the filter and is vulnerable
         file = BaseTest.getResourceAsFile(this, "javascript/ember.js");
         dependency = new Dependency(file);
         engine.addDependency(dependency);
-        assertEquals(1, engine.getDependencies().length);
+        assertEquals(1, engine.getDependencies().size());
         analyzer.analyze(dependency, engine);
-        assertEquals(0, engine.getDependencies().length);
+        assertEquals(0, engine.getDependencies().size());
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzerIT.java
@@ -17,12 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import edu.emory.mathcs.backport.java.util.Arrays;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -32,20 +26,21 @@ import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
+import org.owasp.dependencycheck.data.update.exception.UpdateException;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.dependency.Vulnerability;
 import org.owasp.dependencycheck.exception.ExceptionCollection;
+import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.owasp.dependencycheck.data.update.exception.UpdateException;
-import org.owasp.dependencycheck.exception.InitializationException;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import org.owasp.dependencycheck.dependency.EvidenceType;
+
+import java.io.File;
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for {@link RubyBundleAuditAnalyzer}.
@@ -123,8 +118,8 @@ public class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
             final String resource = "ruby/vulnerable/gems/rails-4.1.15/Gemfile.lock";
             final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, resource));
             analyzer.analyze(result, engine);
-            final Dependency[] dependencies = engine.getDependencies();
-            final int size = dependencies.length;
+            final Collection<Dependency> dependencies = engine.getDependencies();
+            final int size = dependencies.size();
             assertTrue(size >= 1);
             boolean found = false;
             for (Dependency dependency : dependencies) {
@@ -156,7 +151,7 @@ public class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
             final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                     "ruby/vulnerable/gems/sinatra/Gemfile.lock"));
             analyzer.analyze(result, engine);
-            Dependency dependency = engine.getDependencies()[0];
+            Dependency dependency = engine.getDependencies().get(0);
             Vulnerability vulnerability = dependency.getVulnerabilities(true).iterator().next();
             assertEquals(vulnerability.getCvssScore(), 5.0f, 0.0);
 
@@ -209,8 +204,7 @@ public class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
                 Assume.assumeNoException("Exception setting up RubyBundleAuditAnalyzer; bundle audit may not be installed, or property \"analyzer.bundle.audit.path\" may not be set.", ex);
                 return;
             }
-            Dependency[] dependencies = engine.getDependencies();
-            LOGGER.info("{} dependencies found.", dependencies.length);
+            LOGGER.info("{} dependencies found.", engine.getDependencies().size());
         }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
@@ -7,14 +7,13 @@ import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.CoreMatchers.equalTo;
+import org.owasp.dependencycheck.dependency.EvidenceType;
 
 import java.io.File;
-import org.owasp.dependencycheck.dependency.EvidenceType;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for CocoaPodsAnalyzer.
@@ -111,25 +110,26 @@ public class SwiftAnalyzersTest extends BaseTest {
                 "swift/cocoapods/Podfile.lock"));
         podsAnalyzer.analyze(result, engine);
 
-        assertThat(engine.getDependencies().length, equalTo(9));
-        assertThat(engine.getDependencies()[0].getName(), equalTo("Bolts"));
-        assertThat(engine.getDependencies()[0].getVersion(), equalTo("1.9.0"));
-        assertThat(engine.getDependencies()[1].getName(), equalTo("Bolts/AppLinks"));
-        assertThat(engine.getDependencies()[1].getVersion(), equalTo("1.9.0"));
-        assertThat(engine.getDependencies()[2].getName(), equalTo("Bolts/Tasks"));
-        assertThat(engine.getDependencies()[2].getVersion(), equalTo("1.9.0"));
-        assertThat(engine.getDependencies()[3].getName(), equalTo("FBSDKCoreKit"));
-        assertThat(engine.getDependencies()[3].getVersion(), equalTo("4.33.0"));
-        assertThat(engine.getDependencies()[4].getName(), equalTo("FBSDKLoginKit"));
-        assertThat(engine.getDependencies()[4].getVersion(), equalTo("4.33.0"));
-        assertThat(engine.getDependencies()[5].getName(), equalTo("FirebaseCore"));
-        assertThat(engine.getDependencies()[5].getVersion(), equalTo("5.0.1"));
-        assertThat(engine.getDependencies()[6].getName(), equalTo("GoogleToolboxForMac/Defines"));
-        assertThat(engine.getDependencies()[6].getVersion(), equalTo("2.1.4"));
-        assertThat(engine.getDependencies()[7].getName(), equalTo("GoogleToolboxForMac/NSData+zlib"));
-        assertThat(engine.getDependencies()[7].getVersion(), equalTo("2.1.4"));
-        assertThat(engine.getDependencies()[8].getName(), equalTo("OCMock"));
-        assertThat(engine.getDependencies()[8].getVersion(), equalTo("3.4.1"));
+        assertThat(engine.getDependencies().size(), equalTo(9));
+        final List<Dependency> dependencies = engine.getDependencies();
+        assertThat(dependencies.get(0).getName(), equalTo("Bolts"));
+        assertThat(dependencies.get(0).getVersion(), equalTo("1.9.0"));
+        assertThat(dependencies.get(1).getName(), equalTo("Bolts/AppLinks"));
+        assertThat(dependencies.get(1).getVersion(), equalTo("1.9.0"));
+        assertThat(dependencies.get(2).getName(), equalTo("Bolts/Tasks"));
+        assertThat(dependencies.get(2).getVersion(), equalTo("1.9.0"));
+        assertThat(dependencies.get(3).getName(), equalTo("FBSDKCoreKit"));
+        assertThat(dependencies.get(3).getVersion(), equalTo("4.33.0"));
+        assertThat(dependencies.get(4).getName(), equalTo("FBSDKLoginKit"));
+        assertThat(dependencies.get(4).getVersion(), equalTo("4.33.0"));
+        assertThat(dependencies.get(5).getName(), equalTo("FirebaseCore"));
+        assertThat(dependencies.get(5).getVersion(), equalTo("5.0.1"));
+        assertThat(dependencies.get(6).getName(), equalTo("GoogleToolboxForMac/Defines"));
+        assertThat(dependencies.get(6).getVersion(), equalTo("2.1.4"));
+        assertThat(dependencies.get(7).getName(), equalTo("GoogleToolboxForMac/NSData+zlib"));
+        assertThat(dependencies.get(7).getVersion(), equalTo("2.1.4"));
+        assertThat(dependencies.get(8).getName(), equalTo("OCMock"));
+        assertThat(dependencies.get(8).getVersion(), equalTo("3.4.1"));
     }
 
     @Test

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -19,6 +19,8 @@ package org.owasp.dependencycheck.maven;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
+import org.apache.maven.artifact.resolver.filter.ExcludesArtifactFilter;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.execution.MavenSession;
@@ -35,15 +37,16 @@ import org.apache.maven.reporting.MavenReport;
 import org.apache.maven.reporting.MavenReportException;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Server;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.shared.dependency.graph.traversal.CollectingDependencyNodeVisitor;
+import org.apache.maven.shared.model.fileset.FileSet;
+import org.apache.maven.shared.model.fileset.util.FileSetManager;
 import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
 import org.apache.maven.shared.transfer.artifact.TransferUtils;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
-import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
-import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
-import org.apache.maven.shared.dependency.graph.DependencyNode;
-import org.apache.maven.shared.model.fileset.FileSet;
-import org.apache.maven.shared.model.fileset.util.FileSetManager;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.JarAnalyzer;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
@@ -69,12 +72,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
-import org.apache.maven.artifact.resolver.filter.ExcludesArtifactFilter;
-import org.apache.maven.shared.dependency.graph.traversal.CollectingDependencyNodeVisitor;
 
 /**
  * @author Jeremy Long
@@ -1718,7 +1719,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * @throws MojoFailureException thrown if a CVSS score is found that is
      * higher then the threshold set
      */
-    protected void checkForFailure(Dependency[] dependencies) throws MojoFailureException {
+    protected void checkForFailure(Collection<Dependency> dependencies) throws MojoFailureException {
         final StringBuilder ids = new StringBuilder();
         for (Dependency d : dependencies) {
             boolean addName = true;
@@ -1756,11 +1757,10 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     /**
      * Generates a warning message listing a summary of dependencies and their
      * associated CPE and CVE entries.
-     *
-     * @param mp the Maven project for which the summary is shown
+     *  @param mp the Maven project for which the summary is shown
      * @param dependencies a list of dependency objects
      */
-    protected void showSummary(MavenProject mp, Dependency[] dependencies) {
+    protected void showSummary(MavenProject mp, Collection<Dependency> dependencies) {
         if (showSummary) {
             final StringBuilder summary = new StringBuilder();
             for (Dependency d : dependencies) {

--- a/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
+++ b/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
@@ -17,13 +17,6 @@
  */
 package org.owasp.dependencycheck.maven;
 
-import java.io.File;
-import java.net.URISyntaxException;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Tested;
@@ -32,8 +25,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.testing.stubs.ArtifactStub;
 import org.apache.maven.project.MavenProject;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import org.junit.Assume;
 import org.junit.Test;
 import org.owasp.dependencycheck.Engine;
@@ -41,6 +32,16 @@ import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
 import org.owasp.dependencycheck.exception.ExceptionCollection;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.*;
 
 /**
  *
@@ -100,14 +101,14 @@ public class BaseDependencyCheckMojoTest extends BaseTest {
             try (Engine engine = new Engine(getSettings())) {
                 getSettings().setBoolean(Settings.KEYS.AUTO_UPDATE, autoUpdate);
 
-                assertTrue(engine.getDependencies().length == 0);
+                assertTrue(engine.getDependencies().size() == 0);
                 BaseDependencyCheckMojoImpl instance = new BaseDependencyCheckMojoImpl();
                 try { //the mock above fails under some JDKs
                     instance.scanArtifacts(project, engine);
                 } catch (NullPointerException ex) {
                     Assume.assumeNoException(ex);
                 }
-                assertFalse(engine.getDependencies().length == 0);
+                assertFalse(engine.getDependencies().size() == 0);
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,7 @@ Copyright (c) 2012 - Jeremy Long
         <gmavenplus-plugin.version>1.5</gmavenplus-plugin.version>
         <com.h3xstream.retirejs.core.version>3.0.1</com.h3xstream.retirejs.core.version>
         <com.google.guava.version>27.0.1-jre</com.google.guava.version>
+        <jackson.version>2.4.5</jackson.version>
         <surefireArgLine/>
     </properties>
     <distributionManagement>
@@ -815,6 +816,11 @@ Copyright (c) 2012 - Jeremy Long
     </reporting>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.vdurmont</groupId>
                 <artifactId>semver4j</artifactId>


### PR DESCRIPTION

## Fixes Issue #

partial fix for jeremylong/dependency-check-gradle#100

## Description of Change

Caches some intermediate results and updates loops to more efficient Java 8 Streams and Lambdas.  Lays some of the groundwork to reduce duplicated effort within a single job (currently theis mostly affects Aggregate). More work is required to reduce effort across multiple subprojects for analyze to realize efficiency gains.

## Have test cases been added to cover the new functionality?

N/A