### PR TITLE
Improve Error Reporting

### DIFF
--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -1560,16 +1560,17 @@ public class Check extends Update {
                     }
                 }
             }
-
+            ExceptionCollection exceptions = null;
             try {
                 engine.analyzeDependencies();
             } catch (ExceptionCollection ex) {
                 if (this.isFailOnError()) {
                     throw new BuildException(ex);
                 }
+                exceptions = ex;
             }
             for (String format : getReportFormats()) {
-                engine.writeReports(getProjectName(), new File(reportOutputDirectory), format);
+                engine.writeReports(getProjectName(), new File(reportOutputDirectory), format, exceptions);
             }
 
             if (this.failBuildOnCVSS <= 10) {

--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -254,7 +254,7 @@ public class App {
             }
 
             try {
-                engine.writeReports(applicationName, new File(reportDirectory), outputFormat);
+                engine.writeReports(applicationName, new File(reportDirectory), outputFormat, exCol);
             } catch (ReportException ex) {
                 if (exCol != null) {
                     exCol.addException(ex);

--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -1155,8 +1155,8 @@ public class Engine implements FileFilter, AutoCloseable {
         exceptions.add(throwable);
         throw new ExceptionCollection(exceptions, true);
     }
-    
-        /**
+
+    /**
      * Writes the report to the given output directory.
      *
      * @param applicationName the name of the application/project
@@ -1164,23 +1164,28 @@ public class Engine implements FileFilter, AutoCloseable {
      * file name if the format is not ALL)
      * @param format the report format (ALL, HTML, CSV, JSON, etc.)
      * @throws ReportException thrown if there is an error generating the report
+     * @deprecated use {@link #writeReports(java.lang.String, java.io.File, java.lang.String, org.owasp.dependencycheck.exception.ExceptionCollection)
      */
+    @Deprecated
     public void writeReports(String applicationName, File outputDir, String format) throws ReportException {
         writeReports(applicationName, null, null, null, outputDir, format, null);
     }
-        /**
+
+    /**
      * Writes the report to the given output directory.
      *
      * @param applicationName the name of the application/project
      * @param outputDir the path to the output directory (can include the full
      * file name if the format is not ALL)
      * @param format the report format (ALL, HTML, CSV, JSON, etc.)
-     * @param exceptions a collection of exceptions that may have occurred during the analysis
+     * @param exceptions a collection of exceptions that may have occurred
+     * during the analysis
      * @throws ReportException thrown if there is an error generating the report
      */
     public void writeReports(String applicationName, File outputDir, String format, ExceptionCollection exceptions) throws ReportException {
         writeReports(applicationName, null, null, null, outputDir, format, exceptions);
     }
+
     /**
      * Writes the report to the given output directory.
      *
@@ -1192,12 +1197,15 @@ public class Engine implements FileFilter, AutoCloseable {
      * file name if the format is not ALL)
      * @param format the report format (ALL, HTML, CSV, JSON, etc.)
      * @throws ReportException thrown if there is an error generating the report
+     * @deprecated use {@link #writeReports(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.io.File, java.lang.String, org.owasp.dependencycheck.exception.ExceptionCollection)
      */
+    @Deprecated
     public synchronized void writeReports(String applicationName, @Nullable final String groupId,
             @Nullable final String artifactId, @Nullable final String version,
             @NotNull final File outputDir, String format) throws ReportException {
         writeReports(applicationName, groupId, artifactId, version, outputDir, format, null);
     }
+
     /**
      * Writes the report to the given output directory.
      *
@@ -1208,7 +1216,8 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param outputDir the path to the output directory (can include the full
      * file name if the format is not ALL)
      * @param format the report format (ALL, HTML, CSV, JSON, etc.)
-     * @param exceptions a collection of exceptions that may have occurred during the analysis
+     * @param exceptions a collection of exceptions that may have occurred
+     * during the analysis
      * @throws ReportException thrown if there is an error generating the report
      */
     public synchronized void writeReports(String applicationName, @Nullable final String groupId,

--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -1155,7 +1155,32 @@ public class Engine implements FileFilter, AutoCloseable {
         exceptions.add(throwable);
         throw new ExceptionCollection(exceptions, true);
     }
-
+    
+        /**
+     * Writes the report to the given output directory.
+     *
+     * @param applicationName the name of the application/project
+     * @param outputDir the path to the output directory (can include the full
+     * file name if the format is not ALL)
+     * @param format the report format (ALL, HTML, CSV, JSON, etc.)
+     * @throws ReportException thrown if there is an error generating the report
+     */
+    public void writeReports(String applicationName, File outputDir, String format) throws ReportException {
+        writeReports(applicationName, null, null, null, outputDir, format, null);
+    }
+        /**
+     * Writes the report to the given output directory.
+     *
+     * @param applicationName the name of the application/project
+     * @param outputDir the path to the output directory (can include the full
+     * file name if the format is not ALL)
+     * @param format the report format (ALL, HTML, CSV, JSON, etc.)
+     * @param exceptions a collection of exceptions that may have occurred during the analysis
+     * @throws ReportException thrown if there is an error generating the report
+     */
+    public void writeReports(String applicationName, File outputDir, String format, ExceptionCollection exceptions) throws ReportException {
+        writeReports(applicationName, null, null, null, outputDir, format, exceptions);
+    }
     /**
      * Writes the report to the given output directory.
      *
@@ -1171,29 +1196,34 @@ public class Engine implements FileFilter, AutoCloseable {
     public synchronized void writeReports(String applicationName, @Nullable final String groupId,
             @Nullable final String artifactId, @Nullable final String version,
             @NotNull final File outputDir, String format) throws ReportException {
+        writeReports(applicationName, groupId, artifactId, version, outputDir, format, null);
+    }
+    /**
+     * Writes the report to the given output directory.
+     *
+     * @param applicationName the name of the application/project
+     * @param groupId the Maven groupId
+     * @param artifactId the Maven artifactId
+     * @param version the Maven version
+     * @param outputDir the path to the output directory (can include the full
+     * file name if the format is not ALL)
+     * @param format the report format (ALL, HTML, CSV, JSON, etc.)
+     * @param exceptions a collection of exceptions that may have occurred during the analysis
+     * @throws ReportException thrown if there is an error generating the report
+     */
+    public synchronized void writeReports(String applicationName, @Nullable final String groupId,
+            @Nullable final String artifactId, @Nullable final String version,
+            @NotNull final File outputDir, String format, ExceptionCollection exceptions) throws ReportException {
         if (mode == Mode.EVIDENCE_COLLECTION) {
             throw new UnsupportedOperationException("Cannot generate report in evidence collection mode.");
         }
         final DatabaseProperties prop = database.getDatabaseProperties();
-        final ReportGenerator r = new ReportGenerator(applicationName, groupId, artifactId, version, dependencies, getAnalyzers(), prop, settings);
+        final ReportGenerator r = new ReportGenerator(applicationName, groupId, artifactId, version, dependencies, getAnalyzers(), prop, settings, exceptions);
         try {
             r.write(outputDir.getAbsolutePath(), format);
         } catch (ReportException ex) {
             final String msg = String.format("Error generating the report for %s", applicationName);
             throw new ReportException(msg, ex);
         }
-    }
-
-    /**
-     * Writes the report to the given output directory.
-     *
-     * @param applicationName the name of the application/project
-     * @param outputDir the path to the output directory (can include the full
-     * file name if the format is not ALL)
-     * @param format the report format (ALL, HTML, CSV, JSON, etc.)
-     * @throws ReportException thrown if there is an error generating the report
-     */
-    public void writeReports(String applicationName, File outputDir, String format) throws ReportException {
-        writeReports(applicationName, null, null, null, outputDir, format);
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/exception/ExceptionCollection.java
+++ b/core/src/main/java/org/owasp/dependencycheck/exception/ExceptionCollection.java
@@ -134,6 +134,9 @@ public class ExceptionCollection extends Exception {
      * @param ex the exception to add
      */
     public void addException(Throwable ex) {
+        if (ex instanceof ExceptionCollection) {
+            this.exceptions.addAll(((ExceptionCollection) ex).getExceptions());
+        }
         this.exceptions.add(ex);
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
+++ b/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
@@ -59,6 +59,7 @@ import org.owasp.dependencycheck.analyzer.Analyzer;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseProperties;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.EvidenceType;
+import org.owasp.dependencycheck.exception.ExceptionCollection;
 import org.owasp.dependencycheck.exception.ReportException;
 import org.owasp.dependencycheck.utils.FileUtils;
 import org.owasp.dependencycheck.utils.Settings;
@@ -129,6 +130,7 @@ public class ReportGenerator {
      */
     private final Settings settings;
 
+    //CSOFF: ParameterNumber
     /**
      * Constructs a new ReportGenerator.
      *
@@ -138,13 +140,31 @@ public class ReportGenerator {
      * @param properties the database properties (containing timestamps of the
      * NVD CVE data)
      * @param settings a reference to the database settings
+     * @deprecated Please use
+     * {@link #ReportGenerator(java.lang.String, java.util.List, java.util.List, org.owasp.dependencycheck.data.nvdcve.DatabaseProperties, org.owasp.dependencycheck.utils.Settings, org.owasp.dependencycheck.exception.ExceptionCollection)}
      */
+    @Deprecated
     public ReportGenerator(String applicationName, List<Dependency> dependencies, List<Analyzer> analyzers,
             DatabaseProperties properties, Settings settings) {
-        this.settings = settings;
-        velocityEngine = createVelocityEngine();
-        velocityEngine.init();
-        context = createContext(applicationName, dependencies, analyzers, properties);
+        this(applicationName, dependencies, analyzers, properties, settings, null);
+    }
+
+    /**
+     * Constructs a new ReportGenerator.
+     *
+     * @param applicationName the application name being analyzed
+     * @param dependencies the list of dependencies
+     * @param analyzers the list of analyzers used
+     * @param properties the database properties (containing timestamps of the
+     * NVD CVE data)
+     * @param settings a reference to the database settings
+     * @param exceptions a collection of exceptions that may have occurred
+     * during the analysis
+     * @since 5.1.0
+     */
+    public ReportGenerator(String applicationName, List<Dependency> dependencies, List<Analyzer> analyzers,
+            DatabaseProperties properties, Settings settings, ExceptionCollection exceptions) {
+        this(applicationName, null, null, null, dependencies, analyzers, properties, settings, exceptions);
     }
 
     /**
@@ -159,30 +179,39 @@ public class ReportGenerator {
      * @param properties the database properties (containing timestamps of the
      * NVD CVE data)
      * @param settings a reference to the database settings
+     * @deprecated Please use
+     * {@link #ReportGenerator(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.List, java.util.List, org.owasp.dependencycheck.data.nvdcve.DatabaseProperties, org.owasp.dependencycheck.utils.Settings, org.owasp.dependencycheck.exception.ExceptionCollection)}
      */
-    //CSOFF: ParameterNumber
+    @Deprecated
     public ReportGenerator(String applicationName, String groupID, String artifactID, String version,
             List<Dependency> dependencies, List<Analyzer> analyzers, DatabaseProperties properties, Settings settings) {
-        this(applicationName, dependencies, analyzers, properties, settings);
-        if (version != null) {
-            context.put("applicationVersion", version);
-        }
-        if (artifactID != null) {
-            context.put("artifactID", artifactID);
-        }
-        if (groupID != null) {
-            context.put("groupID", groupID);
-        }
+        this(applicationName, groupID, artifactID, version, dependencies, analyzers, properties, settings, null);
     }
-    //CSON: ParameterNumber
 
     /**
-     * Creates a new Velocity Engine.
+     * Constructs a new ReportGenerator.
      *
-     * @return a velocity engine
+     * @param applicationName the application name being analyzed
+     * @param groupID the group id of the project being analyzed
+     * @param artifactID the application id of the project being analyzed
+     * @param version the application version of the project being analyzed
+     * @param dependencies the list of dependencies
+     * @param analyzers the list of analyzers used
+     * @param properties the database properties (containing timestamps of the
+     * NVD CVE data)
+     * @param settings a reference to the database settings
+     * @param exceptions a collection of exceptions that may have occurred
+     * during the analysis
+     * @since 5.1.0
      */
-    private VelocityEngine createVelocityEngine() {
-        return new VelocityEngine();
+    public ReportGenerator(String applicationName, String groupID, String artifactID, String version,
+            List<Dependency> dependencies, List<Analyzer> analyzers, DatabaseProperties properties,
+            Settings settings, ExceptionCollection exceptions) {
+        this.settings = settings;
+        velocityEngine = createVelocityEngine();
+        velocityEngine.init();
+        context = createContext(applicationName, dependencies, analyzers, properties, groupID,
+                artifactID, version, exceptions);
     }
 
     /**
@@ -198,7 +227,7 @@ public class ReportGenerator {
      */
     @SuppressWarnings("JavaTimeDefaultTimeZone")
     private VelocityContext createContext(String applicationName, List<Dependency> dependencies,
-            List<Analyzer> analyzers, DatabaseProperties properties) {
+            List<Analyzer> analyzers, DatabaseProperties properties, String groupID, String artifactID, String version, ExceptionCollection exceptions) {
 
         final ZonedDateTime dt = ZonedDateTime.now();
         final String scanDate = DateTimeFormatter.RFC_1123_DATE_TIME.format(dt);
@@ -221,7 +250,29 @@ public class ReportGenerator {
         ctxt.put("VERSION", EvidenceType.VERSION);
         ctxt.put("version", settings.getString(Settings.KEYS.APPLICATION_VERSION, "Unknown"));
         ctxt.put("settings", settings);
+        if (version != null) {
+            context.put("applicationVersion", version);
+        }
+        if (artifactID != null) {
+            context.put("artifactID", artifactID);
+        }
+        if (groupID != null) {
+            context.put("groupID", groupID);
+        }
+        if (exceptions != null) {
+            context.put("exceptions", exceptions);
+        }
         return ctxt;
+    }
+    //CSON: ParameterNumber
+
+    /**
+     * Creates a new Velocity Engine.
+     *
+     * @return a velocity engine
+     */
+    private VelocityEngine createVelocityEngine() {
+        return new VelocityEngine();
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
+++ b/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
@@ -251,16 +251,16 @@ public class ReportGenerator {
         ctxt.put("version", settings.getString(Settings.KEYS.APPLICATION_VERSION, "Unknown"));
         ctxt.put("settings", settings);
         if (version != null) {
-            context.put("applicationVersion", version);
+            ctxt.put("applicationVersion", version);
         }
         if (artifactID != null) {
-            context.put("artifactID", artifactID);
+            ctxt.put("artifactID", artifactID);
         }
         if (groupID != null) {
-            context.put("groupID", groupID);
+            ctxt.put("groupID", groupID);
         }
         if (exceptions != null) {
-            context.put("exceptions", exceptions);
+            ctxt.put("exceptions", exceptions.getExceptions());
         }
         return ctxt;
     }

--- a/core/src/main/resources/schema/dependency-check.2.2.xsd
+++ b/core/src/main/resources/schema/dependency-check.2.2.xsd
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema id="analysis"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           targetNamespace="https://jeremylong.github.io/DependencyCheck/dependency-check.2.2.xsd"
+           xmlns:dc="https://jeremylong.github.io/DependencyCheck/dependency-check.2.2.xsd">
+    <xs:complexType name="exception">
+        <xs:sequence>
+            <xs:element name="message" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="stackTrace" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="trace" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="cause" type="dc:exception" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="scanInfo">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element name="engineVersion" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="dataSource">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                            <xs:element name="timestamp" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+            <xs:element name="analysisExceptions" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="exception" type="dc:exception"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="projectInfo">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="groupID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="artifactID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="version" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="reportDate" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="credits" type="xs:string" minOccurs="1" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="identifier">
+        <xs:sequence>
+            <xs:element name="id" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="url" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="notes" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="confidence" type="xs:string" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="relatedDependency">
+        <xs:sequence>
+            <xs:element name="filePath" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="sha256" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="sha1" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="md5" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="identifiers" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="package" type="dc:identifier"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="isVirtual" type="xs:boolean" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="evidence">
+        <xs:sequence>
+            <xs:element name="source" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="value" type="xs:string" minOccurs="1" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="type" type="xs:string" use="required"/>
+        <xs:attribute name="confidence" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="cvssV2">
+        <xs:sequence>
+            <xs:element name="score" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="accessVector" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="accessComplexity" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="authenticationr" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="confidentialImpact" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="integrityImpact" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="availabilityImpact" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="severity" type="xs:string" minOccurs="1" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="cvssV3">
+        <xs:sequence>
+            <xs:element name="baseScore" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="attackVector" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="attackComplexity" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="privilegesRequired" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="userInteraction" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="scope" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="confidentialityImpact" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="integrityImpact" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="availabilityImpact" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="baseSeverity" type="xs:string" minOccurs="1" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="reference">
+        <xs:sequence>
+            <xs:element name="source" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="url" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="software">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="vulnerabilityIdMatched" type="xs:boolean"/>
+                <xs:attribute name="versionStartIncluding" type="xs:string"/>
+                <xs:attribute name="versionStartExcluding" type="xs:string"/>
+                <xs:attribute name="versionEndIncluding" type="xs:string"/>
+                <xs:attribute name="versionEndExcluding" type="xs:string"/>
+                <xs:attribute name="vulnerable" type="xs:boolean"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="vulnerability">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="severity" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="cvssV2" type="dc:cvssV2" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="cvssV3" type="dc:cvssV3" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="cwes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="cwe" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="notes" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="references" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="reference" type="dc:reference"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="vulnerableSoftware" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="software" type="dc:software"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="source" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="dependency">
+        <xs:sequence>
+            <xs:element name="fileName" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="filePath" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="md5" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="sha1" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="sha256" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="license" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="projectReferences" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="projectReference" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="relatedDependencies" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="relatedDependency" type="dc:relatedDependency"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="evidenceCollected" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="evidence" type="dc:evidence"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="identifiers" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="package" type="dc:identifier"/>
+                        </xs:sequence>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="vulnerabilityIds" type="dc:identifier"/>
+                        </xs:sequence>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="suppressedVulnerabilityIds" type="dc:identifier"/>
+                        </xs:sequence>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="vulnerabilities" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="vulnerability" type="dc:vulnerability"/>
+                        </xs:sequence>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="suppressedVulnerability" type="dc:vulnerability"/>
+                        </xs:sequence>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="isVirtual" type="xs:boolean" use="required"/>
+    </xs:complexType>
+
+    <xs:element name="analysis">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="scanInfo" type="dc:scanInfo"/>
+                <xs:element name="projectInfo" type="dc:projectInfo"/>
+                <xs:element name="dependencies">
+                    <xs:complexType>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="dependency" type="dc:dependency"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -624,6 +624,36 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                         <li class="scaninfo hidden"><i>$enc.html($prop.key)</i>: $enc.html($prop.value)</li>
                         #end
                     </ul><br/>
+                #set($cnt=0)
+#if($exceptions)
+    #macro( writeException $type $ex $depth)
+        #set($cnt=$cnt+1)
+        <h4 id="header$cnt" class="subsectionheader expandable expandablesubsection white">$enc.html($ex.getMessage())</h4>
+        <div id="content$cnt" class="subsectioncontent standardsubsection hidden">
+        <b>$type</b>: $enc.html($ex.toString())
+        #if($ex.getStackTrace())
+            <pre>
+            #foreach($t in $ex.getStackTrace())
+                $enc.html($t.toString())<br/>
+            #end
+            </pre>
+        #end
+        #if($ex.getCause() && $depth<20)
+            #set($cause="cause")
+            #set($currentDepth=$depth+1)
+            #writeException($cause $ex.getCause() $currentDepth)
+        #end
+        </div>
+    #end
+        <h2>Analysis Exceptions</h2>
+            #foreach($ex in $exceptions)
+                #set($type="exception")
+                #set($d=0)
+                #writeException($type $ex $d)
+            #end
+        <br/>
+#end
+<h2>Summary</h2>
                 Display:&nbsp;<a href="#" title="Click to toggle display" onclick="return toggleDisplay(this, '.notvulnerable', 'Showing Vulnerable Dependencies (click to show all)', 'Showing All Dependencies (click to show less)'); return false;">Showing Vulnerable Dependencies (click to show all)</a><br/><br/>
                 #set($lnkcnt=0)
                 <table id="summaryTable" class="lined">
@@ -715,7 +745,6 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                 </table>
                 <h2>Dependencies</h2>
                 #set($lnkcnt=0)
-                #set($cnt=0)
                 #set($vsctr=0) ##counter to create unique groups for vulnerable software
                 #foreach($dependency in $dependencies)
                     #set($lnkcnt=$lnkcnt+1)

--- a/core/src/main/resources/templates/jsonReport.vsl
+++ b/core/src/main/resources/templates/jsonReport.vsl
@@ -10,6 +10,33 @@
             }
         #end
         ]
+
+    #if($exceptions)
+        #macro( writeException $type $ex $depth)
+            "$type":{"message":"$enc.json($ex.toString())"
+            #if($ex.getStackTrace())
+                ,"stackTrace":[
+                #foreach($t in $ex.getStackTrace())
+                    #if($foreach.count > 1),#end"$enc.json($t.toString())"
+                #end
+                ]
+            #end
+            #if($ex.getCause() && $depth<20)
+                #set($cause="cause")
+                #set($currentDepth=$depth+1)
+                ,#writeException($cause $ex.getCause() $currentDepth)
+            #end
+            }
+        #end
+            ,"analysisExceptions":[
+                #foreach($ex in $exceptions)
+                    #set($type="exception")
+                    #set($d=0)
+                    #if($foreach.count > 1),#end{#writeException($type $ex $d)}
+                #end
+            ]
+    #end
+
     },
     "projectInfo": {
         "name": "$enc.json($applicationName)",

--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -19,7 +19,7 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
 @version 2.0
 
 *#<?xml version="1.0"?>
-<analysis xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.2.1.xsd">
+<analysis xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.2.2.xsd">
     <scanInfo>
         <engineVersion>$version</engineVersion>
 #foreach($prop in $properties.getMetaData().entrySet())
@@ -27,6 +27,31 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
             <name>$enc.xml($prop.key)</name>
             <timestamp>$enc.xml($prop.value)</timestamp>
         </dataSource>
+#end
+#if($exceptions)
+    #macro( writeException $type $ex $depth)
+        <$type><message>$enc.xml($ex.toString())</message>
+        #if($ex.getStackTrace())
+            <stackTrace>
+            #foreach($t in $ex.getStackTrace())
+                <trace>$enc.xml($t.toString())</trace>
+            #end
+            </stackTrace>
+        #end
+        #if($ex.getCause() && $depth<20)
+            #set($cause="cause")
+            #set($currentDepth=$depth+1)
+            #writeException($cause $ex.getCause() $currentDepth)
+        #end
+        </$type>
+    #end
+        <analysisExceptions>
+            #foreach($ex in $exceptions)
+                #set($type="exception")
+                #set($d=0)
+                #writeException($type $ex $d)
+            #end
+        </analysisExceptions>
 #end
     </scanInfo>
     <projectInfo>

--- a/core/src/test/java/org/owasp/dependencycheck/EngineIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/EngineIT.java
@@ -53,6 +53,7 @@ public class EngineIT extends BaseDBTestCase {
         getSettings().setBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED, false);
         getSettings().setBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED, false);
         getSettings().setBoolean(Settings.KEYS.ANALYZER_EXPERIMENTAL_ENABLED, true);
+        ExceptionCollection exceptions = null;
         try (Engine instance = new Engine(getSettings())) {
             instance.scan(testClasses);
             assertTrue(instance.getDependencies().length > 0);
@@ -62,6 +63,7 @@ public class EngineIT extends BaseDBTestCase {
                 Set<String> allowedMessages = new HashSet<>();
                 allowedMessages.add("bundle-audit");
                 allowedMessages.add("AssemblyAnalyzer");
+                allowedMessages.add("Failed to request component-reports");
                 allowedMessages.add("ailed to read results from the NPM Audit API");
                 for (Throwable t : ex.getExceptions()) {
                     boolean isOk = false;
@@ -76,9 +78,10 @@ public class EngineIT extends BaseDBTestCase {
                     if (!isOk) {
                         throw ex;
                     }
+                    exceptions = ex;
                 }
             }
-            instance.writeReports("dependency-check sample", new File("./target/"), "ALL");
+            instance.writeReports("dependency-check sample", new File("./target/"), "ALL", exceptions);
         }
     }
 }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1400,7 +1400,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 try {
                     final MavenProject p = this.getProject();
                     for (String f : getFormats()) {
-                        engine.writeReports(p.getName(), p.getGroupId(), p.getArtifactId(), p.getVersion(), outputDir, f);
+                        engine.writeReports(p.getName(), p.getGroupId(), p.getArtifactId(), p.getVersion(), outputDir, f, exCol);
                     }
                 } catch (ReportException ex) {
                     if (exCol == null) {


### PR DESCRIPTION
Adds error reporting to JSON, XML, and HTML reports. Instead of exceptions only being displayed on command line output - the details are now included in the report to make it easier so one can be alerted if there are issues with the ODC analysis.