### PR TITLE
SonarQube - Optimizing String.lastIndexOf() for single char 

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzer.java
@@ -147,7 +147,7 @@ public class MSBuildProjectAnalyzer extends AbstractFileTypeAnalyzer {
                 child.addEvidence(EvidenceType.PRODUCT, "msbuild", "id", id, Confidence.HIGHEST);
                 child.addEvidence(EvidenceType.VERSION, "msbuild", "version", version, Confidence.HIGHEST);
 
-                if (id.indexOf(".") > 0) {
+                if (id.indexOf('.') > 0) {
                     final String[] parts = id.split("\\.");
 
                     // example: Microsoft.EntityFrameworkCore
@@ -155,7 +155,7 @@ public class MSBuildProjectAnalyzer extends AbstractFileTypeAnalyzer {
                     child.addEvidence(EvidenceType.PRODUCT, "msbuild", "id", parts[1], Confidence.MEDIUM);
 
                     if (parts.length > 2) {
-                        final String rest = id.substring(id.indexOf(".") + 1);
+                        final String rest = id.substring(id.indexOf('.') + 1);
                         child.addEvidence(EvidenceType.PRODUCT, "msbuild", "id", rest, Confidence.MEDIUM);
                     }
                 } else {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzer.java
@@ -184,7 +184,7 @@ public class NugetconfAnalyzer extends AbstractFileTypeAnalyzer {
                 child.addEvidence(EvidenceType.PRODUCT, "packages.config", "id", np.getId(), Confidence.HIGHEST);
 
                 // handle package names the same way as the MSBuild analyzer
-                if (id.indexOf(".") > 0) {
+                if (id.indexOf('.') > 0) {
                     final String[] parts = id.split("\\.");
 
                     // example: Microsoft.EntityFrameworkCore
@@ -192,7 +192,7 @@ public class NugetconfAnalyzer extends AbstractFileTypeAnalyzer {
                     child.addEvidence(EvidenceType.PRODUCT, "packages.config", "id", parts[1], Confidence.MEDIUM);
 
                     if (parts.length > 2) {
-                        final String rest = id.substring(id.indexOf(".") + 1);
+                        final String rest = id.substring(id.indexOf('.') + 1);
                         child.addEvidence(EvidenceType.PRODUCT, "packages.config", "id", rest, Confidence.MEDIUM);
                     }
                 } else {


### PR DESCRIPTION
Replacing `String.lastIndexOf("/")` with `String.lastIndexOf('/')` which can be more performant.

This fixes SonarQube violations of the rule: [String function use should be optimized for single characters](https://rules.sonarsource.com/java/RSPEC-3027)