### PR TITLE
remove warnings on optional, and not installed node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ _site/**
 /cov-int/
 /dependency-check-core/nbproject/
 cov-scan.bat
-/core/data/dc.h2.db
+
+/core/data/

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
@@ -251,8 +251,14 @@ public class NodePackageAnalyzer extends AbstractNpmAnalyzer {
                 final JsonObject jo = (JsonObject) entry.getValue();
                 final String name = entry.getKey();
                 final String version = jo.getString("version");
+                final boolean optional = jo.getBoolean("optional", false);
                 final File base = Paths.get(baseDir.getPath(), "node_modules", name).toFile();
                 final File f = new File(base, PACKAGE_JSON);
+
+                if(optional && !f.exists()){
+                    LOGGER.warn("node module {} seems optional and not installed, skip it", name);
+                    continue;
+                }
 
                 if (jo.containsKey("dependencies")) {
                     final String subPackageName = String.format("%s/%s:%s", parentPackage, name, version);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzerTest.java
@@ -123,7 +123,10 @@ public class NodePackageAnalyzerTest extends BaseTest {
         engine.addDependency(toCombine);
         analyzer.analyze(toScan, engine);
         analyzer.analyze(toCombine, engine);
-        assertEquals("Expected 90 dependency", 90, engine.getDependencies().length);
+
+        //with npm install run on a "non-macOs" system, 90 else
+        assertEquals("Expected 24 dependencies", 24, engine.getDependencies().length);
+
         Dependency result = null;
         for (Dependency dep : engine.getDependencies()) {
             if ("dns-sync".equals(dep.getName())) {
@@ -161,7 +164,9 @@ public class NodePackageAnalyzerTest extends BaseTest {
         assertEquals(1, engine.getDependencies().length); //package-lock was removed without analysis
         assertTrue(shrinkwrap.equals(engine.getDependencies()[0]));
         analyzer.analyze(shrinkwrap, engine);
-        assertEquals(90, engine.getDependencies().length); //shrinkwrap was removed with analysis adding 90 dependency
+
+        //with npm install run on a "non-macOs" system, 90 else
+        assertEquals("Expected 24 dependencies", 24, engine.getDependencies().length);
         assertFalse(shrinkwrap.equals(engine.getDependencies()[0]));
     }
 }


### PR DESCRIPTION
## Fixes Issue #
Not really issues, but warnings

## Description of Change

My change remove the "useless" warnings of node_modules optional, and not installed .

In This case, `fsevents`, this dependency, is just too polyfill some function about change events in folder, on macOs ... So, on all other system, he is not installed ...
So, `node_modules/fsevents` doesn't exist, so the dependencies of fsevents ( in subfolders ), doesn't exist too ...

Finally, with the test data, fsevents generate more than 50 lines of warning ... for nothing ...

So, now, I check if module is optionnal, and if the folder exist ( because optional can be installed too ) . 

It's maybe not enough to catch them all ( because we can add in our package.json the os required, and the dependency using your dependency need to add it in `optionalDependencies`, else this dependency is not optionnal ... and same problem because the folder will not exist ... )

Oh yes, and about the .gitignore, in fact running tests on my computer add some files in `/core/data` : `odc.mv.db ` and `odc.trace.db`, so I exluded it .

## Have test cases been added to cover the new functionality?

yes