### PR TITLE
Employ File and URI capabilities to build the config root

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,11 +368,11 @@ Copyright (c) 2012 - Jeremy Long
                             <scripts>
                                 <script><![CDATA[
                                 if ("dependency-check-parent".equals("${project.artifactId}")) {
-                                    config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/src/main/config"
+                                    relConfig = "src/main/config"
                                 } else {
-                                    config = new URI("file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/../src/main/config").normalize().toString()
+                                    relConfig = "../src/main/config"
                                 }
-                                project.properties['odc.config']= config
+                                project.properties['odc.config']= project.basedir.absoluteFile.toURI().resolve(relConfig).normalize().toString()
                                 ]]></script>
                             </scripts>
                         </configuration>
@@ -387,11 +387,11 @@ Copyright (c) 2012 - Jeremy Long
                             <scripts>
                                 <script><![CDATA[
                                 if ("dependency-check-parent".equals("${project.artifactId}")) {
-                                    config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/src/main/config"
+                                    relConfig = "src/main/config"
                                 } else {
-                                    config = new URI("file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/../src/main/config").normalize().toString()
+                                    relConfig = "../src/main/config"
                                 }
-                                project.properties['odc.config']= config
+                                project.properties['odc.config']= project.basedir.absoluteFile.toURI().resolve(relConfig).normalize().toString()
                                 ]]></script>
                             </scripts>
                         </configuration>
@@ -407,11 +407,11 @@ Copyright (c) 2012 - Jeremy Long
                             <scripts>
                                 <script><![CDATA[
                                 if ("dependency-check-parent".equals("${project.artifactId}")) {
-                                    config = "file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/src/main/config"
+                                    relConfig = "src/main/config"
                                 } else {
-                                    config = new URI("file:///"+project.basedir.absolutePath.replace('\\','\\\\')+"/../src/main/config").normalize().toString()
+                                    relConfig = "../src/main/config"
                                 }
-                                project.properties['odc.config']= config
+                                project.properties['odc.config']= project.basedir.absoluteFile.toURI().resolve(relConfig).normalize().toString()
                                 ]]></script>
                             </scripts>
                         </configuration>


### PR DESCRIPTION
## Fixes Issue #2876

## Description of Change
As the original switch to a normalized URI of MR #2855 was breaking windows builds I've rewritten the groovy-script that resolves the root-URI for the config folder to fully build the URI using File.toURI and the java.net.URI API

## Have test cases been added to cover the new functionality?
No, not applicable, but a test-run with existing tests has been run using
`mvn -s settings.xml install site site:stage -DreleaseTesting -Danalyzer.node.package.enabled=false -Danalyzer.node.audit.enabled=false`
On MacOS it passes, on Windows I ran into unrelated test-errors

## Known issues
integration tests of core fail on Windows (at least ReportGeneratorIT, both on my VM and a natively running windows on my company laptop):
```
[INFO] Analysis Complete (1 seconds)
[ERROR] Unable to generate pretty report, caused by: Failed to delete original file 'C:\Users\aikebah\Development\DependencyCheck\core\target\test-reports\Report.xml.pretty' after copy to 'C:\Users\aikebah\Development\DependencyCheck\core\target\test-reports\Report.xml'
[ERROR] Unable to generate pretty report, caused by: Failed to delete original file 'C:\Users\aikebah\Development\DependencyCheck\core\target\test-reports\junit.xml.pretty' after copy to 'C:\Users\aikebah\Development\DependencyCheck\core\target\test-reports\junit.xml'
[INFO] Element event queue destroyed: org.apache.commons.jcs.engine.control.event.ElementEventQueue@965bc67
```
followed by
```
[ERROR] testGenerateReport(org.owasp.dependencycheck.reporting.ReportGeneratorIT)  Time elapsed: 6 s  <<< FAILURE!
java.lang.AssertionError: C:\Users\aikebah\Development\DependencyCheck\core\target\test-reports\Report.xml (Het systeem kan het opgegeven bestand niet vinden)
        at org.owasp.dependencycheck.reporting.ReportGeneratorIT.generateReport(ReportGeneratorIT.java:205)
        at org.owasp.dependencycheck.reporting.ReportGeneratorIT.testGenerateReport(ReportGeneratorIT.java:75)
```

Fired up laptop with Windows to validate the issue.... those trigger same issue. Will open an issue for that.