### PR TITLE
Update sonar-maven-plugin to its relocation groupId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -657,7 +657,7 @@ Copyright (c) 2012 - Jeremy Long
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
                 <version>3.6.0.1398</version>
             </plugin>


### PR DESCRIPTION
## Fixes Issue #2490 

## Description of Change

Updated the groupId to the relocation target where SonarSource has moved its plugin to

## Have test cases been added to cover the new functionality?

no, not applicable for this change