### PR TITLE
Mysql schema init: fix typo and issue in sql script

### DIFF
--- a/core/src/main/resources/data/initialize_mysql.sql
+++ b/core/src/main/resources/data/initialize_mysql.sql
@@ -31,7 +31,7 @@ target_sw VARCHAR(255), target_hw VARCHAR(255), other VARCHAR(255), ecosystem VA
 CREATE TABLE software (cveid INT, cpeEntryId INT, versionEndExcluding VARCHAR(50), versionEndIncluding VARCHAR(50), 
                        versionStartExcluding VARCHAR(50), versionStartIncluding VARCHAR(50), vulnerable BOOLEAN
     , CONSTRAINT fkSoftwareCve FOREIGN KEY (cveid) REFERENCES vulnerability(id) ON DELETE CASCADE
-    , CONSTRAINT fkSoftwareCpeProduct FOREIGN KEY (cpeEntryId) REFERENCES cpeEntry(id))
+    , CONSTRAINT fkSoftwareCpeProduct FOREIGN KEY (cpeEntryId) REFERENCES cpeEntry(id)
     , PRIMARY KEY (cveid, cpeEntryId));
     
 CREATE TABLE cweEntry (cveid INT, cwe VARCHAR(20),
@@ -61,4 +61,4 @@ DELIMITER ;
 
 GRANT EXECUTE ON PROCEDURE dependencycheck.save_property TO 'dcuser';
 
-UPDATE properties SET value='4.1' WHERE ID='version';
+INSERT INTO properties(id, value) VALUES ('version', '4.1');


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

Fixes a typo in the create schema command for the 'software' table, and
switches the version property comamnd from insert to update as script
is intended for db initialisation.

## Have test cases been added to cover the new functionality?

*no*