### PR TITLE
Fix for issue #2170

### DIFF
--- a/core/src/main/resources/data/dbStatements_microsoft sql server.properties
+++ b/core/src/main/resources/data/dbStatements_microsoft sql server.properties
@@ -1,0 +1,17 @@
+# Copyright 2015 OWASP.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Microsoft SQL Server has its own specific syntax to alias a table in an update statement
+## https://stackoverflow.com/questions/4981481/how-to-write-update-sql-with-table-alias-in-sql-server-2008
+UPDATE_ECOSYSTEM=UPDATE u SET u.ecosystem = (SELECT q.eco FROM cpeEntry e INNER JOIN (SELECT DISTINCT vendor, product, MIN(ecosystem) eco FROM cpeEntry WHERE ecosystem is not null GROUP BY vendor, product) q ON q.vendor = e.vendor AND q.product = e.product AND e.id = u.id) FROM cpeEntry u WHERE exists (SELECT * FROM cpeEntry e INNER JOIN (SELECT DISTINCT vendor, product, MIN(ecosystem) eco FROM cpeEntry WHERE ecosystem is not null GROUP BY vendor, product) q ON q.vendor = e.vendor AND q.product = e.product AND e.id = u.id) AND u.ecosystem is null


### PR DESCRIPTION
## Fixes Issue #2170

## Description of Change

Add a specific resource for the Microsoft SQL Server database to use a custom syntax for the UPDATE_ECOSYSTEM query that uses a SQL-Server compatible update-query-with-alias

## Have test cases been added to cover the new functionality?

no; the fix has been locally tested with a project against a freshly installed SQL-Server in a docker container. Given the time it takes to fill a SQL Server Database with initial vulnerability data it appears to not be an appropriate target for a test-case.

Validated successful run of the query with the initial filling run
```text
...
[INFO] Processing Complete for NVD CVE - 2018  (24923111 ms)
[INFO] Download Started for NVD CVE - Modified
[INFO] Download Complete for NVD CVE - Modified  (1467 ms)
[INFO] Processing Started for NVD CVE - Modified
[INFO] Processing Complete for NVD CVE - Modified  (381385 ms)
[INFO] Begin database maintenance
[INFO] End database maintenance (17626 ms)
[INFO] Check for updates complete (61767875 ms)
...
```

and a subsequent incremental update run
```text
...
[INFO] Parsed regions [POM, NODEAUDIT, CENTRAL]
[INFO] Finished configuration in 48 ms.
[INFO] Checking for updates
[INFO] Download Started for NVD CVE - Modified
[INFO] Download Complete for NVD CVE - Modified  (1280 ms)
[INFO] Processing Started for NVD CVE - Modified
[INFO] Processing Complete for NVD CVE - Modified  (406148 ms)
[INFO] Begin database maintenance
[INFO] End database maintenance (641 ms)
[INFO] Skipping RetireJS update since last update was within 24 hours.
[INFO] Check for updates complete (408604 ms)
[INFO] Element event queue destroyed: org.apache.commons.jcs.engine.control.event.ElementEventQueue@22590e3e
...
```
