### PR TITLE
CMake variable resolution, some heuristics on product naming

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -48,7 +48,7 @@ import org.owasp.dependencycheck.exception.InitializationException;
  * command, plus some other observed patterns of version inclusion in real CMake
  * projects. Many projects make use of older versions of CMake and/or use custom
  * "homebrew" ways to insert version information. Hopefully as the newer CMake
- * call pattern grows in usage, this analyzer allow more CPEs to be 
+ * call pattern grows in usage, this analyzer allow more CPEs to be
  * identified.</p>
  *
  * @author Dale Visser
@@ -152,9 +152,9 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
      * Analyzes python packages and adds evidence to the dependency.
      *
      * @param dependency the dependency being analyzed
-     * @param engine     the engine being used to perform the scan
-     * @throws AnalysisException thrown if there is an unrecoverable error analyzing
-     *                           the dependency
+     * @param engine the engine being used to perform the scan
+     * @throws AnalysisException thrown if there is an unrecoverable error
+     * analyzing the dependency
      */
     @Override
     protected void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
@@ -165,7 +165,8 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
         try {
             contents = FileUtils.readFileToString(file, Charset.defaultCharset()).trim();
         } catch (IOException e) {
-            throw new AnalysisException("Problem occurred while reading dependency file.", e);
+            throw new AnalysisException(
+                    "Problem occurred while reading dependency file.", e);
         }
         if (StringUtils.isNotBlank(contents)) {
             HashMap<String, String> vars = new HashMap<String, String>();
@@ -196,8 +197,9 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
             int count = 0;
             while (m.find()) {
                 count++;
-                LOGGER.debug(
-                        String.format("Found project command match with %d groups: %s", m.groupCount(), m.group(0)));
+                LOGGER.debug(String.format(
+                        "Found project command match with %d groups: %s",
+                        m.groupCount(), m.group(0)));
                 final String group = m.group(1);
                 LOGGER.debug("Group 1: {}", group);
                 dependency.addEvidence(EvidenceType.PRODUCT, name, "Project", group, Confidence.HIGH);
@@ -210,7 +212,8 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
             LOGGER.debug("Found {} matches.", count);
             final Matcher mVersion = PROJECT_VERSION.matcher(contents_replaced);
             while (mVersion.find()) {
-                LOGGER.debug(String.format("Found set version command match with %d groups: %s", mVersion.groupCount(),
+                LOGGER.debug(String.format(
+                        "Found set version command match with %d groups: %s", mVersion.groupCount(),
                         mVersion.group(0)));
                 final String group = mVersion.group(1);
                 LOGGER.debug("Group 1: {}", group);
@@ -226,8 +229,8 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
      * Collect defined CMake variables
      *
      * @param dependency the dependency being analyzed
-     * @param engine     the dependency-check engine
-     * @param contents   the version information
+     * @param engine the dependency-check engine
+     * @param contents the version information
      */
     private void collectDefinedVariables(Dependency dependency, Engine engine, String contents,
             HashMap<String, String> vars) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -16,6 +16,7 @@
  * Copyright (c) 2015 Institute for Defense Analyses. All Rights Reserved.
  */
 package org.owasp.dependencycheck.analyzer;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.owasp.dependencycheck.Engine;
@@ -27,6 +28,7 @@ import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -40,15 +42,14 @@ import org.owasp.dependencycheck.exception.InitializationException;
 /**
  * <p>
  * Used to analyze CMake build files, and collect information that can be used
- * to determine the associated CPE.
- * </p>
+ * to determine the associated CPE.</p>
  * <p>
  * Note: This analyzer catches straightforward invocations of the project
  * command, plus some other observed patterns of version inclusion in real CMake
  * projects. Many projects make use of older versions of CMake and/or use custom
  * "homebrew" ways to insert version information. Hopefully as the newer CMake
- * call pattern grows in usage, this analyzer allow more CPEs to be identified.
- * </p>
+ * call pattern grows in usage, this analyzer allow more CPEs to be 
+ * identified.</p>
  *
  * @author Dale Visser
  */
@@ -140,11 +141,11 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
      *
      * @param engine a reference to the dependency-check engine
      * @throws InitializationException thrown if an exception occurs getting an
-     *                                 instance of SHA1
+     * instance of SHA1
      */
     @Override
     protected void prepareFileTypeAnalyzer(Engine engine) throws InitializationException {
-        // do nothing
+        //do nothing
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -213,8 +213,8 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
             final Matcher mVersion = PROJECT_VERSION.matcher(contents_replaced);
             while (mVersion.find()) {
                 LOGGER.debug(String.format(
-                        "Found set version command match with %d groups: %s", mVersion.groupCount(),
-                        mVersion.group(0)));
+                        "Found set version command match with %d groups: %s",
+                        mVersion.groupCount(), mVersion.group(0)));
                 final String group = mVersion.group(1);
                 LOGGER.debug("Group 1: {}", group);
                 dependency.addEvidence(EvidenceType.VERSION, name, "VERSION", group, Confidence.HIGH);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -16,7 +16,7 @@
  * Copyright (c) 2015 Institute for Defense Analyses. All Rights Reserved.
  */
 package org.owasp.dependencycheck.analyzer;
-
+​
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.owasp.dependencycheck.Engine;
@@ -28,44 +28,46 @@ import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+​
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.exception.InitializationException;
-
+​
 /**
  * <p>
  * Used to analyze CMake build files, and collect information that can be used
- * to determine the associated CPE.</p>
+ * to determine the associated CPE.
+ * </p>
  * <p>
  * Note: This analyzer catches straightforward invocations of the project
  * command, plus some other observed patterns of version inclusion in real CMake
  * projects. Many projects make use of older versions of CMake and/or use custom
  * "homebrew" ways to insert version information. Hopefully as the newer CMake
- * call pattern grows in usage, this analyzer allow more CPEs to be
- * identified.</p>
+ * call pattern grows in usage, this analyzer allow more CPEs to be identified.
+ * </p>
  *
  * @author Dale Visser
  */
 @Experimental
 public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
-
+​
     /**
      * A descriptor for the type of dependencies processed or added by this
      * analyzer.
      */
     public static final String DEPENDENCY_ECOSYSTEM = "CMAKE";
-
+​
     /**
      * The logger.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(CMakeAnalyzer.class);
-
+​
     /**
      * Used when compiling file scanning regex patterns.
      */
@@ -73,12 +75,22 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * Regex to obtain the project version.
      */
-    private static final Pattern PROJECT_VERSION = Pattern.compile("^\\s*set\\s*\\(\\s*VERSION\\s*\"([^\"]*)\"\\)", REGEX_OPTIONS);
+    private static final Pattern PROJECT_VERSION = Pattern.compile("^\\s*set\\s*\\(\\s*VERSION\\s*\"([^\"]*)\"\\)",
+            REGEX_OPTIONS);
+    /**
+     * Regex to obtain variables.
+     */
+    private static final Pattern SET_VAR_REGEX = Pattern.compile(
+            "^\\s*set\\s*\\(\\s*([a-zA-Z0-9_\\-]*)\\s+\"?([a-zA-Z0-9_\\-\\.\\$\\{\\}]*)\"?\\s*\\)", REGEX_OPTIONS);
+    /**
+     * Regex to find inlined variables to replace them.
+     */
+    private static final Pattern INL_VAR_REGEX = Pattern.compile("(\\$\\s*\\{([^\\}]*)\\s*\\})", REGEX_OPTIONS);
     /**
      * Regex to extract the product information.
      */
     private static final Pattern PROJECT = Pattern.compile("^ *project *\\([ \\n]*(\\w+)[ \\n]*.*?\\)", REGEX_OPTIONS);
-
+​
     /**
      * Regex to extract product and version information.
      *
@@ -86,14 +98,15 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
      *
      * Group 2: Version
      */
-    private static final Pattern SET_VERSION = Pattern.compile("^ *set\\s*\\(\\s*(\\w+)_version\\s+\"?(\\d+(?:\\.\\d+)+)[\\s\"]?\\)", REGEX_OPTIONS);
-
+    private static final Pattern SET_VERSION = Pattern
+            .compile("^\\s*set\\s*\\(\\s*(\\w+)_version\\s+\"?([^\"\\)]*)\\s*\"?\\)", REGEX_OPTIONS);
+​
     /**
      * Detects files that can be analyzed.
      */
     private static final FileFilter FILTER = FileFilterBuilder.newInstance().addExtensions(".cmake")
             .addFilenames("CMakeLists.txt").build();
-
+​
     /**
      * Returns the name of the CMake analyzer.
      *
@@ -103,7 +116,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
     public String getName() {
         return "CMake Analyzer";
     }
-
+​
     /**
      * Tell that we are used for information collection.
      *
@@ -113,7 +126,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
     public AnalysisPhase getAnalysisPhase() {
         return AnalysisPhase.INFORMATION_COLLECTION;
     }
-
+​
     /**
      * Returns the set of supported file extensions.
      *
@@ -123,26 +136,26 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
     protected FileFilter getFileFilter() {
         return FILTER;
     }
-
+​
     /**
      * Initializes the analyzer.
      *
      * @param engine a reference to the dependency-check engine
      * @throws InitializationException thrown if an exception occurs getting an
-     * instance of SHA1
+     *                                 instance of SHA1
      */
     @Override
     protected void prepareFileTypeAnalyzer(Engine engine) throws InitializationException {
-        //do nothing
+        // do nothing
     }
-
+​
     /**
      * Analyzes python packages and adds evidence to the dependency.
      *
      * @param dependency the dependency being analyzed
-     * @param engine the engine being used to perform the scan
-     * @throws AnalysisException thrown if there is an unrecoverable error
-     * analyzing the dependency
+     * @param engine     the engine being used to perform the scan
+     * @throws AnalysisException thrown if there is an unrecoverable error analyzing
+     *                           the dependency
      */
     @Override
     protected void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
@@ -153,17 +166,39 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
         try {
             contents = FileUtils.readFileToString(file, Charset.defaultCharset()).trim();
         } catch (IOException e) {
-            throw new AnalysisException(
-                    "Problem occurred while reading dependency file.", e);
+            throw new AnalysisException("Problem occurred while reading dependency file.", e);
         }
         if (StringUtils.isNotBlank(contents)) {
-            final Matcher m = PROJECT.matcher(contents);
+            HashMap<String, String> vars = new HashMap<String, String>();
+            collectDefinedVariables(dependency, engine, contents, vars);
+​
+            String contents_replacer = new String(contents);
+            Matcher r = INL_VAR_REGEX.matcher(contents);
+            while (r.find()) {
+                boolean leastOne = false;
+                if (vars.containsKey(r.group(2))) {
+                    contents_replacer = contents_replacer.replace(r.group(1), vars.get(r.group(2)));
+                    r = INL_VAR_REGEX.matcher(contents_replacer);
+                    leastOne = true;
+                }
+                while (r.find()) {
+                    if (vars.containsKey(r.group(2))) {
+                        contents_replacer = contents_replacer.replace(r.group(1), vars.get(r.group(2)));
+                        r = INL_VAR_REGEX.matcher(contents_replacer);
+                        leastOne = true;
+                    }
+                }
+                if (!leastOne)
+                    break;
+                r = INL_VAR_REGEX.matcher(contents_replacer);
+            }
+            String contents_replaced = contents_replacer.toString();
+            final Matcher m = PROJECT.matcher(contents_replaced);
             int count = 0;
             while (m.find()) {
                 count++;
-                LOGGER.debug(String.format(
-                        "Found project command match with %d groups: %s",
-                        m.groupCount(), m.group(0)));
+                LOGGER.debug(
+                        String.format("Found project command match with %d groups: %s", m.groupCount(), m.group(0)));
                 final String group = m.group(1);
                 LOGGER.debug("Group 1: {}", group);
                 dependency.addEvidence(EvidenceType.PRODUCT, name, "Project", group, Confidence.HIGH);
@@ -174,39 +209,60 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
                 dependency.addEvidence(EvidenceType.VENDOR, "CmakeAnalyzer", "hint", "gnu", Confidence.MEDIUM);
             }
             LOGGER.debug("Found {} matches.", count);
-            final Matcher mVersion = PROJECT_VERSION.matcher(contents);
+            final Matcher mVersion = PROJECT_VERSION.matcher(contents_replaced);
             while (mVersion.find()) {
-                LOGGER.debug(String.format(
-                        "Found set version command match with %d groups: %s",
-                        mVersion.groupCount(), mVersion.group(0)));
+                LOGGER.debug(String.format("Found set version command match with %d groups: %s", mVersion.groupCount(),
+                        mVersion.group(0)));
                 final String group = mVersion.group(1);
                 LOGGER.debug("Group 1: {}", group);
                 dependency.addEvidence(EvidenceType.VERSION, name, "VERSION", group, Confidence.HIGH);
                 dependency.setVersion(group);
             }
-
-            analyzeSetVersionCommand(dependency, engine, contents);
+​
+            analyzeSetVersionCommand(dependency, engine, contents_replaced, vars);
         }
     }
-
+​
     /**
-     * Extracts the version information from the contents. If more then one
-     * version is found additional dependencies are added to the dependency
-     * list.
+     * Collect defined CMake variables
      *
      * @param dependency the dependency being analyzed
-     * @param engine the dependency-check engine
-     * @param contents the version information
+     * @param engine     the dependency-check engine
+     * @param contents   the version information
      */
-    private void analyzeSetVersionCommand(Dependency dependency, Engine engine, String contents) {
+    private void collectDefinedVariables(Dependency dependency, Engine engine, String contents,
+            HashMap<String, String> vars) {
+        final Matcher m = SET_VAR_REGEX.matcher(contents);
+        int count = 0;
+        while (m.find()) {
+            count++;
+            LOGGER.debug("Found set variable command match with {} groups: {}", m.groupCount(), m.group(0));
+            String name = m.group(1);
+            final String value = m.group(2);
+            LOGGER.debug("Group 1: {}", name);
+            LOGGER.debug("Group 2: {}", value);
+            vars.put(name, value);
+        }
+        LOGGER.debug("Found {} matches.", count);
+    }
+​
+    /**
+     * Extracts the version information from the contents. If more then one version
+     * is found additional dependencies are added to the dependency list.
+     *
+     * @param dependency the dependency being analyzed
+     * @param engine     the dependency-check engine
+     * @param contents   the version information
+     */
+    private void analyzeSetVersionCommand(Dependency dependency, Engine engine, String contents,
+            HashMap<String, String> vars) {
         Dependency currentDep = dependency;
-
+​
         final Matcher m = SET_VERSION.matcher(contents);
         int count = 0;
         while (m.find()) {
             count++;
-            LOGGER.debug("Found project command match with {} groups: {}",
-                    m.groupCount(), m.group(0));
+            LOGGER.debug("Found project command match with {} groups: {}", m.groupCount(), m.group(0));
             String product = m.group(1);
             final String version = m.group(2);
             LOGGER.debug("Group 1: {}", product);
@@ -220,7 +276,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
                 currentDep.setEcosystem(DEPENDENCY_ECOSYSTEM);
                 final String filePath = String.format("%s:%s", dependency.getFilePath(), product);
                 currentDep.setFilePath(filePath);
-
+​
                 currentDep.setSha1sum(Checksum.getSHA1Checksum(filePath));
                 currentDep.setSha256sum(Checksum.getSHA256Checksum(filePath));
                 currentDep.setMd5sum(Checksum.getMD5Checksum(filePath));
@@ -230,6 +286,21 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
             currentDep.addEvidence(EvidenceType.PRODUCT, source, "Product", product, Confidence.MEDIUM);
             currentDep.addEvidence(EvidenceType.VENDOR, source, "Vendor", product, Confidence.MEDIUM);
             currentDep.addEvidence(EvidenceType.VERSION, source, "Version", version, Confidence.MEDIUM);
+            if (product.toLowerCase().endsWith("lib")) {
+                currentDep = new Dependency(dependency.getActualFile());
+                currentDep.setEcosystem(DEPENDENCY_ECOSYSTEM);
+                final String filePath = String.format("%s:%s", dependency.getFilePath(), product);
+                currentDep.setFilePath(filePath);
+​
+                currentDep.setSha1sum(Checksum.getSHA1Checksum(filePath));
+                currentDep.setSha256sum(Checksum.getSHA256Checksum(filePath));
+                currentDep.setMd5sum(Checksum.getMD5Checksum(filePath));
+                engine.addDependency(currentDep);
+                product = "lib" + product.toLowerCase().substring(0, product.length() - 3);
+                currentDep.addEvidence(EvidenceType.PRODUCT, source, "Product", product, Confidence.MEDIUM);
+                currentDep.addEvidence(EvidenceType.VENDOR, source, "Vendor", product, Confidence.MEDIUM);
+                currentDep.addEvidence(EvidenceType.VERSION, source, "Version", version, Confidence.MEDIUM);
+            }
             if (StringUtils.isEmpty(currentDep.getName())) {
                 currentDep.setName(product);
             }
@@ -239,7 +310,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
         }
         LOGGER.debug("Found {} matches.", count);
     }
-
+​
     @Override
     protected String getAnalyzerEnabledSettingKey() {
         return Settings.KEYS.ANALYZER_CMAKE_ENABLED;

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -16,7 +16,6 @@
  * Copyright (c) 2015 Institute for Defense Analyses. All Rights Reserved.
  */
 package org.owasp.dependencycheck.analyzer;
-​
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.owasp.dependencycheck.Engine;
@@ -28,7 +27,6 @@ import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-​
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -38,7 +36,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.exception.InitializationException;
-​
+
 /**
  * <p>
  * Used to analyze CMake build files, and collect information that can be used
@@ -56,18 +54,18 @@ import org.owasp.dependencycheck.exception.InitializationException;
  */
 @Experimental
 public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
-​
+
     /**
      * A descriptor for the type of dependencies processed or added by this
      * analyzer.
      */
     public static final String DEPENDENCY_ECOSYSTEM = "CMAKE";
-​
+
     /**
      * The logger.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(CMakeAnalyzer.class);
-​
+
     /**
      * Used when compiling file scanning regex patterns.
      */
@@ -90,7 +88,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
      * Regex to extract the product information.
      */
     private static final Pattern PROJECT = Pattern.compile("^ *project *\\([ \\n]*(\\w+)[ \\n]*.*?\\)", REGEX_OPTIONS);
-​
+
     /**
      * Regex to extract product and version information.
      *
@@ -100,13 +98,13 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
      */
     private static final Pattern SET_VERSION = Pattern
             .compile("^\\s*set\\s*\\(\\s*(\\w+)_version\\s+\"?([^\"\\)]*)\\s*\"?\\)", REGEX_OPTIONS);
-​
+
     /**
      * Detects files that can be analyzed.
      */
     private static final FileFilter FILTER = FileFilterBuilder.newInstance().addExtensions(".cmake")
             .addFilenames("CMakeLists.txt").build();
-​
+
     /**
      * Returns the name of the CMake analyzer.
      *
@@ -116,7 +114,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
     public String getName() {
         return "CMake Analyzer";
     }
-​
+
     /**
      * Tell that we are used for information collection.
      *
@@ -126,7 +124,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
     public AnalysisPhase getAnalysisPhase() {
         return AnalysisPhase.INFORMATION_COLLECTION;
     }
-​
+
     /**
      * Returns the set of supported file extensions.
      *
@@ -136,7 +134,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
     protected FileFilter getFileFilter() {
         return FILTER;
     }
-​
+
     /**
      * Initializes the analyzer.
      *
@@ -148,7 +146,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
     protected void prepareFileTypeAnalyzer(Engine engine) throws InitializationException {
         // do nothing
     }
-​
+
     /**
      * Analyzes python packages and adds evidence to the dependency.
      *
@@ -171,7 +169,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
         if (StringUtils.isNotBlank(contents)) {
             HashMap<String, String> vars = new HashMap<String, String>();
             collectDefinedVariables(dependency, engine, contents, vars);
-​
+
             String contents_replacer = new String(contents);
             Matcher r = INL_VAR_REGEX.matcher(contents);
             while (r.find()) {
@@ -218,11 +216,11 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
                 dependency.addEvidence(EvidenceType.VERSION, name, "VERSION", group, Confidence.HIGH);
                 dependency.setVersion(group);
             }
-​
+
             analyzeSetVersionCommand(dependency, engine, contents_replaced, vars);
         }
     }
-​
+
     /**
      * Collect defined CMake variables
      *
@@ -245,7 +243,6 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
         }
         LOGGER.debug("Found {} matches.", count);
     }
-​
     /**
      * Extracts the version information from the contents. If more then one version
      * is found additional dependencies are added to the dependency list.
@@ -257,7 +254,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
     private void analyzeSetVersionCommand(Dependency dependency, Engine engine, String contents,
             HashMap<String, String> vars) {
         Dependency currentDep = dependency;
-​
+
         final Matcher m = SET_VERSION.matcher(contents);
         int count = 0;
         while (m.find()) {
@@ -276,7 +273,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
                 currentDep.setEcosystem(DEPENDENCY_ECOSYSTEM);
                 final String filePath = String.format("%s:%s", dependency.getFilePath(), product);
                 currentDep.setFilePath(filePath);
-​
+
                 currentDep.setSha1sum(Checksum.getSHA1Checksum(filePath));
                 currentDep.setSha256sum(Checksum.getSHA256Checksum(filePath));
                 currentDep.setMd5sum(Checksum.getMD5Checksum(filePath));
@@ -291,7 +288,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
                 currentDep.setEcosystem(DEPENDENCY_ECOSYSTEM);
                 final String filePath = String.format("%s:%s", dependency.getFilePath(), product);
                 currentDep.setFilePath(filePath);
-​
+
                 currentDep.setSha1sum(Checksum.getSHA1Checksum(filePath));
                 currentDep.setSha256sum(Checksum.getSHA256Checksum(filePath));
                 currentDep.setMd5sum(Checksum.getMD5Checksum(filePath));
@@ -310,7 +307,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
         }
         LOGGER.debug("Found {} matches.", count);
     }
-​
+
     @Override
     protected String getAnalyzerEnabledSettingKey() {
         return Settings.KEYS.ANALYZER_CMAKE_ENABLED;


### PR DESCRIPTION
This contribution was made possible during a 'LogMeIn Inc.' event.

## Description of Change
- Resolve $SOME_CMAKE_VARIABLE stuff, recursively
- heuristically apply ASDLIB -> LIBASD, while keeping original too in 'product' field(s)
- some fixes, extensions to the regexes that handle version information

## Have test cases been added to cover the new functionality?
no.
Tested manually with libpng
