### PR TITLE
Fix broken checkstyle config after checkstyle-plugin update to v3.1.1

### DIFF
--- a/src/main/config/checkstyle-checks.xml
+++ b/src/main/config/checkstyle-checks.xml
@@ -52,9 +52,15 @@
         <property name="maximum" value="0"/>
     </module>
 
+    <module name="LineLength">
+        <property name="ignorePattern" value="^ *\* *[^ ]+$"/>
+        <property name="max" value="150"/>
+        <property name="fileExtensions" value="java" />
+    </module>
+
     <module name="TreeWalker">
         <property name="tabWidth" value="4"/>
-        
+
         <module name="SuppressionCommentFilter">
             <property name="offCommentFormat" value="CSOFF\: ([\w\|]+)"/>
             <property name="onCommentFormat" value="CSON\: ([\w\|]+)"/>
@@ -78,9 +84,8 @@
         <module name="JavadocType">
             <property name="authorFormat" value="\S"/>
         </module>
-        <module name="JavadocMethod">
-            <property name="allowUndeclaredRTE" value="true"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
+        <module name="JavadocMethod"/>
+        <module name="MissingJavadocMethod">
             <property name="allowMissingPropertyJavadoc" value="true"/>
         </module>
         <module name="JavadocVariable"/>
@@ -107,10 +112,6 @@
         </module>
 
         <module name="OuterTypeNumber"/>
-        <module name="LineLength">
-            <property name="ignorePattern" value="^ *\* *[^ ]+$"/>
-            <property name="max" value="150"/>
-        </module>
 
         <module name="MethodCount">
             <property name="maxTotal" value="80"/>


### PR DESCRIPTION
Update Checkstyle config for the breaking changes between v8.19 (maven plugin v3.1.0) and v8.29 (maven plugin v3.1.1)

## Fixes Issue #2492 

## Description of Change
Updated Checkstyle config to the updated Checkstyle version used by plugin v3.1.1

Decided to just remove `allowUndeclaredRTE` and `allowThrowsTagsForSubclasses` and not introduce anything for that as per CheckStyle's own recommendation in their ticket.


## Have test cases been added to cover the new functionality?

no, not applicable; validated with `mvn -s settings.xml install site site:stage -DreleaseTesting -Danalyzer.node.package.enabled=false -Danalyzer.node.audit.enabled=false` that checkstyle checks properly pass now