### PR TITLE
Issue 977

### DIFF
--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -115,6 +115,14 @@ public class Check extends Update {
      */
     private String nexusUrl;
     /**
+     * The username to authenticate to the Nexus Server's REST API Endpoint.
+     */
+    private String nexusUser;
+    /**
+     * The password to authenticate to the Nexus Server's REST API Endpoint.
+     */
+    private String nexusPassword;
+    /**
      * Whether or not the defined proxy should be used when connecting to Nexus.
      */
     private Boolean nexusUsesProxy;
@@ -1068,6 +1076,42 @@ public class Check extends Update {
     }
 
     /**
+     * Get the value of nexusUser.
+     *
+     * @return the value of nexusUser
+     */
+    public String getNexusUser() {
+        return nexusUser;
+    }
+
+    /**
+     * Set the value of nexusUser.
+     *
+     * @param nexusUser new value of nexusUser
+     */
+    public void setNexusUser(String nexusUser) {
+        this.nexusUser = nexusUser;
+    }
+
+    /**
+     * Get the value of nexusPassword.
+     *
+     * @return the value of nexusPassword
+     */
+    public String getNexusPassword() {
+        return nexusPassword;
+    }
+
+    /**
+     * Set the value of nexusPassword.
+     *
+     * @param nexusPassword new value of nexusPassword
+     */
+    public void setNexusPassword(String nexusPassword) {
+        this.nexusPassword = nexusPassword;
+    }
+
+    /**
      * Get the value of nexusUsesProxy.
      *
      * @return the value of nexusUsesProxy
@@ -1394,6 +1438,8 @@ public class Check extends Update {
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARCHIVE_ENABLED, archiveAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_ASSEMBLY_ENABLED, assemblyAnalyzerEnabled);
         getSettings().setStringIfNotEmpty(Settings.KEYS.ANALYZER_NEXUS_URL, nexusUrl);
+        getSettings().setStringIfNotEmpty(Settings.KEYS.ANALYZER_NEXUS_USER, nexusUser);
+        getSettings().setStringIfNotEmpty(Settings.KEYS.ANALYZER_NEXUS_PASSWORD, nexusPassword);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_NEXUS_USES_PROXY, nexusUsesProxy);
         getSettings().setStringIfNotEmpty(Settings.KEYS.ADDITIONAL_ZIP_EXTENSIONS, zipExtensions);
         getSettings().setStringIfNotEmpty(Settings.KEYS.ANALYZER_ASSEMBLY_MONO_PATH, pathToMono);

--- a/ant/src/site/markdown/configuration.md
+++ b/ant/src/site/markdown/configuration.md
@@ -71,6 +71,8 @@ jarAnalyzer                         | Sets whether the Jar Analyzer will be used
 centralAnalyzerEnabled              | Sets whether the Central Analyzer will be used. **Disabling this analyzer is not recommended as it could lead to false negatives (e.g. libraries that have vulnerabilities may not be reported correctly).** If this analyzer is being disabled there is a good chance you also want to disable the Nexus Analyzer (see below).                                  | true
 nexusAnalyzerEnabled                | Sets whether Nexus Analyzer will be used (requires Nexus Pro). This analyzer is superceded by the Central Analyzer; however, you can configure this to run against a Nexus Pro installation. | true
 nexusUrl                            | Defines the Nexus web service endpoint (example http://domain.enterprise/nexus/service/local/). If not set the Nexus Analyzer will be disabled. | &nbsp;
+nexusUser                           | The username to authenticate to the Nexus Server's web service end point. If not set the Nexus Analyzer will use an unauthenticated connection. | &nbsp;
+nexusPassword                       | The password to authenticate to the Nexus Server's web service end point. If not set the Nexus Analyzer will use an unauthenticated connection. | &nbsp;
 nexusUsesProxy                      | Whether or not the defined proxy should be used when connecting to Nexus.                                  | true
 artifactoryAnalyzerEnabled          | Sets whether Artifactory analyzer will be used                                                             | false
 artifactoryAnalyzerUrl              | The Artifactory server URL.                                                                                | &nbsp;

--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -398,6 +398,8 @@ public class App {
         final String[] suppressionFiles = cli.getSuppressionFiles();
         final String hintsFile = cli.getHintsFile();
         final String nexusUrl = cli.getNexusUrl();
+        final String nexusUser = cli.getNexusUsername();
+        final String nexusPass = cli.getNexusPassword();
         final String databaseDriverName = cli.getDatabaseDriverName();
         final String databaseDriverPath = cli.getDatabaseDriverPath();
         final String connectionString = cli.getConnectionString();
@@ -492,6 +494,8 @@ public class App {
 
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_PATH, cli.getPathToBundleAudit());
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_NEXUS_URL, nexusUrl);
+        settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_NEXUS_USER, nexusUser);
+        settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_NEXUS_PASSWORD, nexusPass);
         settings.setBoolean(Settings.KEYS.ANALYZER_NEXUS_USES_PROXY, nexusUsesProxy);
         settings.setStringIfNotEmpty(Settings.KEYS.DB_DRIVER_NAME, databaseDriverName);
         settings.setStringIfNotEmpty(Settings.KEYS.DB_DRIVER_PATH, databaseDriverPath);

--- a/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
@@ -365,6 +365,12 @@ public final class CliParser {
         final Option nexusUrl = Option.builder().argName("url").hasArg().longOpt(ARGUMENT.NEXUS_URL)
                 .desc("The url to the Nexus Server's REST API Endpoint (http://domain/nexus/service/local). "
                         + "If not set the Nexus Analyzer will be disabled.").build();
+        final Option nexusUsername = Option.builder().argName("username").hasArg().longOpt(ARGUMENT.NEXUS_USERNAME)
+                .desc("The username to authenticate to the Nexus Server's REST API Endpoint. "
+                        + "If not set the Nexus Analyzer will use an unauthenticated connection.").build();
+        final Option nexusPassword = Option.builder().argName("password").hasArg().longOpt(ARGUMENT.NEXUS_PASSWORD)
+                .desc("The password to authenticate to the Nexus Server's REST API Endpoint. "
+                        + "If not set the Nexus Analyzer will use an unauthenticated connection.").build();
         final Option nexusUsesProxy = Option.builder().argName("true/false").hasArg().longOpt(ARGUMENT.NEXUS_USES_PROXY)
                 .desc("Whether or not the configured proxy should be used when connecting to Nexus.").build();
         final Option additionalZipExtensions = Option.builder().argName("extensions").hasArg()
@@ -501,6 +507,8 @@ public final class CliParser {
                         .argName("url").hasArg(true).build())
                 .addOption(retireJsFilters)
                 .addOption(nexusUrl)
+                .addOption(nexusUsername)
+                .addOption(nexusPassword)
                 .addOption(nexusUsesProxy)
                 .addOption(additionalZipExtensions)
                 .addOption(pathToMono)
@@ -824,6 +832,26 @@ public final class CliParser {
         } else {
             return line.getOptionValue(ARGUMENT.NEXUS_URL);
         }
+    }
+
+    /**
+     * Returns the username to authenticate to the nexus server if one was specified.
+     *
+     * @return the username to authenticate to the nexus server; if none was specified this will
+     * return null;
+     */
+    public String getNexusUsername() {
+        return line.getOptionValue(ARGUMENT.NEXUS_USERNAME);
+    }
+
+    /**
+     * Returns the password to authenticate to the nexus server if one was specified.
+     *
+     * @return the password to authenticate to the nexus server; if none was specified this will
+     * return null;
+     */
+    public String getNexusPassword() {
+        return line.getOptionValue(ARGUMENT.NEXUS_PASSWORD);
     }
 
     /**
@@ -1574,6 +1602,14 @@ public final class CliParser {
          * The URL of the nexus server.
          */
         public static final String NEXUS_URL = "nexus";
+        /**
+         * The username for the nexus server.
+         */
+        public static final String NEXUS_USERNAME = "nexusUser";
+        /**
+         * The password for the nexus server.
+         */
+        public static final String NEXUS_PASSWORD = "nexusPass";
         /**
          * Whether or not the defined proxy should be used when connecting to
          * Nexus.

--- a/cli/src/site/markdown/arguments.md
+++ b/cli/src/site/markdown/arguments.md
@@ -60,6 +60,8 @@ Advanced Options
 |       | \-\-artifactoryApiToken    | \<token\>   | The API token to connect to Artifactory instance, only used if the username or the API key are not defined by artifactoryAnalyzerServerId,artifactoryAnalyzerUsername or artifactoryAnalyzerApiToken | &nbsp; |
 |       | \-\-artifactoryBearerToken | \<token\>   | The bearer token to connect to Artifactory instance                                                        | &nbsp; |
 |       | \-\-nexus              | \<url\>         | The url to the Nexus Server's web service end point (example: http://domain.enterprise/nexus/service/local/). If not set the Nexus Analyzer will be disabled. | &nbsp; |
+|       | \-\-nexusUser          |                 | The username to authenticate to the Nexus Server's web service end point. If not set the Nexus Analyzer will use an unauthenticated connection. | &nbsp; |
+|       | \-\-nexusPass          |                 | The password to authenticate to the Nexus Server's web service end point. If not set the Nexus Analyzer will use an unauthenticated connection. | &nbsp; |
 |       | \-\-nexusUsesProxy     | \<true\|false\> | Whether or not the defined proxy should be used when connecting to Nexus.        | true |
 |       | \-\-disableNuspec      |                 | Sets whether or not the .NET Nuget Nuspec Analyzer will be used.                 | false |
 |       | \-\-disableNugetconf   |                 | Sets whether or not the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used.        | false |

--- a/maven/src/site/markdown/configuration.md
+++ b/maven/src/site/markdown/configuration.md
@@ -51,6 +51,7 @@ jarAnalyzerEnabled            | Sets whether Jar Analyzer will be used.         
 centralAnalyzerEnabled        | Sets whether Central Analyzer will be used. If this analyzer is being disabled there is a good chance you also want to disable the Nexus Analyzer (see below). | true
 nexusAnalyzerEnabled          | Sets whether Nexus Analyzer will be used (requires Nexus Pro). This analyzer is superceded by the Central Analyzer; however, you can configure this to run against a Nexus Pro installation. | true
 nexusUrl                      | Defines the Nexus Server's web service end point (example http://domain.enterprise/service/local/). If not set the Nexus Analyzer will be disabled. | &nbsp;
+nexusServerId                 | The id of a server defined in the settings.xml that configures the credentials (username and password) for a Nexus server's REST API end point. When not specified the communication with the Nexus server's REST API will be unauthenticated. | &nbsp;
 nexusUsesProxy                | Whether or not the defined proxy should be used when connecting to Nexus. | true
 artifactoryAnalyzerEnabled    | Sets whether Artifactory analyzer will be used | false
 artifactoryAnalyzerUrl        | The Artifactory server URL. | &nbsp;

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -367,6 +367,14 @@ public final class Settings {
          */
         public static final String ANALYZER_NEXUS_URL = "analyzer.nexus.url";
         /**
+         * The properties key for the Nexus search credentials username.
+         */
+        public static final String ANALYZER_NEXUS_USER = "analyzer.nexus.username";
+        /**
+         * The properties key for the Nexus search credentials password.
+         */
+        public static final String ANALYZER_NEXUS_PASSWORD = "analyzer.nexus.password";
+        /**
          * The properties key for using the proxy to reach Nexus.
          */
         public static final String ANALYZER_NEXUS_USES_PROXY = "analyzer.nexus.proxy";


### PR DESCRIPTION
## Fixes Issue #977 

## Description of Change
Enable basic authentication against the Nexus REST API to allow use of a private, authentication-protected Nexus instance as the analysis source for Maven artifacts.

## Have test cases been added to cover the new functionality?
No, there is no publicly available protected Nexus instance to tetst against. The Maven plugin and CLI I've tested locally against my server. For the Ant module I don't have a project at hand that I could use for local testing.
