### PR TITLE
Improve suppression

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/reporting/ReportTool.java
+++ b/core/src/main/java/org/owasp/dependencycheck/reporting/ReportTool.java
@@ -49,7 +49,7 @@ public class ReportTool {
     public String identifierToSuppressionId(Identifier id) {
         if (id instanceof PurlIdentifier) {
             final PurlIdentifier purl = (PurlIdentifier) id;
-            return purl.toGav();
+            return purl.toString();
         } else if (id instanceof CpeIdentifier) {
             try {
                 final CpeIdentifier cpeId = (CpeIdentifier) id;

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionHandler.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionHandler.java
@@ -58,6 +58,10 @@ public class SuppressionHandler extends DefaultHandler {
      * The CVE element name.
      */
     public static final String CVE = "cve";
+    /**
+     * The vulnerabilityName element name.
+     */
+    public static final String VULNERABILITY_NAME = "vulnerabilityName";
 
     /**
      * The CVE element name.
@@ -76,6 +80,10 @@ public class SuppressionHandler extends DefaultHandler {
      * The GAV element name.
      */
     public static final String GAV = "gav";
+        /**
+     * The Package URL element name.
+     */
+    public static final String PACKAGE_URL = "packageUrl";
     /**
      * The cvssBelow element name.
      */
@@ -167,6 +175,9 @@ public class SuppressionHandler extends DefaultHandler {
                 case GAV:
                     rule.setGav(processPropertyType());
                     break;
+                case PACKAGE_URL:
+                    rule.setPackageUrl(processPropertyType());
+                    break;
                 case CPE:
                     rule.addCpe(processPropertyType());
                     break;
@@ -175,6 +186,9 @@ public class SuppressionHandler extends DefaultHandler {
                     break;
                 case CVE:
                     rule.addCve(currentText.toString());
+                    break;
+                case VULNERABILITY_NAME:
+                    rule.addVulnerabilityName(processPropertyType());
                     break;
                 case NOTES:
                     rule.addNotes(currentText.toString());

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionParser.java
@@ -53,6 +53,10 @@ public class SuppressionParser {
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(SuppressionParser.class);
     /**
+     * The suppression schema file location for v 1.3.
+     */
+    public static final String SUPPRESSION_SCHEMA_1_3 = "schema/dependency-suppression.1.3.xsd";
+    /**
      * The suppression schema file location for v 1.2.
      */
     public static final String SUPPRESSION_SCHEMA_1_2 = "schema/dependency-suppression.1.2.xsd";
@@ -94,11 +98,12 @@ public class SuppressionParser {
      */
     public List<SuppressionRule> parseSuppressionRules(InputStream inputStream) throws SuppressionParseException, SAXException {
         try (
+                InputStream schemaStream13 = FileUtils.getResourceAsStream(SUPPRESSION_SCHEMA_1_3);
                 InputStream schemaStream12 = FileUtils.getResourceAsStream(SUPPRESSION_SCHEMA_1_2);
                 InputStream schemaStream11 = FileUtils.getResourceAsStream(SUPPRESSION_SCHEMA_1_1);
                 InputStream schemaStream10 = FileUtils.getResourceAsStream(SUPPRESSION_SCHEMA_1_0)) {
             final SuppressionHandler handler = new SuppressionHandler();
-            final SAXParser saxParser = XmlUtils.buildSecureSaxParser(schemaStream12, schemaStream11, schemaStream10);
+            final SAXParser saxParser = XmlUtils.buildSecureSaxParser(schemaStream13, schemaStream12, schemaStream11, schemaStream10);
             final XMLReader xmlReader = saxParser.getXMLReader();
             xmlReader.setErrorHandler(new SuppressionErrorHandler());
             xmlReader.setContentHandler(handler);

--- a/core/src/main/resources/schema/dependency-suppression.1.3.xsd
+++ b/core/src/main/resources/schema/dependency-suppression.1.3.xsd
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema id="suppressions"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           targetNamespace="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"
+           xmlns:dc="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+
+    <xs:complexType name="regexStringType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="regex" use="optional" type="xs:boolean" default="false"/>
+                <xs:attribute name="caseSensitive" use="optional" type="xs:boolean" default="false"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:simpleType name="cvssScoreType">
+        <xs:restriction base="xs:decimal">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="10"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="cveType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="((\w+\-)?CVE\-\d\d\d\d\-\d+|\d+)"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="sha1Type">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-fA-F0-9]{40}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="suppressions">
+        <xs:complexType>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="suppress">
+                    <xs:complexType>
+                        <xs:sequence minOccurs="1" maxOccurs="1">
+                            <xs:sequence minOccurs="0" maxOccurs="1">
+                                <xs:element name="notes" type="xs:string"/>
+                            </xs:sequence>
+                            <xs:choice minOccurs="0" maxOccurs="1">
+                                <xs:element name="filePath" type="dc:regexStringType"/>
+                                <xs:element name="sha1" type="dc:sha1Type"/>
+                                <xs:element name="gav" type="dc:regexStringType"/>
+                                <xs:element name="packageUrl" type="dc:regexStringType"/>
+                            </xs:choice>
+                            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                                <xs:element name="cpe" type="dc:regexStringType"/>
+                                <xs:element name="cve" type="dc:cveType"/>
+                                <xs:element name="vulnerabilityName" type="dc:regexStringType"/>
+                                <xs:element name="cwe" type="xs:positiveInteger"/>
+                                <xs:element name="cvssBelow" type="dc:cvssScoreType"/>
+                            </xs:choice>
+                        </xs:sequence>
+                        <xs:attribute name="base" use="optional" type="xs:boolean" default="false"/>
+                        <xs:attribute name="until" use="optional" type="xs:date">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    When specified the suppression will only be active when the specified date is still in the future. On and after the 'until' date the suppression will no longer be active.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -16,7 +16,7 @@ limitations under the License.
 Copyright (c) 2012 Jeremy Long. All Rights Reserved.
 
 @author Jeremy Long <jeremy.long@owasp.org>
-@version 1.2
+@version 1.3
 *#
 
 
@@ -79,7 +79,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                     setTimeout('$("#modal-content,#modal-background").toggleClass("active");',100);
                 });
                 $('#modal-add-header').click(function () {
-                    xml = '<?xml version="1.0" encoding="UTF-8"?>\n<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">\n   ';
+                    xml = '<?xml version="1.0" encoding="UTF-8"?>\n<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">\n   ';
                     xml += $("#modal-text").text().replace(/\n/g,'\n   ');
                     xml += '\n</suppressions>';
                     $('#modal-add-header').toggleClass('active');
@@ -852,9 +852,9 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                             #if($vuln.getSource().name().equals("NVD"))
                                 <p><b><a target="_blank" href="http://web.nvd.nist.gov/view/vuln/detail?vulnId=$enc.url($vuln.name)">$enc.html($vuln.name)</a></b>&nbsp;&nbsp;<button class="copybutton" title="Generate Suppression XML for this CCE for this file" onclick="copyText('$enc.javascript($dependency.DisplayFileName)', '$enc.javascript($dependency.Sha1sum)', '#if($suppressGav)$enc.javascript($suppressGav)#end', 'cve', '$enc.javascript($vuln.name)')">suppress</button></p>
                             #elseif($vuln.getSource().name().equals("NPM"))
-                                <p><b><a target="_blank" href="https://www.npmjs.com/advisories/$enc.url($vuln.name)">NPM-$enc.html($vuln.name)</a></b></p>
+                                <p><b><a target="_blank" href="https://www.npmjs.com/advisories/$enc.url($vuln.name)">NPM-$enc.html($vuln.name)</a></b>&nbsp;&nbsp;<button class="copybutton" title="Generate Suppression XML for this CCE for this file" onclick="copyText('$enc.javascript($dependency.DisplayFileName)', '$enc.javascript($dependency.Sha1sum)', '#if($suppressGav)$enc.javascript($suppressGav)#end', 'vulnerabilityName', '$enc.javascript($vuln.name)')">suppress</button></p>
                             #else
-                                <p><b>$enc.html($vuln.name)</b> ($vuln.getSource().name())</p>
+                                <p><b>$enc.html($vuln.name)</b>&nbsp;($vuln.getSource().name())</b>&nbsp;&nbsp;<button class="copybutton" title="Generate Suppression XML for this CCE for this file" onclick="copyText('$enc.javascript($dependency.DisplayFileName)', '$enc.javascript($dependency.Sha1sum)', '#if($suppressGav)$enc.javascript($suppressGav)#end', 'vulnerabilityName', '$enc.javascript($vuln.name)')">suppress</button></p>
                             #end
                             <p>#if($vuln.description)
                             <pre>$enc.html($vuln.description)</pre>

--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -88,7 +88,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             });
             function suppressSwitchTo(switchTo) {
                 $('#modal-suppress-change-to-sha1').toggleClass('active');
-                $('#modal-suppress-change-to-gav').toggleClass('active');
+                $('#modal-suppress-change-to-packageUrl').toggleClass('active');
                 if (!$('#modal-add-header').hasClass('active')) {
                     $('#modal-add-header').toggleClass('active');
                 }
@@ -98,37 +98,37 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                             $('#suppress-type').val(), 
                             $('#suppress-val').val());
             }
-            function copyText(name, sha1, gav, type, val) {
+            function copyText(name, sha1, packageUrl, type, val) {
                 $('#suppress-name').val(name);
                 $('#suppress-type').val(type);
                 $('#suppress-val').val(val);
                 $('#suppress-sha1').val(sha1);
-                $('#suppress-gav').val(gav);
-                if (gav=='') {
-                    if ($('#modal-suppress-change-to-gav').hasClass('active')) {
-                        $('#modal-suppress-change-to-gav').toggleClass('active');
+                $('#suppress-packageUrl').val(packageUrl);
+                if (packageUrl=='') {
+                    if ($('#modal-suppress-change-to-packageUrl').hasClass('active')) {
+                        $('#modal-suppress-change-to-packageUrl').toggleClass('active');
                     }
                     if ($('#modal-suppress-change-to-sha1').hasClass('active')) {
                         $('#modal-suppress-change-to-sha1').toggleClass('active');
                     }
                     setCopyText(name, 'sha1', sha1, type, val);
                 } else {
-                    if ($('#modal-suppress-change-to-gav').hasClass('active')) {
-                        $('#modal-suppress-change-to-gav').toggleClass('active');
+                    if ($('#modal-suppress-change-to-packageUrl').hasClass('active')) {
+                        $('#modal-suppress-change-to-packageUrl').toggleClass('active');
                     }
                     if (!$('#modal-suppress-change-to-sha1').hasClass('active')) {
                         $('#modal-suppress-change-to-sha1').toggleClass('active');
                     }
-                    setCopyText(name, 'gav', gav, type, val);
+                    setCopyText(name, 'packageUrl', packageUrl, type, val);
                 }
             }
             function setCopyText(name, matchType, matchValue, suppressType, suppressVal) {
                 xml =  '<suppress>\n';
                 xml += '   <notes><!'+'[CDATA[\n   file name: ' + name + '\n   ]]'+'></notes>\n';
-                if (matchType=='gav') {
-                    v = matchValue.match(/^[^:]+:[^:]+:/);
+                if (matchType=='packageUrl') {
+                    v = matchValue.match(/^[^@]+/);
                     if (v && v[0]) {
-                        xml += '   <'+matchType+' regex="true">^' + v[0].replace(/\./g,'\\.') + '.*$</'+matchType+'>\n';
+                        xml += '   <'+matchType+' regex="true">^' + v[0].replace(/\./g,'\\.') + '@.*$</'+matchType+'>\n';
                     } else {
                         xml += '   <'+matchType+'>' + matchValue + '</'+matchType+'>\n';
                     }
@@ -567,11 +567,11 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <div id="modal-background"></div>
         <div id="modal-content">
             <div>Press CTR-C to copy XML&nbsp;<a href="http://jeremylong.github.io/DependencyCheck/general/suppression.html" class="infolink" target="_blank" title="Help with suppressing false positives">[help]</a></div>
-                <button onclick="suppressSwitchTo('gav')" id="modal-suppress-change-to-gav" class="modal-button suppresstype" title="Supress by Maven Group Artifact Version">Suppress By GAV</button>
+                <button onclick="suppressSwitchTo('packageUrl')" id="modal-suppress-change-to-packageUrl" class="modal-button suppresstype" title="Supress by Maven Group Artifact Version">Suppress By GAV</button>
                 <button onclick="suppressSwitchTo('sha1')" id="modal-suppress-change-to-sha1" class="modal-button suppresstype" title="Supress by SHA1 hash">Suppress By SHA1</button><br/>
                 <input type="hidden" id="suppress-name"/>
                 <input type="hidden" id="suppress-type"/><input type="hidden" id="suppress-val"/>
-                <input type="hidden" id="suppress-sha1"/><input type="hidden" id="suppress-gav"/>
+                <input type="hidden" id="suppress-sha1"/><input type="hidden" id="suppress-packageUrl"/>
                 <textarea id="modal-text" cols="50" rows="10" readonly></textarea><br/>
                 <button id="modal-add-header" title="Add the parent XML nodes to create the complete XML file that can be used to suppress this finding" class="modal-button">Complete XML Doc</button><button id="modal-close" class="modal-button-right">Close</button>
         </div>
@@ -800,14 +800,14 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                         <h4 id="header$cnt" class="subsectionheader white">Identifiers</h4>
                         ##:&nbsp;<a href="https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=$enc.url($cpevalue)" target="_blank">$enc.html($cpevalue)</a></h4>
                         <div id="content$cnt" class="subsectioncontent standardsubsection">
-                        #set($suppressGav='')
+                        #set($supressPkgUrl='')
                         #if ($dependency.getSoftwareIdentifiers().size()==0 && $dependency.getVulnerableSoftwareIdentifiers().size()==0)
                             <ul><li><b>None</b></li></ul>
                         #else
                             <ul>
                             #foreach($id in $dependency.getSoftwareIdentifiers())
-                                #set($suppressGav=$rpt.identifierToSuppressionId($id))
-                                #if ($suppressGav)
+                                #set($supressPkgUrl=$rpt.identifierToSuppressionId($id))
+                                #if ($supressPkgUrl)
                                     #break
                                 #end
                             #end
@@ -834,7 +834,7 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                                 #if ($id.confidence)
                                     &nbsp;&nbsp;(<i>Confidence</i>:$WordUtils.capitalizeFully($id.confidence.toString()))
                                 #end
-                                &nbsp;&nbsp;<button class="copybutton" title="Generate Suppression XML for the identified vulnerability identifier" onclick="copyText('$enc.javascript($dependency.DisplayFileName)', '$enc.javascript($dependency.Sha1sum)', '#if($suppressGav)$enc.javascript($suppressGav)#end', 'cpe', '$enc.javascript($rpt.identifierToSuppressionId($id))')">suppress</button>
+                                &nbsp;&nbsp;<button class="copybutton" title="Generate Suppression XML for the identified vulnerability identifier" onclick="copyText('$enc.javascript($dependency.DisplayFileName)', '$enc.javascript($dependency.Sha1sum)', '#if($supressPkgUrl)$enc.javascript($supressPkgUrl)#end', 'cpe', '$enc.javascript($rpt.identifierToSuppressionId($id))')">suppress</button>
                                 #if ($id.notes)
                                     <ul><li>Notes: $enc.html($id.notes)</li></ul>
                                 #end
@@ -850,11 +850,11 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                         #foreach($vuln in $dependency.getVulnerabilities(true))
                             #set($vsctr=$vsctr+1)
                             #if($vuln.getSource().name().equals("NVD"))
-                                <p><b><a target="_blank" href="http://web.nvd.nist.gov/view/vuln/detail?vulnId=$enc.url($vuln.name)">$enc.html($vuln.name)</a></b>&nbsp;&nbsp;<button class="copybutton" title="Generate Suppression XML for this CCE for this file" onclick="copyText('$enc.javascript($dependency.DisplayFileName)', '$enc.javascript($dependency.Sha1sum)', '#if($suppressGav)$enc.javascript($suppressGav)#end', 'cve', '$enc.javascript($vuln.name)')">suppress</button></p>
+                                <p><b><a target="_blank" href="http://web.nvd.nist.gov/view/vuln/detail?vulnId=$enc.url($vuln.name)">$enc.html($vuln.name)</a></b>&nbsp;&nbsp;<button class="copybutton" title="Generate Suppression XML for this CCE for this file" onclick="copyText('$enc.javascript($dependency.DisplayFileName)', '$enc.javascript($dependency.Sha1sum)', '#if($supressPkgUrl)$enc.javascript($supressPkgUrl)#end', 'cve', '$enc.javascript($vuln.name)')">suppress</button></p>
                             #elseif($vuln.getSource().name().equals("NPM"))
-                                <p><b><a target="_blank" href="https://www.npmjs.com/advisories/$enc.url($vuln.name)">NPM-$enc.html($vuln.name)</a></b>&nbsp;&nbsp;<button class="copybutton" title="Generate Suppression XML for this CCE for this file" onclick="copyText('$enc.javascript($dependency.DisplayFileName)', '$enc.javascript($dependency.Sha1sum)', '#if($suppressGav)$enc.javascript($suppressGav)#end', 'vulnerabilityName', '$enc.javascript($vuln.name)')">suppress</button></p>
+                                <p><b><a target="_blank" href="https://www.npmjs.com/advisories/$enc.url($vuln.name)">NPM-$enc.html($vuln.name)</a></b>&nbsp;&nbsp;<button class="copybutton" title="Generate Suppression XML for this CCE for this file" onclick="copyText('$enc.javascript($dependency.DisplayFileName)', '$enc.javascript($dependency.Sha1sum)', '#if($supressPkgUrl)$enc.javascript($supressPkgUrl)#end', 'vulnerabilityName', '$enc.javascript($vuln.name)')">suppress</button></p>
                             #else
-                                <p><b>$enc.html($vuln.name)</b>&nbsp;($vuln.getSource().name())</b>&nbsp;&nbsp;<button class="copybutton" title="Generate Suppression XML for this CCE for this file" onclick="copyText('$enc.javascript($dependency.DisplayFileName)', '$enc.javascript($dependency.Sha1sum)', '#if($suppressGav)$enc.javascript($suppressGav)#end', 'vulnerabilityName', '$enc.javascript($vuln.name)')">suppress</button></p>
+                                <p><b>$enc.html($vuln.name)</b>&nbsp;($vuln.getSource().name())</b>&nbsp;&nbsp;<button class="copybutton" title="Generate Suppression XML for this CCE for this file" onclick="copyText('$enc.javascript($dependency.DisplayFileName)', '$enc.javascript($dependency.Sha1sum)', '#if($supressPkgUrl)$enc.javascript($supressPkgUrl)#end', 'vulnerabilityName', '$enc.javascript($vuln.name)')">suppress</button></p>
                             #end
                             <p>#if($vuln.description)
                             <pre>$enc.html($vuln.description)</pre>

--- a/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionRuleTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionRuleTest.java
@@ -507,6 +507,40 @@ public class SuppressionRuleTest extends BaseTest {
 
     }
 
+    @Test
+    public void testProcessVulnerabilityNames() throws CpeValidationException, MalformedPackageURLException {
+        File spring = BaseTest.getResourceAsFile(this, "spring-security-web-3.0.0.RELEASE.jar");
+        Dependency dependency = new Dependency(spring);
+        dependency.addVulnerableSoftwareIdentifier(new CpeIdentifier("vmware", "springsource_spring_security", "3.0.0", Confidence.HIGH));
+        dependency.addSoftwareIdentifier(new PurlIdentifier("maven", "org.springframework.security", "spring-security-web", "3.0.0.RELEASE", Confidence.HIGH));
+
+        dependency.addVulnerability(createVulnerability());
+        SuppressionRule instance = new SuppressionRule();
+        //gav
+        PropertyType pt = new PropertyType();
+        pt.setValue("pkg:maven/org.springframework.security/spring-security-web@3.0.0.RELEASE");
+        pt.setRegex(false);
+        pt.setCaseSensitive(false);
+        instance.setPackageUrl(pt);
+
+        pt = new PropertyType();
+        pt.setValue("CVE-2013-1338");
+        instance.addVulnerabilityName(pt);
+
+        instance.process(dependency);
+        assertEquals(1, dependency.getVulnerabilities().size());
+        assertEquals(0, dependency.getSuppressedVulnerabilities().size());
+
+        
+        pt = new PropertyType();
+        pt.setValue("CVE-2013-1337");
+        instance.addVulnerabilityName(pt);
+        
+        instance.process(dependency);
+        assertEquals(0, dependency.getVulnerabilities().size());
+        assertEquals(1, dependency.getSuppressedVulnerabilities().size());
+    }
+
     private Vulnerability createVulnerability() {
         Vulnerability v = new Vulnerability();
         v.addCwe("CWE-287 Improper Authentication");

--- a/src/site/markdown/general/suppression.md
+++ b/src/site/markdown/general/suppression.md
@@ -6,7 +6,7 @@ A sample suppression file would look like:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
    <suppress>
       <notes><![CDATA[
       file name: some.jar
@@ -26,7 +26,7 @@ HTML version of the report. The other common scenario would be to ignore all CVE
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes><![CDATA[
         This suppresses cpe:/a:csv:csv:1.0 for some.jar in the "c:\path\to" directory.
@@ -70,6 +70,13 @@ HTML version of the report. The other common scenario would be to ignore all CVE
         <cpe>cpe:/a:springsource:spring_framework</cpe>
         <cpe>cpe:/a:mod_security:mod_security</cpe>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        This suppresses false positives identified on spring security.
+        ]]></notes>
+        <gav regex="true">org\.springframework\.security:spring.*</gav>
+        <vulnerabilityName regex="true"></vulnerabilityName>
+    </suppress>
     <suppress until="2020-01-01Z">
         <notes><![CDATA[
         This suppresses a specific cve for any dependency in any directory that has the specified sha1 checksum. If current date is not yet on or beyond 1 Jan 2020.
@@ -84,7 +91,7 @@ It is also possible to set an expiration date for a suppression rule:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress until="2020-01-01Z">
         <notes><![CDATA[
         Suppresses a given CVE for a dependency with the given sha1 until the current date is 1 Jan 2020 or beyond.
@@ -95,7 +102,7 @@ It is also possible to set an expiration date for a suppression rule:
 </suppressions>
 ```
 
-The full schema for suppression files can be found here: [suppression.xsd](https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd "Suppression Schema")
+The full schema for suppression files can be found here: [suppression.xsd](https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd "Suppression Schema")
 
 Please see the appropriate configuration option in each interfaces configuration guide:
 

--- a/src/site/markdown/general/suppression.md
+++ b/src/site/markdown/general/suppression.md
@@ -29,6 +29,13 @@ HTML version of the report. The other common scenario would be to ignore all CVE
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes><![CDATA[
+        This suppresses a CVE identified by OSS Index using the vulnerability name and packageUrl.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty-server@.*$</packageUrl>
+        <vulnerabilityName>CVE-2017-7656</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
         This suppresses cpe:/a:csv:csv:1.0 for some.jar in the "c:\path\to" directory.
         ]]></notes>
         <filePath>c:\path\to\some.jar</filePath>


### PR DESCRIPTION
## Fixes Issue #1973, #1903, #1733, #892

## Description of Change

Enhanced the suppression mechanism to support both the Package URL (in addition to the GAV) to identify which dependency to apply the suppression rule. Also, added `vulnerabilityName` as an option to suppress a specific vulnerability.  This allows one to suppress findings from NSP, Ruby's Bundle Audit, RetireJS, and OSS Index.

## Have test cases been added to cover the new functionality?

yes