### PR TITLE
Fix `UPDATE_ECOSYSTEM2` for MySQL

### DIFF
--- a/core/src/main/resources/data/dbStatements_mysql.properties
+++ b/core/src/main/resources/data/dbStatements_mysql.properties
@@ -15,3 +15,4 @@
 MERGE_PROPERTY=CALL save_property(?, ?)
 CLEANUP_ORPHANS=call cleanup_orphans()
 UPDATE_ECOSYSTEM=call update_ecosystems()
+UPDATE_ECOSYSTEM2=UPDATE cpeEntry e SET e.ecosystem = NULL WHERE e.id IN (SELECT * FROM (SELECT DISTINCT entry.id FROM vulnerability v INNER JOIN software s ON v.id = s.cveid INNER JOIN cpeEntry r ON s.cpeentryid=r.id INNER JOIN cpeEntry entry ON r.part = entry.part AND r.vendor = entry.vendor AND r.product = entry.product WHERE description like '%bindings%' AND r.ecosystem is not null AND entry.ecosystem is not null UNION ALL SELECT z.id FROM cpeEntry z WHERE z.ecosystem is not null AND z.vendor = 'apache' AND z.product = 'zookeeper') x)


### PR DESCRIPTION
## Fixes Issue #
#2537 

## Description of Change

This fixes the `UPDATE_ECOSYSTEM2` SQL query for me on Percona Server 5.7.22.

Wrapping the "offending" subquery in another subquery fixes the issue by breaking certain optimizations. Seems very fragile to me, but it does the job.

See also: https://stackoverflow.com/questions/45494/mysql-error-1093-cant-specify-target-table-for-update-in-from-clause

*Note:* This patch is untested.

## Have test cases been added to cover the new functionality?

*no*