### PR TITLE
Fix NoSuchMethodError in commons-io

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -169,6 +169,10 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
     </build>
     <dependencies>
         <dependency>
+            <groupId>org.anarres.jdiagnostics</groupId>
+            <artifactId>jdiagnostics</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.whitesource</groupId>
             <artifactId>pecoff4j</artifactId>
         </dependency>

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
@@ -17,6 +17,7 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
+import com.google.common.io.ByteStreams;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileFilter;
@@ -44,7 +45,6 @@ import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2Utils;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipUtils;
-import org.apache.commons.compress.utils.IOUtils;
 
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
@@ -579,7 +579,7 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
             throw new AnalysisException(msg);
         }
         try (FileOutputStream fos = new FileOutputStream(file)) {
-            IOUtils.copy(input, fos);
+            ByteStreams.copy(input, fos);
         } catch (FileNotFoundException ex) {
             LOGGER.debug("", ex);
             final String msg = String.format("Unable to find file '%s'.", file.getName());
@@ -602,7 +602,7 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
     private void decompressFile(CompressorInputStream inputStream, File outputFile) throws ArchiveExtractionException {
         LOGGER.debug("Decompressing '{}'", outputFile.getPath());
         try (FileOutputStream out = new FileOutputStream(outputFile)) {
-            IOUtils.copy(inputStream, out);
+            ByteStreams.copy(inputStream, out);
         } catch (IOException ex) {
             LOGGER.debug("", ex);
             throw new ArchiveExtractionException(ex);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
@@ -19,6 +19,7 @@ package org.owasp.dependencycheck.analyzer;
 
 import com.github.packageurl.MalformedPackageURLException;
 
+import com.google.common.io.ByteStreams;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -27,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
@@ -151,7 +151,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
             final AssemblyData data = parser.parse(proc.getInputStream());
 
             // Try evacuating the error stream
-            final String errorStream = IOUtils.toString(proc.getErrorStream(), StandardCharsets.UTF_8);
+            final String errorStream = new String(ByteStreams.toByteArray(proc.getErrorStream()), StandardCharsets.UTF_8);
             if (null != errorStream && !errorStream.isEmpty()) {
                 LOGGER.warn("Error from GrokAssembly: {}", errorStream);
             }
@@ -379,7 +379,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
             final ProcessBuilder pb = new ProcessBuilder(baseArgumentList);
             final Process p = pb.start();
             // Try evacuating the error stream
-            IOUtils.copy(p.getErrorStream(), NullOutputStream.NULL_OUTPUT_STREAM);
+            ByteStreams.copy(p.getErrorStream(), NullOutputStream.NULL_OUTPUT_STREAM);
 
             final GrokParser grok = new GrokParser();
             final AssemblyData data = grok.parse(p.getInputStream());

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -20,6 +20,7 @@ package org.owasp.dependencycheck.analyzer;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.github.packageurl.PackageURLBuilder;
+import com.google.common.io.ByteStreams;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileFilter;
@@ -51,7 +52,6 @@ import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 
-import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jsoup.Jsoup;
@@ -550,7 +550,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
         }
         try (InputStream input = jar.getInputStream(entry);
                 FileOutputStream fos = new FileOutputStream(file)) {
-            IOUtils.copy(input, fos);
+            ByteStreams.copy(input, fos);
         } catch (IOException ex) {
             LOGGER.warn("An error occurred reading '{}' from '{}'.", path, jar.getName());
             LOGGER.error("", ex);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzer.java
@@ -20,13 +20,13 @@ package org.owasp.dependencycheck.analyzer;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.github.packageurl.PackageURLBuilder;
+import com.google.common.io.ByteStreams;
 import com.h3xstream.retirejs.repo.JsLibrary;
 import com.h3xstream.retirejs.repo.JsLibraryResult;
 import com.h3xstream.retirejs.repo.JsVulnerability;
 import com.h3xstream.retirejs.repo.ScannerFacade;
 import com.h3xstream.retirejs.repo.VulnerabilitiesRepository;
 import com.h3xstream.retirejs.repo.VulnerabilitiesRepositoryLoader;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
@@ -252,7 +252,7 @@ public class RetireJsAnalyzer extends AbstractFileTypeAnalyzer {
     @Override
     public void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
         try (InputStream fis = new FileInputStream(dependency.getActualFile())) {
-            final byte[] fileContent = IOUtils.toByteArray(fis);
+            final byte[] fileContent = ByteStreams.toByteArray(fis);
             final ScannerFacade scanner = new ScannerFacade(jsRepository);
             final List<JsLibraryResult> results;
             try {

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/ConnectionFactory.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/ConnectionFactory.java
@@ -29,6 +29,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import javax.annotation.concurrent.ThreadSafe;
+import org.anarres.jdiagnostics.DefaultQuery;
 import org.apache.commons.io.IOUtils;
 import org.owasp.dependencycheck.utils.DBUtils;
 import org.owasp.dependencycheck.utils.DependencyVersion;
@@ -331,6 +332,8 @@ public final class ConnectionFactory {
             }
         } catch (IOException ex) {
             throw new DatabaseException("Unable to create database schema", ex);
+        } catch (NoSuchMethodError ex) {
+            LOGGER.debug(new DefaultQuery(ex).call().toString());
         }
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/ConnectionFactory.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/ConnectionFactory.java
@@ -332,7 +332,7 @@ public final class ConnectionFactory {
             }
         } catch (IOException ex) {
             throw new DatabaseException("Unable to create database schema", ex);
-        } catch (NoSuchMethodError ex) {
+        } catch (LinkageError ex) {
             LOGGER.debug(new DefaultQuery(ex).call().toString());
         }
     }

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/EngineVersionCheck.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/EngineVersionCheck.java
@@ -17,13 +17,13 @@
  */
 package org.owasp.dependencycheck.data.update;
 
+import com.google.common.io.ByteStreams;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.commons.io.IOUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.data.nvdcve.CveDB;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
@@ -217,7 +217,7 @@ public class EngineVersionCheck implements CachedWebDataSource {
             if (conn.getResponseCode() != 200) {
                 return null;
             }
-            final String releaseVersion = IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
+            final String releaseVersion = new String(ByteStreams.toByteArray(conn.getInputStream()), StandardCharsets.UTF_8);
             if (releaseVersion != null) {
                 return releaseVersion.trim();
             }

--- a/core/src/main/java/org/owasp/dependencycheck/utils/ExtractionUtil.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/ExtractionUtil.java
@@ -17,6 +17,7 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import com.google.common.io.ByteStreams;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -33,7 +34,6 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
-import org.apache.commons.compress.utils.IOUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.analyzer.exception.ArchiveExtractionException;
@@ -120,7 +120,7 @@ public final class ExtractionUtil {
                             throw new ExtractionException(msg);
                         }
                         try (FileOutputStream fos = new FileOutputStream(file)) {
-                            IOUtils.copy(zis, fos);
+                            ByteStreams.copy(zis, fos);
                         } catch (FileNotFoundException ex) {
                             LOGGER.debug("", ex);
                             final String msg = String.format("Unable to find file '%s'.", file.getName());
@@ -180,7 +180,7 @@ public final class ExtractionUtil {
                         throw new ExtractionException("Archive contains a file that would be extracted outside of the target directory.");
                     }
                     try (FileOutputStream fos = new FileOutputStream(file)) {
-                        IOUtils.copy(zis, fos);
+                        ByteStreams.copy(zis, fos);
                     } catch (FileNotFoundException ex) {
                         LOGGER.debug("", ex);
                         final String msg = String.format("Unable to find file '%s'.", file.getName());
@@ -292,7 +292,7 @@ public final class ExtractionUtil {
                 createParentFile(file);
 
                 try (FileOutputStream fos = new FileOutputStream(file)) {
-                    IOUtils.copy(input, fos);
+                    ByteStreams.copy(input, fos);
                 } catch (FileNotFoundException ex) {
                     LOGGER.debug("", ex);
                     final String msg = String.format("Unable to find file '%s'.", file.getName());
@@ -346,7 +346,7 @@ public final class ExtractionUtil {
         try (FileInputStream fis = new FileInputStream(gzip);
                 GZIPInputStream cin = new GZIPInputStream(fis);
                 FileOutputStream out = new FileOutputStream(newFile)) {
-            IOUtils.copy(cin, out);
+            ByteStreams.copy(cin, out);
         } finally {
             if (gzip.isFile() && !org.apache.commons.io.FileUtils.deleteQuietly(gzip)) {
                 LOGGER.debug("Failed to delete temporary file when extracting 'gz' {}", gzip.toString());
@@ -378,7 +378,7 @@ public final class ExtractionUtil {
                 ZipInputStream cin = new ZipInputStream(fis);
                 FileOutputStream out = new FileOutputStream(newFile)) {
             cin.getNextEntry();
-            IOUtils.copy(cin, out);
+            ByteStreams.copy(cin, out);
         } finally {
             if (zip.isFile() && !org.apache.commons.io.FileUtils.deleteQuietly(zip)) {
                 LOGGER.debug("Failed to delete temporary file when extracting 'zip' {}", zip.toString());

--- a/pom.xml
+++ b/pom.xml
@@ -868,6 +868,11 @@ Copyright (c) 2012 - Jeremy Long
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.anarres.jdiagnostics</groupId>
+                <artifactId>jdiagnostics</artifactId>
+                <version>1.0.6</version>
+            </dependency>
+            <dependency>
                 <groupId>org.mock-server</groupId>
                 <artifactId>mockserver-netty</artifactId>
                 <version>5.10</version>

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
@@ -17,6 +17,7 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import com.google.common.io.ByteStreams;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -26,7 +27,6 @@ import java.io.OutputStream;
 import java.net.URL;
 import static java.lang.String.format;
 import java.nio.charset.StandardCharsets;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,7 +92,7 @@ public final class Downloader {
         try (HttpResourceConnection conn = new HttpResourceConnection(settings, useProxy);
                 OutputStream out = new FileOutputStream(outputPath)) {
             in = conn.fetch(url);
-            IOUtils.copy(in, out);
+            ByteStreams.copy(in, out);
         } catch (IOException ex) {
             final String msg = format("Download failed, unable to copy '%s' to '%s'", url.toString(), outputPath.getAbsolutePath());
             throw new DownloadFailedException(msg, ex);
@@ -124,7 +124,7 @@ public final class Downloader {
         try (HttpResourceConnection conn = new HttpResourceConnection(settings, useProxy);
                 ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             in = conn.fetch(url);
-            IOUtils.copy(in, out);
+            ByteStreams.copy(in, out);
             return out.toString(UTF8);
         } catch (IOException ex) {
             final String msg = format("Download failed, unable to retrieve '%s'", url.toString());


### PR DESCRIPTION
## Fixes Issue #2509 

Fixes #2509

## Description of Change

Avoids clash with Gradle ClassLoader between commons-io 1.4 and commons-io 2.6 by taking advantage of the fact that we have a much more recent Guava on the classpath, and it's generally a nicer API. This project doesn't use commons-io to any significant benefit, and another few minutes would easily remove this obsolete dependency entirely.

## Have test cases been added to cover the new functionality?

Can't figure out how to tickle this in a test case.