### PR TITLE
Node Audit Analyzer support for package(-lock).json files that do not…

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NodeAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NodeAuditAnalyzer.java
@@ -177,12 +177,12 @@ public class NodeAuditAnalyzer extends AbstractNpmAnalyzer {
             // Retrieves the contents of package-lock.json from the Dependency
             final JsonObject packageJson = jsonReader.readObject();
 
-            final String projectName = packageJson.getString("name");
-            final String projectVersion = packageJson.getString("version");
-            if (projectName != null) {
+            final String projectName = packageJson.getString("name", "");
+            final String projectVersion = packageJson.getString("version", "");
+            if (!projectName.isEmpty()) {
                 dependency.setName(projectName);
             }
-            if (projectVersion != null) {
+            if (!projectVersion.isEmpty()) {
                 dependency.setVersion(projectVersion);
             }
 

--- a/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/SanitizePackage.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/SanitizePackage.java
@@ -50,8 +50,14 @@ public final class SanitizePackage {
      */
     public static JsonObject sanitize(JsonObject packageJson) {
         final JsonObjectBuilder payloadBuilder = Json.createObjectBuilder();
-        payloadBuilder.add("name", packageJson.getString("name"));
-        payloadBuilder.add("version", packageJson.getString("version"));
+        final String projectName = packageJson.getString("name", "");
+        final String projectVersion = packageJson.getString("version", "");
+        if (!projectName.isEmpty()) {
+            payloadBuilder.add("name", projectName);
+        }
+        if (!projectVersion.isEmpty()) {
+            payloadBuilder.add("version", projectVersion);
+        }
 
         // In most package-lock.json files, 'requires' is a boolean, however, NPM Audit expects
         // 'requires' to be an object containing key/value pairs corresponding to the module


### PR DESCRIPTION

## Fixes Issue #1577 and #1603

## Description of Change
Handle package(-lock).json files without version/name for Node Audit Analyzer support of files that do not have a version or name field and avoid throwing a NullPointerException.
Note that the name and version fields are optional according to https://docs.npmjs.com/files/package.json

## Have test cases been added to cover the new functionality?

no