### PR TITLE
#2197: fix declaration of volumes in Dockerfile

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -37,7 +37,7 @@ RUN apk update                                                                  
     
 USER ${user}
 
-VOLUME ["/src" "/usr/share/dependency-check/data" "/report"]
+VOLUME ["/src", "/usr/share/dependency-check/data", "/report"]
 
 WORKDIR /src
 


### PR DESCRIPTION
## Fixes Issue #2197

## Description of Change

Uses commas to split the items in the VOLUME list in the Dockerfile, so the list is correctly parsed.

## Have test cases been added to cover the new functionality?

*no*

It  has been manually tested.
Previous output of `docker inspect` was
```json
            "Volumes": {
                "/report]": {},
                "/usr/share/dependency-check/data": {},
                "[/src": {}
            },
```

With the proposed fix the output is:
```json
            "Volumes": {
                "/report": {},
                "/src": {},
                "/usr/share/dependency-check/data": {}
            },
```
