### PR TITLE
Make KEYS.DB_FILE_NAME configurable in Maven Plugin

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -730,6 +730,14 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     @SuppressWarnings("CanBeFinal")
     @Parameter(property = "dataDirectory")
     private String dataDirectory;
+
+    /**
+     * The name of the DC DB.
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "dbFilename")
+    private String dbFilename;
+
     /**
      * Data Mirror URL for CVE 1.2.
      */
@@ -1861,6 +1869,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
             settings.setStringIfNotEmpty(Settings.KEYS.DB_PASSWORD, databasePassword);
         }
         settings.setStringIfNotEmpty(Settings.KEYS.DATA_DIRECTORY, dataDirectory);
+        settings.setStringIfNotEmpty(Settings.KEYS.DB_FILE_NAME, dbFilename);
         settings.setStringIfNotEmpty(Settings.KEYS.CVE_MODIFIED_JSON, cveUrlModified);
         settings.setStringIfNotEmpty(Settings.KEYS.CVE_BASE_JSON, cveUrlBase);
         settings.setIntIfNotNull(Settings.KEYS.CVE_CHECK_VALID_FOR_HOURS, cveValidForHours);


### PR DESCRIPTION
## Description of Change

The data_directory and jdbc connection string is configurable, but when using h2 as a database the database filename must be odc.mv.db, or database existence check fails. This change makes the database filename configurable to fix this problem.

## Have test cases been added to cover the new functionality?

no