### PR TITLE
Dependency Classifier Specification Fix

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -976,7 +976,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
 
         final ArtifactType type = session.getRepositorySession().getArtifactTypeRegistry().get(dependency.getType());
         coordinate.setExtension(type.getExtension());
-        coordinate.setClassifier(type.getClassifier());
+        coordinate.setClassifier((null == dependency.getClassifier() || dependency.getClassifier().isEmpty()) ? type.getClassifier() : dependency.getClassifier());
 
         final Artifact artifact = artifactResolver.resolveArtifact(buildingRequest, coordinate).getArtifact();
 


### PR DESCRIPTION
## Fixes Issue #2231 

## Description of Change

Added logic to check first the dependency specification, then the type specification for the details.  the Dependency can be null if not specified, but I wanted to make sure even if it was specified, but was an empty specification (which is allowed) that it would still provide the proper tracing.

## Have test cases been added to cover the new functionality?

*no*