### PR TITLE
Add missing cleanup to UpdateMojo

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/UpdateMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/UpdateMojo.java
@@ -91,6 +91,8 @@ public class UpdateMojo extends BaseDependencyCheckMojo {
                 throw new MojoExecutionException(msg, ex);
             }
             getLog().error(msg);
+        } finally {
+            getSettings().cleanup();
         }
     }
 


### PR DESCRIPTION
## Fixes Issue #2749 

## Description of Change

Add the missing cleanup routing to the UpdateMojo to remove the temporary folder at the end of an update-only run

## Have test cases been added to cover the new functionality?

no, ran update-only goal locally and verified that now the dctemp folder in the temp directory is removed 