### PR TITLE
Fix/Update jlink path in Cli Dockerfile

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,5 +1,6 @@
 FROM azul/zulu-openjdk-alpine:11 AS jlink
-RUN jlink --compress=2 --module-path /opt/java/openjdk/jmods --add-modules java.base,java.compiler,java.datatransfer,jdk.crypto.ec,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.scripting,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.unsupported --output /jlinked
+
+RUN $JAVA_HOME/bin/jlink --compress=2 --module-path /opt/java/openjdk/jmods --add-modules java.base,java.compiler,java.datatransfer,jdk.crypto.ec,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.scripting,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.unsupported --output /jlinked
 
 FROM mcr.microsoft.com/dotnet/core/runtime:2.2-alpine3.9
 


### PR DESCRIPTION
## Fixes Issue (No ticket)
 ---
## Description of Change
jlink binary is not in path - this change points the dockerfile directly to the binary uses java_home and the predictable jlink path.

## Have test cases been added to cover the new functionality?
No - not necessary