### PR TITLE
Bump commons-compress from 1.18 to 1.19 to fix CVE-2019-12402

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@ Copyright (c) 2012 - Jeremy Long
         <jmockit.version>1.48</jmockit.version>
         <mockito-core.version>3.0.0</mockito-core.version>
         <jsoup.version>1.12.1</jsoup.version>
-        <commons-compress.version>1.18</commons-compress.version>
+        <commons-compress.version>1.19</commons-compress.version>
         <org.apache.maven.shared.file-management.version>3.0.0</org.apache.maven.shared.file-management.version>
         <maven-plugin-testing-harness.version>3.3.0</maven-plugin-testing-harness.version>
         <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>


### PR DESCRIPTION
@jeremylong Could you check why @dependabot-bot didn't pick up this upgrade? Version 1.19 was released one month ago according to Sonatype repo.