### PR TITLE
update MS SQL syntax

### DIFF
--- a/core/src/main/resources/data/initialize_mssql.sql
+++ b/core/src/main/resources/data/initialize_mssql.sql
@@ -28,12 +28,12 @@ version VARCHAR(255), update_version VARCHAR(255), edition VARCHAR(255), lang VA
 target_sw VARCHAR(255), target_hw VARCHAR(255), other VARCHAR(255), ecosystem VARCHAR(255));
 
 CREATE TABLE software (cveid INT, cpeEntryId INT, versionEndExcluding VARCHAR(50), versionEndIncluding VARCHAR(50), 
-                       versionStartExcluding VARCHAR(50), versionStartIncluding VARCHAR(50), vulnerable BOOLEAN
+                       versionStartExcluding VARCHAR(50), versionStartIncluding VARCHAR(50), vulnerable BIT
     , CONSTRAINT FK_SoftwareCve FOREIGN KEY (cveid) REFERENCES vulnerability(id) ON DELETE CASCADE
     , CONSTRAINT FK_SoftwareCpeProduct FOREIGN KEY (cpeEntryId) REFERENCES cpeEntry(id)
     , PRIMARY KEY (cveid, cpeEntryId));
 CREATE TABLE cweEntry (cveid INT, cwe VARCHAR(20)
-    , CONSTRAINT FK_CweEntry FOREIGN KEY (cveid) REFERENCES vulnerability(id) ON DELETE CASCADE)
+    , CONSTRAINT FK_CweEntry FOREIGN KEY (cveid) REFERENCES vulnerability(id) ON DELETE CASCADE
     , PRIMARY KEY (cveid, cwe));
 
 CREATE INDEX idxCwe ON cweEntry(cveid);


### PR DESCRIPTION
## Fixes Issue #
In the initialize_mssql.sql script the datatype BOOLEAN throws an error and should be BIT for MS SQL.
There is an extra ')' character in the create software table statement that cuts off the primary key constraint and causes a syntax error.

## Description of Change

Updating the syntax in the initialize_mssql.sql script so that schema can be initialized on MS SQL 2017

## Have test cases been added to cover the new functionality?

no