### PR TITLE
GoModAnalyzer - include transitive dependencies

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
@@ -304,8 +304,8 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
                 }
             }
             if (!error.toString().equals("")) {
-                LOGGER.warn(error.toString());
-                throw new AnalysisException(error.toString());
+                LOGGER.warn("Warnings from go {}", error.toString());
+                //throw new AnalysisException(error.toString());
             }
             GoModJsonParser.process(process.getInputStream()).forEach(goDep
                     -> engine.addDependency(goDep.toDependency(dependency))

--- a/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModDependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModDependency.java
@@ -115,13 +115,16 @@ public class GoModDependency {
 
         packageURLBuilder.withName(moduleName);
         packageURLBuilder.withNamespace(packageNamespace);
-        packageURLBuilder.withVersion(version);
-
+        if (StringUtils.isNotBlank(version)) {
+            packageURLBuilder.withVersion(version);
+        }
         dep.setEcosystem(DEPENDENCY_ECOSYSTEM);
         dep.setDisplayFileName(name + ":" + version);
         dep.setName(moduleName);
-        dep.setVersion(version);
-        dep.setPackagePath(String.format("%s:%s", name, version));
+        if (StringUtils.isNotBlank(version)) {
+            dep.setVersion(version);
+            dep.setPackagePath(String.format("%s:%s", name, version));
+        }
         dep.setFilePath(filePath);
         dep.setSha1sum(Checksum.getSHA1Checksum(filePath));
         dep.setSha256sum(Checksum.getSHA256Checksum(filePath));
@@ -136,8 +139,9 @@ public class GoModDependency {
         }
         dep.addEvidence(EvidenceType.PRODUCT, GO_MOD, "name", moduleName, Confidence.HIGHEST);
         dep.addEvidence(EvidenceType.VENDOR, GO_MOD, "name", moduleName, Confidence.HIGH);
-        dep.addEvidence(EvidenceType.VERSION, GO_MOD, "version", version, Confidence.HIGHEST);
-
+        if (StringUtils.isNotBlank(version)) {
+            dep.addEvidence(EvidenceType.VERSION, GO_MOD, "version", version, Confidence.HIGHEST);
+        }
         Identifier id;
         try {
             id = new PurlIdentifier(packageURLBuilder.build(), Confidence.HIGHEST);

--- a/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
@@ -17,11 +17,12 @@
  */
 package org.owasp.dependencycheck.data.golang;
 
+import java.io.IOException;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonException;
@@ -32,58 +33,47 @@ import javax.json.stream.JsonParsingException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import org.owasp.dependencycheck.utils.JsonArrayFixingInputStream;
 
 /**
  * Parses json output from `go list -json -m all`.
  *
  * @author Matthijs van den Bos
  */
-@NotThreadSafe
-public class GoModJsonParser {
-
-    /**
-     * The JsonReader for parsing JSON.
-     */
-    private final JsonReader jsonReader;
-
-    /**
-     * The List of ComposerDependencies found.
-     */
-    private final List<GoModDependency> goModDependencies;
+@ThreadSafe
+public final class GoModJsonParser {
 
     /**
      * The LOGGER
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(GoModJsonParser.class);
 
-    /**
-     * Creates a ComposerLockParser from a JsonReader and an InputStream.
-     *
-     * @param inputStream the InputStream to parse
-     */
-    public GoModJsonParser(InputStream inputStream) {
-        LOGGER.debug("Creating a ComposerLockParser");
-        this.jsonReader = Json.createReader(inputStream);
-        this.goModDependencies = new ArrayList<>();
+    private GoModJsonParser() {
     }
 
     /**
      * Process the input stream to create the list of dependencies.
      *
+     * @param inputStream the InputStream to parse
+     * @return the list of dependencies
      * @throws AnalysisException thrown when there is an error parsing the
      * results of `go mod`
      */
-    public void process() throws AnalysisException {
+    public static List<GoModDependency> process(InputStream inputStream) throws AnalysisException {
         LOGGER.debug("Beginning go.mod processing");
-        try {
-            final JsonObject composer = jsonReader.readObject();
-            if (composer.containsKey("Require") && !composer.isNull("Require")) {
-                LOGGER.debug("Found modules");
-                final JsonArray modules = composer.getJsonArray("Require");
+        List<GoModDependency> goModDependencies = new ArrayList<>();
+        try (JsonArrayFixingInputStream jsonStream = new JsonArrayFixingInputStream(inputStream)) {
+//            String array = IOUtils.toString(inputStream, UTF_8);
+//            array = array.trim().replace("}", "},");
+//            array = "[" + array.substring(0, array.length() - 1) + "]";
+//
+//            JsonReader reader = Json.createReader(new StringReader(array));
+            try (JsonReader reader = Json.createReader(jsonStream)) {
+                final JsonArray modules = reader.readArray();
                 for (JsonObject module : modules.getValuesAs(JsonObject.class)) {
                     final String path = module.getString("Path");
-                    String version = module.getString("Version");
-                    if (version.startsWith("v")) {
+                    String version = module.getString("Version", null);
+                    if (version != null && version.startsWith("v")) {
                         version = version.substring(1);
                     }
                     goModDependencies.add(new GoModDependency(path, version));
@@ -96,16 +86,10 @@ public class GoModJsonParser {
         } catch (IllegalStateException ise) {
             throw new AnalysisException("Illegal state in go mod stream", ise);
         } catch (ClassCastException cce) {
-            throw new AnalysisException("JSON not exactly matching output of `go mod edit -json`", cce);
+            throw new AnalysisException("JSON not exactly matching output of `go list -json -m all`", cce);
+        } catch (IOException ex) {
+            throw new AnalysisException("Error reading output of `go list -json -m all`", ex);
         }
-    }
-
-    /**
-     * Gets the list of dependencies.
-     *
-     * @return the list of dependencies
-     */
-    public List<GoModDependency> getDependencies() {
         return goModDependencies;
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
@@ -34,7 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Parses json output from `go mod edit -json`.
+ * Parses json output from `go list -json -m all`.
  *
  * @author Matthijs van den Bos
  */

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzerTest.java
@@ -53,6 +53,13 @@ public class GolangModAnalyzerTest extends BaseTest {
         getSettings().setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
         getSettings().setBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED, false);
         getSettings().setBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED, false);
+        //hack fix because IDE is not correctly pulling in path
+        if (getSettings().getString(Settings.KEYS.ANALYZER_GOLANG_PATH) == null) {
+            File go = new File("/usr/local/bin/go");
+            if (go.isFile() && go.canExecute()) {
+                getSettings().setString(Settings.KEYS.ANALYZER_GOLANG_PATH, "/usr/local/bin/go");
+            }
+        }
         analyzer = new GolangModAnalyzer();
         engine = new Engine(this.getSettings());
         analyzer.initialize(getSettings());
@@ -91,7 +98,7 @@ public class GolangModAnalyzerTest extends BaseTest {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "golang/go.mod"));
         analyzer.analyze(result, engine);
 
-        assertEquals(3, engine.getDependencies().length);
+        assertEquals(7, engine.getDependencies().length);
 
         boolean found = false;
         for (Dependency d : engine.getDependencies()) {

--- a/core/src/test/resources/golang/go.mod
+++ b/core/src/test/resources/golang/go.mod
@@ -1,7 +1,10 @@
 module my/thing
 
 require github.com/ethereum/go-ethereum v1.8.17
-require golang.org/x/crypto/salsa20 v0.0.1
-require  github.com/go-gitea/gitea v1.5.0
+
+require (
+	github.com/go-gitea/gitea v1.5.0
+	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
+)
 
 replace bad/thing v1.4.5 => good/thing v1.4.5

--- a/core/src/test/resources/golang/go.sum
+++ b/core/src/test/resources/golang/go.sum
@@ -1,0 +1,8 @@
+github.com/ethereum/go-ethereum v1.8.17/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=
+github.com/go-gitea/gitea v1.5.0/go.mod h1:g8iUbfFNyuJp8u7GsSggxI8NQyuxeGTyqxogl3imbQM=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -37,6 +37,11 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
     </properties>
     <dependencies>
         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/JsonArrayFixingInputStream.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/JsonArrayFixingInputStream.java
@@ -1,0 +1,226 @@
+/*
+ * This file is part of dependency-check-utils.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2020 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Fixes a poorly formatted jSON array such as those returned by
+ * <code>go list -json -m all</code>.
+ * <p>
+ * Example:</p>
+ * <code>
+ * { "name1": "value" }
+ * { "name2" : "value" }
+ * </code> Would be transformed into:  <code>
+ * [{ "name1": "value" },
+ * { "name2" : "value" }]
+ * </code>
+ * <p>
+ * Note that this is a naive implementation and will incorrectly transform a
+ * stream if there are '}' contained within the names of values.</p>
+ *
+ * @author Jeremy Long
+ */
+public class JsonArrayFixingInputStream extends InputStream {
+
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(JsonArrayFixingInputStream.class);
+    /**
+     * The buffer length.
+     */
+    private static final int BUFFER_SIZE = 2048;
+    /**
+     * The input stream to be filtered.
+     */
+    protected volatile InputStream in;
+    /**
+     * The read buffer.
+     */
+    private final byte[] buffer = new byte[BUFFER_SIZE];
+    /**
+     * The read offset for the buffer.
+     */
+    private int bufferStart = 0;
+    /**
+     * The number characters available to read.
+     */
+    private int bufferAvailable = 0;
+    /**
+     * A flag indicating if the output still requires a trailing curly brace.
+     */
+    private boolean needsTrailingBrace = true;
+    /**
+     * A flag indicating if the stream is just starting.
+     */
+    private boolean firstRead = true;
+
+    /**
+     * Constructs a new filtering input stream used to fix a poorly formatted
+     * JSON array.
+     *
+     * @param in the InputStream containing the poorly formed JSON array
+     */
+    public JsonArrayFixingInputStream(InputStream in) {
+        this.in = in;
+        this.bufferAvailable = 1;
+        buffer[bufferStart] = '[';
+    }
+
+    /**
+     * Advances the buffer to the next block if required.
+     *
+     * @param start the offset to copy the next block into
+     * @return the number of characters read
+     * @throws IOException thrown if there is an error reading from the stream
+     */
+    private boolean advanceStream() throws IOException {
+        boolean chomp = false;
+        if (firstRead) {
+            chomp = true;
+            firstRead = false;
+            bufferStart = 0;
+            bufferAvailable = in.read(buffer, 1, BUFFER_SIZE - 1) + 1;
+        } else if (bufferAvailable == 0) {
+            chomp = true;
+            bufferStart = 0;
+            bufferAvailable = in.read(buffer, 0, BUFFER_SIZE);
+        }
+        if (chomp) {
+            //chomp new lines
+            while (bufferAvailable > 0
+                    && (buffer[bufferStart + bufferAvailable - 1] == '\n'
+                    || buffer[bufferStart + bufferAvailable - 1] == '\r')) {
+                bufferAvailable -= 1;
+            }
+            if (bufferAvailable == 0) {
+                return advanceStream();
+            }
+        }
+        return bufferAvailable > 0;
+    }
+
+    /**
+     * Searches for the offset from the buffer start for the next closing curly
+     * brace.
+     *
+     * @return the offset if found; otherwise <code>-1</code>
+     */
+    private int getClosingBraceOffset() {
+        for (int pos = bufferStart; pos < (bufferStart + bufferAvailable); pos++) {
+            if (buffer[pos] == '}') {
+                return pos - bufferStart;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Increments the buffer start and appropriately inserts any necessary
+     * needed curly braces or commas.
+     *
+     * @throws IOException thrown if there is an error reading from the stream
+     */
+    private void incrementRead() throws IOException {
+        if (buffer[bufferStart] == '}') {
+            if (bufferAvailable > 1) {
+                buffer[bufferStart] = ',';
+            } else {
+                bufferAvailable = 0;
+                if (advanceStream() || needsTrailingBrace) {
+                    if (bufferAvailable >= 1) {
+                        bufferStart = 0;
+                        bufferAvailable += 1;
+                        buffer[bufferStart] = ',';
+                    } else if (needsTrailingBrace) {
+                        needsTrailingBrace = false;
+                        buffer[bufferStart] = ']';
+                        bufferAvailable = 1;
+                    }
+                }
+            }
+        } else {
+            bufferStart += 1;
+            bufferAvailable -= 1;
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (advanceStream()) {
+            int value = buffer[bufferStart];
+            incrementRead();
+            return value;
+        }
+        return -1;
+    }
+
+    @Override
+    public int read(byte b[]) throws IOException {
+        return this.read(b, 0, b.length);
+    }
+
+    @Override
+    public int read(byte b[], int off, int len) throws IOException {
+        if (advanceStream()) {
+            int brace = getClosingBraceOffset();
+            if (brace == 0) {
+                b[off] = buffer[bufferStart];
+                incrementRead();
+                return 1;
+            }
+            int copyLength = bufferAvailable > len ? len : bufferAvailable;
+            if (brace > 0) {
+                copyLength = copyLength > brace ? brace : copyLength;
+            }
+            int copyEnd = copyLength + off;
+            for (int pos = off; pos < copyEnd; pos++) {
+                b[pos] = buffer[bufferStart];
+                bufferStart += 1;
+            }
+            bufferAvailable -= copyLength;
+            return copyLength;
+        }
+        return -1;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        throw new UnsupportedOperationException("Unable to skip using the JsonArrayFixingInputStream");
+    }
+
+    @Override
+    public int available() throws IOException {
+        return in.available() + bufferAvailable;
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+}

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/JsonArrayFixingInputStreamTest.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/JsonArrayFixingInputStreamTest.java
@@ -1,0 +1,288 @@
+/*
+ * This file is part of dependency-check-utils.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2020 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import java.util.Arrays;
+import javax.json.JsonReader;
+import javax.json.Json;
+import javax.json.JsonArray;
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import static org.junit.Assert.assertFalse;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+/**
+ *
+ * @author Jeremy Long
+ */
+public class JsonArrayFixingInputStreamTest {
+
+    String sample1 = "{}";
+    String sample2 = "{}{}";
+    String sample3 = "{'key'='value'}{'key'='value'}\n";
+    String sample4 = "{\n"
+            + "	\"Path\": \"my/thing\",\n"
+            + "	\"Main\": true,\n"
+            + "	\"Dir\": \"/Users/jeremy/Projects/DependencyCheck/core/target/test-classes/golang\",\n"
+            + "	\"GoMod\": \"/Users/jeremy/Projects/DependencyCheck/core/target/test-classes/golang/go.mod\"\n"
+            + "}\n"
+            + "{\n"
+            + "	\"Path\": \"github.com/ethereum/go-ethereum\",\n"
+            + "	\"Version\": \"v1.8.17\",\n"
+            + "	\"Time\": \"2018-10-09T07:35:31Z\",\n"
+            + "	\"GoMod\": \"/Users/jeremy/go/pkg/mod/cache/download/github.com/ethereum/go-ethereum/@v/v1.8.17.mod\"\n"
+            + "}\n"
+            + "{\n"
+            + "	\"Path\": \"github.com/go-gitea/gitea\",\n"
+            + "	\"Version\": \"v1.5.0\",\n"
+            + "	\"Time\": \"2018-08-10T17:16:53Z\",\n"
+            + "	\"GoMod\": \"/Users/jeremy/go/pkg/mod/cache/download/github.com/go-gitea/gitea/@v/v1.5.0.mod\"\n"
+            + "}\n"
+            + "{\n"
+            + "	\"Path\": \"golang.org/x/crypto\",\n"
+            + "	\"Version\": \"v0.0.0-20200820211705-5c72a883971a\",\n"
+            + "	\"Time\": \"2020-08-20T21:17:05Z\",\n"
+            + "	\"Indirect\": true,\n"
+            + "	\"Dir\": \"/Users/jeremy/go/pkg/mod/golang.org/x/crypto@v0.0.0-20200820211705-5c72a883971a\",\n"
+            + "	\"GoMod\": \"/Users/jeremy/go/pkg/mod/cache/download/golang.org/x/crypto/@v/v0.0.0-20200820211705-5c72a883971a.mod\",\n"
+            + "	\"GoVersion\": \"1.11\"\n"
+            + "}\n"
+            + "{\n"
+            + "	\"Path\": \"golang.org/x/net\",\n"
+            + "	\"Version\": \"v0.0.0-20190404232315-eb5bcb51f2a3\",\n"
+            + "	\"Time\": \"2019-04-04T23:23:15Z\",\n"
+            + "	\"Indirect\": true,\n"
+            + "	\"GoMod\": \"/Users/jeremy/go/pkg/mod/cache/download/golang.org/x/net/@v/v0.0.0-20190404232315-eb5bcb51f2a3.mod\"\n"
+            + "}\n"
+            + "{\n"
+            + "	\"Path\": \"golang.org/x/sys\",\n"
+            + "	\"Version\": \"v0.0.0-20190412213103-97732733099d\",\n"
+            + "	\"Time\": \"2019-04-12T21:31:03Z\",\n"
+            + "	\"Indirect\": true,\n"
+            + "	\"GoMod\": \"/Users/jeremy/go/pkg/mod/cache/download/golang.org/x/sys/@v/v0.0.0-20190412213103-97732733099d.mod\",\n"
+            + "	\"GoVersion\": \"1.12\"\n"
+            + "}\n"
+            + "{\n"
+            + "	\"Path\": \"golang.org/x/text\",\n"
+            + "	\"Version\": \"v0.3.0\",\n"
+            + "	\"Time\": \"2017-12-14T13:08:43Z\",\n"
+            + "	\"Indirect\": true,\n"
+            + "	\"GoMod\": \"/Users/jeremy/go/pkg/mod/cache/download/golang.org/x/text/@v/v0.3.0.mod\"\n"
+            + "}\n";
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    /**
+     * Test of read method, of class JsonArrayFixingInputStream.
+     *
+     * @throws Exception because one might happen
+     */
+    @Test
+    public void testRead_0args() throws Exception {
+        try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
+                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+            assertEquals('[', instance.read());
+            assertEquals('{', instance.read());
+            assertEquals('}', instance.read());
+            assertEquals(']', instance.read());
+            assertEquals(-1, instance.read());
+        }
+
+        try (InputStream sample = new ByteArrayInputStream(sample2.getBytes());
+                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+            assertEquals('[', instance.read());
+            assertEquals('{', instance.read());
+            assertEquals('}', instance.read());
+            assertEquals(',', instance.read());
+            assertEquals('{', instance.read());
+            assertEquals('}', instance.read());
+            assertEquals(']', instance.read());
+            assertEquals(-1, instance.read());
+        }
+    }
+
+    /**
+     * Test of read method, of class JsonArrayFixingInputStream.
+     *
+     * @throws Exception because one might happen
+     */
+    @Test
+    public void testRead_byteArr() throws Exception {
+        byte[] b = new byte[9];
+        try (InputStream sample = new ByteArrayInputStream(sample2.getBytes());
+                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+            int read = instance.read(b);
+            assertEquals(2, read);
+            assertEquals('[', b[0]);
+            assertEquals('{', b[1]);
+
+            read = instance.read(b);
+            assertEquals(1, read);
+            assertEquals('}', b[0]);
+
+            read = instance.read(b);
+            assertEquals(2, read);
+            assertEquals(',', b[0]);
+            assertEquals('{', b[1]);
+
+            read = instance.read(b);
+            assertEquals(1, read);
+            assertEquals('}', b[0]);
+
+            read = instance.read(b);
+            assertEquals(1, read);
+            assertEquals(']', b[0]);
+        }
+    }
+
+    @Test()
+    public void testRead_IOUtils() throws Exception {
+        try (InputStream sample = new ByteArrayInputStream(sample3.getBytes());
+                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+            String results = IOUtils.toString(instance, UTF_8);
+            assertEquals("[{'key'='value'},{'key'='value'}]", results);
+
+        }
+    }
+
+    @Test()
+    public void testRead_RealSample() throws Exception {
+        try (InputStream sample = new ByteArrayInputStream(sample4.getBytes());
+                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+            try (JsonReader reader = Json.createReader(instance)) {
+                final JsonArray modules = reader.readArray();
+                assertEquals(7, modules.size());
+            }
+        }
+    }
+
+    /**
+     * Test boundary conditions of the buffer window
+     *
+     * @throws Exception because one might happen
+     */
+    @Test()
+    public void testRead_3args() throws Exception {
+        byte[] input = new byte[2048];
+        Arrays.fill(input, (byte) ' ');
+        input[0] = '{';
+        input[2047] = '}';
+        byte[] results = new byte[2050];
+        byte[] expected = new byte[2050];
+        Arrays.fill(expected, (byte) ' ');
+        expected[0] = '[';
+        expected[1] = '{';
+        expected[2048] = '}';
+        expected[2049] = ']';
+        try (InputStream sample = new ByteArrayInputStream(input);
+                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+            int read = 0;
+            int pos = 0;
+            while (read >= 0) {
+                read = instance.read(results, pos, 2050 - pos);
+                pos += read;
+            }
+            Assert.assertArrayEquals(expected, results);
+        }
+    }
+
+    /**
+     * Test of skip method, of class JsonArrayFixingInputStream.
+     *
+     * @throws Exception because one might happen
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSkip() throws Exception {
+        try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
+                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+            instance.skip(1);
+        }
+    }
+
+    /**
+     * Test of available method, of class JsonArrayFixingInputStream.
+     *
+     * @throws Exception because one might happen
+     */
+    @Test
+    public void testAvailable() throws Exception {
+        try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
+                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+            int results = instance.available();
+            assertTrue(results > 0);
+            String text = IOUtils.toString(instance, UTF_8);
+            int i = instance.read();
+            assertEquals(-1, i);
+            //odd buffer is 0 and we've read to the end - but available on the underlying stream still says 3...
+            //results = instance.available();
+            //assertEquals(0, results);
+        }
+    }
+
+    /**
+     * Test of close method, of class JsonArrayFixingInputStream.
+     *
+     * @throws Exception because one might happen
+     */
+    @Test
+    public void testClose() throws Exception {
+        try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
+                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+            int i = instance.read();
+            instance.close();
+        }
+    }
+
+    /**
+     * Test of markSupported method, of class JsonArrayFixingInputStream.
+     *
+     * @throws Exception because one might happen
+     */
+    @Test
+    public void testMarkSupported() throws Exception {
+        try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
+                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+            boolean result = instance.markSupported();
+            assertFalse(result);
+        }
+    }
+
+}


### PR DESCRIPTION
Per #2680 - dependency-check will being using `go list -json -m all` instead of `go edit -json` to obtain the list of dependencies.