### PR TITLE
Improve Identification of Shaded Jars

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -93,7 +93,7 @@ public class CPEAnalyzer extends AbstractAnalyzer {
     /**
      * The maximum number of query results to return.
      */
-    private static final int MAX_QUERY_RESULTS = 25;
+    private static final int MAX_QUERY_RESULTS = 100;
     /**
      * The weighting boost to give terms when constructing the Lucene query.
      */

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
@@ -453,30 +453,32 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
      * @param engine the engine used to scan all dependencies
      */
     private synchronized void removeDuplicativeEntriesFromJar(Dependency dependency, Engine engine) {
-        if (dependency.getFileName().toLowerCase().endsWith("pom.xml")
-                || DLL_EXE_FILTER.accept(dependency.getActualFile())) {
-            String parentPath = dependency.getFilePath().toLowerCase();
-            if (parentPath.contains(".jar")) {
-                parentPath = parentPath.substring(0, parentPath.indexOf(".jar") + 4);
-                final Dependency[] dependencies = engine.getDependencies();
-                final Dependency parent = findDependency(parentPath, dependencies);
-                if (parent != null) {
-                    final boolean remove = dependency.getVulnerableSoftwareIdentifiers().stream()
-                            .filter((i) -> (i instanceof CpeIdentifier))
-                            .map(i -> (CpeIdentifier) i)
-                            .anyMatch(i -> parent.getVulnerableSoftwareIdentifiers().stream()
-                                    .filter((p) -> (p instanceof CpeIdentifier))
-                                    .map(p -> (CpeIdentifier) p)
-                                    .anyMatch(p -> !p.equals(i)
-                                    && p.getCpe().getPart().equals(i.getCpe().getPart())
-                                    && p.getCpe().getVendor().equals(i.getCpe().getVendor())
-                                    && p.getCpe().getProduct().equals(i.getCpe().getProduct())));
-                    if (remove) {
-                        engine.removeDependency(dependency);
-                    }
-                }
-            }
-        }
+        //Believed to be code that should have been removed several versions ago. This logic
+        // incorreclty removes dependencies such as more than half the pom entries in pax-web-jetty-bundle-6.0.7.jar
+//        if (dependency.getFileName().toLowerCase().endsWith("pom.xml")
+//                || DLL_EXE_FILTER.accept(dependency.getActualFile())) {
+//            String parentPath = dependency.getFilePath().toLowerCase();
+//            if (parentPath.contains(".jar")) {
+//                parentPath = parentPath.substring(0, parentPath.indexOf(".jar") + 4);
+//                final Dependency[] dependencies = engine.getDependencies();
+//                final Dependency parent = findDependency(parentPath, dependencies);
+//                if (parent != null) {
+//                    final boolean remove = dependency.getVulnerableSoftwareIdentifiers().stream()
+//                            .filter((i) -> (i instanceof CpeIdentifier))
+//                            .map(i -> (CpeIdentifier) i)
+//                            .anyMatch(i -> parent.getVulnerableSoftwareIdentifiers().stream()
+//                                    .filter((p) -> (p instanceof CpeIdentifier))
+//                                    .map(p -> (CpeIdentifier) p)
+//                                    .anyMatch(p -> !p.equals(i)
+//                                    && p.getCpe().getPart().equals(i.getCpe().getPart())
+//                                    && p.getCpe().getVendor().equals(i.getCpe().getVendor())
+//                                    && p.getCpe().getProduct().equals(i.getCpe().getProduct())));
+//                    if (remove) {
+//                        engine.removeDependency(dependency);
+//                    }
+//                }
+//            }
+//        }
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -472,7 +472,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
      */
     private Properties retrievePomProperties(String path, final JarFile jar) {
         Properties pomProperties = null;
-        final String propPath = path.substring(0, path.length() - 7) + "pom.properies";
+        final String propPath = path.substring(0, path.length() - 7) + "pom.properties";
         final ZipEntry propEntry = jar.getEntry(propPath);
         if (propEntry != null) {
             try (Reader reader = new InputStreamReader(jar.getInputStream(propEntry), StandardCharsets.UTF_8)) {
@@ -603,12 +603,17 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
         if (groupid != null && !groupid.isEmpty()) {
             foundSomething = true;
             dependency.addEvidence(EvidenceType.VENDOR, "pom", "groupid", groupid, Confidence.HIGHEST);
-            dependency.addEvidence(EvidenceType.PRODUCT, "pom", "groupid", groupid, Confidence.LOW);
+            //In several cases we are seeing the product name at the end of the group identifier.
+            // This may cause several FP on products that have a collection of dependencies (e.g. jetty).
+            //dependency.addEvidence(EvidenceType.PRODUCT, "pom", "groupid", groupid, Confidence.LOW);
+            dependency.addEvidence(EvidenceType.PRODUCT, "pom", "groupid", groupid, Confidence.HIGHEST);
             addMatchingValues(classes, groupid, dependency, EvidenceType.VENDOR);
             addMatchingValues(classes, groupid, dependency, EvidenceType.PRODUCT);
             if (parentGroupId != null && !parentGroupId.isEmpty() && !parentGroupId.equals(groupid)) {
                 dependency.addEvidence(EvidenceType.VENDOR, "pom", "parent-groupid", parentGroupId, Confidence.MEDIUM);
-                dependency.addEvidence(EvidenceType.PRODUCT, "pom", "parent-groupid", parentGroupId, Confidence.LOW);
+                //see note above for groupid
+                //dependency.addEvidence(EvidenceType.PRODUCT, "pom", "parent-groupid", parentGroupId, Confidence.LOW);
+                dependency.addEvidence(EvidenceType.PRODUCT, "pom", "parent-groupid", parentGroupId, Confidence.MEDIUM);
                 addMatchingValues(classes, parentGroupId, dependency, EvidenceType.VENDOR);
                 addMatchingValues(classes, parentGroupId, dependency, EvidenceType.PRODUCT);
             }

--- a/core/src/main/java/org/owasp/dependencycheck/xml/pom/Model.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/pom/Model.java
@@ -311,8 +311,17 @@ public class Model implements Serializable {
      */
     public void processProperties(Properties properties) {
         this.groupId = interpolateString(this.groupId, properties);
+        if (groupId == null && properties.containsKey("groupId")) {
+            this.groupId = properties.getProperty("groupId");
+        }
         this.artifactId = interpolateString(this.artifactId, properties);
+        if (artifactId == null && properties.containsKey("artifactId")) {
+            this.artifactId = properties.getProperty("artifactId");
+        }
         this.version = interpolateString(this.version, properties);
+        if (version == null && properties.containsKey("version")) {
+            this.version = properties.getProperty("version");
+        }
         this.description = interpolateString(this.description, properties);
         for (License l : this.getLicenses()) {
             l.setName(interpolateString(l.getName(), properties));

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -130,6 +130,7 @@
             40. <cpe>cpe:/a:bitmap_project:bitmap</cpe> is a C library #1961
             41. <cpe>cpe:/a:security-framework_project:security-framework</cpe> is a rust library
             42. <cpe>cpe:/a:next:next</cpe> is NeXT system.
+            43. <cpe>cpe:/a:property_pro:property_pro</cpe> is classic ASP
         ]]></notes>
         <filePath regex="true">.*(\.(dll|jar|ear|war|pom|nupkg|nuspec|aar)|pom\.xml|package.json|packages.config)$</filePath>
         <cpe>cpe:/a:sandbox:sandbox</cpe>
@@ -177,6 +178,7 @@
         <cpe>cpe:/a:bitmap_project:bitmap</cpe>
         <cpe>cpe:/a:security-framework_project:security-framework</cpe>
         <cpe>cpe:/a:next:next</cpe>
+        <cpe>cpe:/a:property_pro:property_pro</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
@@ -1052,14 +1054,15 @@
         <notes><![CDATA[
         drop wizard false positives
         ]]></notes>
-        <gav regex="true">org\.eclipse\.jetty:jetty-io:.*</gav>
+        <gav regex="true">org\.eclipse\.jetty\.http2:http2-hpack:.*</gav>
         <cpe>cpe:/a:jetty:jetty</cpe>
+        <cpe>cpe:/a:eclipse:jetty</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        drop wizard false positives
+        FP on osgi bundle - the embedded jetty server is flagged instead of the bundle itself.
         ]]></notes>
-        <gav regex="true">org\.eclipse\.jetty\.http2:http2-hpack:.*</gav>
+        <packageUrl regex="true">^pkg:maven/org\.ops4j\.pax\.web/pax\-web\-jetty\-bundle@.*$</packageUrl>
         <cpe>cpe:/a:jetty:jetty</cpe>
     </suppress>
     <suppress base="true">


### PR DESCRIPTION
## Fixes Issue #2444

Adjust confidence on some evidence entries, increase max results for CPE analyzer, and removes inaccurate logic from JAR Analyzer which incorrectly removed some shaded jars.
