### PR TITLE
Added configuration for Central URL

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearch.java
@@ -228,7 +228,7 @@ public class ArtifactorySearch {
             final String artifactId = pathMatcher.group("artifactId");
             final String version = pathMatcher.group("version");
 
-            result.add(new MavenArtifact(groupId, artifactId, version, downloadUri, MavenArtifact.derivePomUrl(artifactId, version, downloadUri)));
+            result.add(new MavenArtifact(settings, groupId, artifactId, version, downloadUri, MavenArtifact.derivePomUrl(artifactId, version, downloadUri)));
         }
 
         return result;

--- a/core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
@@ -200,7 +200,7 @@ public class CentralSearch {
 //                            }
 //                        }
                         LOGGER.trace("Version: {}", v);
-                        result.add(new MavenArtifact(g, a, v, jarAvailable, pomAvailable));
+                        result.add(new MavenArtifact(settings, g, a, v, jarAvailable, pomAvailable));
                     }
                 }
             } catch (ParserConfigurationException | IOException | SAXException | XPathExpressionException e) {

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/MavenArtifact.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/MavenArtifact.java
@@ -19,6 +19,7 @@ package org.owasp.dependencycheck.data.nexus;
 
 import java.io.Serializable;
 import javax.annotation.concurrent.ThreadSafe;
+import org.owasp.dependencycheck.utils.Settings;
 
 /**
  * Simple bean representing a Maven Artifact.
@@ -36,7 +37,7 @@ public class MavenArtifact implements Serializable {
     /**
      * The base URL for download artifacts from Central.
      */
-    private static final String CENTRAL_CONTENT_URL = "https://search.maven.org/remotecontent?filepath=";
+    private final String centralContentUrl;
 
     /**
      * The groupId
@@ -65,44 +66,51 @@ public class MavenArtifact implements Serializable {
 
     /**
      * Creates an empty MavenArtifact.
+     *
+     * @param settings a reference to the global dependency-check settings
      */
-    public MavenArtifact() {
+    public MavenArtifact(Settings settings) {
+        this.centralContentUrl = settings.getString(Settings.KEYS.CENTRAL_CONTENT_URL);
     }
 
     /**
      * Creates a MavenArtifact with the given attributes.
      *
+     * @param settings a reference to the global dependency-check settings
      * @param groupId the groupId
      * @param artifactId the artifactId
      * @param version the version
      */
-    public MavenArtifact(String groupId, String artifactId, String version) {
+    public MavenArtifact(Settings settings, String groupId, String artifactId, String version) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;
+        this.centralContentUrl = settings.getString(Settings.KEYS.CENTRAL_CONTENT_URL);
     }
 
     /**
      * Creates a MavenArtifact with the given attributes.
      *
+     * @param settings a reference to the global dependency-check settings
      * @param groupId the groupId
      * @param artifactId the artifactId
      * @param version the version
      * @param jarAvailable if the jar file is available from central
      * @param pomAvailable if the pom file is available from central
      */
-    public MavenArtifact(String groupId, String artifactId, String version, boolean jarAvailable, boolean pomAvailable) {
+    public MavenArtifact(Settings settings, String groupId, String artifactId, String version, boolean jarAvailable, boolean pomAvailable) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;
+        this.centralContentUrl = settings.getString(Settings.KEYS.CENTRAL_CONTENT_URL);
         if (jarAvailable) {
             //org/springframework/spring-core/3.2.0.RELEASE/spring-core-3.2.0.RELEASE.pom
-            this.artifactUrl = CENTRAL_CONTENT_URL + groupId.replace('.', '/') + '/' + artifactId + '/'
+            this.artifactUrl = centralContentUrl + groupId.replace('.', '/') + '/' + artifactId + '/'
                     + version + '/' + artifactId + '-' + version + ".jar";
         }
         if (pomAvailable) {
             //org/springframework/spring-core/3.2.0.RELEASE/spring-core-3.2.0.RELEASE.pom
-            this.pomUrl = CENTRAL_CONTENT_URL + groupId.replace('.', '/') + '/' + artifactId + '/'
+            this.pomUrl = centralContentUrl + groupId.replace('.', '/') + '/' + artifactId + '/'
                     + version + '/' + artifactId + '-' + version + ".pom";
         }
     }
@@ -110,12 +118,14 @@ public class MavenArtifact implements Serializable {
     /**
      * Creates a MavenArtifact with the given attributes.
      *
+     * @param settings a reference to the global dependency-check settings
      * @param groupId the groupId
      * @param artifactId the artifactId
      * @param version the version
      * @param url the artifactLink url
      */
-    public MavenArtifact(String groupId, String artifactId, String version, String url) {
+    public MavenArtifact(Settings settings, String groupId, String artifactId, String version, String url) {
+        this.centralContentUrl = settings.getString(Settings.KEYS.CENTRAL_CONTENT_URL);
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;
@@ -125,13 +135,15 @@ public class MavenArtifact implements Serializable {
     /**
      * Creates a MavenArtifact with the given attributes.
      *
+     * @param settings a reference to the global dependency-check settings
      * @param groupId the groupId
      * @param artifactId the artifactId
      * @param version the version
      * @param artifactUrl the artifactLink url
      * @param pomUrl the pomUrl
      */
-    public MavenArtifact(String groupId, String artifactId, String version, String artifactUrl, String pomUrl) {
+    public MavenArtifact(Settings settings, String groupId, String artifactId, String version, String artifactUrl, String pomUrl) {
+        this.centralContentUrl = settings.getString(Settings.KEYS.CENTRAL_CONTENT_URL);
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusSearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusSearch.java
@@ -146,7 +146,7 @@ public class NexusSearch {
                             .evaluate(
                                     "/org.sonatype.nexus.rest.model.NexusArtifact/pomLink",
                                     doc);
-                    final MavenArtifact ma = new MavenArtifact(groupId, artifactId, version);
+                    final MavenArtifact ma = new MavenArtifact(settings, groupId, artifactId, version);
                     if (link != null && !link.isEmpty()) {
                         ma.setArtifactUrl(link);
                     }

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -92,6 +92,7 @@ analyzer.central.query=%s?q=1:%s&wt=xml
 analyzer.central.retry.count=7
 analyzer.central.parallel.analysis=false
 analyzer.central.use.cache=true
+central.content.url=https://search.maven.org/remotecontent?filepath=
 
 analyzer.ossindex.enabled=true
 analyzer.ossindex.url=https://ossindex.sonatype.org

--- a/core/src/test/java/org/owasp/dependencycheck/data/nexus/MavenArtifactTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nexus/MavenArtifactTest.java
@@ -3,15 +3,16 @@ package org.owasp.dependencycheck.data.nexus;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import org.owasp.dependencycheck.BaseTest;
 
-public class MavenArtifactTest {
+public class MavenArtifactTest extends BaseTest {
 
     @Test
     public void getPomUrl() {
         // Given
-        final MavenArtifact mavenArtifact = new MavenArtifact("com.google.code.gson", "gson", "2.1",
+        final MavenArtifact mavenArtifact = new MavenArtifact(getSettings(), "com.google.code.gson", "gson", "2.1",
                 "https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar", MavenArtifact.derivePomUrl("gson", "2.1",
-                "https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar"));
+                        "https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar"));
         // When
         final String pomUrl = mavenArtifact.getPomUrl();
         // Then
@@ -19,13 +20,12 @@ public class MavenArtifactTest {
 
     }
 
-
     @Test
     public void getPomUrlWithQualifier() {
         // Given
-        final MavenArtifact mavenArtifact = new MavenArtifact("com.google.code.gson", "gson", "2.8.5",
+        final MavenArtifact mavenArtifact = new MavenArtifact(getSettings(), "com.google.code.gson", "gson", "2.8.5",
                 "https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar", MavenArtifact.derivePomUrl("gson", "2.8.5",
-                "https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar"));
+                        "https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar"));
         // When
         final String pomUrl = mavenArtifact.getPomUrl();
         // Then

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
@@ -248,7 +248,7 @@ public class DependencyTest extends BaseTest {
     @Test
     public void testAddAsEvidence() {
         Dependency instance = new Dependency();
-        MavenArtifact mavenArtifact = new MavenArtifact("group", "artifact", "version", "url");
+        MavenArtifact mavenArtifact = new MavenArtifact(getSettings(), "group", "artifact", "version", "url");
         instance.addAsEvidence("pom", mavenArtifact, Confidence.HIGH);
         assertTrue(instance.contains(EvidenceType.VENDOR, Confidence.HIGH));
         assertEquals(3, instance.size());
@@ -261,9 +261,9 @@ public class DependencyTest extends BaseTest {
     @Test
     public void testAddAsEvidenceWithEmptyArtifact() {
         Dependency instance = new Dependency();
-        MavenArtifact mavenArtifact = new MavenArtifact(null, null, null, null);
+        MavenArtifact mavenArtifact = new MavenArtifact(getSettings(), null, null, null, null);
         instance.addAsEvidence("pom", mavenArtifact, Confidence.HIGH);
-        assertFalse(instance.getEvidence(EvidenceType.VENDOR).stream().anyMatch(e->e.getConfidence()==Confidence.HIGH));
+        assertFalse(instance.getEvidence(EvidenceType.VENDOR).stream().anyMatch(e -> e.getConfidence() == Confidence.HIGH));
         assertTrue(instance.size() == 0);
         assertTrue(instance.getSoftwareIdentifiers().isEmpty());
     }
@@ -274,9 +274,9 @@ public class DependencyTest extends BaseTest {
     @Test
     public void testAddAsEvidenceWithExisting() {
         Dependency instance = new Dependency();
-        MavenArtifact mavenArtifact = new MavenArtifact("group", "artifact", "version", null);
+        MavenArtifact mavenArtifact = new MavenArtifact(getSettings(), "group", "artifact", "version", null);
         instance.addAsEvidence("pom", mavenArtifact, Confidence.HIGH);
-        assertTrue(instance.getEvidence(EvidenceType.VENDOR).stream().anyMatch(e->e.getConfidence()==Confidence.HIGH));
+        assertTrue(instance.getEvidence(EvidenceType.VENDOR).stream().anyMatch(e -> e.getConfidence() == Confidence.HIGH));
         assertTrue(instance.size() == 3);
         assertFalse(instance.getSoftwareIdentifiers().isEmpty());
 
@@ -284,9 +284,9 @@ public class DependencyTest extends BaseTest {
             assertNull(i.getUrl());
         });
 
-        mavenArtifact = new MavenArtifact("group", "artifact", "version", "url");
+        mavenArtifact = new MavenArtifact(getSettings(), "group", "artifact", "version", "url");
         instance.addAsEvidence("pom", mavenArtifact, Confidence.HIGH);
-        assertTrue(instance.getEvidence(EvidenceType.VENDOR).stream().anyMatch(e->e.getConfidence()==Confidence.HIGH));
+        assertTrue(instance.getEvidence(EvidenceType.VENDOR).stream().anyMatch(e -> e.getConfidence() == Confidence.HIGH));
         assertTrue(instance.size() == 3);
         assertFalse(instance.getSoftwareIdentifiers().isEmpty());
 

--- a/core/src/test/resources/dependencycheck.properties
+++ b/core/src/test/resources/dependencycheck.properties
@@ -89,6 +89,7 @@ analyzer.nexus.proxy=true
 # the URL for searching search.maven.org for SHA-1 and whether it's enabled
 analyzer.central.enabled=true
 analyzer.central.url=https://search.maven.org/solrsearch/select
+central.content.url=https://search.maven.org/remotecontent?filepath=
 # Note - the central query is used in a String.format(query, url, sha1)).
 # As such, it must have two %s and any other % must be escapped by doubling it
 analyzer.central.query=%s?q=1:%s&wt=xml
@@ -129,7 +130,6 @@ analyzer.nuspec.enabled=true
 analyzer.nugetconf.enabled=true
 analyzer.msbuildproject.enabled=true
 analyzer.openssl.enabled=true
-analyzer.central.enabled=true
 analyzer.nexus.enabled=false
 analyzer.cocoapods.enabled=true
 analyzer.swift.package.manager.enabled=true

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1125,7 +1125,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                         }
                     }
                     if (d != null) {
-                        final MavenArtifact ma = new MavenArtifact(groupId, artifactId, version);
+                        final MavenArtifact ma = new MavenArtifact(settings, groupId, artifactId, version);
                         d.addAsEvidence("pom", ma, Confidence.HIGHEST);
                         if (availableVersions != null) {
                             for (ArtifactVersion av : availableVersions) {

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -281,7 +281,8 @@ public final class Settings {
          */
         public static final String ANALYZER_NODE_AUDIT_URL = "analyzer.node.audit.url";
         /**
-         * The properties key for whether Central search results will be cached.
+         * The properties key for whether node audit analyzer results will be
+         * cached.
          */
         public static final String ANALYZER_NODE_AUDIT_USE_CACHE = "analyzer.node.audit.use.cache";
         /**
@@ -427,6 +428,10 @@ public final class Settings {
          * The properties key for whether the Central analyzer is enabled.
          */
         public static final String ANALYZER_CENTRAL_ENABLED = "analyzer.central.enabled";
+        /**
+         * Key for the URL to obtain content from Maven Central.
+         */
+        public static final String CENTRAL_CONTENT_URL = "central.content.url";
         /**
          * The properties key for whether the Central analyzer should use
          * parallel processing.

--- a/utils/src/test/resources/dependencycheck.properties
+++ b/utils/src/test/resources/dependencycheck.properties
@@ -84,6 +84,7 @@ analyzer.nexus.proxy=true
 # the URL for searching search.maven.org for SHA-1 and whether it's enabled
 analyzer.central.enabled=true
 analyzer.central.url=https://search.maven.org/solrsearch/select
+central.content.url=https://search.maven.org/remotecontent?filepath=
 # Note - the central query is used in a String.format(query, url, sha1)).
 # As such, it must have two %s and any other % must be escapped by doubling it
 analyzer.central.query=%s?q=1:%s&wt=xml
@@ -123,7 +124,6 @@ analyzer.assembly.enabled=true
 analyzer.nuspec.enabled=true
 analyzer.nugetconf.enabled=true
 analyzer.openssl.enabled=true
-analyzer.central.enabled=true
 analyzer.nexus.enabled=false
 analyzer.cocoapods.enabled=true
 analyzer.swift.package.manager.enabled=true


### PR DESCRIPTION
## Fixes Issue #2289

## Description of Change

Makes the central search URL for POMs configurable.

## Have test cases been added to cover the new functionality?

Existing test cases cover this change.