### PR TITLE
improve nodeJs robustness

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilder.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilder.java
@@ -17,8 +17,6 @@
  */
 package org.owasp.dependencycheck.data.nodeaudit;
 
-import netscape.javascript.JSObject;
-
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;

--- a/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilder.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilder.java
@@ -17,6 +17,8 @@
  */
 package org.owasp.dependencycheck.data.nodeaudit;
 
+import netscape.javascript.JSObject;
+
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -58,29 +60,34 @@ public final class NpmPayloadBuilder {
         // NPM Audit expects 'requires' to be an object containing key/value
         // pairs corresponding to the module name (key) and version (value).
         final JsonObjectBuilder requiresBuilder = Json.createObjectBuilder();
-        packageJson.getJsonObject("dependencies").entrySet()
-                .stream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        Map.Entry::getValue,
-                        (oldValue, newValue) -> newValue, TreeMap::new))
-                .entrySet()
-                .forEach((entry) -> {
-                    requiresBuilder.add(entry.getKey(), entry.getValue());
-                    dependencyMap.put(entry.getKey(), entry.getValue().toString());
-                });
 
-        packageJson.getJsonObject("devDependencies").entrySet()
-                .stream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        Map.Entry::getValue,
-                        (oldValue, newValue) -> newValue, TreeMap::new))
-                .entrySet()
-                .forEach((entry) -> {
-                    requiresBuilder.add(entry.getKey(), entry.getValue());
-                    dependencyMap.put(entry.getKey(), entry.getValue().toString());
-                });
+        if(packageJson.containsKey("dependencies")){
+            packageJson.getJsonObject("dependencies").entrySet()
+                    .stream()
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            Map.Entry::getValue,
+                            (oldValue, newValue) -> newValue, TreeMap::new))
+                    .entrySet()
+                    .forEach((entry) -> {
+                        requiresBuilder.add(entry.getKey(), entry.getValue());
+                        dependencyMap.put(entry.getKey(), entry.getValue().toString());
+                    });
+        }
+
+        if(packageJson.containsKey("devDependencies")){
+            packageJson.getJsonObject("devDependencies").entrySet()
+                    .stream()
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            Map.Entry::getValue,
+                            (oldValue, newValue) -> newValue, TreeMap::new))
+                    .entrySet()
+                    .forEach((entry) -> {
+                        requiresBuilder.add(entry.getKey(), entry.getValue());
+                        dependencyMap.put(entry.getKey(), entry.getValue().toString());
+                    });
+        }
 
         payloadBuilder.add("requires", requiresBuilder.build());
 
@@ -187,7 +194,11 @@ public final class NpmPayloadBuilder {
     private static JsonObject buildDependencies(JsonObject dep, Map<String, String> dependencyMap) {
         final JsonObjectBuilder depBuilder = Json.createObjectBuilder();
         depBuilder.add("version", dep.getString("version"));
-        depBuilder.add("integrity", dep.getString("integrity"));
+
+        //not installed package (like, dependency of an optional dependency) doesn't contains integrity
+        if(dep.containsKey("integrity")){
+            depBuilder.add("integrity", dep.getString("integrity"));
+        }
         if (dep.containsKey("requires")) {
             depBuilder.add("requires", dep.getJsonObject("requires"));
         }

--- a/core/src/test/java/org/owasp/dependencycheck/reporting/ReportGeneratorIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/reporting/ReportGeneratorIT.java
@@ -57,24 +57,102 @@ public class ReportGeneratorIT extends BaseDBTestCase {
      */
     @Test
     public void testGenerateReport() {
+        File writeTo = new File("target/test-reports/Report.xml");
+        File writeJsonTo = new File("target/test-reports/Report.json");
+        File writeHtmlTo = new File("target/test-reports/Report.html");
+        File writeJunitTo = new File("target/test-reports/junit.xml");
+        File writeCsvTo = new File("target/test-reports/Report.csv");
+        File suppressionFile = BaseTest.getResourceAsFile(this, "incorrectSuppressions.xml");
+        Settings settings = getSettings();
+        settings.setString(Settings.KEYS.SUPPRESSION_FILE, suppressionFile.getAbsolutePath());
+        settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
+        settings.setBoolean(Settings.KEYS.ANALYZER_RETIREJS_ENABLED, false);
+        settings.setBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED, false);
+        settings.setBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED, false);
+        settings.setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
+
+        generateReport(settings, writeTo, writeJsonTo, writeHtmlTo, writeJunitTo, writeCsvTo, suppressionFile);
+    }
+
+    /**
+     * Generates an XML report containing known vulnerabilities and realistic
+     * data and validates the generated XML document against the XSD.
+     */
+    @Test
+    public void testGenerateNodeAuditReport() {
+        File writeTo = new File("target/test-reports/nodeAudit/Report.xml");
+        File writeJsonTo = new File("target/test-reports/nodeAudit/Report.json");
+        File writeHtmlTo = new File("target/test-reports/nodeAudit/Report.html");
+        File writeJunitTo = new File("target/test-reports/nodeAudit/junit.xml");
+        File writeCsvTo = new File("target/test-reports/nodeAudit/Report.csv");
+        File suppressionFile = BaseTest.getResourceAsFile(this, "incorrectSuppressions.xml");
+        Settings settings = getSettings();
+        settings.setString(Settings.KEYS.SUPPRESSION_FILE, suppressionFile.getAbsolutePath());
+        settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
+        settings.setBoolean(Settings.KEYS.ANALYZER_RETIREJS_ENABLED, false);
+        settings.setBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED, true);
+        settings.setBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED, false);
+        settings.setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
+
+        generateReport(settings, writeTo, writeJsonTo, writeHtmlTo, writeJunitTo, writeCsvTo, suppressionFile);
+    }
+
+
+    /**
+     * Generates an XML report containing known vulnerabilities and realistic
+     * data and validates the generated XML document against the XSD.
+     */
+    @Test
+    public void testGenerateRetireJsReport() {
+        File writeTo = new File("target/test-reports/retireJS/Report.xml");
+        File writeJsonTo = new File("target/test-reports/retireJS/Report.json");
+        File writeHtmlTo = new File("target/test-reports/retireJS/Report.html");
+        File writeJunitTo = new File("target/test-reports/retireJS/junit.xml");
+        File writeCsvTo = new File("target/test-reports/retireJS/Report.csv");
+        File suppressionFile = BaseTest.getResourceAsFile(this, "incorrectSuppressions.xml");
+        Settings settings = getSettings();
+        settings.setString(Settings.KEYS.SUPPRESSION_FILE, suppressionFile.getAbsolutePath());
+        settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
+        settings.setBoolean(Settings.KEYS.ANALYZER_RETIREJS_ENABLED, true);
+        settings.setBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED, false);
+        settings.setBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED, false);
+        settings.setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
+
+        generateReport(settings, writeTo, writeJsonTo, writeHtmlTo, writeJunitTo, writeCsvTo, suppressionFile);
+    }
+    /**
+     * Generates an XML report containing known vulnerabilities and realistic
+     * data and validates the generated XML document against the XSD.
+     */
+    @Test
+    public void testGenerateNodePackageReport() {
+        File writeTo = new File("target/test-reports/NodePackage/Report.xml");
+        File writeJsonTo = new File("target/test-reports/NodePackage/Report.json");
+        File writeHtmlTo = new File("target/test-reports/NodePackage/Report.html");
+        File writeJunitTo = new File("target/test-reports/NodePackage/junit.xml");
+        File writeCsvTo = new File("target/test-reports/NodePackage/Report.csv");
+        File suppressionFile = BaseTest.getResourceAsFile(this, "incorrectSuppressions.xml");
+        Settings settings = getSettings();
+        settings.setString(Settings.KEYS.SUPPRESSION_FILE, suppressionFile.getAbsolutePath());
+        settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
+        settings.setBoolean(Settings.KEYS.ANALYZER_RETIREJS_ENABLED, false);
+        settings.setBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED, true);
+        settings.setBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED, true);
+        settings.setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
+
+        generateReport(settings, writeTo, writeJsonTo, writeHtmlTo, writeJunitTo, writeCsvTo, suppressionFile);
+    }
+
+
+    public void generateReport(Settings settings, File writeTo, File writeJsonTo, File writeHtmlTo, File writeJunitTo, File writeCsvTo, File suppressionFile){
         try {
-            File f = new File("target/test-reports");
-            if (!f.exists()) {
-                f.mkdir();
-            }
-            File writeTo = new File("target/test-reports/Report.xml");
-            File writeJsonTo = new File("target/test-reports/Report.json");
-            File writeHtmlTo = new File("target/test-reports/Report.html");
-            File writeJunitTo = new File("target/test-reports/junit.xml");
-            File writeCsvTo = new File("target/test-reports/Report.csv");
-            File suppressionFile = BaseTest.getResourceAsFile(this, "incorrectSuppressions.xml");
-            Settings settings = getSettings();
-            settings.setString(Settings.KEYS.SUPPRESSION_FILE, suppressionFile.getAbsolutePath());
-            settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
-            settings.setBoolean(Settings.KEYS.ANALYZER_RETIREJS_ENABLED, false);
-            settings.setBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED, false);
-            settings.setBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED, false);
-            settings.setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
+            //first check parent folder
+            createParentFolder(writeTo);
+            createParentFolder(writeJsonTo);
+            createParentFolder(writeHtmlTo);
+            createParentFolder(writeJunitTo);
+            createParentFolder(writeCsvTo);
+
 
             //File struts = new File(this.getClass().getClassLoader().getResource("struts2-core-2.1.2.jar").getPath());
             File struts = BaseTest.getResourceAsFile(this, "struts2-core-2.1.2.jar");
@@ -86,9 +164,9 @@ public class ReportGeneratorIT extends BaseDBTestCase {
             File nodeTest = BaseTest.getResourceAsFile(this, "nodejs");
             int vulnCount;
             try (Engine engine = new Engine(settings)) {
-                engine.scan(struts);
-                engine.scan(axis);
-                engine.scan(jetty);
+//                engine.scan(struts);
+//                engine.scan(axis);
+//                engine.scan(jetty);
                 engine.scan(nodeTest);
                 engine.analyzeDependencies();
 
@@ -123,6 +201,20 @@ public class ReportGeneratorIT extends BaseDBTestCase {
             fail(ex.getMessage());
         }
     }
+
+    /**
+     * create the parent folder if doesn't exist
+     * @param file the file
+     * @return boolean is all fine ?
+     */
+    private boolean createParentFolder(File file){
+        if (!file.getParentFile().exists()) {
+            return file.getParentFile().mkdir();
+        }
+        return true;
+    }
+
+
 
     /**
      * Counts the lines in a file. Copied from

--- a/core/src/test/java/org/owasp/dependencycheck/reporting/ReportGeneratorIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/reporting/ReportGeneratorIT.java
@@ -164,9 +164,9 @@ public class ReportGeneratorIT extends BaseDBTestCase {
             File nodeTest = BaseTest.getResourceAsFile(this, "nodejs");
             int vulnCount;
             try (Engine engine = new Engine(settings)) {
-//                engine.scan(struts);
-//                engine.scan(axis);
-//                engine.scan(jetty);
+                engine.scan(struts);
+                engine.scan(axis);
+                engine.scan(jetty);
                 engine.scan(nodeTest);
                 engine.analyzeDependencies();
 


### PR DESCRIPTION
improve tests + allow package json to doesn't contain devDependencies… or dependencies

## Fixes Issue #
No issue

## Description of Change
By checking other things in the code, I see the report can crash if the package.json doesn't contain dependencies AND devDependencies ... 
So I add two check . ( doesn't test without dev and dep, but I things checking dependencies without dependencies doesn't make sense )

Another point, if the optionnal dependency, has other dependency, they are not installed too, but present in the package-lock, they didn't have the `integrity` key

Example : https://github.com/jeremylong/DependencyCheck/blob/master/src/test/resources/nodejs/package-lock.json#L65
fsevent, is optional, and only installed on macOs, so fsevents dependecies are only installed if fsevents is installed, so the `integrity` key can't be computed

## Have test cases been added to cover the new functionality?
yes, I've cloned the reportTest, to do the same test with node audit / node package / retireJS