### PR TITLE
fix(docker): the docker script didn't scan anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ docker pull owasp/dependency-check:$DC_VERSION
 docker run --rm \
     -e user=$USER \
     -u $(id -u ${USER}):$(id -g ${USER}) \
-    --volume $(pwd):/z \
+    --volume $(pwd):/src:z \
     --volume "$DATA_DIRECTORY":/usr/share/dependency-check/data:z \
     --volume $(pwd)/odc-reports:/report:z \
     owasp/dependency-check:$DC_VERSION \


### PR DESCRIPTION
## Fixes Issue #

https://github.com/jeremylong/DependencyCheck/issues/2451

## Description of Change

The script mapped the current source directy to `/z` but then scanned `/src` which resulted in no source code being scanned at all.

## Have test cases been added to cover the new functionality?

no new functionality