### PR TITLE
fix update checks to use seconds

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -747,7 +747,7 @@ public class Engine implements FileFilter, AutoCloseable {
     private void throwFatalDatabaseException(DatabaseException ex, final List<Throwable> exceptions) throws ExceptionCollection {
         final String msg;
         if (ex.getMessage().contains("Unable to connect") && ConnectionFactory.isH2Connection(settings)) {
-            msg = "Unable to update connect to the database - if this error persists it may be "
+            msg = "Unable to connect to the database - if this error persists it may be "
                     + "due to a corrupt database. Consider running `purge` to delete the existing database";
         } else {
             msg = "Unable to connect to the dependency-check database";

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/EngineVersionCheck.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/EngineVersionCheck.java
@@ -135,8 +135,8 @@ public class EngineVersionCheck implements CachedWebDataSource {
 
                 final DatabaseProperties properties = db.getDatabaseProperties();
 
-                final long lastChecked = Long.parseLong(properties.getProperty(ENGINE_VERSION_CHECKED_ON, "0"));
-                final long now = System.currentTimeMillis();
+                final long lastChecked = DateUtil.getEpochValueInSeconds(properties.getProperty(ENGINE_VERSION_CHECKED_ON, "0"));
+                final long now = System.currentTimeMillis()/1000;
                 updateToVersion = properties.getProperty(CURRENT_ENGINE_RELEASE, "");
                 final String currentVersion = settings.getString(Settings.KEYS.APPLICATION_VERSION, "0.0.0");
                 LOGGER.debug("Last checked: {}", lastChecked);

--- a/core/src/main/java/org/owasp/dependencycheck/utils/DateUtil.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/DateUtil.java
@@ -84,20 +84,23 @@ public final class DateUtil {
      * Returns the string value converted to an epoch seconds. Note, in some
      * cases the value provided may be in milliseconds.
      *
-     * @param value the property value
+     * @param epoch the property value
      * @return the value in seconds
      */
-    public static long getEpochValueInSeconds(String value) {
-        if (value.length() >= 13) {
+    public static long getEpochValueInSeconds(String epoch) {
+        String seconds;
+        if (epoch.length() >= 13) {
             //this is in milliseconds - reduce to seconds
-            value = value.substring(0, 10);
+            seconds = epoch.substring(0, 10);
+        } else {
+            seconds = epoch;
         }
-        long lastUpdated = 0;
+        long results = 0;
         try {
-            lastUpdated = Long.parseLong(value);
+            results = Long.parseLong(epoch);
         } catch (NumberFormatException ex) {
-            LOGGER.debug(String.format("Error parsing '%s' property from the database - using zero", value), ex);
+            LOGGER.debug(String.format("Error parsing '%s' property from the database - using zero", epoch), ex);
         }
-        return lastUpdated;
+        return results;
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/utils/DateUtil.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/DateUtil.java
@@ -97,7 +97,7 @@ public final class DateUtil {
         }
         long results = 0;
         try {
-            results = Long.parseLong(epoch);
+            results = Long.parseLong(seconds);
         } catch (NumberFormatException ex) {
             LOGGER.debug(String.format("Error parsing '%s' property from the database - using zero", epoch), ex);
         }

--- a/core/src/main/java/org/owasp/dependencycheck/utils/DateUtil.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/DateUtil.java
@@ -24,6 +24,8 @@ import javax.annotation.concurrent.ThreadSafe;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -33,6 +35,11 @@ import javax.xml.datatype.XMLGregorianCalendar;
 public final class DateUtil {
 
     /**
+     * The logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(DateUtil.class);
+
+    /**
      * Private constructor for utility class.
      */
     private DateUtil() {
@@ -40,9 +47,11 @@ public final class DateUtil {
 
     /**
      * Parses an XML xs:date into a calendar object.
+     *
      * @param xsDate an xs:date string
      * @return a calendar object
-     * @throws ParseException thrown if the date cannot be converted to a calendar
+     * @throws ParseException thrown if the date cannot be converted to a
+     * calendar
      */
     public static Calendar parseXmlDate(String xsDate) throws ParseException {
         try {
@@ -67,7 +76,28 @@ public final class DateUtil {
      */
     public static boolean withinDateRange(long date, long compareTo, int dayRange) {
         // ms = dayRange x 24 hours/day x 60 min/hour x 60 sec/min x 1000 ms/sec
-        final long msRange = dayRange * 24L * 60L * 60L * 1000L;
+        final long msRange = dayRange * 24L * 60L * 60L;
         return (compareTo - date) < msRange;
+    }
+
+    /**
+     * Returns the string value converted to an epoch seconds. Note, in some
+     * cases the value provided may be in milliseconds.
+     *
+     * @param value the property value
+     * @return the value in seconds
+     */
+    public static long getEpochValueInSeconds(String value) {
+        if (value.length() >= 13) {
+            //this is in milliseconds - reduce to seconds
+            value = value.substring(0, 10);
+        }
+        long lastUpdated = 0;
+        try {
+            lastUpdated = Long.parseLong(value);
+        } catch (NumberFormatException ex) {
+            LOGGER.debug(String.format("Error parsing '%s' property from the database - using zero", value), ex);
+        }
+        return lastUpdated;
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/update/EngineVersionCheckTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/update/EngineVersionCheckTest.java
@@ -75,8 +75,8 @@ public class EngineVersionCheckTest extends BaseTest {
         String updateToVersion = "1.2.6";
         String currentVersion = "1.2.6";
 
-        long lastChecked = dateToMilliseconds("2014-12-01");
-        long now = dateToMilliseconds("2014-12-01");
+        long lastChecked = dateToSeconds("2014-12-01");
+        long now = dateToSeconds("2014-12-01");
 
         EngineVersionCheck instance = new EngineVersionCheck(getSettings());
         boolean expResult = false;
@@ -86,8 +86,8 @@ public class EngineVersionCheckTest extends BaseTest {
 
         updateToVersion = "1.2.5";
         currentVersion = "1.2.5";
-        lastChecked = dateToMilliseconds("2014-10-01");
-        now = dateToMilliseconds("2014-12-01");
+        lastChecked = dateToSeconds("2014-10-01");
+        now = dateToSeconds("2014-12-01");
         expResult = true;
         instance.setUpdateToVersion(updateToVersion);
         result = instance.shouldUpdate(lastChecked, now, dbProperties, currentVersion);
@@ -96,8 +96,8 @@ public class EngineVersionCheckTest extends BaseTest {
 
         updateToVersion = "1.2.5";
         currentVersion = "1.2.5";
-        lastChecked = dateToMilliseconds("2014-12-01");
-        now = dateToMilliseconds("2014-12-03");
+        lastChecked = dateToSeconds("2014-12-01");
+        now = dateToSeconds("2014-12-03");
         expResult = false;
         instance.setUpdateToVersion(updateToVersion);
         result = instance.shouldUpdate(lastChecked, now, dbProperties, currentVersion);
@@ -105,8 +105,8 @@ public class EngineVersionCheckTest extends BaseTest {
 
         updateToVersion = "1.2.6";
         currentVersion = "1.2.5";
-        lastChecked = dateToMilliseconds("2014-12-01");
-        now = dateToMilliseconds("2014-12-03");
+        lastChecked = dateToSeconds("2014-12-01");
+        now = dateToSeconds("2014-12-03");
         expResult = true;
         instance.setUpdateToVersion(updateToVersion);
         result = instance.shouldUpdate(lastChecked, now, dbProperties, currentVersion);
@@ -114,8 +114,8 @@ public class EngineVersionCheckTest extends BaseTest {
 
         updateToVersion = "1.2.5";
         currentVersion = "1.2.6";
-        lastChecked = dateToMilliseconds("2014-12-01");
-        now = dateToMilliseconds("2014-12-08");
+        lastChecked = dateToSeconds("2014-12-01");
+        now = dateToSeconds("2014-12-08");
         expResult = false;
         instance.setUpdateToVersion(updateToVersion);
         result = instance.shouldUpdate(lastChecked, now, dbProperties, currentVersion);
@@ -123,8 +123,8 @@ public class EngineVersionCheckTest extends BaseTest {
 
         updateToVersion = "";
         currentVersion = "1.2.5";
-        lastChecked = dateToMilliseconds("2014-12-01");
-        now = dateToMilliseconds("2014-12-03");
+        lastChecked = dateToSeconds("2014-12-01");
+        now = dateToSeconds("2014-12-03");
         expResult = false;
         instance.setUpdateToVersion(updateToVersion);
         result = instance.shouldUpdate(lastChecked, now, dbProperties, currentVersion);
@@ -132,8 +132,8 @@ public class EngineVersionCheckTest extends BaseTest {
 
         updateToVersion = "";
         currentVersion = "1.2.5";
-        lastChecked = dateToMilliseconds("2014-12-01");
-        now = dateToMilliseconds("2015-12-08");
+        lastChecked = dateToSeconds("2014-12-01");
+        now = dateToSeconds("2015-12-08");
         expResult = true;
         instance.setUpdateToVersion(updateToVersion);
         result = instance.shouldUpdate(lastChecked, now, dbProperties, currentVersion);
@@ -156,11 +156,11 @@ public class EngineVersionCheckTest extends BaseTest {
      * Converts a date in the form of yyyy-MM-dd into the epoch milliseconds.
      *
      * @param date a date in the format of yyyy-MM-dd
-     * @return milliseconds
+     * @return seconds
      */
-    private long dateToMilliseconds(String date) {
+    private long dateToSeconds(String date) {
         TemporalAccessor ta = DateTimeFormatter.ISO_LOCAL_DATE.parse(date);
-        return 1000 * LocalDate.from(ta).atStartOfDay(ZoneId.systemDefault()).toEpochSecond();
+        return LocalDate.from(ta).atStartOfDay(ZoneId.systemDefault()).toEpochSecond();
     }
 
 }

--- a/core/src/test/java/org/owasp/dependencycheck/utils/DateUtilTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/DateUtilTest.java
@@ -36,14 +36,14 @@ public class DateUtilTest extends BaseTest {
     public void testWithinDateRange() {
         Calendar c = Calendar.getInstance();
 
-        long current = c.getTimeInMillis();
-        long lastRun = c.getTimeInMillis() - (3 * (1000 * 60 * 60 * 24));
+        long current = c.getTimeInMillis() / 1000;
+        long lastRun = current - (3 * (60 * 60 * 24));
         int range = 7; // 7 days
         boolean expResult = true;
         boolean result = DateUtil.withinDateRange(lastRun, current, range);
         assertEquals(expResult, result);
 
-        lastRun = c.getTimeInMillis() - (8 * (1000 * 60 * 60 * 24));
+        lastRun = c.getTimeInMillis() / 1000 - (8 * (60 * 60 * 24));
         expResult = false;
         result = DateUtil.withinDateRange(lastRun, current, range);
         assertEquals(expResult, result);
@@ -51,6 +51,7 @@ public class DateUtilTest extends BaseTest {
 
     /**
      * Test of parseXmlDate method, of class DateUtil.
+     *
      * @throws ParseException thrown when there is a parse error
      */
     @Test
@@ -61,6 +62,24 @@ public class DateUtilTest extends BaseTest {
         //month is zero based.
         assertEquals(0, result.get(Calendar.MONTH));
         assertEquals(2, result.get(Calendar.DATE));
+    }
+
+    @Test
+    public void testGetEpochValueInSeconds() throws ParseException {
+        String milliseconds = "1550538553466";
+        long expected = 1550538553;
+        long result = DateUtil.getEpochValueInSeconds(milliseconds);
+        assertEquals(expected, result);
+
+        milliseconds = "blahblahblah";
+        expected = 0;
+        result = DateUtil.getEpochValueInSeconds(milliseconds);
+        assertEquals(expected, result);
+
+        milliseconds = "1550538553";
+        expected = 1550538553;
+        result = DateUtil.getEpochValueInSeconds(milliseconds);
+        assertEquals(expected, result);
     }
 
 }


### PR DESCRIPTION
Bug in 5.0.0-M3 - if using a database created with and updated by the M1 or M2 release the M3 version checks break due to invalid comparisons between seconds and milliseconds.

This PR corrects the problem.