### PR TITLE
Suppress FP for jersey-media-moxy

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -816,6 +816,13 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
+        FP per #1673
+        ]]></notes>
+        <gav regex="true">^org\.glassfish\.jersey\.media:jersey-media-moxy:.*$</gav>
+        <cpe>cpe:/a:eclipse:eclipse_ide</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
         Drupal services false positive.
         ]]></notes>
         <filePath regex="true">.*(\.(jar|ear|war|pom)|pom\.xml)</filePath>


### PR DESCRIPTION
## Fixes FP for "jersey-media-moxy"

## Description of Change

While analyzing my project I got next false positive:
```
jersey-media-moxy-2.25.1.jar (cpe:/a:eclipse:eclipse_ide:2.25.1, org.glassfish.jersey.media:jersey-media-moxy:2.25.1) : CVE-2010-4647, CVE-2008-7271
```
Added suppression rule for it.

## Have test cases been added to cover the new functionality?

*no*