### PR TITLE
Use resolved artifact's baseVersion for comparing with reactor projects

### DIFF
--- a/maven/src/it/1527-aggregate-updated-dependencies/invoker.properties
+++ b/maven/src/it/1527-aggregate-updated-dependencies/invoker.properties
@@ -16,6 +16,5 @@
 # Copyright (c) 2014 Jeremy Long. All Rights Reserved.
 #
 
-#invoker.goals = deploy -Ddependency-check.skip=true -DaltDeploymentRepository=nexus::default::https://nexus.aikebah.net/nexus/content/repositories/releases/ -f external/pom.xml
 invoker.goals.1 = install -Dcve.startyear=2018 -Danalyzer.ossindex.enabled=false -f old/pom.xml
 invoker.goals.2 = verify -Dcve.startyear=2018  -Danalyzer.ossindex.enabled=false -f new/pom.xml

--- a/maven/src/it/1527-aggregate-updated-dependencies/new/war/pom.xml
+++ b/maven/src/it/1527-aggregate-updated-dependencies/new/war/pom.xml
@@ -27,11 +27,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <packaging>war</packaging>
     <dependencies>
         <dependency>
-            <groupId>org.apache.james</groupId>
-            <artifactId>apache-mime4j-dom</artifactId>
-            <version>0.7.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.owasp.test.aggregate.issue-1527</groupId>
             <artifactId>lib</artifactId>
             <version>1.0.0-SNAPSHOT</version>

--- a/maven/src/it/1527-aggregate-updated-dependencies/old/lib/pom.xml
+++ b/maven/src/it/1527-aggregate-updated-dependencies/old/lib/pom.xml
@@ -16,7 +16,8 @@ limitations under the License.
 
 Copyright (c) 2013 Jeremy Long. All Rights Reserved.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.owasp.test.aggregate.issue-1527</groupId>
@@ -28,9 +29,9 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>5.1.0.Final</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
         </dependency>
     </dependencies>
 </project>

--- a/maven/src/it/1527-aggregate-updated-dependencies/old/war/pom.xml
+++ b/maven/src/it/1527-aggregate-updated-dependencies/old/war/pom.xml
@@ -27,11 +27,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <packaging>war</packaging>
     <dependencies>
         <dependency>
-            <groupId>org.apache.james</groupId>
-            <artifactId>apache-mime4j-dom</artifactId>
-            <version>0.7.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.owasp.test.aggregate.issue-1527</groupId>
             <artifactId>lib</artifactId>
             <version>1.0.0-SNAPSHOT</version>

--- a/maven/src/it/1527-aggregate-updated-dependencies/postbuild.groovy
+++ b/maven/src/it/1527-aggregate-updated-dependencies/postbuild.groovy
@@ -21,36 +21,16 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 
 String oldReport = FileUtils.readFileToString(new File(basedir, "old/target/dependency-check-report.xml"), Charset.defaultCharset().name());
-int count = StringUtils.countMatches(oldReport, "pkg:maven/org.owasp.test.aggregate.issue-1527/war@1.0.0-SNAPSHOT");
+int count = StringUtils.countMatches(oldReport, "pkg:maven/org.slf4j/slf4j-api@1.7.30");
 if (count == 0) {
-    System.out.println(String.format("war-1.0.0-SNAPSHOT was not identified"));
-    return false;
-}
-count = StringUtils.countMatches(oldReport, "pkg:maven/org.apache.james/apache-mime4j-core@0.7.2");
-if (count == 0) {
-    System.out.println("org.apache.james:apache-mime4j-core:0.7.2 was not identified and is a dependency of war-1.0.0-SNAPSHOT");
-    return false;
-}
-count = StringUtils.countMatches(oldReport, "pkg:maven/org.hibernate/hibernate-validator@5.1.0.Final");
-if (count == 0) {
-    System.out.println("org.hibernate:hibernate-validator:5.1.0.Final was not identified, but is a transitive dependency of the old war-1.0.0-SNAPSHOT");
+    System.out.println("pkg:maven/org.slf4j/slf4j-api@1.7.30 was not identified and is a dependency of war-1.0.0-SNAPSHOT via lib-1.0.0-SNAPSHOT");
     return false;
 }
 
 String newReport = FileUtils.readFileToString(new File(basedir, "new/target/dependency-check-report.xml"), Charset.defaultCharset().name());
-count = StringUtils.countMatches(newReport, "pkg:maven/org.owasp.test.aggregate.issue-1527/war@1.0.0-SNAPSHOT");
-if (count == 0) {
-    System.out.println(String.format("war-1.0.0-SNAPSHOT was not identified"));
-    return false;
-}
-count = StringUtils.countMatches(newReport, "pkg:maven/org.apache.james/apache-mime4j-core@0.7.2");
-if (count == 0) {
-    System.out.println("org.apache.james:apache-mime4j-core:0.7.2 was not identified and is a dependency of war-1.0.0-SNAPSHOT");
-    return false;
-}
-count = StringUtils.countMatches(newReport, "pkg:maven/org.hibernate/hibernate-validator@5.1.2.Final");
+count = StringUtils.countMatches(newReport, "pkg:maven/org.slf4j/slf4j-api@1.7.30");
 if (count != 0) {
-    System.out.println("org.hibernate:hibernate-validator:5.1.0.Final was identified, but was only a dependency of the old war-1.0.0-SNAPSHOT");
+    System.out.println("pkg:maven/org.slf4j/slf4j-api@1.7.30 was identified but has been removed as a dependency in the new project to simulate mitigating vulnerabilities");
     return false;
 }
 

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1490,12 +1490,12 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         for (MavenProject prj : reactorProjects) {
 
             getLog().debug(String.format("Comparing %s:%s:%s to %s:%s:%s",
-                    artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(),
+                    artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion(),
                     prj.getGroupId(), prj.getArtifactId(), prj.getVersion()));
 
             if (prj.getArtifactId().equals(artifact.getArtifactId())
                     && prj.getGroupId().equals(artifact.getGroupId())
-                    && prj.getVersion().equals(artifact.getVersion())) {
+                    && prj.getVersion().equals(artifact.getBaseVersion())) {
 
                 final String displayName = String.format("%s:%s:%s",
                         prj.getGroupId(), prj.getArtifactId(), prj.getVersion());
@@ -1509,7 +1509,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 } else {
                     d = new Dependency(true);
                 }
-                final String key = String.format("%s:%s:%s", artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
+                final String key = String.format("%s:%s:%s", prj.getGroupId(), prj.getArtifactId(), prj.getVersion());
                 d.setSha1sum(Checksum.getSHA1Checksum(key));
                 d.setSha256sum(Checksum.getSHA256Checksum(key));
                 d.setMd5sum(Checksum.getMD5Checksum(key));


### PR DESCRIPTION
## Fixes Issue #2806

## Use resolved artifact's baseVersion for comparing with reactor projects
As artifacts resolved from a maven repository have a unique timestamped version for SNAPSHOT artifacts the comparison with in-reactor projects needs to use baseVersion of the artifact in order to match with the reactor-project's maven coordinates for the same SNAPSHOT.

## Have test cases been added to cover the new functionality?
no, existing integration-testcase 1527-aggregate-updated-dependencies has been updated to have less of a burden on bandwith and diskspace usage by using a small artifact, but properly testing the issue would require a maven repository where the build-artifact 'old' version could be stored by an integration test and then resolved from for the build of the 'new' version.
Manually verified that the sequence indicated in the issue now properly uses the in-reactor projects as a virtual dependency.

```
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] parent                                                             [pom]
[INFO] lib                                                                [jar]
[INFO] war                                                                [war]
[INFO] ear                                                                [ear]
[INFO] 
[INFO] -------------< org.owasp.test.aggregate.issue-1527:parent >-------------
[INFO] Building parent 1.0.0-SNAPSHOT                                     [1/4]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ parent ---
[INFO] Deleting /Users/aikebah/NetBeansProjects/DependencyCheck/maven/src/it/1527-aggregate-updated-dependencies/new/target
Downloading from nexus: https://nexus.aikebah.net/nexus/content/groups/public/org/owasp/test/aggregate/issue-1527/lib/1.0.0-SNAPSHOT/maven-metadata.xml
Progress (1): 788 B
                   
Downloaded from nexus: https://nexus.aikebah.net/nexus/content/groups/public/org/owasp/test/aggregate/issue-1527/lib/1.0.0-SNAPSHOT/maven-metadata.xml (788 B at 2.1 kB/s)
Downloading from nexus: https://nexus.aikebah.net/nexus/content/groups/public/org/owasp/test/aggregate/issue-1527/lib/1.0.0-SNAPSHOT/lib-1.0.0-20201001.201321-4.jar
Progress (1): 2.2 kB
                    
Downloaded from nexus: https://nexus.aikebah.net/nexus/content/groups/public/org/owasp/test/aggregate/issue-1527/lib/1.0.0-SNAPSHOT/lib-1.0.0-20201001.201321-4.jar (2.2 kB at 62 kB/s)
Downloading from nexus: https://nexus.aikebah.net/nexus/content/groups/public/org/owasp/test/aggregate/issue-1527/war/1.0.0-SNAPSHOT/maven-metadata.xml
Progress (1): 788 B
                   
Downloaded from nexus: https://nexus.aikebah.net/nexus/content/groups/public/org/owasp/test/aggregate/issue-1527/war/1.0.0-SNAPSHOT/maven-metadata.xml (788 B at 10.0 kB/s)
Downloading from nexus: https://nexus.aikebah.net/nexus/content/groups/public/org/owasp/test/aggregate/issue-1527/war/1.0.0-SNAPSHOT/war-1.0.0-20201001.201322-4.war
Progress (1): 4.1/41 kB
Progress (1): 7.8/41 kB
Progress (1): 12/41 kB 
Progress (1): 16/41 kB
Progress (1): 20/41 kB
Progress (1): 24/41 kB
Progress (1): 28/41 kB
Progress (1): 32/41 kB
Progress (1): 36/41 kB
Progress (1): 41/41 kB
Progress (1): 41 kB   
                   
Downloaded from nexus: https://nexus.aikebah.net/nexus/content/groups/public/org/owasp/test/aggregate/issue-1527/war/1.0.0-SNAPSHOT/war-1.0.0-20201001.201322-4.war (41 kB at 931 kB/s)
[INFO] 
[INFO] --- dependency-check-maven:6.0.3-SNAPSHOT:aggregate (default) @ parent ---
[INFO] Found snapshot reactor project in aggregate for org.owasp.test.aggregate.issue-1527:war:1.0.0-SNAPSHOT - creating a virtual dependency as the snapshot found in the repository may contain outdated dependencies.
[INFO] Found snapshot reactor project in aggregate for org.owasp.test.aggregate.issue-1527:lib:1.0.0-SNAPSHOT - creating a virtual dependency as the snapshot found in the repository may contain outdated dependencies.
[INFO] Checking for updates
```