### PR TITLE
Fix vulnerabilityIds id and url mistake for XML format output

### DIFF
--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -158,7 +158,7 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
 #end
                 </package>
 #end
-#foreach($id in $dependency.getSoftwareIdentifiers())
+#foreach($id in $dependency.getVulnerableSoftwareIdentifiers())
                 <vulnerabilityIds #if($id.confidence)confidence="$id.confidence"#end>
                     <id>$enc.xml($id.value)</id>
 #if( $id.url )


### PR DESCRIPTION
## Fixes Issue 

#2355 

## Description of Change

vulnerabilityIds id and url are provided by `getVulnerableSoftwareIdentifiers()` instead of `getSoftwareIdentifiers()`.

## Have test cases been added to cover the new functionality?

no