### PR TITLE
Don't modify global EXTENSIONS in ArchiveAnalyzer

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -92,13 +93,13 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * The set of things we can handle with Zip methods
      */
-    private static final Set<String> KNOWN_ZIP_EXT = newHashSet("zip", "ear", "war", "jar", "sar", "apk", "nupkg", "aar");
+    private static final Set<String> KNOWN_ZIP_EXT = Collections.unmodifiableSet(newHashSet("zip", "ear", "war", "jar", "sar", "apk", "nupkg", "aar"));
     /**
      * The set of file extensions supported by this analyzer. Note for
      * developers, any additions to this list will need to be explicitly handled
      * in {@link #extractFiles(File, File, Engine)}.
      */
-    private static final Set<String> EXTENSIONS = newHashSet("tar", "gz", "tgz", "bz2", "tbz2");
+    private static final Set<String> EXTENSIONS = Collections.unmodifiableSet(newHashSet("tar", "gz", "tgz", "bz2", "tbz2"));
 
     /**
      * Detects files with extensions to remove from the engine's collection of
@@ -641,12 +642,13 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
      */
     private void initializeSettings() {
         maxScanDepth = getSettings().getInt("archive.scan.depth", 3);
+        final Set<String> extensions = new HashSet<>(EXTENSIONS);
+        extensions.addAll(KNOWN_ZIP_EXT);
         final String additionalZipExt = getSettings().getString(Settings.KEYS.ADDITIONAL_ZIP_EXTENSIONS);
         if (additionalZipExt != null) {
             final String[] ext = additionalZipExt.split("\\s*,\\s*");
-            Collections.addAll(KNOWN_ZIP_EXT, ext);
+            Collections.addAll(extensions, ext);
         }
-        EXTENSIONS.addAll(KNOWN_ZIP_EXT);
-        fileFilter = FileFilterBuilder.newInstance().addExtensions(EXTENSIONS).build();
+        fileFilter = FileFilterBuilder.newInstance().addExtensions(extensions).build();
     }
 }


### PR DESCRIPTION
## Fixes Issue #

Fixes occasional instances of this in our build
```
Caused by: java.util.ConcurrentModificationException
	at org.owasp.dependencycheck.utils.FileFilterBuilder.addExtensions(FileFilterBuilder.java:100)
	at org.owasp.dependencycheck.analyzer.ArchiveAnalyzer.initializeSettings(ArchiveAnalyzer.java:650)
	at org.owasp.dependencycheck.analyzer.ArchiveAnalyzer.initialize(ArchiveAnalyzer.java:132)
	at org.owasp.dependencycheck.Engine.lambda$loadAnalyzers$1(Engine.java:284)
	at org.owasp.dependencycheck.Engine.loadAnalyzers(Engine.java:283)
	at org.owasp.dependencycheck.Engine.initializeEngine(Engine.java:254)
	at org.owasp.dependencycheck.Engine.<init>(Engine.java:243)
	at org.owasp.dependencycheck.Engine.<init>(Engine.java:219)
	at org.owasp.dependencycheck.Engine.<init>(Engine.java:209)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at org.owasp.dependencycheck.gradle.tasks.AbstractAnalyze.analyze(AbstractAnalyze.groovy:80)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:103)
	at org.gradle.api.internal.project.taskfactory.StandardTaskAction.doExecute(StandardTaskAction.java:48)
```


## Description of Change

Now makes a local copy of `EXTENSIONS` when initializing rather than modifying it in-place.

## Have test cases been added to cover the new functionality?

No