### PR TITLE
fix AbstractMemoryIndex usageCount

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/cpe/AbstractMemoryIndex.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/cpe/AbstractMemoryIndex.java
@@ -167,9 +167,7 @@ public abstract class AbstractMemoryIndex implements MemoryIndex {
      */
     @Override
     public synchronized void close() {
-        final int count = instance().usageCount.get() - 1;
-        if (count <= 0) {
-            instance().usageCount.set(0);
+        if (instance().usageCount.addAndGet(-1) == 0) {
             if (searchingAnalyzer != null) {
                 searchingAnalyzer.close();
                 searchingAnalyzer = null;


### PR DESCRIPTION
## Fixes Issue #

The usageCount can not be decreased, will lead to memory leak in a concurrent environment.

## Description of Change


## Have test cases been added to cover the new functionality?

no