### PR TITLE
Bump mockserver-netty from 5.8.1 to 5.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -870,7 +870,13 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>org.mock-server</groupId>
                 <artifactId>mockserver-netty</artifactId>
-                <version>5.8.1</version>
+                <version>5.9.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mock-server</groupId>
+                <artifactId>mockserver-junit-rule</artifactId>
+                <version>5.9.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -66,7 +66,11 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <version>5.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-junit-rule</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Fixes PR #2457

#2457 failed because the junit rule was moved to a separate dependency.