### PR TITLE
point to https images

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -54,11 +54,11 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <logo name="JProfiler" href="https://www.ej-technologies.com/products/jprofiler/overview.html"
               title="JProfiler Java Profiler" width="170px"
               alt="JProfiler Java Profiler"
-              img="http://jeremylong.github.io/DependencyCheck/images/logos/jprofiler.png"/>
+              img="https://jeremylong.github.io/DependencyCheck/images/logos/jprofiler.png"/>
         <logo name="IntelliJ" href="http://www.jetbrains.com/idea/"
               title="developed using IntelliJ" width="170px"
               alt="developed using IntelliJ"
-              img="http://jeremylong.github.io/DependencyCheck/images/logos/logo_intellij_idea.png"/>
+              img="https://jeremylong.github.io/DependencyCheck/images/logos/logo_intellij_idea.png"/>
     </poweredBy>
 
     <body>


### PR DESCRIPTION
## Fixes Issue #
Doc pages show https warning in firefox due to images pointing to http

## Description of Change
Points directly to https

*Please add a description of the proposed change*

## Have test cases been added to cover the new functionality?
Images available over https

*yes/no*