### PR TITLE
Add support for Rubys rbenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ _site/**
 cov-scan.bat
 
 /core/data/
+
+# Apple macOS operating system Desktop Services Store files
+.DS_Store

--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -256,6 +256,10 @@ public class Check extends Update {
      */
     private String bundleAuditPath;
     /**
+     * Sets the path for the working directory that the bundle-audit binary should be executed from.
+     */
+    private String bundleAuditWorkingDirectory;
+    /**
      * Whether or not the CocoaPods Analyzer is enabled.
      */
     private Boolean cocoapodsAnalyzerEnabled;
@@ -801,6 +805,24 @@ public class Check extends Update {
      */
     public void setBundleAuditPath(String bundleAuditPath) {
         this.bundleAuditPath = bundleAuditPath;
+    }
+
+    /**
+     * Sets the path to the working directory that the bundle audit executable should be executed from.
+     *
+     * @param bundleAuditWorkingDirectory the path to the working directory that the bundle audit executable should be executed from.
+     */
+    public void setBundleAuditWorkingDirectory(String bundleAuditWorkingDirectory) {
+        this.bundleAuditWorkingDirectory = bundleAuditWorkingDirectory;
+    }
+
+    /**
+     * Returns the path to the working directory that the bundle audit executable should be executed from.
+     *
+     * @return the path to the working directory that the bundle audit executable should be executed from.
+     */
+    public String getBundleAuditWorkingDirectory() {
+        return bundleAuditWorkingDirectory;
     }
 
     /**
@@ -1620,6 +1642,7 @@ public class Check extends Update {
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_COCOAPODS_ENABLED, cocoapodsAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_ENABLED, bundleAuditAnalyzerEnabled);
         getSettings().setStringIfNotNull(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_PATH, bundleAuditPath);
+        getSettings().setStringIfNotNull(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_WORKING_DIRECTORY, bundleAuditWorkingDirectory);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_AUTOCONF_ENABLED, autoconfAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_COMPOSER_LOCK_ENABLED, composerAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED, nodeAnalyzerEnabled);

--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -505,6 +505,7 @@ public class App {
                 cli.getStringArgument(CliParser.ARGUMENT.ARTIFACTORY_BEARER_TOKEN));
 
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_PATH, cli.getPathToBundleAudit());
+        settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_WORKING_DIRECTORY, cli.getPathToBundleAuditWorkingDirectory());
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_NEXUS_URL, nexusUrl);
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_NEXUS_USER, nexusUser);
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_NEXUS_PASSWORD, nexusPass);

--- a/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
@@ -404,6 +404,9 @@ public final class CliParser {
         final Option pathToBundleAudit = Option.builder().argName("path").hasArg()
                 .longOpt(ARGUMENT.PATH_TO_BUNDLE_AUDIT)
                 .desc("The path to bundle-audit for Gem bundle analysis.").build();
+        final Option pathToBundleAuditWorkingDirectory = Option.builder().argName("path").hasArg()
+                .longOpt(ARGUMENT.PATH_TO_BUNDLE_AUDIT_WORKING_DIRECTORY)
+                .desc("The path to working directory that the bundle-audit command should be executed from when doing Gem bundle analysis.").build();
         final Option connectionTimeout = Option.builder(ARGUMENT.CONNECTION_TIMEOUT_SHORT).argName("timeout").hasArg()
                 .longOpt(ARGUMENT.CONNECTION_TIMEOUT).desc("The connection timeout (in milliseconds) to use when downloading resources.")
                 .build();
@@ -488,6 +491,7 @@ public final class CliParser {
                 .addOption(disableArchiveAnalyzer)
                 .addOption(disableAssemblyAnalyzer)
                 .addOption(pathToBundleAudit)
+                .addOption(pathToBundleAuditWorkingDirectory)
                 .addOption(disablePythonDistributionAnalyzer)
                 .addOption(disableCmakeAnalyzer)
                 .addOption(disablePythonPackageAnalyzer)
@@ -554,7 +558,6 @@ public final class CliParser {
                 .addOption(nexusUsesProxy)
                 .addOption(additionalZipExtensions)
                 .addOption(pathToCore)
-                .addOption(pathToBundleAudit)
                 .addOption(purge);
     }
 
@@ -1126,6 +1129,15 @@ public final class CliParser {
      */
     public String getPathToBundleAudit() {
         return line.getOptionValue(ARGUMENT.PATH_TO_BUNDLE_AUDIT);
+    }
+
+    /**
+     * Returns the path to the working directory that should be used when the bundle-audit command is used for Ruby bundle analysis.
+     *
+     * @return the path to the working directory that should be used when the bundle-audit command is used for Ruby bundle analysis.
+     */
+    public String getPathToBundleAuditWorkingDirectory() {
+        return line.getOptionValue(ARGUMENT.PATH_TO_BUNDLE_AUDIT_WORKING_DIRECTORY);
     }
 
     /**
@@ -1785,6 +1797,11 @@ public final class CliParser {
          * bundle analysis.
          */
         public static final String PATH_TO_BUNDLE_AUDIT = "bundleAudit";
+        /**
+         * The CLI argument name for setting the path that should be used as the working directory that the bundle-audit
+         * command used for Ruby bundle analysis should be executed from. This will allow for the usage of rbenv
+         */
+        public static final String PATH_TO_BUNDLE_AUDIT_WORKING_DIRECTORY = "bundleAuditWorkingDirectory";
         /**
          * The CLI argument to enable the experimental analyzers.
          */

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
@@ -149,12 +149,23 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
                 bundleAudit = null;
             }
         }
-        args.add(bundleAudit != null && bundleAudit.isFile() ? bundleAudit.getAbsolutePath() : "bundle-audit");
+        args.add(bundleAudit != null ? bundleAudit.getAbsolutePath() : "bundle-audit");
         args.addAll(bundleAuditArgs);
         final ProcessBuilder builder = new ProcessBuilder(args);
-        builder.directory(folder);
+
+        final String bundleAuditWorkingDirectoryPath = getSettings().getString(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_WORKING_DIRECTORY);
+        File bundleAuditWorkingDirectory = null;
+        if (bundleAuditWorkingDirectoryPath != null) {
+            bundleAuditWorkingDirectory = new File(bundleAuditWorkingDirectoryPath);
+            if (!bundleAuditWorkingDirectory.isDirectory()) {
+                LOGGER.warn("Supplied `bundleAuditWorkingDirectory` path is incorrect: {}", bundleAuditWorkingDirectoryPath);
+                bundleAuditWorkingDirectory = null;
+            }
+        }
+        File launchBundleAuditFromDirectory = bundleAuditWorkingDirectory != null ? bundleAuditWorkingDirectory : folder;
+        builder.directory(launchBundleAuditFromDirectory);
         try {
-            LOGGER.info("Launching: {} from {}", args, folder);
+            LOGGER.info("Launching: {} from {}", args, launchBundleAuditFromDirectory);
             return builder.start();
         } catch (IOException ioe) {
             throw new AnalysisException("bundle-audit initialization failure; this error can be ignored if you are not analyzing Ruby. "

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
@@ -135,7 +135,7 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
      * @throws AnalysisException thrown when there is an issue launching bundle
      * audit
      */
-    private Process launchBundleAudit(File folder) throws AnalysisException {
+    private Process launchBundleAudit(File folder, List<String> bundleAuditArgs) throws AnalysisException {
         if (!folder.isDirectory()) {
             throw new AnalysisException(String.format("%s should have been a directory.", folder.getAbsolutePath()));
         }
@@ -150,8 +150,7 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
             }
         }
         args.add(bundleAudit != null && bundleAudit.isFile() ? bundleAudit.getAbsolutePath() : "bundle-audit");
-        args.add("check");
-        args.add("--verbose");
+        args.addAll(bundleAuditArgs);
         final ProcessBuilder builder = new ProcessBuilder(args);
         builder.directory(folder);
         try {
@@ -171,15 +170,17 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
      */
     @Override
     public void prepareFileTypeAnalyzer(Engine engine) throws InitializationException {
-        // Now, need to see if bundle-audit actually runs from this location.
         if (engine != null) {
             this.cvedb = engine.getDatabase();
         }
+
+        // Here we check if bundle-audit actually runs from this location. We do this by running the
+        // `bundle-audit version` command and seeing whether or not it succeeds (if it returns with an exit value of 0)
         final Process process;
         try {
-            process = launchBundleAudit(getSettings().getTempDirectory());
+            List<String> bundleAuditArgs = new ArrayList<String>() {{ add("version"); }};
+            process = launchBundleAudit(getSettings().getTempDirectory(), bundleAuditArgs);
         } catch (AnalysisException ae) {
-
             setEnabled(false);
             final String msg = String.format("Exception from bundle-audit process: %s. Disabling %s", ae.getCause(), ANALYZER_NAME);
             throw new InitializationException(msg, ae);
@@ -197,36 +198,48 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
             Thread.currentThread().interrupt();
             throw new InitializationException(msg);
         }
-        if (0 == exitValue) {
-            setEnabled(false);
-            final String msg = String.format("Unexpected exit code from bundle-audit process. Disabling %s: %s", ANALYZER_NAME, exitValue);
-            throw new InitializationException(msg);
-        } else {
+
+        String bundleAuditVersionDetails;
+        if (exitValue != 0) {
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8))) {
                 if (!reader.ready()) {
-                    LOGGER.warn("Bundle-audit error stream unexpectedly not ready. Disabling {}", ANALYZER_NAME);
+                    LOGGER.warn("Unexpected exit value from bundle-audit process and error stream unexpectedly not ready to capture error details. Disabling {}. Exit value was: {}", ANALYZER_NAME, exitValue);
                     setEnabled(false);
                     throw new InitializationException("Bundle-audit error stream unexpectedly not ready.");
                 } else {
                     final String line = reader.readLine();
-                    if (line == null || !line.contains("Errno::ENOENT")) {
-                        LOGGER.warn("Unexpected bundle-audit output. Disabling {}: {}", ANALYZER_NAME, line);
-                        setEnabled(false);
-                        throw new InitializationException("Unexpected bundle-audit output.");
-                    }
+                    setEnabled(false);
+                    LOGGER.warn("Unexpected exit value from bundle-audit process. Disabling {}. Exit value was: {}. error stream output from bundle-audit process was: {}", ANALYZER_NAME, exitValue, line);
+                    throw new InitializationException("Unexpected exit value from bundle-audit process.");
                 }
             } catch (UnsupportedEncodingException ex) {
                 setEnabled(false);
-                throw new InitializationException("Unexpected bundle-audit encoding.", ex);
+                throw new InitializationException("Unexpected bundle-audit encoding when reading error stream.", ex);
             } catch (IOException ex) {
                 setEnabled(false);
-                throw new InitializationException("Unable to read bundle-audit output.", ex);
+                throw new InitializationException("Unable to read bundle-audit output from error stream.", ex);
+            }
+        } else {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                if (!reader.ready()) {
+                    LOGGER.warn("Bundle-audit input stream unexpectedly not ready to capture version details. Disabling {}", ANALYZER_NAME);
+                    setEnabled(false);
+                    throw new InitializationException("Bundle-audit input stream unexpectedly not ready to capture version details.");
+                } else {
+                    bundleAuditVersionDetails = reader.readLine();
+                }
+            } catch (UnsupportedEncodingException ex) {
+                setEnabled(false);
+                throw new InitializationException("Unexpected bundle-audit encoding when reading input stream.", ex);
+            } catch (IOException ex) {
+                setEnabled(false);
+                throw new InitializationException("Unable to read bundle-audit output from input stream.", ex);
             }
         }
 
         if (isEnabled()) {
-            LOGGER.info("{} is enabled. It is necessary to manually run \"bundle-audit update\" "
-                    + "occasionally to keep its database up to date.", ANALYZER_NAME);
+            LOGGER.info("{} is enabled and is using bundle-audit with version details: {}. Note: It is necessary to manually run \"bundle-audit update\" "
+                    + "occasionally to keep its database up to date.", ANALYZER_NAME, bundleAuditVersionDetails);
         }
     }
 
@@ -290,7 +303,8 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
             needToDisableGemspecAnalyzer = false;
         }
         final File parentFile = dependency.getActualFile().getParentFile();
-        final Process process = launchBundleAudit(parentFile);
+        List<String> bundleAuditArgs = new ArrayList<String>() {{ add("check"); add("--verbose"); }};
+        final Process process = launchBundleAudit(parentFile, bundleAuditArgs);
         final int exitValue;
         try {
             exitValue = process.waitFor();

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -528,6 +528,13 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     private String bundleAuditPath;
 
     /**
+     * Sets the path for the working directory that the bundle-audit binary should be executed from.
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "bundleAuditWorkingDirectory")
+    private String bundleAuditWorkingDirectory;
+
+    /**
      * Whether or not the CocoaPods Analyzer is enabled.
      */
     @SuppressWarnings("CanBeFinal")
@@ -1660,6 +1667,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         settings.setStringIfNotNull(Settings.KEYS.ANALYZER_RETIREJS_REPO_JS_URL, retireJsUrl);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_ENABLED, bundleAuditAnalyzerEnabled);
         settings.setStringIfNotNull(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_PATH, bundleAuditPath);
+        settings.setStringIfNotNull(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_WORKING_DIRECTORY, bundleAuditWorkingDirectory);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_COCOAPODS_ENABLED, cocoapodsAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_SWIFT_PACKAGE_MANAGER_ENABLED, swiftPackageManagerAnalyzerEnabled);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_OSSINDEX_ENABLED, ossindexAnalyzerEnabled);

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -464,6 +464,10 @@ public final class Settings {
          */
         public static final String ANALYZER_BUNDLE_AUDIT_PATH = "analyzer.bundle.audit.path";
         /**
+         * The path to bundle-audit, if available.
+         */
+        public static final String ANALYZER_BUNDLE_AUDIT_WORKING_DIRECTORY = "analyzer.bundle.audit.working.directory";
+        /**
          * The additional configured zip file extensions, if available.
          */
         public static final String ADDITIONAL_ZIP_EXTENSIONS = "extensions.zip";


### PR DESCRIPTION
## Fixes Issue #2060

## Description of Change
Added support for Rubys rbenv by adding the `bundleAuditWorkingDirectory` command line arg or the `analyzer.bundle.audit.working.directory` setting. This should allow you to do something like the following and have the appropriate version of `bundler-audit` used for your Ruby project:

```
dependency-check -s /path/to/project/repo --format ALL --out /path/to/dependency_check_out --log /path/to/dependency_check_out/dc.log --noupdate --bundleAuditWorkingDirectory /path/to/project/repo
```