### PR TITLE
fix #2594

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4,21 +4,7 @@
         <notes><![CDATA[
         FP per #2594
         ]]></notes>
-        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback\.contrib/logback\-json\-core@.*$</packageUrl>
-        <cpe>cpe:/a:logback:logback</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per #2594
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback\.contrib/logback\-jackson@.*$</packageUrl>
-        <cpe>cpe:/a:logback:logback</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-        FP per #2594
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback\.contrib/logback\-json\-classic@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback\.contrib/.*$</packageUrl>
         <cpe>cpe:/a:logback:logback</cpe>
     </suppress>
     <suppress base="true">

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -2,6 +2,27 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress base="true">
         <notes><![CDATA[
+        FP per #2594
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback\.contrib/logback\-json\-core@.*$</packageUrl>
+        <cpe>cpe:/a:logback:logback</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per #2594
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback\.contrib/logback\-jackson@.*$</packageUrl>
+        <cpe>cpe:/a:logback:logback</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        FP per #2594
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback\.contrib/logback\-json\-classic@.*$</packageUrl>
+        <cpe>cpe:/a:logback:logback</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
         FP per #2395
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/be\.sysa\.log\-sanitizer/log\-sanitizer\-logback@.*$</packageUrl>


### PR DESCRIPTION
## Fixes Issue #
#2594 
## Description of Change

```ch.qos.logback.contrib*``` is no longer matched with ```cpe:2.3:a:logback:logback:0.1.5:*:*:*:*:*:*:*```

## Have test cases been added to cover the new functionality?

no