### PR TITLE
Added sensitive data masking when calling Settings.setString and Settings.getInt

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1112,7 +1112,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
             }
             if (isResolved && artifactFile != null) {
                 final List<Dependency> deps = engine.scan(artifactFile.getAbsoluteFile(),
-                        project.getName() + ":" + dependencyNode.getArtifact().getScope());
+                        createProjectReferenceName(project, dependencyNode));
                 if (deps != null) {
                     Dependency d = null;
                     if (deps.size() == 1) {
@@ -1159,6 +1159,17 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
             }
         }
         return exCol;
+    }
+    
+    /**
+     * @param project the {@link MavenProject}
+     * @param dependencyNode the {@link DependencyNode}
+     * @return the name to be used when creating a {@link Dependency#getProjectReferences() project reference} in a {@link Dependency}.
+     * The behavior of this method returns {@link MavenProject#getName() project.getName()}<code> + ":" + </code> 
+     * {@link DependencyNode#getArtifact() dependencyNode.getArtifact()}{@link Artifact#getScope() .getScope()}.
+     */
+    protected String createProjectReferenceName(MavenProject project, DependencyNode dependencyNode) {
+        return project.getName() + ":" + dependencyNode.getArtifact().getScope();
     }
 
     /**

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -777,7 +777,7 @@ public final class Settings {
      */
     public void setString(@NotNull final String key, @NotNull final String value) {
         props.setProperty(key, value);
-        LOGGER.debug("Setting: {}='{}'", key, value);
+        LOGGER.debug("Setting: {}='{}'", key, getPrintableValue(key, value));
     }
 
     /**
@@ -1120,7 +1120,7 @@ public final class Settings {
             value = Integer.parseInt(getString(key));
         } catch (NumberFormatException ex) {
             if (!getString(key, "").isEmpty()) {
-                LOGGER.debug("Could not convert property '{}={}' to an int; using {} instead.", key, getString(key), defaultValue);
+                LOGGER.debug("Could not convert property '{}={}' to an int; using {} instead.", key, getPrintableValue(key, getString(key)), defaultValue);
             }
             value = defaultValue;
         }


### PR DESCRIPTION
## Fixes Issue #
#2366 

## Description of Change
Added masking functionality using ```getPrintableValue(String,String)``` for
```LOGGER.debug``` invocations in methods ```setString(String,String)``` and
```getInt(String,int)```


## Have test cases been added to cover the new functionality?
no