### PR TITLE
Normalize the URI for odc.config for the submodules to fix #2853

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@ Copyright (c) 2012 - Jeremy Long
                                 if ("dependency-check-parent".equals("${project.artifactId}")) {
                                     config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/src/main/config"
                                 } else {
-                                    config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/../src/main/config"
+                                    config = new URI("file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/../src/main/config").normalize().toString()
                                 }
                                 project.properties['odc.config']= config
                                 ]]></script>
@@ -389,7 +389,7 @@ Copyright (c) 2012 - Jeremy Long
                                 if ("dependency-check-parent".equals("${project.artifactId}")) {
                                     config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/src/main/config"
                                 } else {
-                                    config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/../src/main/config"
+                                    config = new URI("file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/../src/main/config").normalize().toString()
                                 }
                                 project.properties['odc.config']= config
                                 ]]></script>
@@ -409,7 +409,7 @@ Copyright (c) 2012 - Jeremy Long
                                 if ("dependency-check-parent".equals("${project.artifactId}")) {
                                     config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/src/main/config"
                                 } else {
-                                    config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/../src/main/config"
+                                    config = new URI("file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/../src/main/config").normalize().toString()
                                 }
                                 project.properties['odc.config']= config
                                 ]]></script>


### PR DESCRIPTION
## Fixes Issue #2853

## Description of Change

Change the dynamic property for the submodules to a normalized file-URI to erase the '..'

## Have test cases been added to cover the new functionality?
no, as this is a fix for project config that made the site phases break a test-case is not applicable. Have locally run `mvn -s settings.xml install site site:stage -DreleaseTesting -Danalyzer.node.package.enabled=false -Danalyzer.node.audit.enabled=false` to verify that the reported issue is resolved and the project build still runs successfully.
