### PR TITLE
Improved logging for delete errors

### DIFF
--- a/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
@@ -88,12 +88,16 @@ public final class FileUtils {
             return false;
         }
 
-        final boolean success = org.apache.commons.io.FileUtils.deleteQuietly(file);
-        if (!success) {
-            LOGGER.debug("Failed to delete file: {}; attempting to delete on exit.", file.getPath());
+        try {
+            org.apache.commons.io.FileUtils.forceDelete(file);
+        } catch (IOException ex) {
+            LOGGER.trace(ex.getMessage(), ex);
+            LOGGER.debug("Failed to delete file: {} (error message: {}); attempting to delete on exit.", file.getPath(), ex.getMessage());
             file.deleteOnExit();
+            return false;
         }
-        return success;
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Fixes Issue #
#2760

## Description of Change
Improved logging to help debug problems during file deletions.

Changed to `FileUtils.forceDelete()` method which actually throws the exception and does not ignore it. Stacktrace is only output for TRACE log level.

## Have test cases been added to cover the new functionality?
No, test case already exists.