### PR TITLE
Inroducing perl cpanfile dependency analyzer

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PerlCpanfileAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PerlCpanfileAnalyzer.java
@@ -1,0 +1,164 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2015 Institute for Defense Analyses. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.analyzer;
+
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import com.github.packageurl.PackageURLBuilder;
+import org.apache.commons.io.FileUtils;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.utils.FileFilterBuilder;
+import org.owasp.dependencycheck.utils.Settings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
+import javax.annotation.concurrent.ThreadSafe;
+import javax.json.Json;
+import javax.json.JsonException;
+import javax.json.JsonObject;
+import javax.json.JsonString;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
+import org.owasp.dependencycheck.Engine.Mode;
+import org.owasp.dependencycheck.data.nvd.ecosystem.Ecosystem;
+import org.owasp.dependencycheck.dependency.Confidence;
+import org.owasp.dependencycheck.dependency.EvidenceType;
+import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
+import org.owasp.dependencycheck.exception.InitializationException;
+import org.owasp.dependencycheck.utils.Checksum;
+import org.owasp.dependencycheck.utils.InvalidSettingException;
+import org.owasp.dependencycheck.dependency.Vulnerability;
+import org.owasp.dependencycheck.data.nvdcve.CveDB;
+import org.owasp.dependencycheck.models.VulnerabilityDTO;
+
+import java.sql.ResultSet;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.nio.charset.Charset;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Used to analyze perl cpan files
+ *
+ * @author Harjit Sandhu
+ */
+@ThreadSafe
+public class PerlCpanfileAnalyzer extends AbstractFileTypeAnalyzer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PerlCpanfileAnalyzer.class);
+    private static final FileFilter PACKAGE_FILTER = FileFilterBuilder.newInstance().addFilenames("cpanfile").build();
+    private static final int REGEX_OPTIONS = Pattern.DOTALL | Pattern.CASE_INSENSITIVE;
+    private static final Pattern DEPEND_PERL_CPAN_PATTERN = Pattern.compile("requires '(.*?)'.*?([0-9\\.]+).*", REGEX_OPTIONS);
+    private static List<VulnerabilityDTO> vulnerabileProductList;
+    private static CveDB cveDatabase;
+
+    @Override
+    protected FileFilter getFileFilter() {
+        return PACKAGE_FILTER;
+    }
+
+    @Override
+    protected void prepareFileTypeAnalyzer(Engine engine) throws InitializationException {
+        engine.openDatabase();
+        cveDatabase = engine.getDatabase();
+        vulnerabileProductList = cveDatabase.getPerlVulnerabilities();
+    }
+
+    @Override
+    public String getName() {
+        return "Perl cpanfile Analyzer";
+    }
+
+    @Override
+    public AnalysisPhase getAnalysisPhase() {
+        return AnalysisPhase.INFORMATION_COLLECTION;
+    }
+
+    @Override
+    protected String getAnalyzerEnabledSettingKey() {
+        return Settings.KEYS.ANALYZER_EXPERIMENTAL_ENABLED;
+    }
+
+    @Override
+    protected void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
+        final File file = dependency.getActualFile();
+        final File parent = file.getParentFile();
+        final File[] fileList = parent.listFiles(this.getFileFilter());
+        if (fileList != null) {
+            for (final File sourceFile : fileList) {
+                analyzeFileContents(dependency, sourceFile);
+            }
+        }
+    }
+
+    private void analyzeFileContents(Dependency dependency, File file) throws AnalysisException {
+        final String contents = tryReadFile(file);
+        if (!contents.isEmpty()) {
+            processFileContents(contents.split(";"), dependency);
+        }
+    }
+
+    private String tryReadFile(File file) throws AnalysisException {
+        try {
+            return FileUtils.readFileToString(file, Charset.defaultCharset()).trim();
+        } catch (IOException e) {
+            throw new AnalysisException("Problem occurred while reading dependency file.", e);
+        }
+    }
+
+    private void processFileContents(String[] fileLines, Dependency dependency) throws AnalysisException{
+        final List<Vulnerability> vulns = new ArrayList<>();
+        for(String fileLine:fileLines){  
+            Matcher matcher = DEPEND_PERL_CPAN_PATTERN.matcher(fileLine);
+            LOGGER.debug("perl scanning file:" + fileLine);
+            while(matcher.find()) {
+                int matcherGroupCount = matcher.groupCount();
+                if (matcherGroupCount >= 2){
+                    String dependencyName = matcher.group(1);
+                    String dependencyVersion = matcher.group(2);
+                    String productName = dependencyName.split(":")[0];
+                    LOGGER.debug("Name:" + dependencyName + " - Version:" + dependencyVersion);
+                    dependency.addEvidence(EvidenceType.PRODUCT, dependencyName, productName, dependencyVersion, Confidence.HIGHEST);                
+                    for(VulnerabilityDTO vp : vulnerabileProductList){
+                        if(vp.hasMatch(productName)){
+                            final Vulnerability individualVuln = cveDatabase.getVulnerability(vp.getCveReference());
+                            vulns.add(individualVuln);
+                        }
+                    }
+                }else{
+                    LOGGER.debug("Matcher didn't find have the correct number of groups : " + matcherGroupCount + ", in :" + fileLine);
+                }
+            }
+        }
+        dependency.addVulnerabilities(vulns);
+    }
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDBWrapper.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDBWrapper.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2018 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.nvdcve;
+//CSOFF: AvoidStarImport
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.collections.map.ReferenceMap;
+import org.owasp.dependencycheck.dependency.Vulnerability;
+import org.owasp.dependencycheck.dependency.VulnerableSoftware;
+import org.owasp.dependencycheck.utils.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.IOException;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.collections.map.AbstractReferenceMap.HARD;
+import static org.apache.commons.collections.map.AbstractReferenceMap.SOFT;
+import org.owasp.dependencycheck.analyzer.exception.LambdaExceptionWrapper;
+import org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException;
+import org.owasp.dependencycheck.models.VulnerabilityDTO;
+import org.owasp.dependencycheck.data.nvd.json.BaseMetricV2;
+import org.owasp.dependencycheck.data.nvd.json.BaseMetricV3;
+import org.owasp.dependencycheck.data.nvd.json.CpeMatchStreamCollector;
+import org.owasp.dependencycheck.data.nvd.json.DefCpeMatch;
+import org.owasp.dependencycheck.data.nvd.json.DefCveItem;
+import org.owasp.dependencycheck.data.nvd.json.LangString;
+import org.owasp.dependencycheck.data.nvd.json.NodeFlatteningCollector;
+import org.owasp.dependencycheck.data.nvd.json.ProblemtypeDatum;
+import org.owasp.dependencycheck.data.nvd.json.Reference;
+import static org.owasp.dependencycheck.data.nvdcve.CveDB.PreparedStatementCveDb.*;
+import org.owasp.dependencycheck.data.update.cpe.CpePlus;
+import org.owasp.dependencycheck.dependency.CvssV2;
+import org.owasp.dependencycheck.dependency.CvssV3;
+import org.owasp.dependencycheck.dependency.VulnerableSoftwareBuilder;
+import us.springett.parsers.cpe.Cpe;
+import us.springett.parsers.cpe.CpeBuilder;
+import us.springett.parsers.cpe.CpeParser;
+import us.springett.parsers.cpe.exceptions.CpeParsingException;
+import us.springett.parsers.cpe.exceptions.CpeValidationException;
+
+/**
+ * The database holding information about the NVD CVE data. This class is safe
+ * to be accessed from multiple threads in parallel, however internally only one
+ * connection will be used.
+ *
+ * @author Jeremy Long
+ */
+@ThreadSafe
+public final class CveDBWrapper implements ICveDBWrapper {
+    private CveDB _cveDB;
+    public CveDBWrapper(CveDB cveDB){
+        this._cveDB = cveDB;
+    }
+
+    public Vulnerability getVulnerability(String reference){
+        return _cveDB.getVulnerability(reference);
+    }
+    public List<VulnerabilityDTO> getPerlVulnerabilities(){
+        return _cveDB.getPerlVulnerabilities();
+    }
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/ICveDBWrapper.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/ICveDBWrapper.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2018 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.nvdcve;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.collections.map.ReferenceMap;
+import org.owasp.dependencycheck.dependency.Vulnerability;
+import org.owasp.dependencycheck.dependency.VulnerableSoftware;
+import org.owasp.dependencycheck.utils.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.IOException;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.collections.map.AbstractReferenceMap.HARD;
+import static org.apache.commons.collections.map.AbstractReferenceMap.SOFT;
+import org.owasp.dependencycheck.analyzer.exception.LambdaExceptionWrapper;
+import org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException;
+import org.owasp.dependencycheck.models.VulnerabilityDTO;
+import org.owasp.dependencycheck.data.nvd.json.BaseMetricV2;
+import org.owasp.dependencycheck.data.nvd.json.BaseMetricV3;
+import org.owasp.dependencycheck.data.nvd.json.CpeMatchStreamCollector;
+import org.owasp.dependencycheck.data.nvd.json.DefCpeMatch;
+import org.owasp.dependencycheck.data.nvd.json.DefCveItem;
+import org.owasp.dependencycheck.data.nvd.json.LangString;
+import org.owasp.dependencycheck.data.nvd.json.NodeFlatteningCollector;
+import org.owasp.dependencycheck.data.nvd.json.ProblemtypeDatum;
+import org.owasp.dependencycheck.data.nvd.json.Reference;
+import static org.owasp.dependencycheck.data.nvdcve.CveDB.PreparedStatementCveDb.*;
+import org.owasp.dependencycheck.data.update.cpe.CpePlus;
+import org.owasp.dependencycheck.dependency.CvssV2;
+import org.owasp.dependencycheck.dependency.CvssV3;
+import org.owasp.dependencycheck.dependency.VulnerableSoftwareBuilder;
+import us.springett.parsers.cpe.Cpe;
+import us.springett.parsers.cpe.CpeBuilder;
+import us.springett.parsers.cpe.CpeParser;
+import us.springett.parsers.cpe.exceptions.CpeParsingException;
+import us.springett.parsers.cpe.exceptions.CpeValidationException;
+
+
+public interface ICveDBWrapper {
+    public Vulnerability getVulnerability(String reference); // cveDatabase.getVulnerability(vp.getCveReference());
+    public List<VulnerabilityDTO> getPerlVulnerabilities(); // cveDatabase.getPerlVulnerabilities();
+}

--- a/core/src/main/java/org/owasp/dependencycheck/models/VulnerabilityDTO.java
+++ b/core/src/main/java/org/owasp/dependencycheck/models/VulnerabilityDTO.java
@@ -1,0 +1,58 @@
+package org.owasp.dependencycheck.models;
+
+public class VulnerabilityDTO 
+{ 
+    //cpeEntry.id as cpeEntryId, cpeEntry.vendor, cpeEntry.product, cpeEntry.version, cpeEntry.update_version, vulnerability.cve
+    // Instance Variables 
+    private int _cpeEntryId; 
+    private String _vendor; 
+    private String _product; 
+    private String _vulnerableVersion; 
+    private String _upgradeVersion; 
+    private String _cve; 
+  
+    // Constructor Declaration of Class 
+    public VulnerabilityDTO(int cpeEntryId, String vendor, String product, String vulnerableVersion, String upgradeVersion, String cve) 
+    { 
+        this._cpeEntryId = cpeEntryId; 
+        this._vendor = vendor; 
+        this._product = product; 
+        this._vulnerableVersion = vulnerableVersion; 
+        this._upgradeVersion = upgradeVersion; 
+        this._cve = cve; 
+    } 
+  
+    public int getCpeEntryId() 
+    { 
+        return _cpeEntryId; 
+    }
+  
+    public String getVendor() 
+    { 
+        return _vendor; 
+    }
+  
+    public String getProduct() 
+    { 
+        return _product; 
+    }
+  
+    public String getVulnerableVersion() 
+    { 
+        return _vulnerableVersion; 
+    }
+
+    public String getUpgradeVersion() 
+    { 
+        return _upgradeVersion; 
+    }
+  
+    public String getCveReference() 
+    { 
+        return _cve; 
+    }
+
+    public boolean hasMatch(String search){
+        return this._vendor.toLowerCase().contains(search.toLowerCase()) || this._product.toLowerCase().contains(search.toLowerCase());
+    }
+} 

--- a/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
+++ b/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
@@ -37,3 +37,4 @@ org.owasp.dependencycheck.analyzer.CocoaPodsAnalyzer
 org.owasp.dependencycheck.analyzer.SwiftPackageManagerAnalyzer
 org.owasp.dependencycheck.analyzer.VersionFilterAnalyzer
 org.owasp.dependencycheck.analyzer.OssIndexAnalyzer
+org.owasp.dependencycheck.analyzer.PerlCpanfileAnalyzer

--- a/core/src/main/resources/data/dbStatements.properties
+++ b/core/src/main/resources/data/dbStatements.properties
@@ -39,6 +39,7 @@ SELECT_VULNERABILITY_CWE=SELECT cwe FROM cweEntry WHERE cveid = ?
 SELECT_VULNERABILITY_ID=SELECT id FROM vulnerability WHERE cve = ?
 SELECT_PROPERTIES=SELECT id, value FROM properties
 SELECT_PROPERTY=SELECT id, value FROM properties WHERE id = ?
+SELECT_ALL_PERL_REFERENCES=select cpeEntry.id as cpeEntryId, cpeEntry.vendor, cpeEntry.product, cpeEntry.version, cpeEntry.update_version, vulnerability.cve from vulnerability inner join software on vulnerability.id = software.cveId inner join cpeEntry on cpeEntry.id = software.cpeEntryId where (cpeEntry.target_sw = 'perl' or cpeEntry.ecosystem = 'perl')
 INSERT_PROPERTY=INSERT INTO properties (id, value) VALUES (?, ?)
 UPDATE_PROPERTY=UPDATE properties SET value = ? WHERE id = ?
 DELETE_PROPERTY=DELETE FROM properties WHERE id = ?

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PerlCpanfileAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PerlCpanfileAnalyzerTest.java
@@ -1,0 +1,196 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2017 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.analyzer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.Verifications;
+
+import org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.data.nvd.ecosystem.Ecosystem;
+import org.owasp.dependencycheck.data.nvdcve.CveDB;
+import org.owasp.dependencycheck.data.nvdcve.ICveDBWrapper;
+import org.owasp.dependencycheck.data.nvdcve.CveDBWrapper;
+import org.owasp.dependencycheck.dependency.Confidence;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.Evidence;
+import org.owasp.dependencycheck.dependency.EvidenceType;
+import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
+import org.owasp.dependencycheck.dependency.Vulnerability;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.Engine.Mode;
+import org.owasp.dependencycheck.exception.InitializationException;
+import org.owasp.dependencycheck.models.VulnerabilityDTO;
+import org.owasp.dependencycheck.utils.Checksum;
+import org.owasp.dependencycheck.utils.FileFilterBuilder;
+import org.owasp.dependencycheck.utils.InvalidSettingException;
+import org.owasp.dependencycheck.utils.Settings;
+
+/**
+ *
+ * @author jeremy long
+ */
+public class PerlCpanfileAnalyzerTest extends BaseTest {
+    public class FakeCveDBWrapper implements ICveDBWrapper {
+        private Vulnerability fakeVulnerability;
+        private List<VulnerabilityDTO> fakeVulnerabilities;
+    
+        public FakeCveDBWrapper(){
+            this.fakeVulnerabilities = new ArrayList<VulnerabilityDTO>();
+            this.fakeVulnerabilities.add(new VulnerabilityDTO(1, "Fake Software House Ltd", "Calculator", "0.0.1", "0.1", "CVE001"));
+            this.fakeVulnerabilities.add(new VulnerabilityDTO(1, "ORG", "ORG::OWASP::DEPENDENCYCHECK", "0.1", "0.2", "CVE001"));
+            this.fakeVulnerabilities.add(new VulnerabilityDTO(2, "ORG", "ORG::OWASP::DEPENDENCYCHECK", "0.1", "0.2", "CVE002"));
+        }
+        public Vulnerability getVulnerability(String reference){
+            return new Vulnerability(reference);
+        }
+        public List<VulnerabilityDTO> getPerlVulnerabilities(){
+            return this.fakeVulnerabilities;
+        }
+    }
+
+    /**
+     * Test of getName method, of class PerlCpanfileAnalyzer.
+     */
+    @Test
+    public void testGetName() {
+        PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer();
+        String expResult = "Perl cpanfile Analyzer";
+        String result = instance.getName();
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of getAnalysisPhase method, of class PerlCpanfileAnalyzer.
+     */
+    @Test
+    public void testGetAnalysisPhase() {
+        PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer();
+        AnalysisPhase expResult = AnalysisPhase.INFORMATION_COLLECTION;
+        AnalysisPhase result = instance.getAnalysisPhase();
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of getAnalyzerEnabledSettingKey method, of class PerlCpanfileAnalyzer.
+     */
+    @Test
+    public void testGetAnalyzerEnabledSettingKey() {
+        PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer();
+        String expResult = Settings.KEYS.ANALYZER_EXPERIMENTAL_ENABLED;
+        String result = instance.getAnalyzerEnabledSettingKey();
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of collectTerms method, of class PerlCpanfileAnalyzer.
+     */
+    @Test
+    public void testAnalyzeDependencyWhenDependencyListIsEmpty() throws AnalysisException{
+        Dependency d = new Dependency();
+        List<VulnerabilityDTO> vulnerabileProductList =  new ArrayList<>();
+        String[] dependencyLines = {
+            "requires 'Mojolicious::Plugin::ZAPI' => '>= 2.015", 
+            "requires 'Hash::MoreUtils' => '>= 0.05", 
+            "requires 'JSON::MaybeXS' => '>= 1.002004'; # is_bool", 
+            "# requires 'JSON::MaybeXS' => '>= 1.002004';",
+            "comment about something",
+            "requires 'Test::MockModule';"
+        };
+        PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer(vulnerabileProductList, new FakeCveDBWrapper());
+        instance.processFileContents(dependencyLines, d);
+        assertEquals(d.getVulnerabilities().size(), 0);
+    }
+
+    /**
+     * Test of collectTerms method, of class PerlCpanfileAnalyzer.
+     */
+    @Test
+    public void testAnalyzeDependencyWhenDependencyListHasNoMatchingDependencies() throws AnalysisException{
+        Dependency d = new Dependency();
+        List<VulnerabilityDTO> vulnerabileProductList =  new ArrayList<>();
+        vulnerabileProductList.add(new VulnerabilityDTO(1, "Fake Software House Ltd", "Calculator", "0.0.1", "0.1", "CVE001"));
+        String[] dependencyLines = {
+            "requires 'ORG::OWASP::DEPENDENCYCHECK' => '>= 0.05"
+        };
+        PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer(vulnerabileProductList, new FakeCveDBWrapper());
+        instance.processFileContents(dependencyLines, d);
+        assertEquals(d.getVulnerabilities().size(), 0);
+    }
+
+    /**
+     * Test of collectTerms method, of class PerlCpanfileAnalyzer.
+     */
+    @Test
+    public void testAnalyzeDependencyWhenDependencyListHasOneMatchingDependency() throws AnalysisException{
+        Dependency d = new Dependency();
+        List<VulnerabilityDTO> vulnerabileProductList =  new ArrayList<>();
+        vulnerabileProductList.add(new VulnerabilityDTO(1, "ORG", "ORG::OWASP::DEPENDENCYCHECK", "0.1", "0.2", "CVE001"));
+        String[] dependencyLines = {
+            "requires 'ORG::OWASP::DEPENDENCYCHECK' => '>= 0.05"
+        };
+        PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer(vulnerabileProductList, new FakeCveDBWrapper());
+        instance.processFileContents(dependencyLines, d);
+        assertEquals(d.getVulnerabilities().size(), 1);
+    }
+
+    /**
+     * Test of collectTerms method, of class PerlCpanfileAnalyzer.
+     */
+    @Test
+    public void testAnalyzeDependencyWhenDependencyListHasTwoMatchingDependency() throws AnalysisException{
+        Dependency d = new Dependency();
+        List<VulnerabilityDTO> vulnerabileProductList =  new ArrayList<>();
+        vulnerabileProductList.add(new VulnerabilityDTO(1, "ORG", "ORG::OWASP::DEPENDENCYCHECK", "0.1", "0.2", "CVE001"));
+        vulnerabileProductList.add(new VulnerabilityDTO(2, "ORG", "ORG::OWASP::DEPENDENCYCHECK", "0.1", "0.2", "CVE002"));
+        String[] dependencyLines = {
+            "requires 'ORG::OWASP::DEPENDENCYCHECK' => '>= 0.05"
+        };
+        PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer(vulnerabileProductList, new FakeCveDBWrapper());
+        instance.processFileContents(dependencyLines, d);
+        assertEquals(d.getVulnerabilities().size(), 2);
+    }
+
+    /**
+     * Test of collectTerms method, of class PerlCpanfileAnalyzer.
+     */
+    @Test
+    public void testAnalyzeDependencyWhenDependencyListHasTwogDependenciesButFileContainsNone() throws AnalysisException{
+        Dependency d = new Dependency();
+        List<VulnerabilityDTO> vulnerabileProductList =  new ArrayList<>();
+        vulnerabileProductList.add(new VulnerabilityDTO(1, "ORG", "ORG::OWASP::DEPENDENCYCHECK", "0.1", "0.2", "CVE001"));
+        vulnerabileProductList.add(new VulnerabilityDTO(2, "ORG", "ORG::OWASP::DEPENDENCYCHECK", "0.1", "0.2", "CVE002"));
+        String[] dependencyLines = {
+        };
+        PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer(vulnerabileProductList, new FakeCveDBWrapper());
+        instance.processFileContents(dependencyLines, d);
+        assertEquals(d.getVulnerabilities().size(), 0);
+    }
+}


### PR DESCRIPTION
## Fixes Issue #
No. This is for a new feature I required and wanted to share.

## Description of Change

Added perl scanner using dependencies listed in the cpanfile. Feature is hidden behind the `--enableExperimental` flag.
Example usage:
```
java -classpath "/path/*" -Dapp.name="dependency-check" -Dapp.repo="/hob" -Dapp.home="/path/" -Dbasedir="/path/" org.owasp.dependencycheck.App -s . --enableExperimental
```

## Have test cases been added to cover the new functionality?

*yes*