### PR TITLE
Fix an XML validation issue in results

### DIFF
--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -275,7 +275,7 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
                     </references>
                     <vulnerableSoftware>
 #foreach($vs in $vuln.getVulnerableSoftware())
-                        <software#if($vs == $vuln.matchedVulnerableSoftware) "matched"="true"#end
+                        <software#if($vs == $vuln.matchedVulnerableSoftware) matched="true"#end
                             #if($vs.versionStartIncluding) versionStartIncluding="$enc.xml($vs.versionStartIncluding)"#end
                             #if($vs.versionStartExcluding) versionStartExcluding="$enc.xml($vs.versionStartExcluding)"#end
                             #if($vs.versionEndIncluding) versionEndIncluding="$enc.xml($vs.versionEndIncluding)"#end


### PR DESCRIPTION
Fixes issue #1779 by removing quotes from invalid XML. I filed the issue but noticed that the fix is actually quite trivial.
