### PR TITLE
Do not unconditionally set `SQL_SAFE_UPDATES = 1` on MySQL

### DIFF
--- a/core/src/main/resources/data/initialize_mysql.sql
+++ b/core/src/main/resources/data/initialize_mysql.sql
@@ -65,6 +65,7 @@ GRANT EXECUTE ON PROCEDURE dependencycheck.save_property TO 'dcuser';
 DELIMITER //
 CREATE PROCEDURE update_ecosystems()
 BEGIN
+SET @OLD_SQL_SAFE_UPDATES = (SELECT @@SQL_SAFE_UPDATES);
 SET SQL_SAFE_UPDATES = 0;
 UPDATE cpeEntry n INNER JOIN
     (SELECT DISTINCT vendor, product, MIN(ecosystem) eco
@@ -75,7 +76,7 @@ UPDATE cpeEntry n INNER JOIN
   AND e.product = n.product 
 SET n.ecosystem = e.eco
 WHERE n.ecosystem IS NULL;
-SET SQL_SAFE_UPDATES = 1;
+SET SQL_SAFE_UPDATES = @OLD_SQL_SAFE_UPDATES;
 END //
 DELIMITER ;
 
@@ -84,9 +85,10 @@ GRANT EXECUTE ON PROCEDURE dependencycheck.update_ecosystems TO 'dcuser';
 DELIMITER //
 CREATE PROCEDURE cleanup_orphans()
 BEGIN
+SET @OLD_SQL_SAFE_UPDATES = (SELECT @@SQL_SAFE_UPDATES);
 SET SQL_SAFE_UPDATES = 0;
 DELETE FROM cpeEntry WHERE id not in (SELECT CPEEntryId FROM software);
-SET SQL_SAFE_UPDATES = 1;
+SET SQL_SAFE_UPDATES = @OLD_SQL_SAFE_UPDATES;
 END //
 DELIMITER ;
 


### PR DESCRIPTION
## Fixes Issue #
Both `cleanup_orphans` and `update_ecosystems` have the unintended side effect of activating MySQL's "safe updates" functionality (if it was inactive beforehand)

## Description of Change

We just store the old state and reset the setting afterwards.

## Have test cases been added to cover the new functionality?

no