### PR TITLE
Issue-1751: Make Maven plugin skip artifact resolution for artifacts …

### DIFF
--- a/maven/src/it/1751-use-child-repositories/1751-child-one/pom.xml
+++ b/maven/src/it/1751-use-child-repositories/1751-child-one/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>1751-use-child-repositories</artifactId>
+        <groupId>org.owasp.test</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>1751-child-one</artifactId>
+    <packaging>jar</packaging>
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>http://packages.confluent.io/maven</url>
+        </repository>
+    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+            <version>1.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/src/it/1751-use-child-repositories/1751-child-two/pom.xml
+++ b/maven/src/it/1751-use-child-repositories/1751-child-two/pom.xml
@@ -2,24 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>1751-use-child-repositories</artifactId>
         <groupId>org.owasp.test</groupId>
+        <artifactId>1751-use-child-repositories</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
-    <artifactId>child</artifactId>
+    <artifactId>1751-child-two</artifactId>
     <packaging>jar</packaging>
-    <repositories>
-        <repository>
-            <id>confluent</id>
-            <url>http://packages.confluent.io/maven</url>
-        </repository>
-    </repositories>
     <dependencies>
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-avro-serializer</artifactId>
-            <version>1.0</version>
+            <groupId>org.owasp.test</groupId>
+            <artifactId>1751-child-one</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/maven/src/it/1751-use-child-repositories/pom.xml
+++ b/maven/src/it/1751-use-child-repositories/pom.xml
@@ -9,7 +9,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <modules>
-        <module>child</module>
+        <module>1751-child-one</module>
+        <module>1751-child-two</module>
     </modules>
     <build>
         <plugins>

--- a/maven/src/it/1751-use-child-repositories/postbuild.groovy
+++ b/maven/src/it/1751-use-child-repositories/postbuild.groovy
@@ -19,12 +19,29 @@
 import java.nio.charset.Charset;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
+import groovy.util.XmlSlurper;
 
 String report = FileUtils.readFileToString(new File(basedir, "target/dependency-check-report.xml"), Charset.defaultCharset().name());
 
-int count = StringUtils.countMatches(report, "CVE-2017-15095");
-if (count == 0) {
-    System.out.println("Failed to identify vulnerability CVE-2017-15095 in Jackson through kafka-avro-serializer");
+def analysis = new XmlSlurper().parseText(report);
+def databindDep = analysis.dependencies.'*'.find { node -> node.fileName.text() == 'jackson-databind-2.4.3.jar' };
+def references = databindDep.projectReferences.projectReference;
+
+int refCount = references.size();
+if (refCount != 2) {
+	System.out.println("Failed to find both project references");
+	return false;
+}
+if (!references.find { node -> node.text() == '1751-child-one:compile' }) {
+	System.out.println("Should find reference from 1751-child-one to jackson-databind");
+	return false
+}
+if (!references.find { node -> node.text() == '1751-child-two:compile' }) {
+	System.out.println("Should find reference from 1751-child-two to jackson-databind");
+	return false
+}
+if (!databindDep.vulnerabilities.vulnerability.name.find { node -> node.text() == 'CVE-2017-15095' }) {
+	System.out.println("Failed to identify vulnerability CVE-2017-15095 in Jackson through kafka-avro-serializer");
     return false;
 }
 

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -20,7 +20,6 @@ package org.owasp.dependencycheck.maven;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL.StandardTypes;
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.execution.MavenSession;
@@ -859,7 +858,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
 
             //collect dependencies with the filter - see comment above.
             final List<DependencyNode> nodes = new ArrayList<>(collectorVisitor.getNodes());
-
+            
             return collectDependencies(engine, project, nodes, buildingRequest, aggregate);
         } catch (DependencyGraphBuilderException ex) {
             final String msg = String.format("Unable to build dependency graph on project %s", project.getName());
@@ -983,23 +982,31 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                             + dependencyNode.toNodeString()));
                 }
             } else {
-                final ArtifactCoordinate coordinate = TransferUtils.toArtifactCoordinate(dependencyNode.getArtifact());
+                final Artifact dependencyArtifact = dependencyNode.getArtifact();
                 final Artifact result;
-                try {
-                    result = artifactResolver.resolveArtifact(buildingRequest, coordinate).getArtifact();
-                } catch (ArtifactResolverException ex) {
-                    getLog().debug(String.format("Aggregate : %s", aggregate));
-                    boolean addException = true;
-                    if (!aggregate || addReactorDependency(engine, dependencyNode.getArtifact())) {
-                        addException = false;
-                    }
-                    if (addException) {
-                        if (exCol == null) {
-                            exCol = new ExceptionCollection();
+                if (dependencyArtifact.isResolved()) {
+                    //All transitive dependencies, excluding reactor and dependencyManagement artifacts should have been resolved by Maven prior to invoking the plugin
+                    //Resolving the dependencies manually is unnecessary, and does not work in some cases (issue-1751)
+                    getLog().debug(String.format("Skipping artifact %s, already resolved", dependencyArtifact.getArtifactId()));
+                    result = dependencyArtifact;
+                } else {
+                    final ArtifactCoordinate coordinate = TransferUtils.toArtifactCoordinate(dependencyNode.getArtifact());
+                    try {
+                        result = artifactResolver.resolveArtifact(buildingRequest, coordinate).getArtifact();
+                    } catch (ArtifactResolverException ex) {
+                        getLog().debug(String.format("Aggregate : %s", aggregate));
+                        boolean addException = true;
+                        if (!aggregate || addReactorDependency(engine, dependencyNode.getArtifact())) {
+                            addException = false;
                         }
-                        exCol.addException(ex);
+                        if (addException) {
+                            if (exCol == null) {
+                                exCol = new ExceptionCollection();
+                            }
+                            exCol.addException(ex);
+                        }
+                        continue;
                     }
-                    continue;
                 }
                 if (aggregate && virtualSnapshotsFromReactor
                         && dependencyNode.getArtifact().isSnapshot() && aggregate


### PR DESCRIPTION
…that are already resolved.

The artifact resolution code flattens out all dependencies, and tries to resolve them from the repositories defined in the project the plugin is being executed for. This is wrong for transitive dependencies. For example, given dependency chain A -> B -> C, C may be in a repository only mentioned in B's POM. Running the plugin for A would fail in this case. Since the mojos making use of the artifact resolution code are already configured to require artifact resolution before running, it is better to just use the artifacts Maven has resolved. The only artifacts that need to be manually resolved are reactor projects, and maybe dependencyManagement dependencies that are not actually depended upon.

## Fixes Issue #1751

## Description of Change

The fix for issue 1751 is incomplete. I didn't consider transitive dependencies that may come from repositories that aren't listed in the module being analysed.

The artifact resolution code in BaseDependencyCheckMojo is only correct for dependencies coming from the module being analysed, since it only uses the repositories listed in that module.

Rather than try to rewrite the resolution code, I've simply made the mojo skip resolution for dependencies that are already resolved. I think the only dependencies that are not already resolved are reactor projects, and maybe dependencyManagement dependencies that aren't actually used in the project. Reactor projects are already handled correctly, and dependencyManagement dependencies are supposed to use the repositories listed in the module being analysed, so the artifact resolution code should be right for those.

## Have test cases been added to cover the new functionality?

Yes