### PR TITLE
Improve [Development Usage > Docker] section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Then load the resulting 'dependency-check-report.html' into your favorite browse
 
 In the following example it is assumed that the source to be checked is in the current working directory. Persistent data and report directories are used, allowing you to destroy the container after running.
 
-```
+For Linux:
+```sh
 #!/bin/sh
 
 OWASPDC_DIRECTORY=$HOME/OWASP-Dependency-Check
@@ -114,10 +115,11 @@ DATA_DIRECTORY="$OWASPDC_DIRECTORY/data"
 REPORT_DIRECTORY="$OWASPDC_DIRECTORY/reports"
 
 if [ ! -d "$DATA_DIRECTORY" ]; then
-    echo "Initially creating persistent directories"
+    echo "Initially creating persistent directory: $DATA_DIRECTORY"
     mkdir -p "$DATA_DIRECTORY"
     chmod -R 664 "$DATA_DIRECTORY"
-
+if [ ! -d "$REPORT_DIRECTORY" ]; then
+    echo "Initially creating persistent directory: $REPORT_DIRECTORY"
     mkdir -p "$REPORT_DIRECTORY"
     chmod -R 664 "$REPORT_DIRECTORY"
 fi
@@ -136,7 +138,39 @@ docker run --rm \
     --out /report
     # Use suppression like this: (/src == $pwd)
     # --suppression "/src/security/dependency-check-suppression.xml"
+```
 
+For Windows:
+```bat
+@echo off
+
+set OWASPDC_DIRECTORY=%USERPROFILE%\OWASP-Dependency-Check
+set DATA_DIRECTORY="%OWASPDC_DIRECTORY%\data"
+set REPORT_DIRECTORY="%OWASPDC_DIRECTORY%\reports"
+
+IF NOT EXIST %DATA_DIRECTORY% (
+    echo Initially creating persistent directory: %DATA_DIRECTORY%
+    mkdir %DATA_DIRECTORY%
+)
+IF NOT EXIST %REPORT_DIRECTORY% (
+    echo Initially creating persistent directory: %REPORT_DIRECTORY%
+    mkdir %REPORT_DIRECTORY%
+)
+
+rem Make sure we are using the latest version
+docker pull owasp/dependency-check
+
+docker run --rm ^
+    --volume %cd%:/src ^
+    --volume %DATA_DIRECTORY%:/usr/share/dependency-check/data ^
+    --volume %REPORT_DIRECTORY%:/report ^
+    owasp/dependency-check ^
+    --scan /src ^
+    --format "ALL" ^
+    --project "My OWASP Dependency Check Project" ^
+    --out /report
+    rem Use suppression like this: (/src == $pwd)
+    rem --suppression "/src/security/dependency-check-suppression.xml"
 ```
 
 Building From Source


### PR DESCRIPTION
## Fixes Issue #
\-

## Description of Change
This Pull Request modifies the text in the `README.md` file, [Development Usage > Docker] section:
1. Initial creating of persistent directories in the example script is slightly improved:
    1. Previously only the existence of `$DATA_DIRECTORY` was checked. Now the existence of `$REPORT_DIRECTORY` is checked too.
    2. Now the script prints which exactly directories it creates.
2. The example script is ported to Windows.
3. Syntax highlighting (`sh` for Linux version, and `bat` for Windows version) is switched on.

## Have test cases been added to cover the new functionality?
*no*