### PR TITLE
Added reference to cryptographic signing and validation of releases on bintray.

### DIFF
--- a/ant/src/site/markdown/index.md.vm
+++ b/ant/src/site/markdown/index.md.vm
@@ -7,9 +7,11 @@ identifiers, and the associated Common Vulnerability and Exposure (CVE) entries.
 
 Installation
 ====================
-1. Download dependency-check-ant from [bintray here](http://dl.bintray.com/jeremy-long/owasp/dependency-check-ant-${project.version}-release.zip).
-2. Unzip the archive
-3. Add the taskdef to your build.xml:
+1. Import the GPG key used to sign all Dependency Check releases: `gpg --keyserver hkp://keys.gnupg.net --recv-keys F9514E84AE3708288374BBBE097586CFEA37F9A6`. This is the same key published to [bintray here](https://bintray.com/user/downloadSubjectPublicKey?username=jeremy-long).
+2. Download dependency-check-ant from [bintray here](http://dl.bintray.com/jeremy-long/owasp/dependency-check-ant-${project.version}-release.zip) and the associated GPG signature file from [bintray here](http://dl.bintray.com/jeremy-long/owasp/dependency-check-ant-${project.version}-release.zip.asc).
+3. Verify the cryptographic integrity of your download: `gpg --verify dependency-check-ant-${project.version}-release.zip.asc`.
+4. Unzip the archive
+5. Add the taskdef to your build.xml:
 
     ```xml
     <!-- Set the value to the installation directory's path -->
@@ -24,7 +26,7 @@ Installation
        <classpath refid="dependency-check.path" />
     </taskdef>
     ```
-4. Use the defined taskdefs:
+6. Use the defined taskdefs:
     * [dependency-check](configuration.html) - the primary task used to check the project dependencies.
     * [dependency-check-purge](config-purge.html) - deletes the local copy of the NVD; this should rarely be used (if ever).
     * [dependency-check-update](config-update.html) - downloads and updates the local copy of the NVD.

--- a/cli/src/site/markdown/index.md.vm
+++ b/cli/src/site/markdown/index.md.vm
@@ -7,7 +7,9 @@ identifiers, and the associated Common Vulnerability and Exposure (CVE) entries.
 
 Installation & Usage
 ====================
-Download the dependency-check command line tool [here](http://dl.bintray.com/jeremy-long/owasp/dependency-check-${project.version}-release.zip).
+Import the GPG key used to sign all Dependency Check releases: `gpg --keyserver hkp://keys.gnupg.net --recv-keys F9514E84AE3708288374BBBE097586CFEA37F9A6`. This is the same key published to [bintray here](https://bintray.com/user/downloadSubjectPublicKey?username=jeremy-long).
+Download the dependency-check command line tool [here](http://dl.bintray.com/jeremy-long/owasp/dependency-check-${project.version}-release.zip) and the associated GPG signature file from [bintray here](http://dl.bintray.com/jeremy-long/owasp/dependency-check-${project.version}-release.zip.asc)..
+Verify the cryptographic integrity of your download: `gpg --verify dependency-check-${project.version}-release.zip.asc`.
 Extract the zip file to a location on your computer and put the 'bin' directory into the
 path environment variable.
 


### PR DESCRIPTION
This is a documentation update to reflect that releases on bintray are being signed and to provide users with an explicit acknowledgement of which key is used to sign these releases. Cryptographic signing of releases followed the RFE in [Issue #1311](https://github.com/jeremylong/DependencyCheck/issues/1311).

## Fixes Issue #
Although releases are signed, users will not see the signature files to know this unless they visit the bintray site. This adds a reference to the signature files in the installation instructions for the Ant and CLI packages so that users know that they can verify these packages and how to do so.

Adding the keys to the documentation also may engender trust from other projects that rely on Dependency Check that these keys are correct and that the signed packages are officially supported.

## Description of Change
Updates two documentation pages to include steps for obtaining the appropriate key (by fingerprint), obtaining the package and the signature file, and validating the signature.


## Have test cases been added to cover the new functionality?

N/A - No new functionality