### PR TITLE
add suppression of FP for  postgis-jdbc jar

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -2297,6 +2297,13 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
+        FP per issue #1660 
+        ]]></notes>
+        <cpe>cpe:/a:postgresql:postgresql</cpe>
+        <cpe>cpe:/a:postgresql:postgresql_jdbc_driver</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
         FP per issue #947 - instead of suppressing the whole thing, we will just
             suppress specific CVE that are for the server
         ]]></notes>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -2299,6 +2299,7 @@
         <notes><![CDATA[
         FP per issue #1660 
         ]]></notes>
+        <gav regex="true">^net\.postgis:postgis-jdbc:.*$</gav>
         <cpe>cpe:/a:postgresql:postgresql</cpe>
         <cpe>cpe:/a:postgresql:postgresql_jdbc_driver</cpe>
     </suppress>


### PR DESCRIPTION
## Fixes Issue #1660 
close #1660

## Description of Change
adds suppression of false identification of the postgis jdbc driver, 
Alternatively you may just use the cve's listed in the issue.

## Have test cases been added to cover the new functionality?
no
