### PR TITLE
Update site links to GitHub main branch

### DIFF
--- a/src/site/markdown/data/database.md.vm
+++ b/src/site/markdown/data/database.md.vm
@@ -17,8 +17,8 @@ see the note about Central [here](./index.html).
 
 To setup a centralized database the following generalized steps can be used:
 
-<ol><li>Create the database and tables using either <a href="https://github.com/jeremylong/DependencyCheck/blob/master/core/src/main/resources/data/initialize.sql">initialize.sql</a>
-   or one of the other initialization scripts <a href="https://github.com/jeremylong/DependencyCheck/tree/master/core/src/main/resources/data">found here</a>.</li>
+<ol><li>Create the database and tables using either <a href="https://github.com/jeremylong/DependencyCheck/blob/main/core/src/main/resources/data/initialize.sql">initialize.sql</a>
+   or one of the other initialization scripts <a href="https://github.com/jeremylong/DependencyCheck/tree/main/core/src/main/resources/data">found here</a>.</li>
 <li>The account that the clients will connect using must have select granted on the tables.
      <ul><li>Note, the clients performing the scans should run with the noupdate setting. A single
        instance of the dependency-check client should be setup with updates enabled and the account
@@ -31,9 +31,9 @@ To setup a centralized database the following generalized steps can be used:
        <li>The connection string, database user name, and the database user's password will also need to be configured.</li>
    </ul>
 </li></ol>
-Depending on the database being used, you may need to customize the [dbStatements.properties](https://github.com/jeremylong/DependencyCheck/blob/master/core/src/main/resources/data/dbStatements.properties).
+Depending on the database being used, you may need to customize the [dbStatements.properties](https://github.com/jeremylong/DependencyCheck/blob/main/core/src/main/resources/data/dbStatements.properties).
 Alternatively to modifying the dbStatements.properties it is possible to use a dialect file to support other databases.
-See [dbStatements_h2.properties](https://github.com/jeremylong/DependencyCheck/blob/master/core/src/main/resources/data/dbStatements_h2.properties)
+See [dbStatements_h2.properties](https://github.com/jeremylong/DependencyCheck/blob/main/core/src/main/resources/data/dbStatements_h2.properties)
 as an example.
 
 Also, if using an external database you will need to manually upgrade the schema. See [database upgrades](./upgrade.html) for more information.

--- a/src/site/markdown/data/upgrade.md
+++ b/src/site/markdown/data/upgrade.md
@@ -3,7 +3,7 @@ Database Upgrades
 If using an external database server, such as MySQL, a DBA must manually perform the
 database schema update. In most cases an upgrade requires re-running the initialization script
 which will drop the current tables and re-create them. The initialization can be found in the
-[github repository](https://github.com/jeremylong/DependencyCheck/tree/master/core/src/main/resources/data).
+[github repository](https://github.com/jeremylong/DependencyCheck/tree/main/core/src/main/resources/data).
 
 If you want to use an external database other than one listed in the repo please open an issue on the
 [github issue tracker](https://github.com/jeremylong/DependencyCheck/issues) as an initialization and


### PR DESCRIPTION
## Description of Change

Fix the links from documentation site to GitHub that point at `master` instead of the `main` branch, causing 404-s.

Note, that the SCM urls in the various `pom.xml` were not updated (I’m not sure if that would break something or not).

## Have test cases been added to cover the new functionality?

*no*