### PR TITLE
Issue-1751: Make Maven plugin aggregate goal use <repositories> secti…

### DIFF
--- a/maven/src/it/1751-use-child-repositories/child/pom.xml
+++ b/maven/src/it/1751-use-child-repositories/child/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>1751-use-child-repositories</artifactId>
+        <groupId>org.owasp.test</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>child</artifactId>
+    <packaging>jar</packaging>
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>http://packages.confluent.io/maven</url>
+        </repository>
+    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+            <version>1.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/src/it/1751-use-child-repositories/invoker.properties
+++ b/maven/src/it/1751-use-child-repositories/invoker.properties
@@ -1,0 +1,19 @@
+#
+# This file is part of dependency-check-maven.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+#
+
+invoker.goals = verify -X

--- a/maven/src/it/1751-use-child-repositories/pom.xml
+++ b/maven/src/it/1751-use-child-repositories/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.owasp.test</groupId>
+    <artifactId>1751-use-child-repositories</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <modules>
+        <module>child</module>
+    </modules>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>${odc.version}</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <format>ALL</format>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven/src/it/1751-use-child-repositories/postbuild.groovy
+++ b/maven/src/it/1751-use-child-repositories/postbuild.groovy
@@ -1,0 +1,31 @@
+/*
+ * This file is part of dependency-check-maven.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+
+import java.nio.charset.Charset;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+
+String report = FileUtils.readFileToString(new File(basedir, "target/dependency-check-report.xml"), Charset.defaultCharset().name());
+
+int count = StringUtils.countMatches(report, "CVE-2017-15095");
+if (count == 0) {
+    System.out.println("Failed to identify vulnerability CVE-2017-15095 in Jackson through kafka-avro-serializer");
+    return false;
+}
+
+return true;


### PR DESCRIPTION
…ons of child modules when resolving dependencies

## Fixes Issue #1751 

## Description of Change
Make the aggregate goal use the `<repositories>` of the child module when resolving dependencies for a child, rather than only using `<repositories>` from the parent POM.

Also noticed a test failure in the integration test for 1551, it was due to modification of an immutable collection. The fix is a one liner, and is included here (the wrapping of `collectorVisitor.getNodes()` in a new list).

## Have test cases been added to cover the new functionality?
Yes