### PR TITLE
Use pecoff4j to read dll/exe version information metadata on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ velocity.log
 
 # Apple macOS operating system Desktop Services Store files
 .DS_Store
+/.vscode
+/maven/.factorypath

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -169,6 +169,11 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
     </build>
     <dependencies>
         <dependency>
+            <groupId>org.whitesource</groupId>
+            <artifactId>pecoff4j</artifactId>
+            <version>0.0.2.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-jcs-core</artifactId>
         </dependency>

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzer.java
@@ -130,7 +130,7 @@ public class FileNameAnalyzer extends AbstractAnalyzer {
                 if (version.getVersionParts() == null || version.getVersionParts().size() < 2) {
                     dependency.addEvidence(EvidenceType.VERSION, "file", "version", version.toString(), Confidence.MEDIUM);
                 } else {
-                    dependency.addEvidence(EvidenceType.VERSION, "file", "version", version.toString(), Confidence.HIGHEST);
+                    dependency.addEvidence(EvidenceType.VERSION, "file", "version", version.toString(), Confidence.HIGH);
                 }
                 dependency.addEvidence(EvidenceType.VERSION, "file", "name", packageName, Confidence.MEDIUM);
             }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/FileVersionAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/FileVersionAnalyzer.java
@@ -1,0 +1,131 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2012 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.analyzer;
+
+import java.io.File;
+import java.io.IOError;
+import java.io.IOException;
+
+import org.apache.commons.io.FilenameUtils;
+import org.boris.pecoff4j.PE;
+import org.boris.pecoff4j.ResourceDirectory;
+import org.boris.pecoff4j.ResourceEntry;
+import org.boris.pecoff4j.constant.ResourceType;
+import org.boris.pecoff4j.io.PEParser;
+import org.boris.pecoff4j.io.ResourceParser;
+import org.boris.pecoff4j.resources.StringFileInfo;
+import org.boris.pecoff4j.resources.StringTable;
+import org.boris.pecoff4j.resources.VersionInfo;
+import org.boris.pecoff4j.util.ResourceHelper;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.dependency.Confidence;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.EvidenceType;
+import org.owasp.dependencycheck.utils.Settings;
+
+/**
+ * Takes a dependency and analyze the version from the windows file version metadata, only for .exe and .dll
+ * 
+ * @author Amodio Pesce
+ */
+@ThreadSafe
+public class FileVersionAnalyzer extends AbstractAnalyzer {
+
+    //<editor-fold defaultstate="collapsed" desc="All standard implementation details of Analyzer">
+    /**
+     * The name of the analyzer.
+     */
+    private static final String ANALYZER_NAME = "File Version Analyzer";
+
+    /**
+     * The phase that this analyzer is intended to run in.
+     */
+    private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.INFORMATION_COLLECTION;
+
+    /**
+     * Returns the name of the analyzer.
+     *
+     * @return the name of the analyzer.
+     */
+    @Override
+    public String getName() {
+        return ANALYZER_NAME;
+    }
+
+    /**
+     * Returns the phase that the analyzer is intended to run in.
+     *
+     * @return the phase that the analyzer is intended to run in.
+     */
+    @Override
+    public AnalysisPhase getAnalysisPhase() {
+        return ANALYSIS_PHASE;
+    }
+
+    /**
+     * <p>
+     * Returns the setting key to determine if the analyzer is enabled.</p>
+     *
+     * @return the key for the analyzer's enabled property
+     */
+    @Override
+    protected String getAnalyzerEnabledSettingKey() {
+        return Settings.KEYS.ANALYZER_FILE_VERSION_ENABLED;
+    }
+
+    /**
+     * Collects information about the file name.
+     *
+     * @param dependency the dependency to analyze.
+     * @param engine the engine that is scanning the dependencies
+     */
+    @Override
+    protected void analyzeDependency(final Dependency dependency, final Engine engine) {
+        // strip any path information that may get added by ArchiveAnalyzer, etc.
+        try {
+            final File fileToCheck = dependency.getActualFile();
+            final String ext = FilenameUtils.getExtension(fileToCheck.getName());
+            if (ext.equals("dll") || ext.equals(".exe")) {
+                final PE pe = PEParser.parse(fileToCheck.getPath());
+                final ResourceDirectory rd = pe.getImageData().getResourceTable();
+                final ResourceEntry[] entries = ResourceHelper.findResources(rd, ResourceType.VERSION_INFO);
+                for (int i = 0; i < entries.length; i++) {
+                    final byte[] data = entries[i].getData();
+                    final VersionInfo version = ResourceParser.readVersionInfo(data);
+                    final StringFileInfo strings = version.getStringFileInfo();
+                    final StringTable table = strings.getTable(0);
+                    for (int j = 0; j < table.getCount(); j++) {
+                        final String key = table.getString(j).getKey();
+                        final String value = table.getString(j).getValue();
+                        if (key.equals("ProductVersion")) {
+                            dependency.addEvidence(EvidenceType.VERSION, "winmetadata", "version", value,
+                                    Confidence.HIGHEST);
+                        }
+                    }
+                }
+            }
+        } catch (final IOException e) 
+        {
+
+        }
+    }
+}

--- a/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
+++ b/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
@@ -1,5 +1,6 @@
 org.owasp.dependencycheck.analyzer.ArchiveAnalyzer
 org.owasp.dependencycheck.analyzer.FileNameAnalyzer
+org.owasp.dependencycheck.analyzer.FileVersionAnalyzer
 org.owasp.dependencycheck.analyzer.JarAnalyzer
 org.owasp.dependencycheck.analyzer.HintAnalyzer
 org.owasp.dependencycheck.analyzer.CPEAnalyzer

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -551,6 +551,10 @@ public final class Settings {
          */
         public static final String ANALYZER_FILE_NAME_ENABLED = "analyzer.filename.enabled";
         /**
+         * The key to determine if the File Version analyzer is enabled.
+         */
+        public static final String ANALYZER_FILE_VERSION_ENABLED = "analyzer.fileveraion.enabled";
+        /**
          * The key to determine if the Hint analyzer is enabled.
          */
         public static final String ANALYZER_HINT_ENABLED = "analyzer.hint.enabled";

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -553,7 +553,7 @@ public final class Settings {
         /**
          * The key to determine if the File Version analyzer is enabled.
          */
-        public static final String ANALYZER_FILE_VERSION_ENABLED = "analyzer.fileveraion.enabled";
+        public static final String ANALYZER_FILE_VERSION_ENABLED = "analyzer.fileversion.enabled";
         /**
          * The key to determine if the Hint analyzer is enabled.
          */


### PR DESCRIPTION
## Fixes Issue #
Dll and exe on windows that are not .NET assembly are only analyzed by the filename.
This is often not good enough because the filename can contain other numbers (x86, x64, ...) other than the version.

## Description of Change
To improve the situation I've reduced the confidence of the filename parsed version and created a new analyzer
The FileVersionAnalyzer use the pecoff4j library to extract, if possible, the version from the file metadata

## Have test cases been added to cover the new functionality?
no