### PR TITLE
Adding cveServerId, cveUser, cvePassword for authenticating access to…

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -743,6 +743,24 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     @Parameter(property = "cveUrlBase")
     private String cveUrlBase;
     /**
+     * The username to use when connecting to the CVE-URL.
+     */
+    @Parameter(property = "cveUser")
+    private String cveUser;
+    /**
+     * The password to authenticate to the CVE-URL.
+     */
+    @Parameter(property = "cvePassword")
+    private String cvePassword;
+    /**
+     * The server id in the settings.xml; used to retrieve encrypted passwords
+     * from the settings.xml for cve-URLs.
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "cveServerId")
+    private String cveServerId;
+    /**
+    /**
      * Optionally skip excessive CVE update checks for a designated duration in
      * hours.
      */
@@ -1867,6 +1885,12 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         settings.setBooleanIfNotNull(Settings.KEYS.PRETTY_PRINT, prettyPrint);
         artifactScopeExcluded = new ArtifactScopeExcluded(skipTestScope, skipProvidedScope, skipSystemScope, skipRuntimeScope);
         artifactTypeExcluded = new ArtifactTypeExcluded(skipArtifactType);
+        if (cveUser == null && cvePassword == null && cveServerId != null) {
+            configureServerCredentials(cveServerId, Settings.KEYS.CVE_USER, Settings.KEYS.CVE_PASSWORD);
+        } else {
+            settings.setStringIfNotEmpty(Settings.KEYS.CVE_USER, cveUser);
+            settings.setStringIfNotEmpty(Settings.KEYS.CVE_PASSWORD, cvePassword);
+        }
     }
 
     /**

--- a/maven/src/site/markdown/configuration.md
+++ b/maven/src/site/markdown/configuration.md
@@ -125,6 +125,9 @@ Property             | Description                                              
 ---------------------|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
 cveUrlModified       | URL for the modified CVE JSON data feed.  When mirroring the NVD you must mirror the *.json.gz and the *.meta files. | https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz |
 cveUrlBase           | Base URL for each year's CVE JSON data feed, the %d will be replaced with the year.                                  | https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz       |
+cveServerId          | The id of a server defined in the settings.xml that configures the credentials (username and password) for accessing the cveUrl. | &nbsp; |
+cveUser              | The username used when connecting to the cveUrl. Must be empty if cveServerId is specified and should be used. | &nbsp; |
+cvePassword          | The password used when connecting to the cveUrl. Must be empty if cveServerId is specified and should be used. | &nbsp; |
 connectionTimeout    | Sets the URL Connection Timeout used when downloading external data.                                                 | &nbsp;                                                              |
 dataDirectory        | Sets the data directory to hold SQL CVEs contents. This should generally not be changed.                             | ~/.m2/repository/org/owasp/dependency-check-data/                   |
 databaseDriverName   | The name of the database driver. Example: org.h2.Driver.                                                             | &nbsp;                                                              |

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -178,6 +178,14 @@ public final class Settings {
          */
         public static final String CVE_BASE_JSON = "cve.url.base";
         /**
+         * The username to use when connecting to the CVE-URL.
+         */
+        public static final String CVE_USER = "cve.user";
+        /**
+         * The password to authenticate to the CVE-URL.
+         */
+        public static final String CVE_PASSWORD = "cve.password";
+        /**
          * The properties key for the URL to retrieve the recently modified and
          * added CVE entries (last 8 days).
          */

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/URLConnectionFactory.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/URLConnectionFactory.java
@@ -147,6 +147,15 @@ public final class URLConnectionFactory {
                 LOGGER.debug("Adding user info as basic authorization");
             }
             conn.addRequestProperty("Authorization", basicAuth);
+        } else if (StringUtils.isNotEmpty(settings.getString(Settings.KEYS.CVE_USER)) && StringUtils.isNotEmpty(settings.getString(Settings.KEYS.CVE_PASSWORD))) {
+            final String user = settings.getString(Settings.KEYS.CVE_USER);
+            final String password = settings.getString(Settings.KEYS.CVE_PASSWORD);
+            final String userColonPassword = user + ":" + password;
+            final String basicAuth = "Basic " + Base64.getEncoder().encodeToString(userColonPassword.getBytes(UTF_8));
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Adding user/pw from settings.xml as basic authorization");
+            }
+            conn.addRequestProperty("Authorization", basicAuth);
         }
     }
 


### PR DESCRIPTION
… cveUrl(s)

## Fixes Issue #

## Description of Change

Adds the possibility to use credentials provided via settings.xml to download CVE files in an enterprise environment when no anonymous access is allowed.

## Have test cases been added to cover the new functionality?

no, but I'd like to if you give me a hint where