### PR TITLE
Missing ; at the end of instruction causing database 3.0 -> 4.0 upgrade to fail

### DIFF
--- a/core/src/main/resources/data/upgrade_3.0.sql
+++ b/core/src/main/resources/data/upgrade_3.0.sql
@@ -51,5 +51,5 @@ ALTER TABLE software ADD  COLUMN versionStartIncluding VARCHAR(50);
 ALTER TABLE software ADD  COLUMN vulnerable BOOLEAN;
 
 
-DELETE FROM properties WHERE ID like 'NVD CVE%'
+DELETE FROM properties WHERE ID like 'NVD CVE%';
 UPDATE Properties SET value='4.0' WHERE ID='version';


### PR DESCRIPTION
## Fixes Issue #

#1951