### PR TITLE
fix basic auth issue

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
@@ -125,7 +125,7 @@ public class DownloadTask implements Callable<Future<ProcessTask>> {
             final long startDownload = System.currentTimeMillis();
             try {
                 final Downloader downloader = new Downloader(settings);
-                downloader.fetchFile(url1, file, Settings.KEYS.CVE_USER,Settings.KEYS.CVE_PASSWORD);
+                downloader.fetchFile(url1, file, Settings.KEYS.CVE_USER, Settings.KEYS.CVE_PASSWORD);
             } catch (DownloadFailedException ex) {
                 LOGGER.error("Download Failed for NVD CVE - {}\nSome CVEs may not be reported. Reason: {}",
                         nvdCveInfo.getId(), ex.getMessage());

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
@@ -125,7 +125,7 @@ public class DownloadTask implements Callable<Future<ProcessTask>> {
             final long startDownload = System.currentTimeMillis();
             try {
                 final Downloader downloader = new Downloader(settings);
-                downloader.fetchFile(url1, file);
+                downloader.fetchFile(url1, file, Settings.KEYS.CVE_USER,Settings.KEYS.CVE_PASSWORD);
             } catch (DownloadFailedException ex) {
                 LOGGER.error("Download Failed for NVD CVE - {}\nSome CVEs may not be reported. Reason: {}",
                         nvdCveInfo.getId(), ex.getMessage());

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
@@ -71,7 +71,23 @@ public final class Downloader {
      * @throws ResourceNotFoundException thrown when a 404 is received
      */
     public void fetchFile(URL url, File outputPath) throws DownloadFailedException, TooManyRequestsException, ResourceNotFoundException {
-        fetchFile(url, outputPath, true);
+        fetchFile(url, outputPath, true, null, null);
+    }
+
+    /**
+     * Retrieves a file from a given URL and saves it to the outputPath.
+     *
+     * @param url the URL of the file to download
+     * @param outputPath the path to the save the file to
+     * @param userKey the settings key for the username to be used
+     * @param passwordKey the settings key for the password to be used
+     * @throws org.owasp.dependencycheck.utils.DownloadFailedException is thrown
+     * if there is an error downloading the file
+     * @throws TooManyRequestsException thrown when a 429 is received
+     * @throws ResourceNotFoundException thrown when a 404 is received
+     */
+    public void fetchFile(URL url, File outputPath, String userKey, String passwordKey) throws DownloadFailedException, TooManyRequestsException, ResourceNotFoundException {
+        fetchFile(url, outputPath, true, userKey, passwordKey);
     }
 
     /**
@@ -88,8 +104,27 @@ public final class Downloader {
      */
     public void fetchFile(URL url, File outputPath, boolean useProxy) throws DownloadFailedException,
             TooManyRequestsException, ResourceNotFoundException {
+        fetchFile(url, outputPath, useProxy, null, null);
+    }
+
+    /**
+     * Retrieves a file from a given URL and saves it to the outputPath.
+     *
+     * @param url the URL of the file to download
+     * @param outputPath the path to the save the file to
+     * @param useProxy whether to use the configured proxy when downloading
+     * files
+     * @param userKey the settings key for the username to be used
+     * @param passwordKey the settings key for the password to be used
+     * @throws org.owasp.dependencycheck.utils.DownloadFailedException is thrown
+     * if there is an error downloading the file
+     * @throws TooManyRequestsException thrown when a 429 is received
+     * @throws ResourceNotFoundException thrown when a 404 is received
+     */
+    public void fetchFile(URL url, File outputPath, boolean useProxy, String userKey, String passwordKey) throws DownloadFailedException,
+            TooManyRequestsException, ResourceNotFoundException {
         InputStream in = null;
-        try (HttpResourceConnection conn = new HttpResourceConnection(settings, useProxy);
+        try (HttpResourceConnection conn = new HttpResourceConnection(settings, useProxy, userKey, passwordKey);
                 OutputStream out = new FileOutputStream(outputPath)) {
             in = conn.fetch(url);
             ByteStreams.copy(in, out);

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/HttpResourceConnection.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/HttpResourceConnection.java
@@ -78,6 +78,14 @@ public class HttpResourceConnection implements AutoCloseable {
     private boolean usesProxy;
 
     /**
+     *  The settings key for the username to be used.
+     */
+    private String userKey = null;
+    /**
+     * The settings key for the password to be used.
+     */
+    private String passwordKey = null;
+    /**
      * Constructs a new HttpResourceConnection object.
      *
      * @param settings the configured settings
@@ -96,6 +104,22 @@ public class HttpResourceConnection implements AutoCloseable {
         this.settings = settings;
         this.connFactory = new URLConnectionFactory(settings);
         this.usesProxy = usesProxy;
+    }
+
+    /**
+     * Constructs a new HttpResourceConnection object.
+     *
+     * @param settings the configured settings
+     * @param usesProxy control whether this conn will use the defined proxy
+     * @param userKey the settings key for the username to be used
+     * @param passwordKey the settings key for the password to be used
+     */
+    public HttpResourceConnection(Settings settings, boolean usesProxy, String userKey, String passwordKey) {
+        this.settings = settings;
+        this.connFactory = new URLConnectionFactory(settings);
+        this.usesProxy = usesProxy;
+        this.userKey = userKey;
+        this.passwordKey = passwordKey;
     }
 
     /**
@@ -174,6 +198,9 @@ public class HttpResourceConnection implements AutoCloseable {
         try {
             LOGGER.debug("Attempting retrieval of {}", url.toString());
             conn = connFactory.createHttpURLConnection(url, this.usesProxy);
+            if (userKey!=null && passwordKey !=null) {
+                connFactory.addBasicAuthentication(conn, userKey, passwordKey);
+            }
             conn.setRequestProperty("Accept-Encoding", "gzip, deflate");
             conn.connect();
             int status = conn.getResponseCode();

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/HttpResourceConnection.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/HttpResourceConnection.java
@@ -78,13 +78,14 @@ public class HttpResourceConnection implements AutoCloseable {
     private boolean usesProxy;
 
     /**
-     *  The settings key for the username to be used.
+     * The settings key for the username to be used.
      */
     private String userKey = null;
     /**
      * The settings key for the password to be used.
      */
     private String passwordKey = null;
+
     /**
      * Constructs a new HttpResourceConnection object.
      *
@@ -198,7 +199,7 @@ public class HttpResourceConnection implements AutoCloseable {
         try {
             LOGGER.debug("Attempting retrieval of {}", url.toString());
             conn = connFactory.createHttpURLConnection(url, this.usesProxy);
-            if (userKey!=null && passwordKey !=null) {
+            if (userKey != null && passwordKey != null) {
                 connFactory.addBasicAuthentication(conn, userKey, passwordKey);
             }
             conn.setRequestProperty("Accept-Encoding", "gzip, deflate");

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/URLConnectionFactory.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/URLConnectionFactory.java
@@ -147,10 +147,22 @@ public final class URLConnectionFactory {
                 LOGGER.debug("Adding user info as basic authorization");
             }
             conn.addRequestProperty("Authorization", basicAuth);
-        } else if (StringUtils.isNotEmpty(settings.getString(Settings.KEYS.CVE_USER))
-                && StringUtils.isNotEmpty(settings.getString(Settings.KEYS.CVE_PASSWORD))) {
-            final String user = settings.getString(Settings.KEYS.CVE_USER);
-            final String password = settings.getString(Settings.KEYS.CVE_PASSWORD);
+        }
+    }
+
+    /**
+     * Adds a basic authentication header if the values in the settings are not
+     * null.
+     *
+     * @param conn the connection to add the basic auth header
+     * @param userKey the settings key for the username
+     * @param passwordKey the settings key for the password
+     */
+    public void addBasicAuthentication(HttpURLConnection conn, String userKey, String passwordKey) {
+        if (StringUtils.isNotEmpty(settings.getString(userKey))
+                && StringUtils.isNotEmpty(settings.getString(passwordKey))) {
+            final String user = settings.getString(userKey);
+            final String password = settings.getString(passwordKey);
             final String userColonPassword = user + ":" + password;
             final String basicAuth = "Basic " + Base64.getEncoder().encodeToString(userColonPassword.getBytes(UTF_8));
             if (LOGGER.isDebugEnabled()) {

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/URLConnectionFactoryIT.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/URLConnectionFactoryIT.java
@@ -60,7 +60,7 @@ public class URLConnectionFactoryIT extends BaseTest {
         mockServerClient.when(HttpRequest.request().withMethod("GET")
                 .withPath("/secure/resource.xml"), Times.once())
                 .respond(HttpResponse.response().withBody("Unauthorized").withStatusCode(401));
-        
+
         URL url = new URL("http://localhost:"
                 + mockServerClient.remoteAddress().getPort()
                 + "/secure/resource.xml");
@@ -88,7 +88,7 @@ public class URLConnectionFactoryIT extends BaseTest {
         mockServerClient.when(HttpRequest.request().withMethod("GET")
                 .withPath("/secure/resource.xml"), Times.once())
                 .respond(HttpResponse.response().withBody("Unauthorized").withStatusCode(401));
-        
+
         URL url = new URL("http://username:password@localhost:"
                 + mockServerClient.remoteAddress().getPort()
                 + "/secure/resource.xml");


### PR DESCRIPTION
## Fixes Issue #2886

A basic auth header was added too broadly to all connections if one was configured for retrieving the CVE data feeds. This PR resolves the issue.