### PR TITLE
Add mix audit analyzer for Elixir projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 #group: deprecated-2017Q4
-dist: trusty
+dist: bionic
 
 env:
   global:
@@ -13,7 +13,7 @@ env:
 addons:
   apt:
     sources:
-      - sourceline: "deb https://packages.erlang-solutions.com/ubuntu trusty contrib"
+      - sourceline: "deb https://packages.erlang-solutions.com/ubuntu bionic contrib"
         key_url: "https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc"
     packages:
       - jq

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,12 @@ cache:
     - "$HOME/.m2/repository"
     - "$HOME/.sonar/cache"
 
-# Install binary for golang
+# Install binary for golang via gimme and mix_audit for Elixir
 install:
   - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.12 bash)"
-  - mix escript.install hex mix_audit
+  - mix local.hex --force
+  - mix escript.install --force hex mix_audit
+
 matrix:
   include:
     - jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 #group: deprecated-2017Q4
-dist: xenial
+dist: bionic
 
 env:
   global:
@@ -13,7 +13,7 @@ env:
 addons:
   apt:
     sources:
-      - sourceline: "deb https://packages.erlang-solutions.com/ubuntu xenial contrib"
+      - sourceline: "deb https://packages.erlang-solutions.com/ubuntu bionic contrib"
         key_url: "https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc"
     packages:
       - jq

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,10 @@ cache:
     - "$HOME/.m2/repository"
     - "$HOME/.sonar/cache"
 
-# Install binary for golang via gimme and mix_audit for Elixir
+# Install binary for golang
 install:
   - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.12 bash)"
-  - mix local.hex --force
-  - mix escript.install --force hex mix_audit
-
+  - mix escript.install hex mix_audit
 matrix:
   include:
     - jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 #group: deprecated-2017Q4
-dist: bionic
+dist: xenial
 
 env:
   global:
@@ -13,7 +13,7 @@ env:
 addons:
   apt:
     sources:
-      - sourceline: "deb https://packages.erlang-solutions.com/ubuntu bionic contrib"
+      - sourceline: "deb https://packages.erlang-solutions.com/ubuntu xenial contrib"
         key_url: "https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc"
     packages:
       - jq

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 #group: deprecated-2017Q4
-dist: bionic
+dist: trusty
 
 env:
   global:
@@ -13,7 +13,7 @@ env:
 addons:
   apt:
     sources:
-      - sourceline: "deb https://packages.erlang-solutions.com/ubuntu bionic contrib"
+      - sourceline: "deb https://packages.erlang-solutions.com/ubuntu trusty contrib"
         key_url: "https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc"
     packages:
       - jq

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ addons:
   apt:
     packages:
       - jq
+      - esl-erlang
+      - elixir
   sonarcloud:
     organization: "odc"
     token:
@@ -29,7 +31,7 @@ cache:
 # Install binary for golang
 install:
   - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.12 bash)"
-
+  - mix escript.install hex mix_audit
 matrix:
   include:
     - jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ addons:
   apt:
     packages:
       - jq
-      - esl-erlang
-      - elixir
   sonarcloud:
     organization: "odc"
     token:
@@ -31,7 +29,7 @@ cache:
 # Install binary for golang
 install:
   - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.12 bash)"
-  - mix escript.install hex mix_audit
+
 matrix:
   include:
     - jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ env:
 
 addons:
   apt:
+    sources:
+      - sourceline: "deb https://packages.erlang-solutions.com/ubuntu trusty contrib"
+        key_url: "https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc"
     packages:
       - jq
       - esl-erlang

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ env:
 
 addons:
   apt:
-    sources:
-      - sourceline: "deb https://packages.erlang-solutions.com/ubuntu trusty contrib"
-        key_url: "https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc"
     packages:
       - jq
       - esl-erlang

--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -115,6 +115,10 @@ public class Check extends Update {
      */
     private Boolean pyDistributionAnalyzerEnabled;
     /**
+     * Whether or not the mix audit analyzer is enabled.
+     */
+    private Boolean mixAuditAnalyzerEnabled;
+    /**
      * Whether or not the central analyzer is enabled.
      */
     private Boolean centralAnalyzerEnabled;
@@ -265,6 +269,10 @@ public class Check extends Update {
      * Whether the pip analyzer should be enabled.
      */
     private Boolean pipAnalyzerEnabled;
+    /**
+     * Sets the path for the mix_audit binary.
+     */
+    private String mixAuditPath;
     /**
      * Sets the path for the bundle-audit binary.
      */
@@ -1141,6 +1149,25 @@ public class Check extends Update {
     }
 
     /**
+     * Get the value of mixAuditAnalyzerEnabled.
+     *
+     * @return the value of mixAuditAnalyzerEnabled
+     */
+    public Boolean getMixAuditAnalyzerEnabled() {
+        return mixAuditAnalyzerEnabled;
+    }
+
+    /**
+     * Set the value of mixAuditAnalyzerEnabled.
+     *
+     * @param mixAuditAnalyzerEnabled new value of
+     * mixAuditAnalyzerEnabled
+     */
+    public void setMixAuditAnalyzerEnabled(Boolean mixAuditAnalyzerEnabled) {
+        this.mixAuditAnalyzerEnabled = mixAuditAnalyzerEnabled;
+    }
+
+    /**
      * Get the value of centralAnalyzerEnabled.
      *
      * @return the value of centralAnalyzerEnabled
@@ -1735,7 +1762,8 @@ public class Check extends Update {
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_GOLANG_DEP_ENABLED, golangDepEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_GOLANG_MOD_ENABLED, golangModEnabled);
         getSettings().setStringIfNotNull(Settings.KEYS.ANALYZER_GOLANG_PATH, pathToGo);
-
+        getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_MIX_AUDIT_ENABLED, mixAuditAnalyzerEnabled);
+        getSettings().setStringIfNotNull(Settings.KEYS.ANALYZER_MIX_AUDIT_PATH, mixAuditPath);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_NUSPEC_ENABLED, nuspecAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_NUGETCONF_ENABLED, nugetconfAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, centralAnalyzerEnabled);

--- a/ant/src/site/markdown/configuration.md
+++ b/ant/src/site/markdown/configuration.md
@@ -112,6 +112,8 @@ retireJsUrl                         | The URL to the Retire JS repository.      
 nuspecAnalyzerEnabled               | Sets whether the .NET Nuget Nuspec Analyzer will be used.                                                  | true
 nugetconfAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used. | true
 cocoapodsAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used.                | true
+mixAuditAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) Mix Audit Analyzer should be used.                | true
+mixAuditPath                        | Sets the path to the mix_audit executable; only used if mix audit analyzer is enabled and experimental analyzers are enabled.  | &nbsp;
 bundleAuditAnalyzerEnabled          | Sets whether the [experimental](../analyzers/index.html) Bundle Audit Analyzer should be used.             | true
 bundleAuditPath                     | Sets the path to the bundle audit executable; only used if bundle audit analyzer is enabled and experimental analyzers are enabled.  | &nbsp;
 swiftPackageManagerAnalyzerEnabled  | Sets whether the [experimental](../analyzers/index.html) Switft Package Analyzer should be used.           | true

--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -473,6 +473,8 @@ public class App {
                 !cli.hasDisableOption(CliParser.ARGUMENT.DISABLE_ASSEMBLY, Settings.KEYS.ANALYZER_ASSEMBLY_ENABLED));
         settings.setBoolean(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_ENABLED,
                 !cli.hasDisableOption(CliParser.ARGUMENT.DISABLE_BUNDLE_AUDIT, Settings.KEYS.ANALYZER_BUNDLE_AUDIT_ENABLED));
+        settings.setBoolean(Settings.KEYS.ANALYZER_MIX_AUDIT_ENABLED,
+                !cli.hasDisableOption(CliParser.ARGUMENT.DISABLE_MIX_AUDIT, Settings.KEYS.ANALYZER_MIX_AUDIT_ENABLED));
         settings.setBoolean(Settings.KEYS.ANALYZER_OPENSSL_ENABLED,
                 !cli.hasDisableOption(CliParser.ARGUMENT.DISABLE_OPENSSL, Settings.KEYS.ANALYZER_OPENSSL_ENABLED));
         settings.setBoolean(Settings.KEYS.ANALYZER_COMPOSER_LOCK_ENABLED,
@@ -529,6 +531,8 @@ public class App {
                 cli.getStringArgument(CliParser.ARGUMENT.ARTIFACTORY_API_TOKEN));
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_ARTIFACTORY_BEARER_TOKEN,
                 cli.getStringArgument(CliParser.ARGUMENT.ARTIFACTORY_BEARER_TOKEN));
+        settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_MIX_AUDIT_PATH,
+                cli.getStringArgument(CliParser.ARGUMENT.PATH_TO_MIX_AUDIT));
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_PATH,
                 cli.getStringArgument(CliParser.ARGUMENT.PATH_TO_BUNDLE_AUDIT));
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_WORKING_DIRECTORY,

--- a/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
@@ -397,6 +397,7 @@ public final class CliParser {
                 .addOption(newOption(ARGUMENT.DISABLE_PY_DIST, "Disable the Python Distribution Analyzer."))
                 .addOption(newOption(ARGUMENT.DISABLE_CMAKE, "Disable the Cmake Analyzer."))
                 .addOption(newOption(ARGUMENT.DISABLE_PY_PKG, "Disable the Python Package Analyzer."))
+                .addOption(newOption(ARGUMENT.DISABLE_MIX_AUDIT, "Disable the Elixir mix-audit Analyzer."))
                 .addOption(newOption(ARGUMENT.DISABLE_RUBYGEMS, "Disable the Ruby Gemspec Analyzer."))
                 .addOption(newOption(ARGUMENT.DISABLE_BUNDLE_AUDIT, "Disable the Ruby Bundler-Audit Analyzer."))
                 .addOption(newOption(ARGUMENT.DISABLE_AUTOCONF, "Disable the Autoconf Analyzer."))
@@ -1055,6 +1056,10 @@ public final class CliParser {
          */
         public static final String DISABLE_PY_PKG = "disablePyPkg";
         /**
+         * Disables the Elixir mix audit Analyzer.
+         */
+        public static final String DISABLE_MIX_AUDIT = "disableMixAudit";
+        /**
          * Disables the Golang Dependency Analyzer.
          */
         public static final String DISABLE_GO_DEP = "disableGolangDep";
@@ -1234,6 +1239,11 @@ public final class CliParser {
          * rbenv
          */
         public static final String PATH_TO_BUNDLE_AUDIT_WORKING_DIRECTORY = "bundleAuditWorkingDirectory";
+        /**
+         * The CLI argument name for setting the path to mix_audit for Elixir
+         * analysis.
+         */
+        public static final String PATH_TO_MIX_AUDIT = "mixAudit";
         /**
          * The CLI argument to enable the experimental analyzers.
          */

--- a/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
@@ -397,7 +397,7 @@ public final class CliParser {
                 .addOption(newOption(ARGUMENT.DISABLE_PY_DIST, "Disable the Python Distribution Analyzer."))
                 .addOption(newOption(ARGUMENT.DISABLE_CMAKE, "Disable the Cmake Analyzer."))
                 .addOption(newOption(ARGUMENT.DISABLE_PY_PKG, "Disable the Python Package Analyzer."))
-                .addOption(newOption(ARGUMENT.DISABLE_MIX_AUDIT, "Disable the Elixir mix-audit Analyzer."))
+                .addOption(newOption(ARGUMENT.DISABLE_MIX_AUDIT, "Disable the Elixir mix_audit Analyzer."))
                 .addOption(newOption(ARGUMENT.DISABLE_RUBYGEMS, "Disable the Ruby Gemspec Analyzer."))
                 .addOption(newOption(ARGUMENT.DISABLE_BUNDLE_AUDIT, "Disable the Ruby Bundler-Audit Analyzer."))
                 .addOption(newOption(ARGUMENT.DISABLE_AUTOCONF, "Disable the Autoconf Analyzer."))

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ElixirMixAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ElixirMixAuditAnalyzer.java
@@ -1,0 +1,375 @@
+package org.owasp.dependencycheck.analyzer;
+
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2020 OWASP. All Rights Reserved.
+ */
+
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import com.github.packageurl.PackageURLBuilder;
+import com.google.common.collect.ImmutableList;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.data.elixir.MixAuditJsonParser;
+import org.owasp.dependencycheck.data.elixir.MixAuditResult;
+import org.owasp.dependencycheck.data.nvdcve.CveDB;
+import org.owasp.dependencycheck.dependency.*;
+import org.owasp.dependencycheck.dependency.naming.GenericIdentifier;
+import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
+import org.owasp.dependencycheck.exception.InitializationException;
+import org.owasp.dependencycheck.utils.Checksum;
+import org.owasp.dependencycheck.utils.FileFilterBuilder;
+import org.owasp.dependencycheck.utils.Settings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import us.springett.parsers.cpe.exceptions.CpeValidationException;
+import us.springett.parsers.cpe.values.Part;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+@Experimental
+public class ElixirMixAuditAnalyzer extends AbstractFileTypeAnalyzer {
+
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(ElixirMixAuditAnalyzer.class);
+
+    /**
+     * A descriptor for the type of dependencies processed or added by this
+     * analyzer.
+     */
+    public static final String DEPENDENCY_ECOSYSTEM = "elixir";
+
+    /**
+     * The name of the analyzer.
+     */
+    private static final String ANALYZER_NAME = "Elixir Mix Audit Analyzer";
+
+    /**
+     * The phase that this analyzer is intended to run in.
+     */
+    private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.PRE_INFORMATION_COLLECTION;
+    /**
+     * The filter defining which files will be analyzed.
+     */
+    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addFilenames("mix.lock").build();
+    /**
+     * Name.
+     */
+    public static final String NAME = "Name: ";
+    /**
+     * Version.
+     */
+    public static final String VERSION = "Version: ";
+    /**
+     * Advisory.
+     */
+    public static final String ADVISORY = "Advisory: ";
+    /**
+     * Criticality.
+     */
+    public static final String CRITICALITY = "Criticality: ";
+    /**
+     * The DAL.
+     */
+    private CveDB cvedb = null;
+
+    /**
+     * @return a filter that accepts files named mix.lock
+     */
+    @Override
+    protected FileFilter getFileFilter() {
+        return FILTER;
+    }
+
+    @Override
+    protected void prepareFileTypeAnalyzer(Engine engine) throws InitializationException {
+        if (engine != null) {
+            this.cvedb = engine.getDatabase();
+        }
+
+        // Here we check if mix_audit actually runs from this location. We do this by running the
+        // `mix_audit --version` command and seeing whether or not it succeeds (if it returns with an exit value of 0)
+        final Process process;
+        try {
+            final List<String> mixAuditArgs = ImmutableList.of("--version");
+            process = launchMixAudit(getSettings().getTempDirectory(), mixAuditArgs);
+        } catch (AnalysisException ae) {
+            setEnabled(false);
+            final String msg = String.format("Exception from mix_audit process: %s. Disabling %s", ae.getCause(), ANALYZER_NAME);
+            throw new InitializationException(msg, ae);
+        } catch (IOException ex) {
+            setEnabled(false);
+            throw new InitializationException("Unable to create temporary file, the Mix Audit Analyzer will be disabled", ex);
+        }
+
+        final int exitValue;
+        try {
+            exitValue = process.waitFor();
+        } catch (InterruptedException ex) {
+            setEnabled(false);
+            final String msg = String.format("mix_audit process was interrupted. Disabling %s", ANALYZER_NAME);
+            Thread.currentThread().interrupt();
+            throw new InitializationException(msg);
+        }
+
+        final String mixAuditVersionDetails;
+        if (exitValue != 0) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8))) {
+                if (!reader.ready()) {
+                    LOGGER.warn("Unexpected exit value from mix_audit process and error stream unexpectedly not ready to capture error details. "
+                            + "Disabling {}. Exit value was: {}", ANALYZER_NAME, exitValue);
+                    setEnabled(false);
+                    throw new InitializationException("mix_audit error stream unexpectedly not ready.");
+                } else {
+                    final String line = reader.readLine();
+                    setEnabled(false);
+                    LOGGER.warn("Unexpected exit value from mix_audit process. Disabling {}. Exit value was: {}. "
+                            + "error stream output from mix_audit process was: {}", ANALYZER_NAME, exitValue, line);
+                    throw new InitializationException("Unexpected exit value from bundle-audit process.");
+                }
+            } catch (UnsupportedEncodingException ex) {
+                setEnabled(false);
+                throw new InitializationException("Unexpected mix_audit encoding when reading error stream.", ex);
+            } catch (IOException ex) {
+                setEnabled(false);
+                throw new InitializationException("Unable to read mix_audit output from error stream.", ex);
+            }
+        } else {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                if (!reader.ready()) {
+                    LOGGER.warn("mix_audit input stream unexpectedly not ready to capture version details. Disabling {}", ANALYZER_NAME);
+                    setEnabled(false);
+                    throw new InitializationException("mix_audit input stream unexpectedly not ready to capture version details.");
+                } else {
+                    mixAuditVersionDetails = reader.readLine();
+                }
+            } catch (UnsupportedEncodingException ex) {
+                setEnabled(false);
+                throw new InitializationException("Unexpected mix_audit encoding when reading input stream.", ex);
+            } catch (IOException ex) {
+                setEnabled(false);
+                throw new InitializationException("Unable to read mix_audit output from input stream.", ex);
+            }
+        }
+
+        if (isEnabled()) {
+            LOGGER.info("{} is enabled and is using mix_audit with version: {}.", ANALYZER_NAME, mixAuditVersionDetails);
+        }
+    }
+
+    /**
+     * Returns the key used in the properties file to reference the analyzer's
+     * enabled property.
+     *
+     * @return the analyzer's enabled property setting key
+     */
+    @Override
+    protected String getAnalyzerEnabledSettingKey() {
+        return Settings.KEYS.ANALYZER_MIX_AUDIT_ENABLED;
+    }
+
+    /**
+     * Returns the name of the analyzer.
+     *
+     * @return the name of the analyzer.
+     */
+    @Override
+    public String getName() {
+        return ANALYZER_NAME;
+    }
+
+    /**
+     * Returns the phase that the analyzer is intended to run in.
+     *
+     * @return the phase that the analyzer is intended to run in.
+     */
+    @Override
+    public AnalysisPhase getAnalysisPhase() {
+        return ANALYSIS_PHASE;
+    }
+
+    /**
+     * Launch mix audit.
+     *
+     * @param folder       directory that contains the mix.lock file
+     * @param mixAuditArgs the arguments to pass to mix audit
+     * @return a handle to the process
+     * @throws AnalysisException thrown when there is an issue launching mix audit
+     */
+    private Process launchMixAudit(File folder, List<String> mixAuditArgs) throws AnalysisException {
+        if (!folder.isDirectory()) {
+            throw new AnalysisException(String.format("%s should have been a directory.", folder.getAbsolutePath()));
+        }
+
+        final List<String> args = new ArrayList<>();
+        final String mixAuditPath = getSettings().getString(Settings.KEYS.ANALYZER_MIX_AUDIT_PATH);
+        File mixAudit = null;
+
+        if (mixAuditPath != null) {
+            mixAudit = new File(mixAuditPath);
+            if (!mixAudit.isFile()) {
+                LOGGER.warn("Supplied `mixAudit` path is incorrect: {}", mixAuditPath);
+                mixAudit = null;
+            }
+        } else {
+            Path homePath = Paths.get(System.getProperty("user.home"));
+            Path escriptPath = Paths.get(homePath.toString(), ".mix", "escripts", "mix_audit");
+            mixAudit = escriptPath.toFile();
+        }
+
+        args.add(mixAudit != null ? mixAudit.getAbsolutePath() : "mix_audit");
+        args.addAll(mixAuditArgs);
+        final ProcessBuilder builder = new ProcessBuilder(args);
+
+        builder.directory(folder);
+        try {
+            LOGGER.info("Launching: {} from {}", args, folder);
+            return builder.start();
+        } catch (IOException ioe) {
+            throw new AnalysisException("mix_audit initialization failure; this error can be ignored if you are not analyzing Elixir. "
+                    + "Otherwise ensure that mix_audit is installed and the path to mix_audit is correctly specified", ioe);
+        }
+    }
+
+    /**
+     * Determines if the analyzer can analyze the given file type.
+     *
+     * @param dependency the dependency to determine if it can analyze
+     * @param engine     the dependency-check engine
+     * @throws AnalysisException thrown if there is an analysis exception.
+     */
+    @Override
+    protected void analyzeDependency(Dependency dependency, Engine engine)
+            throws AnalysisException {
+        final File parentFile = dependency.getActualFile().getParentFile();
+        final List<String> mixAuditArgs = ImmutableList.of("--format", "json");
+
+        final Process process = launchMixAudit(parentFile, mixAuditArgs);
+        final int exitValue;
+        try {
+            exitValue = process.waitFor();
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new AnalysisException("mix_audit process interrupted", ie);
+        }
+        if (exitValue < 0 || exitValue > 1) {
+            final String msg = String.format("Unexpected exit code from mix_audit process; exit code: %s", exitValue);
+            throw new AnalysisException(msg);
+        }
+        try {
+            try (BufferedReader errReader = new BufferedReader(new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8))) {
+                while (errReader.ready()) {
+                    final String error = errReader.readLine();
+                    LOGGER.warn(error);
+                }
+            }
+            try (BufferedReader rdr = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                processMixAuditOutput(dependency, engine, rdr);
+            }
+        } catch (IOException | CpeValidationException ioe) {
+            LOGGER.warn("mix_audit failure", ioe);
+        }
+    }
+
+    /**
+     * Processes the mix audit output.
+     *
+     * @param original the dependency
+     * @param engine   the dependency-check engine
+     * @param rdr      the reader of the report
+     * @throws IOException            thrown if the report cannot be read
+     * @throws CpeValidationException if there is an error building the
+     *                                CPE/VulnerableSoftware object
+     */
+    private void processMixAuditOutput(Dependency original, Engine engine, BufferedReader rdr) throws AnalysisException, CpeValidationException {
+        final MixAuditJsonParser parser = new MixAuditJsonParser(rdr);
+        parser.process();
+
+        for (MixAuditResult result : parser.getResults()) {
+            Dependency dependency = createDependency(original, result.getDependencyPackage(), result.getDependencyVersion());
+            Vulnerability vulnerability = cvedb.getVulnerability(result.getCve());
+
+            if(vulnerability == null) {
+                vulnerability = createVulnerability(result);
+            }
+
+            dependency.addVulnerability(vulnerability);
+            engine.addDependency(dependency);
+        }
+    }
+
+    private Dependency createDependency(Dependency parentDependency, String packageName, String version) {
+        final Dependency dep = new Dependency(parentDependency.getActualFile(), true);
+
+        String identifier = String.format("%s:%s", packageName, version);
+
+        dep.setEcosystem(DEPENDENCY_ECOSYSTEM);
+        dep.setDisplayFileName(identifier);
+        dep.setName(packageName);
+        dep.setVersion(version);
+        dep.setPackagePath(identifier);
+        dep.setMd5sum(Checksum.getMD5Checksum(identifier));
+        dep.setSha1sum(Checksum.getSHA1Checksum(identifier));
+        dep.setSha256sum(Checksum.getSHA256Checksum(identifier));
+
+        dep.addEvidence(EvidenceType.VERSION, "mix_audit", "Version", version, Confidence.HIGHEST);
+        dep.addEvidence(EvidenceType.PRODUCT, "mix_audit", "Package", packageName, Confidence.HIGHEST);
+
+        try {
+            final PackageURL purl = PackageURLBuilder.aPackageURL().withType("hex").withName(packageName)
+                    .withVersion(version).build();
+            dep.addSoftwareIdentifier(new PurlIdentifier(purl, Confidence.HIGHEST));
+        } catch (MalformedPackageURLException ex) {
+            LOGGER.debug("Unable to build package url for hex", ex);
+            final GenericIdentifier id = new GenericIdentifier("hex:" + packageName + "@" + version,
+                    Confidence.HIGHEST);
+            dep.addSoftwareIdentifier(id);
+        }
+
+        return dep;
+    }
+
+    private Vulnerability createVulnerability(MixAuditResult result) throws CpeValidationException {
+        final String product = result.getDependencyPackage();
+        final String version = result.getDependencyVersion();
+
+        final Vulnerability vulnerability = new Vulnerability();
+        vulnerability.setSource(Vulnerability.Source.MIXAUDIT);
+
+        final VulnerableSoftwareBuilder builder = new VulnerableSoftwareBuilder();
+        final VulnerableSoftware vs = builder.part(Part.APPLICATION)
+                .vendor(String.format("%s_project", product))
+                .product(product)
+                .version(version).build();
+
+        vulnerability.addVulnerableSoftware(vs);
+        vulnerability.setMatchedVulnerableSoftware(vs);
+
+        vulnerability.setCvssV2(new CvssV2(-1, "-", "-", "-", "-", "-", "-", "unknown"));
+        vulnerability.setDescription(result.getDescription());
+        vulnerability.setName(result.getCve());
+
+        return vulnerability;
+    }
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/elixir/MixAuditJsonParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/elixir/MixAuditJsonParser.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2020 The OWASP Foundation. All Rights Reserved.
+ */
+
+package org.owasp.dependencycheck.data.elixir;
+
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.data.golang.GoModDependency;
+import org.owasp.dependencycheck.data.golang.GoModJsonParser;
+import org.owasp.dependencycheck.dependency.Vulnerability;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import javax.json.*;
+import javax.json.stream.JsonParsingException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parses json output from `mix_audit --format json`.
+ *
+ * @author Christoph Sassenberg
+ */
+@NotThreadSafe
+public class MixAuditJsonParser {
+
+    static final String PASS_FAIL_KEY = "pass";
+    static final String RESULTS_KEY = "vulnerabilities";
+    static final String ADVISORY_KEY = "advisory";
+    static final String DEPENDENCY_KEY = "dependency";
+
+    /**
+     * The JsonReader for parsing JSON.
+     */
+    private final JsonReader jsonReader;
+
+    /**
+     * The List of MixAuditResults found.
+     */
+    private final List<MixAuditResult> mixAuditResults;
+
+    /**
+     * Whether the mix audit passed or failed.
+     */
+    private boolean mixAuditPass;
+
+    /**
+     * The LOGGER
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(MixAuditJsonParser.class);
+
+    /**
+     * Creates a MixAuditJsonParser from a Reader.
+     *
+     * @param Reader the reader to parse
+     */
+    public MixAuditJsonParser(Reader reader) {
+        LOGGER.debug("Creating a MixAuditJsonParser");
+        this.jsonReader = Json.createReader(reader);
+        this.mixAuditResults = new ArrayList<MixAuditResult>();
+        this.mixAuditPass = false;
+    }
+
+    /**
+     * Process the input stream to create the list of dependencies.
+     *
+     * @throws AnalysisException thrown when there is an error parsing the
+     *                           results of `mix_audit --format json`
+     */
+    public void process() throws AnalysisException {
+        LOGGER.debug("Beginning mix_audit json output processing");
+        try {
+            final JsonObject output = jsonReader.readObject();
+            if (output.containsKey(PASS_FAIL_KEY)) {
+                this.mixAuditPass = output.getBoolean(PASS_FAIL_KEY);
+            }
+
+            if (output.containsKey(RESULTS_KEY) && output.isNull(RESULTS_KEY))
+                LOGGER.debug("Found vulnerabilities");
+            final JsonArray results = output.getJsonArray(RESULTS_KEY);
+            for (JsonObject result : results.getValuesAs(JsonObject.class)) {
+                final JsonObject advisory = result.getJsonObject(ADVISORY_KEY);
+                final JsonObject dependency = result.getJsonObject(DEPENDENCY_KEY);
+                ArrayList<String> patchedVersions = new ArrayList<String>();
+
+                for(JsonString patchedVersion : advisory.getJsonArray("patched_versions").getValuesAs(JsonString.class)) {
+                    patchedVersions.add(patchedVersion.getString());
+                }
+
+                MixAuditResult r = new MixAuditResult(
+                        advisory.getString("id"),
+                        advisory.getString("cve"),
+                        advisory.getString("title"),
+                        advisory.getString("description"),
+                        advisory.getString("disclosure_date"),
+                        advisory.getString("url"),
+                        patchedVersions,
+                        dependency.getString("lockfile"),
+                        dependency.getString("package"),
+                        dependency.getString("version")
+                );
+
+                this.mixAuditResults.add(r);
+            }
+        } catch (JsonParsingException jsonpe) {
+            throw new AnalysisException("Error parsing stream", jsonpe);
+        } catch (JsonException jsone) {
+            throw new AnalysisException("Error reading stream", jsone);
+        } catch (IllegalStateException ise) {
+            throw new AnalysisException("Illegal state in go mod stream", ise);
+        } catch (ClassCastException cce) {
+            throw new AnalysisException("JSON not exactly matching output of `go mod edit -json`", cce);
+        }
+    }
+
+    /**
+     * Gets the list of results.
+     *
+     * @return the list of results
+     */
+    public List<MixAuditResult> getResults() {
+        return mixAuditResults;
+    }
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/elixir/MixAuditJsonParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/elixir/MixAuditJsonParser.java
@@ -69,7 +69,7 @@ public class MixAuditJsonParser {
     /**
      * Creates a MixAuditJsonParser from a Reader.
      *
-     * @param Reader the reader to parse
+     * @param reader - the java.io.Reader to read the json character stream from
      */
     public MixAuditJsonParser(Reader reader) {
         LOGGER.debug("Creating a MixAuditJsonParser");
@@ -124,9 +124,9 @@ public class MixAuditJsonParser {
         } catch (JsonException jsone) {
             throw new AnalysisException("Error reading stream", jsone);
         } catch (IllegalStateException ise) {
-            throw new AnalysisException("Illegal state in go mod stream", ise);
+            throw new AnalysisException("Illegal state while parsing mix_audit output", ise);
         } catch (ClassCastException cce) {
-            throw new AnalysisException("JSON not exactly matching output of `go mod edit -json`", cce);
+            throw new AnalysisException("JSON not exactly matching output of `mix_audit --format json`", cce);
         }
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/data/elixir/MixAuditResult.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/elixir/MixAuditResult.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2020 OWASP Foundation. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.elixir;
+
+import java.util.List;
+
+/**
+ * Represents a single vulnerability result from `mix_audit --format json`
+ */
+public class MixAuditResult {
+    private final String id;
+    private final String cve;
+    private final String title;
+    private final String description;
+    private final String disclosureDate;
+    private final String url;
+    private final List<String> patchedVersions;
+
+    private final String dependencyLockfile;
+    private final String dependencyPackage;
+    private final String dependencyVersion;
+
+    public MixAuditResult(String id, String cve, String title, String description, String disclosureDate, String url, List<String> patchedVersions, String dependencyLockfile, String dependencyPackage, String dependencyVersion) {
+        this.id = id;
+        this.cve = cve;
+        this.title = title;
+        this.description = description;
+        this.disclosureDate = disclosureDate;
+        this.url = url;
+        this.patchedVersions = patchedVersions;
+        this.dependencyLockfile = dependencyLockfile;
+        this.dependencyPackage = dependencyPackage;
+        this.dependencyVersion = dependencyVersion;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getCve() {
+        return cve;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getDisclosureDate() {
+        return disclosureDate;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public List<String> getPatchedVersions() {
+        return patchedVersions;
+    }
+
+    public String getDependencyLockfile() {
+        return dependencyLockfile;
+    }
+
+    public String getDependencyPackage() {
+        return dependencyPackage;
+    }
+
+    public String getDependencyVersion() {
+        return dependencyVersion;
+    }
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/elixir/package-info.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/elixir/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains classes for working with various Elixir project data.
+ */
+package org.owasp.dependencycheck.data.elixir;

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
@@ -61,13 +61,17 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
         /**
          * Vulnerability from Bundle Audit.
          */
-        BUNDLEAUDIT
+        BUNDLEAUDIT,
+        /**
+         * Vulnerability from Mix Audit.
+         */
+        MIXAUDIT
     }
 
     /**
      * The serial version uid.
      */
-    private static final long serialVersionUID = 307319490326651052L;
+    private static final long serialVersionUID = 307319490326651053L;
 
     /**
      * The name of the vulnerability.

--- a/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
+++ b/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
@@ -31,6 +31,7 @@ org.owasp.dependencycheck.analyzer.RetireJsAnalyzer
 org.owasp.dependencycheck.analyzer.RubyGemspecAnalyzer
 org.owasp.dependencycheck.analyzer.RubyBundlerAnalyzer
 org.owasp.dependencycheck.analyzer.RubyBundleAuditAnalyzer
+org.owasp.dependencycheck.analyzer.ElixirMixAuditAnalyzer
 org.owasp.dependencycheck.analyzer.ComposerLockAnalyzer
 org.owasp.dependencycheck.analyzer.CocoaPodsAnalyzer
 org.owasp.dependencycheck.analyzer.SwiftPackageManagerAnalyzer

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -115,6 +115,7 @@ analyzer.retirejs.repo.validforhours=24
 analyzer.retirejs.repo.js.url=https://raw.githubusercontent.com/Retirejs/retire.js/master/repository/jsrepository.json
 analyzer.retirejs.filternonvulnerable=false
 analyzer.golang.mod.enabled=true
+analyzer.mix.audit.enabled=true
 analyzer.composer.lock.enabled=true
 analyzer.python.distribution.enabled=true
 analyzer.python.package.enabled=true

--- a/core/src/test/java/org/owasp/dependencycheck/EngineIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/EngineIT.java
@@ -54,6 +54,7 @@ public class EngineIT extends BaseDBTestCase {
         getSettings().setBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED, false);
         getSettings().setBoolean(Settings.KEYS.ANALYZER_EXPERIMENTAL_ENABLED, true);
         getSettings().setBoolean(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_ENABLED, false);
+        getSettings().setBoolean(Settings.KEYS.ANALYZER_MIX_AUDIT_ENABLED, false);
         ExceptionCollection exceptions = null;
         try (Engine instance = new Engine(getSettings())) {
             instance.scan(testClasses);
@@ -63,6 +64,7 @@ public class EngineIT extends BaseDBTestCase {
             } catch (ExceptionCollection ex) {
                 Set<String> allowedMessages = new HashSet<>();
                 allowedMessages.add("bundle-audit");
+                allowedMessages.add("mix_audit");
                 allowedMessages.add("AssemblyAnalyzer");
                 allowedMessages.add("Failed to request component-reports");
                 allowedMessages.add("ailed to read results from the NPM Audit API");

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/ElixirMixAuditAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/ElixirMixAuditAnalyzerIT.java
@@ -1,0 +1,157 @@
+package org.owasp.dependencycheck.analyzer;
+
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.owasp.dependencycheck.BaseDBTestCase;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
+import org.owasp.dependencycheck.dependency.*;
+import org.owasp.dependencycheck.exception.ExceptionCollection;
+import org.owasp.dependencycheck.exception.InitializationException;
+import org.owasp.dependencycheck.utils.Settings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class ElixirMixAuditAnalyzerIT extends BaseDBTestCase {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ElixirMixAuditAnalyzerIT.class);
+
+
+    private ElixirMixAuditAnalyzer analyzer;
+
+    /**
+     * Correctly setup the analyzer for testing.
+     *
+     * @throws Exception thrown if there is a problem
+     */
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        getSettings().setBoolean(Settings.KEYS.AUTO_UPDATE, false);
+        getSettings().setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
+        getSettings().setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
+        analyzer = new ElixirMixAuditAnalyzer();
+        analyzer.initialize(getSettings());
+        analyzer.setFilesMatched(true);
+    }
+
+    /**
+     * Cleanup the analyzer's temp files, etc.
+     *
+     * @throws Exception thrown if there is a problem
+     */
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        if (analyzer != null) {
+            analyzer.close();
+            analyzer = null;
+        }
+        super.tearDown();
+    }
+
+
+    /**
+     * Test Elixir MixAudit analysis.
+     *
+     * @throws AnalysisException is thrown when an exception occurs.
+     */
+    @Test
+    public void testAnalysis() throws AnalysisException, DatabaseException {
+        try (Engine engine = new Engine(getSettings())) {
+            engine.openDatabase();
+            analyzer.prepare(engine);
+            final String resource = "elixir/vulnerable/mix.lock";
+            final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, resource));
+            analyzer.analyze(result, engine);
+
+            final Dependency[] dependencies = engine.getDependencies();
+            assertEquals("should be one result exactly", 1, dependencies.length);
+
+            Dependency d = dependencies[0];
+            assertTrue(d.isVirtual());
+            assertEquals("plug:1.3.4", d.getPackagePath());
+            assertEquals("1.3.4", d.getVersion());
+            assertEquals("plug", d.getName());
+
+            Evidence packageEvidence = d.getEvidence(EvidenceType.PRODUCT).iterator().next();
+            assertEquals("Package", packageEvidence.getName());
+            assertEquals("plug", packageEvidence.getValue());
+
+            Evidence versionEvidence = d.getEvidence(EvidenceType.VERSION).iterator().next();
+            assertEquals("Version", versionEvidence.getName());
+            assertEquals("1.3.4", versionEvidence.getValue());
+
+            assertTrue(d.getFilePath().endsWith(resource));
+            assertTrue(d.getFileName().equals("mix.lock"));
+
+            Vulnerability v = d.getVulnerabilities().iterator().next();
+            assertEquals("2018-1000883", v.getName());
+            assertEquals("Cookie headers were not validated\n", v.getDescription());
+            assertEquals(-1.0f, v.getCvssV2().getScore(), 0.0);
+
+            VulnerableSoftware s = v.getVulnerableSoftware().iterator().next();
+            assertEquals("cpe:2.3:a:plug_project:plug:1.3.4:*:*:*:*:*:*:*", s.toString());
+
+        } catch (InitializationException | DatabaseException | AnalysisException e) {
+            LOGGER.warn("Exception setting up ElixirAuditAnalyzer. Make sure Elixir and the mix_audit escript is installed. You may also need to set property \"analyzer.mix.audit.path\".");
+            Assume.assumeNoException("Exception setting up ElixirMixAuditAnalyzer; mix_audit may not be installed, or property \"analyzer.mix.audit.path\" may not be set.", e);
+        }
+    }
+
+
+    /**
+     * Test when mix_audit is not available on the system or wrongly configured.
+     *
+     * @throws AnalysisException is thrown when an exception occurs.
+     */
+    @Test
+    public void testInvalidMixAuditExecutable() throws AnalysisException, DatabaseException {
+
+        String path = BaseTest.getResourceAsFile(this, "elixir/invalid_executable").getAbsolutePath();
+        getSettings().setString(Settings.KEYS.ANALYZER_MIX_AUDIT_PATH, path);
+        analyzer.initialize(getSettings());
+        try {
+            //initialize should fail.
+            analyzer.prepare(null);
+        } catch (InitializationException e) {
+            //expected, so ignore.
+            assertNotNull(e);
+        } finally {
+            assertFalse(analyzer.isEnabled());
+        }
+    }
+
+    /**
+     * Test Mix dependencies and their paths.
+     *
+     * @throws AnalysisException is thrown when an exception occurs.
+     * @throws DatabaseException thrown when an exception occurs
+     */
+    @Test
+    public void testDependenciesPath() throws AnalysisException, DatabaseException {
+        try (Engine engine = new Engine(getSettings())) {
+            try {
+                engine.scan(BaseTest.getResourceAsFile(this, "elixir/mix.lock"));
+                engine.analyzeDependencies();
+            } catch (NullPointerException ex) {
+                LOGGER.error("NPE", ex);
+                fail(ex.getMessage());
+            } catch (ExceptionCollection ex) {
+                Assume.assumeNoException("Exception setting up ElixirMixAuditAnalyzer; mix_audit may not be installed, or property \"analyzer.mix.audit.path\" may not be set.", ex);
+                return;
+            }
+            Dependency[] dependencies = engine.getDependencies();
+            LOGGER.info("{} dependencies found.", dependencies.length);
+            assertEquals("should find 0 (vulnerable) dependencies", 0, dependencies.length);
+        }
+    }
+}

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/ElixirMixAuditAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/ElixirMixAuditAnalyzerTest.java
@@ -1,0 +1,59 @@
+package org.owasp.dependencycheck.analyzer;
+
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.owasp.dependencycheck.BaseDBTestCase;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
+import org.owasp.dependencycheck.data.update.exception.UpdateException;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.EvidenceType;
+import org.owasp.dependencycheck.dependency.Vulnerability;
+import org.owasp.dependencycheck.exception.ExceptionCollection;
+import org.owasp.dependencycheck.exception.InitializationException;
+import org.owasp.dependencycheck.utils.Settings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
+public class ElixirMixAuditAnalyzerTest extends BaseTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ElixirMixAuditAnalyzerTest.class);
+    private ElixirMixAuditAnalyzer analyzer;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        getSettings().setBoolean(Settings.KEYS.AUTO_UPDATE, false);
+        analyzer = new ElixirMixAuditAnalyzer();
+        analyzer.initialize(getSettings());
+        analyzer.setFilesMatched(true);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (analyzer != null) {
+            analyzer.close();
+            analyzer = null;
+        }
+    }
+
+    @Test
+    public void testGetName() {
+        assertThat(analyzer.getName(), is("Elixir Mix Audit Analyzer"));
+    }
+
+    @Test
+    public void testSupportsFiles() {
+        assertThat(analyzer.accept(new File("mix.lock")), is(true));
+    }
+}

--- a/core/src/test/java/org/owasp/dependencycheck/data/elixir/MixAuditJsonParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/elixir/MixAuditJsonParserTest.java
@@ -1,0 +1,48 @@
+package org.owasp.dependencycheck.data.elixir;
+
+import org.junit.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+
+import java.io.*;
+
+import static org.junit.Assert.assertEquals;
+
+public class MixAuditJsonParserTest {
+
+    @Test
+    public void testEmptyResult() throws AnalysisException, FileNotFoundException {
+        MixAuditJsonParser parser;
+
+        File jsonFixtureFile = BaseTest.getResourceAsFile(this, "elixir/mix_audit/empty.json");
+        FileReader fir = new FileReader(jsonFixtureFile);
+
+        parser = new MixAuditJsonParser(fir);
+        parser.process();
+
+        assertEquals("results must be empty", 0, parser.getResults().size());
+    }
+
+    @Test
+    public void testSingleResult() throws AnalysisException, FileNotFoundException {
+        MixAuditJsonParser parser;
+
+        File jsonFixtureFile = BaseTest.getResourceAsFile(this, "elixir/mix_audit/plug.json");
+        FileReader fir = new FileReader(jsonFixtureFile);
+
+        parser = new MixAuditJsonParser(fir);
+        parser.process();
+
+        assertEquals("must have 1 result", 1, parser.getResults().size());
+
+        MixAuditResult r = parser.getResults().get(0);
+        assertEquals("dc96aba4-4462-4d3b-b73f-28b9349133d8", r.getId());
+        assertEquals("2018-1000883", r.getCve());
+        assertEquals("Header Injection\n", r.getTitle());
+        assertEquals("Cookie headers were not validated\n", r.getDescription());
+        assertEquals("https://github.com/elixir-plug/plug/commit/8857f8ab4acf9b9c22e80480dae2636692f5f573", r.getUrl());
+        assertEquals("/DependencyCheck/core/src/test/resources/elixir/vulnerable/mix.lock", r.getDependencyLockfile());
+        assertEquals("plug", r.getDependencyPackage());
+        assertEquals("1.3.4", r.getDependencyVersion());
+    }
+}

--- a/core/src/test/resources/dependencycheck.properties
+++ b/core/src/test/resources/dependencycheck.properties
@@ -109,6 +109,7 @@ analyzer.node.package.enabled=true
 analyzer.node.audit.enabled=true
 analyzer.composer.lock.enabled=true
 analyzer.golang.mod.enabled=true
+analyzer.mix.audit.enabled=true
 analyzer.python.distribution.enabled=true
 analyzer.python.package.enabled=true
 analyzer.ruby.gemspec.enabled=true

--- a/core/src/test/resources/elixir/mix.lock
+++ b/core/src/test/resources/elixir/mix.lock
@@ -1,0 +1,7 @@
+%{
+  "accept": {:hex, :accept, "0.3.5", "b33b127abca7cc948bbe6caa4c263369abf1347cfa9d8e699c6d214660f10cd1", [:rebar3], [], "hexpm"},
+  "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+  "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm"},
+  "tzdata": {:hex, :tzdata, "0.5.20", "304b9e98a02840fb32a43ec111ffbe517863c8566eb04a061f1c4dbb90b4d84c", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
+}

--- a/core/src/test/resources/elixir/mix_audit/empty.json
+++ b/core/src/test/resources/elixir/mix_audit/empty.json
@@ -1,0 +1,1 @@
+{"pass":true,"vulnerabilities":[]}

--- a/core/src/test/resources/elixir/mix_audit/plug.json
+++ b/core/src/test/resources/elixir/mix_audit/plug.json
@@ -1,0 +1,28 @@
+{
+  "pass": false,
+  "vulnerabilities": [
+    {
+      "advisory": {
+        "cve": "2018-1000883",
+        "description": "Cookie headers were not validated\n",
+        "disclosure_date": "2017-04-17",
+        "id": "dc96aba4-4462-4d3b-b73f-28b9349133d8",
+        "package": "plug",
+        "patched_versions": [
+          ">= 1.3.5",
+          "~> 1.2.5",
+          "~> 1.1.9",
+          "~> 1.0.6"
+        ],
+        "title": "Header Injection\n",
+        "unaffected_versions": [],
+        "url": "https://github.com/elixir-plug/plug/commit/8857f8ab4acf9b9c22e80480dae2636692f5f573"
+      },
+      "dependency": {
+        "lockfile": "/DependencyCheck/core/src/test/resources/elixir/vulnerable/mix.lock",
+        "package": "plug",
+        "version": "1.3.4"
+      }
+    }
+  ]
+}

--- a/core/src/test/resources/elixir/vulnerable/mix.lock
+++ b/core/src/test/resources/elixir/vulnerable/mix.lock
@@ -1,0 +1,4 @@
+%{
+  "plug": {:hex, :plug, "1.3.4", "0933e4d9f12652b12115d5709c0293a1bf78a22578032e9ad0dad4efee6b9eb1", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "076b8bd9552f4966ba1242f412f6c439b731169a36a0ddaaffcd3893828f5bf6"},
+}
+

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -552,6 +552,19 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     private String ossIndexServerId;
 
     /**
+     * Whether or not the Elixir Mix Audit Analyzer is enabled.
+     */
+    @Parameter(property = "mixAuditAnalyzerEnabled")
+    private Boolean mixAuditAnalyzerEnabled;
+
+    /**
+     * Sets the path for the mix_audit binary.
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "mixAuditPath")
+    private String mixAuditPath;
+
+    /**
      * Whether or not the Ruby Bundle Audit Analyzer is enabled.
      */
     @Parameter(property = "bundleAuditAnalyzerEnabled")
@@ -1818,6 +1831,8 @@ final                        Dependency d = new Dependency(artifactFile.getAbsol
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_RETIREJS_ENABLED, retireJsAnalyzerEnabled);
         settings.setStringIfNotNull(Settings.KEYS.ANALYZER_RETIREJS_REPO_JS_URL, retireJsUrl);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_RETIREJS_FORCEUPDATE, retireJsForceUpdate);
+        settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_MIX_AUDIT_ENABLED, mixAuditAnalyzerEnabled);
+        settings.setStringIfNotNull(Settings.KEYS.ANALYZER_MIX_AUDIT_PATH, mixAuditPath);
         settings.setBooleanIfNotNull(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_ENABLED, bundleAuditAnalyzerEnabled);
         settings.setStringIfNotNull(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_PATH, bundleAuditPath);
         settings.setStringIfNotNull(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_WORKING_DIRECTORY, bundleAuditWorkingDirectory);

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -335,6 +335,15 @@ public final class Settings {
          */
         public static final String ANALYZER_PYTHON_PACKAGE_ENABLED = "analyzer.python.package.enabled";
         /**
+         * The properties key for whether the Elixir mix audit analyzer is
+         * enabled.
+         */
+        public static final String ANALYZER_MIX_AUDIT_ENABLED = "analyzer.mix.audit.enabled";
+        /**
+         * The path to mix_audit, if available.
+         */
+        public static final String ANALYZER_MIX_AUDIT_PATH = "analyzer.mix.audit.path";
+        /**
          * The properties key for whether the Golang Mod analyzer is enabled.
          */
         public static final String ANALYZER_GOLANG_MOD_ENABLED = "analyzer.golang.mod.enabled";

--- a/utils/src/test/resources/dependencycheck.properties
+++ b/utils/src/test/resources/dependencycheck.properties
@@ -109,6 +109,7 @@ analyzer.node.package.enabled=true
 analyzer.node.audit.enabled=true
 analyzer.composer.lock.enabled=true
 analyzer.golang.mod.enabled=true
+analyzer.mix.audit.enabled=true
 analyzer.python.distribution.enabled=true
 analyzer.python.package.enabled=true
 analyzer.ruby.gemspec.enabled=true


### PR DESCRIPTION
## Fixes Issue #

There is no issue for Elixir support yet, but a stale PR #1340

## Description of Change

Adds support for Elixir dependencies found in `mix.lock` files by the fairly new [mix_audit](https://github.com/mirego/mix_audit) tool.

The implementation is kept fairly close to that of the `bundle-audit` analyzer with the following differences:

- bundle audit creates bogus temporary files, so that hashes on the dependency created will differ. This implementation manually creates the hashes derived from the package name.
- We try to find the vulnerability from the `cveDb`, as the result of mix audit contains that id. In case it cannot be found, a fallback vulnerability with limited information (and unknown severity) is built.

As I'm not too familiar with the code base and the project, this is an inital stab at the implementation and some rework is probably needed. Any feedback is greatly appreciated.
 
## Have test cases been added to cover the new functionality?

*yes*