### PR TITLE
Update DependencyManagement Handling in ODC Mojo

### DIFF
--- a/maven/src/it/1677-dependency-management/invoker.properties
+++ b/maven/src/it/1677-dependency-management/invoker.properties
@@ -1,0 +1,19 @@
+#
+# This file is part of dependency-check-maven.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+#
+
+invoker.goals = install  -Danalyzer.ossindex.enabled=false -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -Dformat=ALL -DskipDependencyManagement=false

--- a/maven/src/it/1677-dependency-management/pom.xml
+++ b/maven/src/it/1677-dependency-management/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2017 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.owasp.test</groupId>
+    <artifactId>verify-dependency-management</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>(,2.6.3]</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/src/it/1677-dependency-management/postbuild.groovy
+++ b/maven/src/it/1677-dependency-management/postbuild.groovy
@@ -1,0 +1,32 @@
+/*
+ * This file is part of dependency-check-maven.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import java.nio.charset.Charset;
+
+
+// Check to see if jackson-dataformat-xml-2.4.5.jar was identified.
+//TODO change this to xpath and check for CVE-2016-3720
+String log = FileUtils.readFileToString(new File(basedir, "target/dependency-check-report.xml"), Charset.defaultCharset().name());
+int count = StringUtils.countMatches(log, "<name>CVE-2016-7051</name>");
+if (count == 0){
+    System.out.println(String.format("jackson-dataformat-xml (CVE-2016-7051) was not identified", count));
+    return false;
+}
+return true;


### PR DESCRIPTION
## Fixes Issue #1677

The maven plugin has been updated to attempt to get the correct version if a version range is specified in the DependencyManagement section. This may still fail if the dependency defined in the DependencyManagement section has a version range and the dependency is not actually used.

## Have test cases been added to cover the new functionality?

yes