### PR TITLE
Fix typo when referring to property in maven plugin POM

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -37,7 +37,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <tag>HEAD</tag>
     </scm>
     <prerequisites>
-        <maven>${maven.api.version>}</maven>
+        <maven>${maven.api.version}</maven>
     </prerequisites>
     <build>
         <resources>


### PR DESCRIPTION
## Fixes Issue #

Typo when referring to property in maven plugin POM.

## Description of Change

Fixed typo.

## Have test cases been added to cover the new functionality?

No.