### PR TITLE
fix for #1942

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -610,7 +610,15 @@ public class CPEAnalyzer extends AbstractAnalyzer {
         if (text == null) {
             return false;
         }
-        final String[] words = text.split("[\\s_-]");
+        // Check if we have an exact match
+        final String textLC = text.toLowerCase();
+        for (Evidence e : evidence) {
+            if (e.getValue().toLowerCase().equals(textLC)) {
+                return true;
+            }
+        }
+
+        final String[] words = text.split("[\\s_-]+");
         final List<String> list = new ArrayList<>();
         String tempWord = null;
         final CharArraySet stopWords = SearchFieldAnalyzer.getStopWords();
@@ -643,11 +651,19 @@ public class CPEAnalyzer extends AbstractAnalyzer {
             return false;
         }
         boolean isValid = true;
+
+        // Prepare the evidence values, e.g. remove the characters we used for splitting
+        List<String> evidenceValues = new ArrayList<>(evidence.size());
+        for (Evidence e : evidence) {
+            evidenceValues.add(e.getValue().toLowerCase().replaceAll("[\\s_-]+", ""));
+        }
+
         for (String word : list) {
+            word = word.toLowerCase();
             boolean found = false;
-            for (Evidence e : evidence) {
-                if (e.getValue().toLowerCase().contains(word.toLowerCase())) {
-                    if ("http".equals(word) && e.getValue().contains("http:")) {
+            for (String e : evidenceValues) {
+                if (e.contains(word)) {
+                    if ("http".equals(word) && e.contains("http:")) {
                         continue;
                     }
                     found = true;


### PR DESCRIPTION
## Fixes Issue #

#1942

## Description of Change

Improved the method CPEAnalyzer.collectionContainsString(..):

1. Before splitting the search text into words we check if `text` is a complete match to one of the evidence values (and we therefore can skip the text splitting)

2. In case the code section that does `single letter words should be concatenated with the next word` is triggered the concatenated strings do no longer match the value in the evidence if the evidence string contains the following characters: [\s_-]. Therefore the evidence value is "normalized" by removing those characters to make a match possible.

BTW: the comment in the code was/is wrong, not only single letter words are concatenated but also two-letter words. I left the functionality as it was. 

## Have test cases been added to cover the new functionality?

yes.

One existing unit test was improved and extended (it was heavily inefficient copied the database multiple times).
The other unit tests seem to rely on the existence of a real JAR, therefore I added the new unit test `testAnalyzeDependency` to cover the changes.

I also tried to generate a test case for the section `if ("http".equals(word) && e.contains("http:"))` but I failed. If made no mistake this code is and was dead code assuming that it id dedicated to remove the `http` word in case `text` is like `http://www.example.org`. But as `text` is only split by white-space, underscore and dash a word `http` will never occur as we do not split by `:` or `/`.
