### PR TITLE
Add closing `fi` to `if` statement within *nix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ if [ ! -d "$DATA_DIRECTORY" ]; then
     echo "Initially creating persistent directory: $DATA_DIRECTORY"
     mkdir -p "$DATA_DIRECTORY"
     chmod -R 664 "$DATA_DIRECTORY"
+fi
+
 if [ ! -d "$REPORT_DIRECTORY" ]; then
     echo "Initially creating persistent directory: $REPORT_DIRECTORY"
     mkdir -p "$REPORT_DIRECTORY"


### PR DESCRIPTION
# Description of Change

Fixes unclosed if statement in Docker instructions for running dependency-check

## Have test cases been added to cover the new functionality?

Not needed