### PR TITLE
workaround for capacity problems of npmjs.org

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NodeAuditSearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NodeAuditSearch.java
@@ -28,6 +28,8 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 import javax.annotation.concurrent.ThreadSafe;
 import org.json.JSONObject;
 import org.owasp.dependencycheck.utils.Settings;
@@ -99,7 +101,7 @@ public class NodeAuditSearch {
      * @throws IOException if it's unable to connect to Node Audit API
      */
     public List<Advisory> submitPackage(JsonObject packageJson) throws SearchException, IOException {
-       return submitPackage(packageJson,0);
+       return submitPackage(packageJson, 0);
     }
 
     /**
@@ -113,7 +115,7 @@ public class NodeAuditSearch {
      * package
      * @throws IOException if it's unable to connect to Node Audit API
      */
-    private  List<Advisory> submitPackage(JsonObject packageJson, int count) throws SearchException, IOException {
+    private List<Advisory> submitPackage(JsonObject packageJson, int count) throws SearchException, IOException {
         try {
             final byte[] packageDatabytes = packageJson.toString().getBytes(StandardCharsets.UTF_8);
             final URLConnectionFactory factory = new URLConnectionFactory(settings);
@@ -143,13 +145,13 @@ public class NodeAuditSearch {
                         return parser.parse(jsonResponse);
                     }
                 case 503:
-                    LOGGER.debug("Invalid payload submitted to Node Audit API. Received response code: {} {}",
+                    LOGGER.debug("Node Audit API returned `{} {}` - retrying request.",
                             conn.getResponseCode(), conn.getResponseMessage());
                     if (count > 5){
+                        LockSupport.parkNanos(TimeUnit.MICROSECONDS.toNanos(500) * count);
                         return submitPackage(packageJson, ++count);
                     }
-                    throw new SearchException("Could not perform Node Audit analysis. Invalid payload submitted to Node Audit API.");
-
+                    throw new SearchException("Could not perform Node Audit analysis - service returned a 503.");
                 case 400:
                     LOGGER.debug("Invalid payload submitted to Node Audit API. Received response code: {} {}",
                             conn.getResponseCode(), conn.getResponseMessage());

--- a/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NodeAuditSearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NodeAuditSearch.java
@@ -99,6 +99,21 @@ public class NodeAuditSearch {
      * @throws IOException if it's unable to connect to Node Audit API
      */
     public List<Advisory> submitPackage(JsonObject packageJson) throws SearchException, IOException {
+       return submitPackage(packageJson,0);
+    }
+
+    /**
+     * Submits the package.json file to the Node Audit API and returns a list of
+     * zero or more Advisories.
+     *
+     * @param packageJson the package.json file retrieved from the Dependency
+     * @param count the current retry count
+     * @return a List of zero or more Advisory object
+     * @throws SearchException if Node Audit API is unable to analyze the
+     * package
+     * @throws IOException if it's unable to connect to Node Audit API
+     */
+    private  List<Advisory> submitPackage(JsonObject packageJson, int count) throws SearchException, IOException {
         try {
             final byte[] packageDatabytes = packageJson.toString().getBytes(StandardCharsets.UTF_8);
             final URLConnectionFactory factory = new URLConnectionFactory(settings);
@@ -127,6 +142,14 @@ public class NodeAuditSearch {
                         final NpmAuditParser parser = new NpmAuditParser();
                         return parser.parse(jsonResponse);
                     }
+                case 503:
+                    LOGGER.debug("Invalid payload submitted to Node Audit API. Received response code: {} {}",
+                            conn.getResponseCode(), conn.getResponseMessage());
+                    if (count > 5){
+                        return submitPackage(packageJson, ++count);
+                    }
+                    throw new SearchException("Could not perform Node Audit analysis. Invalid payload submitted to Node Audit API.");
+
                 case 400:
                     LOGGER.debug("Invalid payload submitted to Node Audit API. Received response code: {} {}",
                             conn.getResponseCode(), conn.getResponseMessage());


### PR DESCRIPTION
## Fixes Issue #
this is a workaround for npmjs.org audit-API capacity problems #1685 and #1679.

## Description of Change

Added retry counter for npmjs.org Audit-API requests.
