### PR TITLE
False negative fix

### DIFF
--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>4.0.1</version>
+        <version>4.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>dependency-check-ant</artifactId>

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -21,7 +21,7 @@ Copyright (c) 2017 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>4.0.1</version>
+        <version>4.0.2-SNAPSHOT</version>
     </parent>
     <groupId>org.owasp</groupId>
     <artifactId>dependency-check-plugin</artifactId>

--- a/build-reporting/pom.xml
+++ b/build-reporting/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2017 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>4.0.1</version>
+        <version>4.0.2-SNAPSHOT</version>
     </parent>
     <name>Dependency-Check Build-Reporting</name>
     <artifactId>build-reporting</artifactId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>4.0.1</version>
+        <version>4.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>dependency-check-cli</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>4.0.1</version>
+        <version>4.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>dependency-check-core</artifactId>

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -564,18 +564,8 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
             groupid = parentGroupId;
         }
 
-        final String originalGroupID = groupid;
-        if (groupid != null && (groupid.startsWith("org.") || groupid.startsWith("com."))) {
-            groupid = groupid.substring(4);
-        }
-
         if ((artifactid == null || artifactid.isEmpty()) && parentArtifactId != null && !parentArtifactId.isEmpty()) {
             artifactid = parentArtifactId;
-        }
-
-        final String originalArtifactID = artifactid;
-        if (artifactid != null && (artifactid.startsWith("org.") || artifactid.startsWith("com."))) {
-            artifactid = artifactid.substring(4);
         }
 
         if ((version == null || version.isEmpty()) && parentVersion != null && !parentVersion.isEmpty()) {
@@ -625,7 +615,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
         }
 
         if (addAsIdentifier) {
-            dependency.addIdentifier("maven", String.format("%s:%s:%s", originalGroupID, originalArtifactID, version), null, Confidence.HIGH);
+            dependency.addIdentifier("maven", String.format("%s:%s:%s", groupid, artifactid, version), null, Confidence.HIGH);
         }
 
         // org name

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>4.0.1</version>
+        <version>4.0.2-SNAPSHOT</version>
     </parent>
     <artifactId>dependency-check-maven</artifactId>
     <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 - Jeremy Long
 
     <groupId>org.owasp</groupId>
     <artifactId>dependency-check-parent</artifactId>
-    <version>4.0.1</version>
+    <version>4.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>4.0.1</version>
+        <version>4.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>dependency-check-utils</artifactId>


### PR DESCRIPTION
## Resolves reported false negative

JarAnalyzer incorrectly removed the org or com prefix from some evidence that is later used by the hint analyzer - this results in false negatives.

Please see https://groups.google.com/forum/#!topic/dependency-check/8YIc1NkBrdA
