### PR TITLE
Fix for issue #2203: Stop eating the exception.

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/cache/DataCacheFactory.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/cache/DataCacheFactory.java
@@ -83,7 +83,7 @@ public class DataCacheFactory {
                 try {
                     cacheDirectory = new File(settings.getDataDirectory(), CACHE_DIRECTORY);
                 } catch (IOException ex) {
-                    throw new CacheException("Unable to obtain disk cache directory path");
+                    throw new CacheException("Unable to obtain disk cache directory path", ex);
                 }
                 if (!cacheDirectory.isDirectory() && !cacheDirectory.mkdirs()) {
                     throw new CacheException("Unable to create disk cache: " + cacheDirectory.toString());


### PR DESCRIPTION
## Fixes Issue #
This fixes issue #2203.

## Description of Change
When catching the `IOException`, just pass it on to the `CacheException` as the cause.

## Have test cases been added to cover the new functionality?
no