### PR TITLE
Add a link to the Maven plugin goals page

### DIFF
--- a/maven/src/site/site.xml
+++ b/maven/src/site/site.xml
@@ -30,6 +30,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <menu name="Getting Started">
             <item name="Usage" href="index.html"/>
             <item name="Configuration" href="configuration.html"/>
+            <item name="Goals" href="plugin-info.html"/>
         </menu>
         <menu ref="reports"/>
     </body>


### PR DESCRIPTION
## Description of Change
Add a link to the Maven plugin goals page, this is a generated page, but hides away in the "Project Reports" section, while being a very helpful resource.

Adding this in a similar way that the Mojohaus project does, eg. https://www.mojohaus.org/versions-maven-plugin/plugin-info.html
