### PR TITLE
Suppress FP for withdrawn CVE of issue 2247

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -35,6 +35,13 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
+            FP per #2247 CVE candidate was withdrawn by the CNA
+        ]]></notes>
+            <packageUrl regex="true">^pkg:maven/org\.owasp\.antisamy/antisamy@.*$</packageUrl>
+            <vulnerabilityName>CVE-2018-1000643</vulnerabilityName>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
         This suppresses false positives identified on spring security.
         ]]></notes>
         <filePath regex="true">.*spring-security-[^\\/]*\.jar$</filePath>


### PR DESCRIPTION
## Fixes Issue #2247

## Description of Change
Suppress the withdrawn CVE for any version of antisamy

## Have test cases been added to cover the new functionality?
no, ran a local test to verify that suppression of this CVE was properly done
