### PR TITLE
Node.js False Positives

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -601,6 +601,11 @@ public class CPEAnalyzer extends AbstractAnalyzer {
         return isValid;
     }
 
+    /**
+     * Only returns alpha numeric characters contained in a given package name.
+     * @param name the package name to cleanse
+     * @return the cleansed packaage name
+     */
     private String cleanPackageName(String name) {
         if (name == null) {
             return "";

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -600,18 +600,6 @@ public class CPEAnalyzer extends AbstractAnalyzer {
         }
         return isValid;
     }
-
-    /**
-     * Only returns alpha numeric characters contained in a given package name.
-     * @param name the package name to cleanse
-     * @return the cleansed packaage name
-     */
-    private String cleanPackageName(String name) {
-        if (name == null) {
-            return "";
-        }
-        return name.replaceAll("[^a-zA-Z0-9]+", "");
-    }
     /**
      * Only returns alpha numeric characters contained in a given package name.
      * @param name the package name to cleanse

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -601,6 +601,12 @@ public class CPEAnalyzer extends AbstractAnalyzer {
         return isValid;
     }
 
+    private String cleanPackageName(String name) {
+        if (name == null) {
+            return "";
+        }
+        return name.replaceAll("[^a-zA-Z0-9]+", "");
+    }
     /**
      * Only returns alpha numeric characters contained in a given package name.
      * @param name the package name to cleanse

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -66,6 +66,8 @@ import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.dependency.naming.CpeIdentifier;
+import org.owasp.dependencycheck.dependency.naming.Identifier;
+import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
 import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.DependencyVersion;
 import org.owasp.dependencycheck.utils.DependencyVersionUtil;
@@ -579,17 +581,32 @@ public class CPEAnalyzer extends AbstractAnalyzer {
      */
     private boolean verifyEntry(final IndexEntry entry, final Dependency dependency) {
         boolean isValid = false;
-
         //TODO - does this nullify some of the fuzzy matching that happens in the lucene search?
         // for instance CPE some-component and in the evidence we have SomeComponent.
-        if (collectionContainsString(dependency.getEvidence(EvidenceType.PRODUCT), entry.getProduct())
+
+        //TODO - should this have a package manager only flag instead of just looking for NPM
+        if (Ecosystem.NODEJS.equals(dependency.getEcosystem())) {
+            for (Identifier i : dependency.getSoftwareIdentifiers()) {
+                if (i instanceof PurlIdentifier) {
+                    PurlIdentifier p = (PurlIdentifier) i;
+                    if (cleanPackageName(p.getName()).equals(cleanPackageName(entry.getProduct()))) {
+                        isValid=true;
+                    }
+                }
+            }
+        } else if (collectionContainsString(dependency.getEvidence(EvidenceType.PRODUCT), entry.getProduct())
                 && collectionContainsString(dependency.getEvidence(EvidenceType.VENDOR), entry.getVendor())) {
-            //&& collectionContainsVersion(dependency.getVersionEvidence(), entry.getVersion())
             isValid = true;
         }
         return isValid;
     }
 
+    private String cleanPackageName(String name) {
+        if (name == null) {
+            return "";
+        }
+        return name.replaceAll("[^a-zA-Z0-9]+", "");
+    }
     /**
      * Used to determine if the EvidenceCollection contains a specific string.
      *

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NvdCveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NvdCveAnalyzer.java
@@ -142,7 +142,14 @@ public class NvdCveAnalyzer extends AbstractAnalyzer {
         dependency.addVulnerabilities(vulns);
     }
 
-    private List<Vulnerability>  filterEcosystem(String ecosystem, List<Vulnerability> vulnerabilities) {
+    /**
+     * Filters the list of vulnerabilities for the given ecosystem.
+     *
+     * @param ecosystem the dependency's ecosystem
+     * @param vulnerabilities the list of vulnerabilities to filter
+     * @return the filtered list of vulnerabilities
+     */
+    private List<Vulnerability> filterEcosystem(String ecosystem, List<Vulnerability> vulnerabilities) {
         List<Vulnerability> remove = new ArrayList<>();
         vulnerabilities.forEach((v) -> {
             boolean found = false;
@@ -168,6 +175,16 @@ public class NvdCveAnalyzer extends AbstractAnalyzer {
         return vulnerabilities;
     }
 
+    /**
+     * Determines if the target software matches the given ecosystem. Currently,
+     * this is very Node JS specific and broadly returns matches for everything
+     * else.
+     *
+     * @param ecosystem the ecosystem to match against
+     * @param targetSoftware the target software from the NVD
+     * @return <code>true</code> if there is a match; otherwise
+     * <code>false</code>
+     */
     private boolean ecosystemMatchesTargetSoftware(String ecosystem, String targetSoftware) {
         if ("*".equals(targetSoftware) || "-".equals(targetSoftware)) {
             return true;


### PR DESCRIPTION
## Fixes Issue #2796

Filter npm vulnerabilities when CPE doesn't match the product. Additionally, if the CPE contains a target_sw - ensure it is valid for Node.js.