### PR TITLE
Custom unixBinTemplate to allow spaces in JVM_OPTS

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -84,6 +84,7 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                     <useWildcardClassPath>true</useWildcardClassPath>
                     <configurationDirectory>plugins/*</configurationDirectory>
                     <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
+                    <unixScriptTemplate>${project.basedir}/src/main/conf/unixBinTemplate</unixScriptTemplate>
                 </configuration>
                 <executions>
                     <execution>

--- a/cli/src/main/conf/unixBinTemplate
+++ b/cli/src/main/conf/unixBinTemplate
@@ -1,0 +1,124 @@
+#!/usr/bin/env sh
+@LICENSE_HEADER@
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+PRGDIR=`dirname "$PRG"`
+BASEDIR=`cd "$PRGDIR/.." >/dev/null; pwd`
+
+# Reset the REPO variable. If you need to influence this use the environment setup file.
+REPO=
+@ENV_SETUP@
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+case "`uname`" in
+  CYGWIN*) cygwin=true ;;
+  Darwin*) darwin=true
+           if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+		   if [ -z "$JAVA_HOME" ]; then
+		      if [ -x "/usr/libexec/java_home" ]; then
+			      JAVA_HOME=`/usr/libexec/java_home`
+			  else
+			      JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+			  fi
+           fi       
+           ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=`java-config --jre-home`
+  fi
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# If a specific java binary isn't specified search for the standard 'java' binary
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=`which java`
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." 1>&2
+  echo "  We cannot execute $JAVACMD" 1>&2
+  exit 1
+fi
+
+if [ -z "$REPO" ]
+then
+  REPO="$BASEDIR"/@REPO@
+fi
+
+CLASSPATH=@CLASSPATH@
+
+ENDORSED_DIR=@ENDORSED_DIR@
+if [ -n "$ENDORSED_DIR" ] ; then
+  CLASSPATH=$BASEDIR/$ENDORSED_DIR/*:$CLASSPATH
+fi
+
+if [ -n "$CLASSPATH_PREFIX" ] ; then
+  CLASSPATH=$CLASSPATH_PREFIX:$CLASSPATH
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
+  [ -n "$HOME" ] && HOME=`cygpath --path --windows "$HOME"`
+  [ -n "$BASEDIR" ] && BASEDIR=`cygpath --path --windows "$BASEDIR"`
+  [ -n "$REPO" ] && REPO=`cygpath --path --windows "$REPO"`
+fi
+
+#exec "$JAVACMD" $JAVA_OPTS @EXTRA_JVM_ARGUMENTS@ \
+#  -classpath "$CLASSPATH" \
+#  -Dapp.name="@APP_NAME@" \
+#  -Dapp.pid="$$" \
+#  -Dapp.repo="$REPO" \
+#  -Dapp.home="$BASEDIR" \
+#  -Dbasedir="$BASEDIR" \
+#  @MAINCLASS@ \
+#  @APP_ARGUMENTS@"$@"@UNIX_BACKGROUND@
+
+CMDS=("$JAVACMD" \
+  -classpath "$CLASSPATH" \
+  -Dapp.name="@APP_NAME@" \
+  -Dapp.pid="$$" \
+  -Dapp.repo="$REPO" \
+  -Dapp.home="$BASEDIR" \
+  -Dbasedir="$BASEDIR" \
+  @MAINCLASS@)
+
+for arg; do
+CMDS+=("$arg")
+done
+exec "${CMDS[@]@UNIX_BACKGROUND@}"

--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -291,7 +291,7 @@
             <evidence type="product" source="hint analyzer" name="product" value="web services" confidence="MEDIUM"/>
         </add>
     </hint>
-        <hint>
+    <hint>
         <given>
             <evidence regex="true" type="product" source="pom" name="artifactid" value="^.*[\.-]ws([\.-].*)?$"/>
         </given>
@@ -300,4 +300,12 @@
             <evidence type="product" source="hint analyzer" name="product" value="web services" confidence="MEDIUM"/>
         </add>
     </hint>
+    <hint>
+        <given>
+            <evidence type="vendor" source="pom" name="groupid" value="zeroturnaround"/>
+        </given>
+        <add>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="jrebel" confidence="HIGHEST"/>
+        </add>
+    </hint>   
 </hints>

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/CPEAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/CPEAnalyzerIT.java
@@ -256,7 +256,7 @@ public class CPEAnalyzerIT extends BaseDBTestCase {
 
             callDetermieIdentifiers("eclipse", "jetty", "20.4.8.v20171121", "cpe:2.3:a:eclipse:jetty:20.4.8:20171121:*:*:*:*:*:*", instance);
             callDetermieIdentifiers("openssl", "openssl", "1.0.1c", "cpe:2.3:a:openssl:openssl:1.0.1c:*:*:*:*:*:*:*", instance);
-            callDetermieIdentifiers("zeroturnaround", "zt-zip", "1.0", "cpe:2.3:a:zeroturnaround:zt-zip:1.0:*:*:*:*:*:*:*", instance);
+            callDetermieIdentifiers("jrebel", "zt-zip", "1.0", "cpe:2.3:a:jrebel:zt-zip:1.0:*:*:*:*:*:*:*", instance);
 
             instance.close();
         }
@@ -305,12 +305,12 @@ public class CPEAnalyzerIT extends BaseDBTestCase {
             callAnalyzeDependency("eclipse", "jetty", "20.4.8.v20171121", "cpe:2.3:a:eclipse:jetty:20.4.8:20171121:*:*:*:*:*:*", instance, engine);
             callAnalyzeDependency("openssl", "openssl", "1.0.1c", "cpe:2.3:a:openssl:openssl:1.0.1c:*:*:*:*:*:*:*", instance, engine);
             callAnalyzeDependency("apache", "commons-httpclient", "3.0", "cpe:2.3:a:apache:httpclient:3.0:*:*:*:*:*:*:*", instance, engine);
-            callAnalyzeDependency("zeroturnaround", "zt-zip", "1.0", "cpe:2.3:a:zeroturnaround:zt-zip:1.0:*:*:*:*:*:*:*", instance, engine);
+            callAnalyzeDependency("jrebel", "zt-zip", "1.0", "cpe:2.3:a:jrebel:zt-zip:1.0:*:*:*:*:*:*:*", instance, engine);
 
             // Non-exact matches
             callAnalyzeDependency("org.apache", "commons-httpclient", "3.0", "cpe:2.3:a:apache:httpclient:3.0:*:*:*:*:*:*:*", instance, engine);
             callAnalyzeDependency("org.apache", "httpclient", "3.0", "cpe:2.3:a:apache:httpclient:3.0:*:*:*:*:*:*:*", instance, engine);
-            callAnalyzeDependency("org.zeroturnaround", "zt-zip", "1.0", "cpe:2.3:a:zeroturnaround:zt-zip:1.0:*:*:*:*:*:*:*", instance, engine);
+            callAnalyzeDependency("org.jrebel", "zt-zip", "1.0", "cpe:2.3:a:jrebel:zt-zip:1.0:*:*:*:*:*:*:*", instance, engine);
 
             instance.close();
         }


### PR DESCRIPTION
## Fixes Issue #2282

Add an updated version of the `unixBinTemplate` to use a bash array instead of the default way the command line is built by the `appassembler-maven-plugin`.

Thanks to @vweng for providing the resolution to #2282.

Note - this does remove the [extraJvmArguments](https://www.mojohaus.org/appassembler/appassembler-maven-plugin/assemble-mojo.html#extraJvmArguments) capabilities from the template - but dependency-check does not use the feature.  If we could get the extraJvmArguments working we could submit a PR to the `appassembler-maven-plugin`.