### PR TITLE
Restore idxCpe on initialize.sql to mitigate performance degradation when using h2 CveDB

### DIFF
--- a/core/src/main/resources/data/initialize.sql
+++ b/core/src/main/resources/data/initialize.sql
@@ -45,6 +45,7 @@ CREATE INDEX idxReference ON reference(cveid);
 CREATE INDEX idxSoftwareCve ON software(cveid);
 CREATE INDEX idxSoftwareCpe ON software(cpeEntryId);
 CREATE INDEX idxCpeEntry ON cpeEntry(part, vendor, product, version, update_version, edition, lang, sw_edition, target_sw, target_hw, other);
+CREATE INDEX idxCpe ON cpeEntry(vendor, product);
 
 CREATE ALIAS update_vulnerability FOR "org.owasp.dependencycheck.data.nvdcve.H2Functions.updateVulnerability";
 CREATE ALIAS insert_software FOR "org.owasp.dependencycheck.data.nvdcve.H2Functions.insertSoftware";


### PR DESCRIPTION
## Fixes Issue #2861

## Description of Change

Restore the index on vendor,product for the CpeEntry table to restore performance of getCPEs

## Have test cases been added to cover the new functionality?

N/A, covered by existing testcases; validated that all tests including the integration tests still pass