### PR TITLE
Update hashCode, equals, and compareTo to use builders

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -38,6 +38,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.document.Document;
@@ -1117,10 +1118,10 @@ public class CPEAnalyzer extends AbstractAnalyzer {
          */
         @Override
         public int hashCode() {
-            int hash = 5;
-            hash = 97 * hash + (this.identifierConfidence != null ? this.identifierConfidence.hashCode() : 0);
-            hash = 97 * hash + (this.identifier != null ? this.identifier.hashCode() : 0);
-            return hash;
+            return new HashCodeBuilder(115, 303)
+                    .append(identifierConfidence)
+                    .append(identifier)
+                    .toHashCode();
         }
 
         /**
@@ -1134,9 +1135,11 @@ public class CPEAnalyzer extends AbstractAnalyzer {
             if (obj == null || !(obj instanceof IdentifierMatch)) {
                 return false;
             }
+            if (this == obj) {
+                return true;
+            }
             final IdentifierMatch other = (IdentifierMatch) obj;
             return new EqualsBuilder()
-                    .appendSuper(super.equals(obj))
                     .append(identifierConfidence, other.identifierConfidence)
                     .append(identifier, other.identifier)
                     .build();

--- a/core/src/main/java/org/owasp/dependencycheck/data/composer/ComposerDependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/composer/ComposerDependency.java
@@ -17,6 +17,9 @@
  */
 package org.owasp.dependencycheck.data.composer;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -83,31 +86,27 @@ public final class ComposerDependency {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof ComposerDependency)) {
+            return false;
+        }
+        if (this == obj) {
             return true;
         }
-        if (!(o instanceof ComposerDependency)) {
-            return false;
-        }
-
-        final ComposerDependency that = (ComposerDependency) o;
-
-        if (group != null ? !group.equals(that.group) : that.group != null) {
-            return false;
-        }
-        if (project != null ? !project.equals(that.project) : that.project != null) {
-            return false;
-        }
-        return !(version != null ? !version.equals(that.version) : that.version != null);
-
+        final ComposerDependency other = (ComposerDependency) obj;
+        return new EqualsBuilder()
+                .append(group, other.group)
+                .append(project, other.project)
+                .append(version, other.version)
+                .build();
     }
 
     @Override
     public int hashCode() {
-        int result = group != null ? group.hashCode() : 0;
-        result = 31 * result + (project != null ? project.hashCode() : 0);
-        result = 31 * result + (version != null ? version.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder(103, 199)
+                .append(group)
+                .append(project)
+                .append(version)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/data/cpe/IndexEntry.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/cpe/IndexEntry.java
@@ -23,6 +23,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
@@ -160,7 +161,6 @@ public class IndexEntry implements Serializable {
     @Override
     public int hashCode() {
         return new HashCodeBuilder(5, 27)
-                .appendSuper(super.hashCode())
                 .append(documentId)
                 .append(vendor)
                 .append(product)
@@ -170,17 +170,17 @@ public class IndexEntry implements Serializable {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (obj == null || !(obj instanceof IndexEntry)) {
             return false;
         }
-        if (!(obj instanceof IndexEntry)) {
-            return false;
+        if (this == obj) {
+            return true;
         }
-        final IndexEntry other = (IndexEntry) obj;
-        if ((this.vendor == null) ? (other.vendor != null) : !this.vendor.equals(other.vendor)) {
-            return false;
-        }
-        return !((this.product == null) ? (other.product != null) : !this.product.equals(other.product));
+        final IndexEntry rhs = (IndexEntry) obj;
+        return new EqualsBuilder()
+                .append(vendor, rhs.vendor)
+                .append(product, rhs.product)
+                .isEquals();
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/data/lucene/AlphaNumericFilter.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/lucene/AlphaNumericFilter.java
@@ -117,7 +117,7 @@ public final class AlphaNumericFilter extends AbstractTokenizingFilter {
      */
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(13, 27)
+        return new HashCodeBuilder(13, 103)
                 .appendSuper(super.hashCode())
                 .append(posIncrementAttribute)
                 .append(skipCounter)
@@ -131,6 +131,9 @@ public final class AlphaNumericFilter extends AbstractTokenizingFilter {
     public boolean equals(Object obj) {
         if (obj == null || !(obj instanceof AlphaNumericFilter)) {
             return false;
+        }
+        if (this == obj) {
+            return true;
         }
         final AlphaNumericFilter rhs = (AlphaNumericFilter) obj;
         return new EqualsBuilder()

--- a/core/src/main/java/org/owasp/dependencycheck/data/lucene/TokenPairConcatenatingFilter.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/lucene/TokenPairConcatenatingFilter.java
@@ -137,14 +137,11 @@ public final class TokenPairConcatenatingFilter extends TokenFilter {
      */
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (obj == null || !(obj instanceof TokenPairConcatenatingFilter)) {
             return false;
         }
-        if (obj == this) {
+        if (this == obj) {
             return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
         }
         final TokenPairConcatenatingFilter rhs = (TokenPairConcatenatingFilter) obj;
         return new EqualsBuilder()

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetPackage.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetPackage.java
@@ -17,6 +17,9 @@
  */
 package org.owasp.dependencycheck.data.nuget;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -120,29 +123,30 @@ public class NugetPackage extends NugetPackageReference {
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || !(other instanceof NugetPackage)) {
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof NugetPackage)) {
             return false;
         }
-        final NugetPackage o = (NugetPackage) other;
-        return super.equals(this)
-                && o.getTitle().equals(title)
-                && o.getAuthors().equals(authors)
-                && o.getOwners().equals(owners)
-                && o.getLicenseUrl().equals(licenseUrl);
+        if (this == obj) {
+            return true;
+        }
+        final NugetPackage rhs = (NugetPackage) obj;
+        return new EqualsBuilder()
+                .appendSuper(super.equals(obj))
+                .append(title, rhs.title)
+                .append(authors, rhs.authors)
+                .append(owners, rhs.owners)
+                .append(licenseUrl, rhs.licenseUrl)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        int hash = 7;
-        hash = 31 * hash + super.hashCode();
-        hash = 31 * hash + (null == title ? 0 : title.hashCode());
-        hash = 31 * hash + (null == authors ? 0 : authors.hashCode());
-        hash = 31 * hash + (null == owners ? 0 : owners.hashCode());
-        hash = 31 * hash + (null == licenseUrl ? 0 : licenseUrl.hashCode());
-        return hash;
+        return new HashCodeBuilder(33, 87)
+                .append(title)
+                .append(authors)
+                .append(owners)
+                .append(licenseUrl)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetPackageReference.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/NugetPackageReference.java
@@ -17,6 +17,9 @@
  */
 package org.owasp.dependencycheck.data.nuget;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 /**
  * Represents a reference to a NuGet package and version.
  *
@@ -74,16 +77,18 @@ public class NugetPackageReference {
      * {@inheritDoc}
      */
     @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || !(other instanceof NugetPackageReference)) {
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof NugetPackageReference)) {
             return false;
         }
-        final NugetPackageReference o = (NugetPackageReference) other;
-        return o.getId().equals(id)
-                && o.getVersion().equals(version);
+        if (this == obj) {
+            return true;
+        }
+        final NugetPackageReference rhs = (NugetPackageReference) obj;
+        return new EqualsBuilder()
+                .append(id, rhs.id)
+                .append(version, rhs.version)
+                .isEquals();
     }
 
     /**
@@ -91,9 +96,9 @@ public class NugetPackageReference {
      */
     @Override
     public int hashCode() {
-        int hash = 7;
-        hash = 31 * hash + (null == id ? 0 : id.hashCode());
-        hash = 31 * hash + (null == version ? 0 : version.hashCode());
-        return hash;
+        return new HashCodeBuilder(7, 89)
+                .append(id)
+                .append(version)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DriverShim.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DriverShim.java
@@ -17,6 +17,8 @@
  */
 package org.owasp.dependencycheck.data.nvdcve;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -173,9 +175,9 @@ class DriverShim implements Driver {
      */
     @Override
     public int hashCode() {
-        int hash = 7;
-        hash = 97 * hash + (this.driver != null ? this.driver.hashCode() : 0);
-        return hash;
+        return new HashCodeBuilder(7, 97)
+                .append(driver)
+                .toHashCode();
     }
 
     /**
@@ -186,14 +188,16 @@ class DriverShim implements Driver {
      */
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (obj == null || !(obj instanceof DriverShim)) {
             return false;
         }
-        if (!(obj instanceof DriverShim)) {
-            return false;
+        if (this == obj) {
+            return true;
         }
-        final DriverShim other = (DriverShim) obj;
-        return this.driver == other.driver || (this.driver != null && this.driver.equals(other.driver));
+        final DriverShim rhs = (DriverShim) obj;
+        return new EqualsBuilder()
+                .append(driver, rhs.driver)
+                .isEquals();
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+
 import org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException;
 import org.owasp.dependencycheck.dependency.naming.CpeIdentifier;
 import org.owasp.dependencycheck.dependency.naming.Identifier;
@@ -186,9 +187,9 @@ public class Dependency extends EvidenceCollection implements Serializable {
     /**
      * Constructs a new Dependency object.
      *
-     * @param file the File to create the dependency object from.
+     * @param file      the File to create the dependency object from.
      * @param isVirtual specifies if the dependency is virtual indicating the
-     * file doesn't actually exist.
+     *                  file doesn't actually exist.
      */
     public Dependency(File file, boolean isVirtual) {
         this();
@@ -221,7 +222,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * Constructs a new Dependency object.
      *
      * @param isVirtual specifies if the dependency is virtual indicating the
-     * file doesn't actually exist.
+     *                  file doesn't actually exist.
      */
     public Dependency(boolean isVirtual) {
         this();
@@ -506,9 +507,9 @@ public class Dependency extends EvidenceCollection implements Serializable {
     /**
      * Adds the Maven artifact as evidence.
      *
-     * @param source The source of the evidence
+     * @param source        The source of the evidence
      * @param mavenArtifact The Maven artifact
-     * @param confidence The confidence level of this evidence
+     * @param confidence    The confidence level of this evidence
      */
     public void addAsEvidence(String source, MavenArtifact mavenArtifact, Confidence confidence) {
         if (mavenArtifact.getGroupId() != null && !mavenArtifact.getGroupId().isEmpty()) {
@@ -835,6 +836,9 @@ public class Dependency extends EvidenceCollection implements Serializable {
         if (obj == null || !(obj instanceof Dependency)) {
             return false;
         }
+        if (this == obj) {
+            return true;
+        }
         final Dependency other = (Dependency) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
@@ -946,10 +950,9 @@ public class Dependency extends EvidenceCollection implements Serializable {
          *
          * @param file the source for the checksum
          * @return the string representation of the checksum
-         * @throws IOException thrown if there is an I/O error
+         * @throws IOException              thrown if there is an I/O error
          * @throws NoSuchAlgorithmException thrown if the algorithm is not found
          */
         String hash(File file) throws IOException, NoSuchAlgorithmException;
     }
-
 }

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Evidence.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Evidence.java
@@ -19,6 +19,8 @@ package org.owasp.dependencycheck.dependency;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.CompareToBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.jetbrains.annotations.NotNull;
 
@@ -37,14 +39,6 @@ public class Evidence implements Serializable, Comparable<Evidence> {
      * The serial version UID for serialization.
      */
     private static final long serialVersionUID = 2402386455919067874L;
-    /**
-     * Used as starting point for generating the value in {@link #hashCode()}.
-     */
-    private static final int MAGIC_HASH_INIT_VALUE = 3;
-    /**
-     * Used as a multiplier for generating the value in {@link #hashCode()}.
-     */
-    private static final int MAGIC_HASH_MULTIPLIER = 67;
 
     /**
      * The name of the evidence.
@@ -75,9 +69,9 @@ public class Evidence implements Serializable, Comparable<Evidence> {
     /**
      * Creates a new Evidence objects.
      *
-     * @param source the source of the evidence.
-     * @param name the name of the evidence.
-     * @param value the value of the evidence.
+     * @param source     the source of the evidence.
+     * @param name       the name of the evidence.
+     * @param value      the value of the evidence.
      * @param confidence the confidence of the evidence.
      */
     public Evidence(String source, String name, String value, Confidence confidence) {
@@ -166,7 +160,7 @@ public class Evidence implements Serializable, Comparable<Evidence> {
      */
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(MAGIC_HASH_INIT_VALUE, MAGIC_HASH_MULTIPLIER)
+        return new HashCodeBuilder(303, 367)
                 .append(StringUtils.lowerCase(name))
                 .append(StringUtils.lowerCase(source))
                 .append(StringUtils.lowerCase(value))
@@ -177,26 +171,24 @@ public class Evidence implements Serializable, Comparable<Evidence> {
     /**
      * Implements equals for Evidence.
      *
-     * @param that an object to check the equality of.
+     * @param obj an object to check the equality of.
      * @return whether the two objects are equal.
      */
-    @SuppressWarnings("deprecation")
     @Override
-    public boolean equals(Object that) {
-        if (this == that) {
-            return true;
-        }
-        if (!(that instanceof Evidence)) {
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof Evidence)) {
             return false;
         }
-        final Evidence e = (Evidence) that;
-
-        //TODO the call to ObjectUtils.equals needs to be replaced when we
-        //stop supporting Jenkins 1.6 requirement.
-        return StringUtils.equalsIgnoreCase(name, e.name)
-                && StringUtils.equalsIgnoreCase(source, e.source)
-                && StringUtils.equalsIgnoreCase(value, e.value)
-                && ObjectUtils.equals(confidence, e.confidence);
+        if (this == obj) {
+            return true;
+        }
+        final Evidence o = (Evidence) obj;
+        return new EqualsBuilder()
+                .append(this.source == null ? null : this.source.toLowerCase(), o.source == null ? null : o.source.toLowerCase())
+                .append(this.name == null ? null : this.name.toLowerCase(), o.name == null ? null : o.name.toLowerCase())
+                .append(this.value == null ? null : this.value.toLowerCase(), o.value == null ? null : o.value.toLowerCase())
+                .append(this.confidence, o.getConfidence())
+                .build();
     }
 
     /**
@@ -208,28 +200,12 @@ public class Evidence implements Serializable, Comparable<Evidence> {
     @SuppressWarnings("deprecation")
     @Override
     public int compareTo(@NotNull Evidence o) {
-        if (o == null) {
-            throw new IllegalArgumentException("Unable to compare null evidence");
-        }
-        if (StringUtils.equalsIgnoreCase(source, o.source)) {
-            if (StringUtils.equalsIgnoreCase(name, o.name)) {
-                if (StringUtils.equalsIgnoreCase(value, o.value)) {
-                    //TODO the call to ObjectUtils.equals needs to be replaced when we
-                    //stop supporting Jenkins 1.6 requirement.
-                    if (ObjectUtils.equals(confidence, o.confidence)) {
-                        return 0; //they are equal
-                    } else {
-                        return ObjectUtils.compare(confidence, o.confidence);
-                    }
-                } else {
-                    return compareToIgnoreCaseWithNullCheck(value, o.value);
-                }
-            } else {
-                return compareToIgnoreCaseWithNullCheck(name, o.name);
-            }
-        } else {
-            return compareToIgnoreCaseWithNullCheck(source, o.source);
-        }
+        return new CompareToBuilder()
+                .append(this.source == null ? null : this.source.toLowerCase(), o.source == null ? null : o.source.toLowerCase())
+                .append(this.name == null ? null : this.name.toLowerCase(), o.name == null ? null : o.name.toLowerCase())
+                .append(this.value == null ? null : this.value.toLowerCase(), o.value == null ? null : o.value.toLowerCase())
+                .append(this.confidence, o.getConfidence())
+                .toComparison();
     }
 
     /**
@@ -237,7 +213,7 @@ public class Evidence implements Serializable, Comparable<Evidence> {
      * {@link java.lang.String#compareToIgnoreCase(java.lang.String) String.compareToIgnoreCase}
      * with an exhaustive, possibly duplicative, check against nulls.
      *
-     * @param me the value to be compared
+     * @param me    the value to be compared
      * @param other the other value to be compared
      * @return true if the values are equal; otherwise false
      */

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/EvidenceCollection.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/EvidenceCollection.java
@@ -390,9 +390,11 @@ class EvidenceCollection implements Serializable {
         if (obj == null || !(obj instanceof EvidenceCollection)) {
             return false;
         }
+        if (this == obj) {
+            return true;
+        }
         final EvidenceCollection other = (EvidenceCollection) obj;
         return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
                 .append(this.vendors, other.vendors)
                 .append(this.vendorWeightings, other.vendorWeightings)
                 .append(this.products, other.products)

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Reference.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Reference.java
@@ -20,6 +20,8 @@ package org.owasp.dependencycheck.dependency;
 import java.io.Serializable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.lang3.builder.CompareToBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -109,29 +111,27 @@ public class Reference implements Serializable, Comparable<Reference> {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (obj == null || !(obj instanceof Reference)) {
             return false;
         }
-        if (!(obj instanceof Reference)) {
-            return false;
+        if (this == obj) {
+            return true;
         }
-        final Reference other = (Reference) obj;
-        if ((this.name == null) ? (other.name != null) : !this.name.equals(other.name)) {
-            return false;
-        }
-        if ((this.url == null) ? (other.url != null) : !this.url.equals(other.url)) {
-            return false;
-        }
-        return !((this.source == null) ? (other.source != null) : !this.source.equals(other.source));
+        final Reference rhs = (Reference) obj;
+        return new EqualsBuilder()
+                .append(source, rhs.source)
+                .append(name, rhs.name)
+                .append(url, rhs.url)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        int hash = 5;
-        hash = 67 * hash + (this.name != null ? this.name.hashCode() : 0);
-        hash = 67 * hash + (this.url != null ? this.url.hashCode() : 0);
-        hash = 67 * hash + (this.source != null ? this.source.hashCode() : 0);
-        return hash;
+        return new HashCodeBuilder(5, 67)
+                .append(source)
+                .append(name)
+                .append(url)
+                .toHashCode();
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
@@ -24,7 +24,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.concurrent.NotThreadSafe;
+
 import org.apache.commons.lang3.builder.CompareToBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -210,8 +213,8 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
      * Adds a reference.
      *
      * @param referenceSource the source of the reference
-     * @param referenceName the referenceName of the reference
-     * @param referenceUrl the url of the reference
+     * @param referenceName   the referenceName of the reference
+     * @param referenceUrl    the url of the reference
      */
     public void addReference(String referenceSource, String referenceName, String referenceUrl) {
         final Reference ref = new Reference();
@@ -361,21 +364,23 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (obj == null || !(obj instanceof Vulnerability)) {
             return false;
         }
-        if (!(obj instanceof Vulnerability)) {
-            return false;
+        if (this == obj) {
+            return true;
         }
         final Vulnerability other = (Vulnerability) obj;
-        return !((this.name == null) ? (other.name != null) : !this.name.equals(other.name));
+        return new EqualsBuilder()
+                .append(name, other.name)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        int hash = 5;
-        hash = 41 * hash + (this.name != null ? this.name.hashCode() : 0);
-        return hash;
+        return new HashCodeBuilder(3, 73)
+                .append(name)
+                .toHashCode();
     }
 
     @Override
@@ -401,14 +406,14 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
     /**
      * Compares two vulnerabilities.
      *
-     * @param v a vulnerability to be compared
+     * @param o a vulnerability to be compared
      * @return a negative integer, zero, or a positive integer as this object is
      * less than, equal to, or greater than the specified vulnerability
      */
     @Override
-    public int compareTo(@NotNull Vulnerability v) {
+    public int compareTo(@NotNull Vulnerability o) {
         return new CompareToBuilder()
-                .append(this.name, v.name)
+                .append(this.name, o.name)
                 .toComparison();
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/VulnerableSoftware.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/VulnerableSoftware.java
@@ -24,6 +24,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.jetbrains.annotations.NotNull;
 import org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException;
 import org.owasp.dependencycheck.utils.DependencyVersion;
 import us.springett.parsers.cpe.Cpe;
@@ -118,7 +119,7 @@ public class VulnerableSoftware extends Cpe implements Serializable {
     }
 
     @Override
-    public int compareTo(Object o) {
+    public int compareTo(@NotNull Object o) {
         if (o instanceof VulnerableSoftware) {
             final VulnerableSoftware other = (VulnerableSoftware) o;
             return new CompareToBuilder()
@@ -150,14 +151,11 @@ public class VulnerableSoftware extends Cpe implements Serializable {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (obj == null || !(obj instanceof VulnerableSoftware)) {
             return false;
         }
-        if (obj == this) {
+        if (this == obj) {
             return true;
-        }
-        if (!(obj instanceof VulnerableSoftware)) {
-            return false;
         }
         final VulnerableSoftware rhs = (VulnerableSoftware) obj;
         return new EqualsBuilder()

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/naming/CpeIdentifier.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/naming/CpeIdentifier.java
@@ -61,7 +61,7 @@ public class CpeIdentifier implements Identifier {
      * Constructs a new CPE Identifier from a CPE object with the given
      * confidence.
      *
-     * @param cpe the CPE value
+     * @param cpe        the CPE value
      * @param confidence the confidence in the identifiers match
      */
     public CpeIdentifier(Cpe cpe, Confidence confidence) {
@@ -74,8 +74,8 @@ public class CpeIdentifier implements Identifier {
      * Constructs a new CPE Identifier from a CPE object with the given
      * confidence.
      *
-     * @param cpe the CPE value
-     * @param url the URL for the identifier
+     * @param cpe        the CPE value
+     * @param url        the URL for the identifier
      * @param confidence the confidence in the identifiers match
      */
     public CpeIdentifier(Cpe cpe, String url, Confidence confidence) {
@@ -88,12 +88,12 @@ public class CpeIdentifier implements Identifier {
      * Constructs a new CPE Identifier from a CPE object with the given
      * confidence.
      *
-     * @param vendor the vendor
-     * @param product the product name
-     * @param version the version
+     * @param vendor     the vendor
+     * @param product    the product name
+     * @param version    the version
      * @param confidence the confidence in the identifiers match
      * @throws CpeValidationException thrown if there is an error converting the
-     * vendor, product, and version into a CPE object
+     *                                vendor, product, and version into a CPE object
      */
     public CpeIdentifier(String vendor, String product, String version, Confidence confidence) throws CpeValidationException {
         final CpeBuilder builder = new CpeBuilder();
@@ -163,7 +163,7 @@ public class CpeIdentifier implements Identifier {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
+        return new HashCodeBuilder(95,183)
                 .append(this.cpe)
                 .append(this.confidence)
                 .append(this.url)
@@ -173,14 +173,11 @@ public class CpeIdentifier implements Identifier {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (obj == null || !(obj instanceof CpeIdentifier)) {
             return false;
         }
-        if (obj == this) {
+        if (this == obj) {
             return true;
-        }
-        if (!(obj instanceof CpeIdentifier)) {
-            return false;
         }
         final CpeIdentifier other = (CpeIdentifier) obj;
         return new EqualsBuilder().append(cpe, other.cpe)

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/naming/GenericIdentifier.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/naming/GenericIdentifier.java
@@ -147,8 +147,10 @@ public class GenericIdentifier implements Identifier {
         if (obj == null || !(obj instanceof GenericIdentifier)) {
             return false;
         }
+        if (this == obj) {
+            return true;
+        }
         final GenericIdentifier other = (GenericIdentifier) obj;
-
         return new EqualsBuilder()
                 .append(this.value, other.value)
                 .append(this.url, other.url)

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/naming/PurlIdentifier.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/naming/PurlIdentifier.java
@@ -232,7 +232,7 @@ public class PurlIdentifier implements Identifier {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
+        return new HashCodeBuilder(93,187)
                 .append(this.purl)
                 .append(this.confidence)
                 .append(this.url)
@@ -242,19 +242,17 @@ public class PurlIdentifier implements Identifier {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (obj == null || !(obj instanceof PurlIdentifier)) {
             return false;
         }
-        if (obj == this) {
+        if (this == obj) {
             return true;
-        }
-        if (!(obj instanceof PurlIdentifier)) {
-            return false;
         }
         final PurlIdentifier other = (PurlIdentifier) obj;
         return new EqualsBuilder().append(purl, other.purl)
                 .append(this.confidence, other.confidence)
                 .append(this.url, other.url)
-                .append(this.notes, other.notes).isEquals();
+                .append(this.notes, other.notes)
+                .isEquals();
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/utils/DependencyVersion.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/DependencyVersion.java
@@ -24,6 +24,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -134,11 +135,11 @@ public class DependencyVersion implements Iterable<String>, Comparable<Dependenc
      */
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (obj == null || !(obj instanceof DependencyVersion)) {
             return false;
         }
-        if (!(obj instanceof DependencyVersion)) {
-            return false;
+        if (this == obj) {
+            return true;
         }
         final DependencyVersion other = (DependencyVersion) obj;
         final int minVersionMatchLength = (this.versionParts.size() < other.versionParts.size())
@@ -189,9 +190,9 @@ public class DependencyVersion implements Iterable<String>, Comparable<Dependenc
      */
     @Override
     public int hashCode() {
-        int hash = 5;
-        hash = 71 * hash + (this.versionParts != null ? this.versionParts.hashCode() : 0);
-        return hash;
+        return new HashCodeBuilder(5, 71)
+                .append(versionParts)
+                .toHashCode();
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/utils/Pair.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/Pair.java
@@ -17,6 +17,9 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -99,10 +102,10 @@ public class Pair<L, R> {
      */
     @Override
     public int hashCode() {
-        int hash = 3;
-        hash = 53 * hash + (this.left != null ? this.left.hashCode() : 0);
-        hash = 53 * hash + (this.right != null ? this.right.hashCode() : 0);
-        return hash;
+        return new HashCodeBuilder(19, 53)
+                .append(left)
+                .append(right)
+                .toHashCode();
     }
 
     /**
@@ -114,16 +117,16 @@ public class Pair<L, R> {
      */
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (obj == null || !(obj instanceof Pair)) {
             return false;
         }
-        if (!(obj instanceof Pair)) {
-            return false;
+        if (this == obj) {
+            return true;
         }
-        final Pair<?, ?> other = (Pair<?, ?>) obj;
-        if (this.left != other.left && (this.left == null || !this.left.equals(other.left))) {
-            return false;
-        }
-        return !(this.right != other.right && (this.right == null || !this.right.equals(other.right)));
+        final Pair<?, ?> rhs = (Pair) obj;
+        return new EqualsBuilder()
+                .append(left, rhs.left)
+                .append(right, rhs.right)
+                .isEquals();
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/xml/pom/License.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/pom/License.java
@@ -17,6 +17,9 @@
  */
 package org.owasp.dependencycheck.xml.pom;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -96,10 +99,10 @@ public class License {
      */
     @Override
     public int hashCode() {
-        int hash = 7;
-        hash = 89 * hash + (this.url != null ? this.url.hashCode() : 0);
-        hash = 89 * hash + (this.name != null ? this.name.hashCode() : 0);
-        return hash;
+        return new HashCodeBuilder(13, 49)
+                .append(name)
+                .append(url)
+                .toHashCode();
     }
 
     /**
@@ -110,17 +113,17 @@ public class License {
      */
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (obj == null || !(obj instanceof License)) {
             return false;
         }
-        if (!(obj instanceof License)) {
-            return false;
+        if (this == obj) {
+            return true;
         }
-        final License other = (License) obj;
-        if ((this.url == null) ? (other.url != null) : !this.url.equals(other.url)) {
-            return false;
-        }
-        return !((this.name == null) ? (other.name != null) : !this.name.equals(other.name));
+        final License rhs = (License) obj;
+        return new EqualsBuilder()
+                .append(name, rhs.name)
+                .append(url, rhs.url)
+                .isEquals();
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/PropertyType.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/PropertyType.java
@@ -17,6 +17,9 @@
  */
 package org.owasp.dependencycheck.xml.suppression;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import java.util.regex.Pattern;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -48,7 +51,6 @@ public class PropertyType {
      * Gets the value of the value property.
      *
      * @return the value of the value property
-     *
      */
     public String getValue() {
         return value;
@@ -67,7 +69,6 @@ public class PropertyType {
      * Returns whether or not the value is a regex.
      *
      * @return true if the value is a regex, otherwise false
-     *
      */
     public boolean isRegex() {
         return regex;
@@ -77,7 +78,6 @@ public class PropertyType {
      * Sets whether the value property is a regex.
      *
      * @param value true if the value is a regex, otherwise false
-     *
      */
     public void setRegex(boolean value) {
         this.regex = value;
@@ -87,7 +87,6 @@ public class PropertyType {
      * Gets the value of the caseSensitive property.
      *
      * @return true if the value is case sensitive
-     *
      */
     public boolean isCaseSensitive() {
         return caseSensitive;
@@ -97,7 +96,6 @@ public class PropertyType {
      * Sets the value of the caseSensitive property.
      *
      * @param value whether the value is case sensitive
-     *
      */
     public void setCaseSensitive(boolean value) {
         this.caseSensitive = value;
@@ -133,6 +131,7 @@ public class PropertyType {
     }
 
     //<editor-fold defaultstate="collapsed" desc="standard implementations of hashCode, equals, and toString">
+
     /**
      * Default implementation of hashCode.
      *
@@ -140,11 +139,11 @@ public class PropertyType {
      */
     @Override
     public int hashCode() {
-        int hash = 3;
-        hash = 59 * hash + (this.value != null ? this.value.hashCode() : 0);
-        hash = 59 * hash + (this.regex ? 1 : 0);
-        hash = 59 * hash + (this.caseSensitive ? 1 : 0);
-        return hash;
+        return new HashCodeBuilder(3, 59)
+                .append(value)
+                .append(regex)
+                .append(caseSensitive)
+                .toHashCode();
     }
 
     /**
@@ -155,20 +154,18 @@ public class PropertyType {
      */
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (obj == null || !(obj instanceof PropertyType)) {
             return false;
         }
-        if (!(obj instanceof PropertyType)) {
-            return false;
+        if (this == obj) {
+            return true;
         }
-        final PropertyType other = (PropertyType) obj;
-        if ((this.value == null) ? (other.value != null) : !this.value.equals(other.value)) {
-            return false;
-        }
-        if (this.regex != other.regex) {
-            return false;
-        }
-        return this.caseSensitive == other.caseSensitive;
+        final PropertyType rhs = (PropertyType) obj;
+        return new EqualsBuilder()
+                .append(value, rhs.value)
+                .append(regex, rhs.regex)
+                .append(caseSensitive, rhs.caseSensitive)
+                .isEquals();
     }
 
     /**

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzerIT.java
@@ -27,9 +27,12 @@ import org.owasp.dependencycheck.dependency.Evidence;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.dependency.Vulnerability;
 import org.owasp.dependencycheck.utils.Settings;
+
 import java.io.File;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
+
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.data.update.RetireJSDataSource;
 


### PR DESCRIPTION
To ensure consistency this PR updates the hashCode, equals, and compareMethods to use the commons-lang3 builders.