### PR TITLE
use Jetbrains annotations instead of findbugs #1703

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -187,7 +187,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
+            <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <optional>true</optional>
         </dependency>

--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -60,6 +60,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.owasp.dependencycheck.exception.H2DBLockException;
 import org.owasp.dependencycheck.utils.H2DBLock;
@@ -202,7 +204,7 @@ public class Engine implements FileFilter, AutoCloseable {
      *
      * @param settings reference to the configured settings
      */
-    public Engine(Settings settings) {
+    public Engine(@NotNull final Settings settings) {
         this(Mode.STANDALONE, settings);
     }
 
@@ -212,7 +214,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param mode the mode of operation
      * @param settings reference to the configured settings
      */
-    public Engine(Mode mode, Settings settings) {
+    public Engine(@NotNull final Mode mode, @NotNull final Settings settings) {
         this(Thread.currentThread().getContextClassLoader(), mode, settings);
     }
 
@@ -222,7 +224,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param serviceClassLoader a reference the class loader being used
      * @param settings reference to the configured settings
      */
-    public Engine(ClassLoader serviceClassLoader, Settings settings) {
+    public Engine(@NotNull final ClassLoader serviceClassLoader, @NotNull final Settings settings) {
         this(serviceClassLoader, Mode.STANDALONE, settings);
     }
 
@@ -233,7 +235,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param mode the mode of the engine
      * @param settings reference to the configured settings
      */
-    public Engine(ClassLoader serviceClassLoader, Mode mode, Settings settings) {
+    public Engine(@NotNull final ClassLoader serviceClassLoader, @NotNull final Mode mode, @NotNull final Settings settings) {
         this.settings = settings;
         this.serviceClassLoader = serviceClassLoader;
         this.mode = mode;
@@ -320,7 +322,7 @@ public class Engine implements FileFilter, AutoCloseable {
      *
      * @param dependency the dependency to remove.
      */
-    public synchronized void removeDependency(Dependency dependency) {
+    public synchronized void removeDependency(@NotNull final Dependency dependency) {
         dependencies.remove(dependency);
         dependenciesExternalView = null;
     }
@@ -342,7 +344,7 @@ public class Engine implements FileFilter, AutoCloseable {
      *
      * @param dependencies the dependencies
      */
-    public synchronized void setDependencies(List<Dependency> dependencies) {
+    public synchronized void setDependencies(@NotNull final List<Dependency> dependencies) {
         this.dependencies.clear();
         this.dependencies.addAll(dependencies);
         dependenciesExternalView = null;
@@ -357,7 +359,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @return the list of dependencies scanned
      * @since v0.3.2.5
      */
-    public List<Dependency> scan(String[] paths) {
+    public List<Dependency> scan(@NotNull final String[] paths) {
         return scan(paths, null);
     }
 
@@ -372,7 +374,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @return the list of dependencies scanned
      * @since v1.4.4
      */
-    public List<Dependency> scan(String[] paths, String projectReference) {
+    public List<Dependency> scan(@NotNull final String[] paths, @Nullable final String projectReference) {
         final List<Dependency> deps = new ArrayList<>();
         for (String path : paths) {
             final List<Dependency> d = scan(path, projectReference);
@@ -391,7 +393,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param path the path to a file or directory to be analyzed
      * @return the list of dependencies scanned
      */
-    public List<Dependency> scan(String path) {
+    public List<Dependency> scan(@NotNull final String path) {
         return scan(path, null);
     }
 
@@ -406,7 +408,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @return the list of dependencies scanned
      * @since v1.4.4
      */
-    public List<Dependency> scan(String path, String projectReference) {
+    public List<Dependency> scan(@NotNull final String path, String projectReference) {
         final File file = new File(path);
         return scan(file, projectReference);
     }
@@ -502,7 +504,8 @@ public class Engine implements FileFilter, AutoCloseable {
      * @return the list of dependencies scanned
      * @since v1.4.4
      */
-    public List<Dependency> scan(File file, String projectReference) {
+    @Nullable
+    public List<Dependency> scan(@NotNull final File file, String projectReference) {
         if (file.exists()) {
             if (file.isDirectory()) {
                 return scanDirectory(file, projectReference);
@@ -539,7 +542,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @return the list of Dependency objects scanned
      * @since v1.4.4
      */
-    protected List<Dependency> scanDirectory(File dir, String projectReference) {
+    protected List<Dependency> scanDirectory(@NotNull final File dir, @Nullable final String projectReference) {
         final File[] files = dir.listFiles();
         final List<Dependency> deps = new ArrayList<>();
         if (files != null) {
@@ -567,7 +570,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param file The file to scan
      * @return the scanned dependency
      */
-    protected Dependency scanFile(File file) {
+    protected Dependency scanFile(@NotNull final File file) {
         return scanFile(file, null);
     }
 
@@ -581,7 +584,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @return the scanned dependency
      * @since v1.4.4
      */
-    protected synchronized Dependency scanFile(File file, String projectReference) {
+    protected synchronized Dependency scanFile(@NotNull final File file, @Nullable final String projectReference) {
         Dependency dependency = null;
         if (file.isFile()) {
             if (accept(file)) {
@@ -697,7 +700,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param exceptions a collection to store non-fatal exceptions
      * @throws ExceptionCollection thrown if fatal exceptions occur
      */
-    private void initializeAndUpdateDatabase(final List<Throwable> exceptions) throws ExceptionCollection {
+    private void initializeAndUpdateDatabase(@NotNull final List<Throwable> exceptions) throws ExceptionCollection {
         if (!mode.isDatabaseRequired()) {
             return;
         }
@@ -762,7 +765,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param analyzer the analyzer to execute
      * @throws ExceptionCollection thrown if exceptions occurred during analysis
      */
-    protected void executeAnalysisTasks(Analyzer analyzer, List<Throwable> exceptions) throws ExceptionCollection {
+    protected void executeAnalysisTasks(@NotNull final Analyzer analyzer, List<Throwable> exceptions) throws ExceptionCollection {
         LOGGER.debug("Starting {}", analyzer.getName());
         final List<AnalysisTask> analysisTasks = getAnalysisTasks(analyzer, exceptions);
         final ExecutorService executorService = getExecutorService(analyzer);
@@ -828,7 +831,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @throws InitializationException thrown when there is a problem
      * initializing the analyzer
      */
-    protected void initializeAnalyzer(Analyzer analyzer) throws InitializationException {
+    protected void initializeAnalyzer(@NotNull final Analyzer analyzer) throws InitializationException {
         try {
             LOGGER.debug("Initializing {}", analyzer.getName());
             analyzer.prepare(this);
@@ -860,7 +863,7 @@ public class Engine implements FileFilter, AutoCloseable {
      *
      * @param analyzer the analyzer to close
      */
-    protected void closeAnalyzer(Analyzer analyzer) {
+    protected void closeAnalyzer(@NotNull final Analyzer analyzer) {
         LOGGER.debug("Closing Analyzer '{}'", analyzer.getName());
         try {
             analyzer.close();
@@ -1011,6 +1014,7 @@ public class Engine implements FileFilter, AutoCloseable {
      *
      * @return a list of Analyzers
      */
+    @NotNull
     public List<Analyzer> getAnalyzers() {
         final List<Analyzer> ret = new ArrayList<>();
         //insteae of forEach - we can just do a collect
@@ -1028,7 +1032,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * supported
      */
     @Override
-    public boolean accept(File file) {
+    public boolean accept(@Nullable final File file) {
         if (file == null) {
             return false;
         }
@@ -1070,7 +1074,7 @@ public class Engine implements FileFilter, AutoCloseable {
      *
      * @param fta the file type analyzer to add
      */
-    protected void addFileTypeAnalyzer(FileTypeAnalyzer fta) {
+    protected void addFileTypeAnalyzer(@NotNull final FileTypeAnalyzer fta) {
         this.fileTypeAnalyzers.add(fta);
     }
 
@@ -1095,7 +1099,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @throws ExceptionCollection a collection of exceptions that occurred
      * during analysis
      */
-    private void throwFatalExceptionCollection(String message, Throwable throwable, List<Throwable> exceptions) throws ExceptionCollection {
+    private void throwFatalExceptionCollection(String message, @NotNull final Throwable throwable, @NotNull final List<Throwable> exceptions) throws ExceptionCollection {
         LOGGER.error(message);
         LOGGER.debug("", throwable);
         exceptions.add(throwable);
@@ -1114,8 +1118,9 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param format the report format (ALL, HTML, CSV, JSON, etc.)
      * @throws ReportException thrown if there is an error generating the report
      */
-    public synchronized void writeReports(String applicationName, String groupId, String artifactId,
-            String version, File outputDir, String format) throws ReportException {
+    public synchronized void writeReports(String applicationName, @Nullable final String groupId,
+                                          @Nullable final String artifactId, @Nullable final String version,
+                                          @NotNull final File outputDir, String format) throws ReportException {
         if (mode == Mode.EVIDENCE_COLLECTION) {
             throw new UnsupportedOperationException("Cannot generate report in evidence collection mode.");
         }

--- a/core/src/main/java/org/owasp/dependencycheck/data/lucene/LuceneUtils.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/lucene/LuceneUtils.java
@@ -17,7 +17,6 @@
  */
 package org.owasp.dependencycheck.data.lucene;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -66,9 +65,6 @@ public final class LuceneUtils {
      * @param text the data to be escaped
      */
     @SuppressWarnings("fallthrough")
-    @SuppressFBWarnings(
-            value = "SF_SWITCH_NO_DEFAULT",
-            justification = "The switch below does have a default.")
     public static void appendEscapedLuceneQuery(StringBuilder buf,
             final CharSequence text) {
 

--- a/core/src/test/resources/jmockit-1.26.pom
+++ b/core/src/test/resources/jmockit-1.26.pom
@@ -234,7 +234,8 @@
 
    <dependencies>
       <dependency>
-         <groupId>com.google.code.findbugs</groupId><artifactId>jsr305</artifactId><version>3.0.0</version>
+         <groupId>org.jetbrains</groupId>
+         <artifactId>annotations</artifactId>
          <optional>true</optional>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -147,9 +147,10 @@ Copyright (c) 2012 - Jeremy Long
         <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
         <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
 
+        <jetbrains.annotations.version>17.0.0</jetbrains.annotations.version>
+
         <!-- analysis core (used by Jenkins) uses 1.6-->
         <joda-time.version>1.6</joda-time.version>
-        <com.google.code.findbugs.annotations.version>3.0.1u2</com.google.code.findbugs.annotations.version>
         <com.google.code.gson.version>2.8.5</com.google.code.gson.version>
         <!-- upgrade to 1.4.197 prevents Java 7 compatability -->
         <com.h2database.version>1.4.196</com.h2database.version>
@@ -859,9 +860,9 @@ Copyright (c) 2012 - Jeremy Long
                 <version>${joda-time.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.code.findbugs</groupId>
+                <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
-                <version>${com.google.code.findbugs.annotations.version}</version>
+                <version>${jetbrains.annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>
@@ -1073,7 +1074,7 @@ Copyright (c) 2012 - Jeremy Long
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
+            <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/ExpectedObjectInputStream.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/ExpectedObjectInputStream.java
@@ -25,7 +25,6 @@ import java.io.ObjectStreamClass;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * An ObjectInputStream that will only deserialize expected classes.
@@ -33,7 +32,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * @author Jeremy Long
  * @version $Id: $Id
  */
-@NotThreadSafe
+// NotThreadSafe
 public class ExpectedObjectInputStream extends ObjectInputStream {
 
     /**

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
@@ -20,11 +20,15 @@ package org.owasp.dependencycheck.utils;
 import java.io.*;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 import org.apache.commons.lang3.SystemUtils;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A collection of utilities for processing information about files.
@@ -60,9 +64,10 @@ public final class FileUtils {
      * @param fileName the file name to retrieve the file extension from.
      * @return the file extension.
      */
-    public static String getFileExtension(String fileName) {
-        final String fileExt = FilenameUtils.getExtension(fileName);
-        return null == fileExt || fileExt.isEmpty() ? null : fileExt.toLowerCase();
+    @Nullable
+    public static String getFileExtension(@NotNull String fileName) {
+        @Nullable final String fileExt = FilenameUtils.getExtension(fileName);
+        return StringUtils.isNoneEmpty(fileExt)? StringUtils.lowerCase(fileExt) : null;
     }
 
     /**
@@ -72,7 +77,13 @@ public final class FileUtils {
      * @param file the File to delete
      * @return true if the file was deleted successfully, otherwise false
      */
-    public static boolean delete(File file) {
+    @NotNull
+    public static boolean delete(@Nullable File file) {
+        if(file == null) {
+            LOGGER.warn("cannot delete null File");
+            return false;
+        }
+
         final boolean success = org.apache.commons.io.FileUtils.deleteQuietly(file);
         if (!success) {
             LOGGER.debug("Failed to delete file: {}; attempting to delete on exit.", file.getPath());
@@ -89,7 +100,8 @@ public final class FileUtils {
      * @throws java.io.IOException thrown when a directory cannot be created within the
      * base directory
      */
-    public static File createTempDirectory(File base) throws IOException {
+    @NotNull
+    public static File createTempDirectory(@Nullable final File base) throws IOException {
         final File tempDir = new File(base, "dctemp" + UUID.randomUUID().toString());
         if (tempDir.exists()) {
             return createTempDirectory(base);
@@ -107,12 +119,9 @@ public final class FileUtils {
      *
      * @return a String containing the bit bucket
      */
+    @NotNull
     public static String getBitBucket() {
-        if (SystemUtils.IS_OS_WINDOWS) {
-            return BIT_BUCKET_WIN;
-        } else {
-            return BIT_BUCKET_UNIX;
-        }
+        return SystemUtils.IS_OS_WINDOWS ? BIT_BUCKET_WIN : BIT_BUCKET_UNIX;
     }
 
     /**
@@ -121,7 +130,7 @@ public final class FileUtils {
      *
      * @param closeable to be closed
      */
-    public static void close(Closeable closeable) {
+    public static void close(@Nullable final Closeable closeable) {
         if (null != closeable) {
             try {
                 closeable.close();
@@ -137,7 +146,8 @@ public final class FileUtils {
      * @param resource path
      * @return the input stream for the given resource
      */
-    public static InputStream getResourceAsStream(final String resource) {
+    @Nullable
+    public static InputStream getResourceAsStream(@NotNull String resource) {
         final ClassLoader classLoader = FileUtils.class.getClassLoader();
         final InputStream inputStream = classLoader != null
                 ? classLoader.getResourceAsStream(resource)

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -21,6 +21,8 @@ import com.google.gson.Gson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -568,7 +570,7 @@ public final class Settings {
      *
      * @param propertiesFilePath the path to the base properties file to load
      */
-    public Settings(String propertiesFilePath) {
+    public Settings(@NotNull final String propertiesFilePath) {
         initialize(propertiesFilePath);
     }
 
@@ -577,7 +579,7 @@ public final class Settings {
      *
      * @param propertiesFilePath the path to the settings property file
      */
-    private void initialize(String propertiesFilePath) {
+    private void initialize(@NotNull final String propertiesFilePath) {
         props = new Properties();
         try (InputStream in = FileUtils.getResourceAsStream(propertiesFilePath)) {
             props.load(in);
@@ -619,10 +621,10 @@ public final class Settings {
      * @param header the header to print with the log message
      * @param properties the properties to log
      */
-    private void logProperties(String header, Properties properties) {
+    private void logProperties(@NotNull final String header, @NotNull final Properties properties) {
         if (LOGGER.isDebugEnabled()) {
             final StringWriter sw = new StringWriter();
-            try (PrintWriter pw = new PrintWriter(sw)) {
+            try (final PrintWriter pw = new PrintWriter(sw)) {
                 pw.format("%s:%n%n", header);
                 final Enumeration<?> e = properties.propertyNames();
                 while (e.hasMoreElements()) {
@@ -649,7 +651,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setString(String key, String value) {
+    public void setString(@NotNull final String key, @NotNull final String value) {
         props.setProperty(key, value);
         LOGGER.debug("Setting: {}='{}'", key, value);
     }
@@ -660,7 +662,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setStringIfNotNull(String key, String value) {
+    public void setStringIfNotNull(@NotNull final String key, @Nullable final String value) {
         if (null != value) {
             setString(key, value);
         }
@@ -672,7 +674,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setStringIfNotEmpty(String key, String value) {
+    public void setStringIfNotEmpty(@NotNull final String key, @Nullable final String value) {
         if (null != value && !value.isEmpty()) {
             setString(key, value);
         }
@@ -684,7 +686,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setArrayIfNotEmpty(String key, String[] value) {
+    public void setArrayIfNotEmpty(@NotNull final String key, @Nullable final String[] value) {
         if (null != value && value.length > 0) {
             setString(key, new Gson().toJson(value));
         }
@@ -696,7 +698,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setArrayIfNotEmpty(String key, List<String> value) {
+    public void setArrayIfNotEmpty(@NotNull final String key, @Nullable final List<String> value) {
         if (null != value && !value.isEmpty()) {
             setString(key, new Gson().toJson(value));
         }
@@ -708,7 +710,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setBoolean(String key, boolean value) {
+    public void setBoolean(@NotNull final String key, boolean value) {
         setString(key, Boolean.toString(value));
     }
 
@@ -718,7 +720,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setBooleanIfNotNull(String key, Boolean value) {
+    public void setBooleanIfNotNull(@NotNull final String key, @Nullable final Boolean value) {
         if (null != value) {
             setBoolean(key, value);
         }
@@ -730,7 +732,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setInt(String key, int value) {
+    public void setInt(@NotNull final String key, @NotNull final int value) {
         props.setProperty(key, String.valueOf(value));
         LOGGER.debug("Setting: {}='{}'", key, value);
     }
@@ -741,7 +743,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setIntIfNotNull(String key, Integer value) {
+    public void setIntIfNotNull(@NotNull final String key, @Nullable final Integer value) {
         if (null != value) {
             setInt(key, value);
         }
@@ -759,7 +761,7 @@ public final class Settings {
      * @throws java.io.IOException is thrown when there is an exception loading/merging
      * the properties
      */
-    public void mergeProperties(File filePath) throws FileNotFoundException, IOException {
+    public void mergeProperties(@NotNull final File filePath) throws FileNotFoundException, IOException {
         try (FileInputStream fis = new FileInputStream(filePath)) {
             mergeProperties(fis);
         }
@@ -777,7 +779,7 @@ public final class Settings {
      * @throws java.io.IOException is thrown when there is an exception loading/merging
      * the properties
      */
-    public void mergeProperties(String filePath) throws FileNotFoundException, IOException {
+    public void mergeProperties(@NotNull final String filePath) throws FileNotFoundException, IOException {
         try (FileInputStream fis = new FileInputStream(filePath)) {
             mergeProperties(fis);
         }
@@ -793,7 +795,7 @@ public final class Settings {
      * @throws java.io.IOException is thrown when there is an exception loading/merging
      * the properties
      */
-    public void mergeProperties(InputStream stream) throws IOException {
+    public void mergeProperties(@NotNull final InputStream stream) throws IOException {
         props.load(stream);
         logProperties("Properties updated via merge", props);
     }
@@ -807,7 +809,8 @@ public final class Settings {
      * @param key the key to lookup within the properties file
      * @return the property from the properties file converted to a File object
      */
-    public File getFile(String key) {
+    @Nullable
+    public File getFile(@NotNull final String key) {
         final String file = getString(key);
         if (file == null) {
             return null;
@@ -829,7 +832,7 @@ public final class Settings {
      * @param key the key to lookup within the properties file
      * @return the property from the properties file converted to a File object
      */
-    protected File getDataFile(String key) {
+    protected File getDataFile(@NotNull final String key) {
         final String file = getString(key);
         LOGGER.debug("Settings.getDataFile() - file: '{}'", file);
         if (file == null) {
@@ -883,7 +886,7 @@ public final class Settings {
      * @param defaultValue the default value for the requested property
      * @return the property from the properties file
      */
-    public String getString(String key, String defaultValue) {
+    public String getString(@NotNull final String key, @Nullable final String defaultValue) {
         return System.getProperty(key, props.getProperty(key, defaultValue));
     }
 
@@ -910,7 +913,7 @@ public final class Settings {
      * @param key the key to lookup within the properties file
      * @return the property from the properties file
      */
-    public String getString(String key) {
+    public String getString(@NotNull final String key) {
         return System.getProperty(key, props.getProperty(key));
     }
 
@@ -922,7 +925,7 @@ public final class Settings {
      * @param key the key to get from this {@link org.owasp.dependencycheck.utils.Settings}.
      * @return the list or {@code null} if the key wasn't present.
      */
-    public String[] getArray(final String key) {
+    public String[] getArray(@NotNull final String key) {
         final String string = getString(key);
         if (string != null) {
             if (string.charAt(0) == '{' || string.charAt(0) == '[') {
@@ -940,7 +943,7 @@ public final class Settings {
      *
      * @param key the property key to remove
      */
-    public void removeProperty(String key) {
+    public void removeProperty(@NotNull final String key) {
         props.remove(key);
     }
 
@@ -955,7 +958,7 @@ public final class Settings {
      * @throws org.owasp.dependencycheck.utils.InvalidSettingException is thrown if there is an error retrieving
      * the setting
      */
-    public int getInt(String key) throws InvalidSettingException {
+    public int getInt(@NotNull final String key) throws InvalidSettingException {
         try {
             return Integer.parseInt(getString(key));
         } catch (NumberFormatException ex) {
@@ -974,7 +977,7 @@ public final class Settings {
      * @return the property from the properties file or the defaultValue if the
      * property does not exist or cannot be converted to an integer
      */
-    public int getInt(String key, int defaultValue) {
+    public int getInt(@NotNull final String key, int defaultValue) {
         int value;
         try {
             value = Integer.parseInt(getString(key));
@@ -998,7 +1001,7 @@ public final class Settings {
      * @throws org.owasp.dependencycheck.utils.InvalidSettingException is thrown if there is an error retrieving
      * the setting
      */
-    public long getLong(String key) throws InvalidSettingException {
+    public long getLong(@NotNull final String key) throws InvalidSettingException {
         try {
             return Long.parseLong(getString(key));
         } catch (NumberFormatException ex) {
@@ -1018,7 +1021,7 @@ public final class Settings {
      * @throws org.owasp.dependencycheck.utils.InvalidSettingException is thrown if there is an error retrieving
      * the setting
      */
-    public boolean getBoolean(String key) throws InvalidSettingException {
+    public boolean getBoolean(@NotNull final String key) throws InvalidSettingException {
         return Boolean.parseBoolean(getString(key));
     }
 
@@ -1036,7 +1039,7 @@ public final class Settings {
      * @throws org.owasp.dependencycheck.utils.InvalidSettingException is thrown if there is an error retrieving
      * the setting
      */
-    public boolean getBoolean(String key, boolean defaultValue) throws InvalidSettingException {
+    public boolean getBoolean(@NotNull final String key, boolean defaultValue) throws InvalidSettingException {
         return Boolean.parseBoolean(getString(key, Boolean.toString(defaultValue)));
     }
 
@@ -1052,7 +1055,7 @@ public final class Settings {
      * exist
      * @return the property from the properties file
      */
-    public float getFloat(String key, float defaultValue) {
+    public float getFloat(@NotNull final String key, float defaultValue) {
         float retValue = defaultValue;
         try {
             retValue = Float.parseFloat(getString(key));
@@ -1152,7 +1155,7 @@ public final class Settings {
      * @return a temporary File
      * @throws java.io.IOException if any.
      */
-    public File getTempFile(String prefix, String extension) throws IOException {
+    public File getTempFile(@NotNull final String prefix, @NotNull final String extension) throws IOException {
         final File dir = getTempDirectory();
         final String tempFileName = String.format("%s%s.%s", prefix, UUID.randomUUID().toString(), extension);
         final File tempFile = new File(dir, tempFileName);

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/URLConnectionFactory.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/URLConnectionFactory.java
@@ -17,7 +17,6 @@
  */
 package org.owasp.dependencycheck.utils;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
@@ -72,7 +71,6 @@ public final class URLConnectionFactory {
      * @return an HttpURLConnection
      * @throws org.owasp.dependencycheck.utils.URLConnectionFailureException thrown if there is an exception
      */
-    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE", justification = "Just being extra safe")
     public HttpURLConnection createHttpURLConnection(URL url) throws URLConnectionFailureException {
         HttpURLConnection conn = null;
         final String proxyHost = settings.getString(Settings.KEYS.PROXY_SERVER);


### PR DESCRIPTION
## Fixes Issue #1703

## Description of Change

When calling dependencycheck code from Kotlin it's handy to have the API make use of `@NotNull` and `@Nullable` annotations. I had previously made a PR to use javax.annotation as it was already pulled in by the findbugs dependency. This PR instead removes findbugs and uses:

```xml
    <dependency>
        <groupId>org.jetbrains</groupId>
        <artifactId>annotations</artifactId>
        <version>17.0.0</version>
    </dependency>
``` 

as per comment on #1703 using the Jetbrains equivalent is a better option.

## Have test cases been added to cover the new functionality?

*no*