### PR TITLE
Fix for temp directory not being deleted after run

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgent.java
+++ b/core/src/main/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgent.java
@@ -978,10 +978,10 @@ public class DependencyCheckScanAgent {
             }
             throw new ScanAgentException("One or more exceptions occurred during analysis; please see the debug log for more details.", ex);
         } finally {
-            settings.cleanup(true);
             if (engine != null) {
                 engine.close();
             }
+            settings.cleanup(true);
         }
         return engine;
     }


### PR DESCRIPTION
## Fixes Issue #
https://github.com/jeremylong/DependencyCheck/issues/1954

## Description of Change
Clean up the temporary files only after the engine has been closed, otherwise the cleanup will fail to delete the files and will queue it for deletion on JVM exit.

## Have test cases been added to cover the new functionality?
No. Wasn't able to devise a test case as not only is settings private to the DependencyCheckScanAgent, the initial settings.cleanup(true) causes the tempDirectory in settings to be set to null so can't determine the actual tempDirectory used after execute is run. Manually tested by stepping through DependencyCheckScanAgentIT.testComponentMetadata() both before and after the fix.