### PR TITLE
properly resolve artifact types

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -41,6 +41,7 @@ import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
 import org.apache.maven.shared.transfer.artifact.TransferUtils;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
+import org.eclipse.aether.artifact.ArtifactType;
 import org.apache.maven.shared.artifact.filter.PatternExcludesArtifactFilter;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
@@ -880,8 +881,10 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         coordinate.setGroupId(dependency.getGroupId());
         coordinate.setArtifactId(dependency.getArtifactId());
         coordinate.setVersion(dependency.getVersion());
-        coordinate.setExtension(dependency.getType());
-        coordinate.setClassifier(dependency.getClassifier());
+
+        final ArtifactType type = session.getRepositorySession().getArtifactTypeRegistry().get(dependency.getType());
+        coordinate.setExtension(type.getExtension());
+        coordinate.setClassifier(type.getClassifier());
 
         final Artifact artifact = artifactResolver.resolveArtifact(buildingRequest, coordinate).getArtifact();
 


### PR DESCRIPTION
## Fixes Issue #
Test dependencies were not properly resolved when scanning <dependencyManagement/> section

## Description of Change
Use ArtifactTypeRegistry from Maven Session to properly resolve artifact types

## Have test cases been added to cover the new functionality?
no
