### PR TITLE
Fix emplates to return general unscored severity.

### DIFF
--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -693,6 +693,9 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                                     #set($cveSeverity=$enc.html($vuln.cvssV2.severity))
                                 #end
                             #end
+                            #if ($vuln.unscoredSeverity)
+                                #set($cveSeverity=$enc.html($vuln.unscoredSeverity))
+                            #end
                         #end
                         #set($sortValue=$cveImpact*10)
                         <td data-sort-value="$sortValue">$cveSeverity</td>

--- a/core/src/main/resources/templates/jsonReport.vsl
+++ b/core/src/main/resources/templates/jsonReport.vsl
@@ -145,6 +145,7 @@
             #foreach($vuln in $dependency.getVulnerabilities(true))#if($foreach.count > 1),#end {
                 "source": "$enc.json($vuln.getSource().name())",
                 "name": "$enc.json($vuln.name)",
+                #if($vuln.UnscoredSeverity)"severity" : "$enc.json($vuln.unscoredSeverity)",#end
 #if($vuln.cvssV2)
                     "cvssv2": {
                         "score": $vuln.cvssV2.score,

--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -165,6 +165,9 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
 #foreach($vuln in $dependency.getVulnerabilities(true))
                 <vulnerability source="$enc.xml($vuln.getSource().name())">
                     <name>$enc.xml($vuln.name)</name>
+#if($vuln.unscoredSeverity)
+                    <severity>$enc.xml($vuln.unscoredSeverity)</severity>
+#end
 #if($vuln.cvssV2)
                     <cvssV2>
                         <score>$vuln.cvssV2.score</score>


### PR DESCRIPTION
## Fixes Issue #

This closes #1605.

## Description of Change

Modify the HTML, JSON, and XML templates to include the general un-scored
severity in the event we cannot rely on CVSS scored severity.

I would particularly like feedback on the HTML template because that hacks
into the Highest Severity section which hacks together a table cell for both
CVSS2 and CVSS3 scores. I presume modifications for sorting is needed.

If I must adjust the template and misunderstood guidance, please let me know.

## Have test cases been added to cover the new functionality?

No, as this is changing just templates. I am willing to work on tests if needed,
but the comments from developers suggested only template changes are what
is needed here.