### PR TITLE
Remove volume data

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -37,7 +37,7 @@ RUN apk update                                                                  
     
 USER ${user}
 
-VOLUME ["/src", "/usr/share/dependency-check/data", "/report"]
+VOLUME ["/src", "/report"]
 
 WORKDIR /src
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -30,6 +30,7 @@ RUN apk update                                                                  
         | tar -xz --directory "/usr/share/dependency-check/plugins" --strip-components=1 --no-same-owner \
             "mysql-connector-java-${MYSQL_DRIVER_VERSION}/mysql-connector-java-${MYSQL_DRIVER_VERSION}.jar" && \
     addgroup -S ${user} && adduser -S -G ${user} ${user}                                             && \
+    mkdir /usr/share/dependency-check/data                                                           && \
     chown -R ${user}:${user} /usr/share/dependency-check                                             && \
     mkdir /report                                                                                    && \
     chown -R ${user}:${user} /report                                                                 && \


### PR DESCRIPTION
By using dependency check with a mirror (e.g. postgres), I do not want to mount data folder. _VOLUME_ declarations are not changeable after declaration and a _VOLUME_ has the user _root_. As the dependency check container runs with a non root user, dependency check fails.
