### PR TITLE
Update Max Query Limit during CPE analysis

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nvd/ecosystem/Ecosystem.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvd/ecosystem/Ecosystem.java
@@ -17,7 +17,10 @@
  */
 package org.owasp.dependencycheck.data.nvd.ecosystem;
 
+import org.owasp.dependencycheck.utils.Settings;
+
 /**
+ * Collection of the standard ecosystems for dependency-check.
  *
  * @author Jeremy Long
  */
@@ -38,4 +41,27 @@ public final class Ecosystem {
     public final static String PERL = "perl";
     public final static String ELIXIR = "exlixir";
 
+    private final Settings settings;
+    private final int defaultQuerySize;
+
+    /**
+     * Instantiates the ecosystem utility class.
+     *
+     * @param settings the ODC configuration
+     */
+    public Ecosystem(Settings settings) {
+        this.settings = settings;
+        this.defaultQuerySize = settings.getInt(Settings.KEYS.MAX_QUERY_SIZE_DEFAULT, 100);
+    }
+
+    /**
+     * Returns the max query result size for the Lucene search for each
+     * ecosystem.
+     *
+     * @param ecosystem the ecosystem
+     * @return the max query result size
+     */
+    public int getLuceneMaxQueryLimitFor(String ecosystem) {
+        return settings.getInt(Settings.KEYS.MAX_QUERY_SIZE_PREFIX + ecosystem, defaultQuerySize);
+    }
 }

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -154,3 +154,7 @@ database.batchinsert.enabled=true
 database.batchinsert.maxsize=1000
 analyzer.artifactory.enabled=false
 odc.reports.pretty.print=false
+
+## The following controls the max query limit used in the CPE searches for each ecosystem
+odc.ecosystem.maxquerylimit.native=1000
+odc.ecosystem.maxquerylimit.default=100

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/CPEAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/CPEAnalyzerIT.java
@@ -34,6 +34,7 @@ import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import org.owasp.dependencycheck.data.nvd.ecosystem.Ecosystem;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.dependency.naming.Identifier;
 
@@ -373,7 +374,7 @@ public class CPEAnalyzerIT extends BaseDBTestCase {
 
             Set<String> productWeightings = Collections.singleton("struts2");
             Set<String> vendorWeightings = Collections.singleton("apache");
-            List<IndexEntry> result = instance.searchCPE(vendor, product, vendorWeightings, productWeightings);
+            List<IndexEntry> result = instance.searchCPE(vendor, product, vendorWeightings, productWeightings, Ecosystem.JAVA);
 
             boolean found = false;
             for (IndexEntry entry : result) {

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -654,6 +654,16 @@ public final class Settings {
          * that ODC will "skip" updating that years data feed if not present.
          */
         public static final String NVD_NEW_YEAR_GRACE_PERIOD = "nvd.newyear.grace.period";
+        /**
+         * The properties key for the default max query size for Lucene query
+         * results.
+         */
+        public static final String MAX_QUERY_SIZE_DEFAULT = "odc.ecosystem.maxquerylimit.default";
+        /**
+         * The properties key prefix for the default max query size for Lucene
+         * query results; append the ecosystem to obtain the default query size.
+         */
+        public static final String MAX_QUERY_SIZE_PREFIX = "odc.ecosystem.maxquerylimit.";
 
         /**
          * private constructor because this is a "utility" class containing


### PR DESCRIPTION
## Fixes Issue #1853

Makes the lucene max query size configurable per analyzer. By default cmake will use a higher limit then the default of 100.