### PR TITLE
Remove multiple output format description

### DIFF
--- a/dependency-check-cli/arguments.html
+++ b/dependency-check-cli/arguments.html
@@ -122,7 +122,7 @@
 <td> -f   </td>
 <td> --format             </td>
 <td> &lt;format&gt;      </td>
-<td> The output format to write to (XML, HTML, CSV, JSON, JUNIT, ALL). Multiple formats can be specified by specifying the parameter multiple times. The default is HTML. </td>
+<td> The output format to write to (XML, HTML, CSV, JSON, JUNIT, ALL). The default is HTML. </td>
 <td> Required </td></tr>
 <tr class="b">
 <td>       </td>


### PR DESCRIPTION
As this is not true on current latest v4.0.2

## Fixes Issue #

## Description of Change
The docs say multiple output formats are supported by specifying the --format flag multiple times, but this is not the case in v4.0.2 which is the latest stable.
