### PR TITLE
Add completion for `dependency-check.sh`

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -44,6 +44,13 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                 </includes>
             </resource>
             <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>completion-for-dependency-check.sh</include>
+                </includes>
+                <targetPath>${project.build.directory}/release/bin</targetPath>
+            </resource>
+            <resource>
                 <directory>${basedir}</directory>
                 <targetPath>META-INF</targetPath>
                 <includes>

--- a/cli/src/main/assembly/release.xml
+++ b/cli/src/main/assembly/release.xml
@@ -17,7 +17,7 @@
                 <include>*.sh</include>
             </includes>
             <fileMode>0755</fileMode>
-        </fileSet>
+        </fileSet>     
         <fileSet>
             <outputDirectory>dependency-check/bin</outputDirectory>
             <directory>${project.build.directory}/release/bin</directory>

--- a/cli/src/main/assembly/release.xml
+++ b/cli/src/main/assembly/release.xml
@@ -17,7 +17,7 @@
                 <include>*.sh</include>
             </includes>
             <fileMode>0755</fileMode>
-        </fileSet>     
+        </fileSet>
         <fileSet>
             <outputDirectory>dependency-check/bin</outputDirectory>
             <directory>${project.build.directory}/release/bin</directory>

--- a/cli/src/main/resources/completion-for-dependency-check.sh
+++ b/cli/src/main/resources/completion-for-dependency-check.sh
@@ -111,7 +111,7 @@ _odc_completions()
 
 
     case "${prev}" in
-        -o|--out|-d|--data|--bundleAudit|--bundleAuditWorkingDirectory|--dbDriverPath|--dotnet|--go|-P|--propertyfile|--suppression|--hint|-l|--log)
+        -s|--scan|-o|--out|-d|--data|--bundleAudit|--bundleAuditWorkingDirectory|--dbDriverPath|--dotnet|--go|-P|--propertyfile|--suppression|--hint|-l|--log)
             COMPREPLY=( $(compgen -f -o default -- ${cur}) )
             return 0
             ;;

--- a/cli/src/main/resources/completion-for-dependency-check.sh
+++ b/cli/src/main/resources/completion-for-dependency-check.sh
@@ -1,0 +1,135 @@
+#/usr/bin/env bash
+
+pattern="^.*completion-for-dependency-check.sh$";
+if [[ "$0" =~ $pattern ]]; then 
+    echo
+    echo "To use completion for dependency-check you must run:"
+    echo
+    echo "         source completion-for-dependency-check.sh"
+    echo
+    exit
+fi
+
+_odc_completions()
+{
+    # Pointer to current completion word.
+    local options="
+            --advancedHelp
+            --artifactoryApiToken
+            --artifactoryBearerToken
+            --artifactoryParallelAnalysis
+            --artifactoryUseProxy
+            --artifactoryUsername
+            --bundleAudit
+            --bundleAuditWorkingDirectory
+        -c --connectiontimeout
+            --connectionString
+            --cveUrlBase
+            --cveUrlModified
+            --cveValidForHours
+        -d --data
+            --dbDriverName
+            --dbDriverPath
+            --dbPassword
+            --dbUser
+            --disableArchive
+            --disableAssembly
+            --disableAutoconf
+            --disableBundleAudit
+            --disableCentral
+            --disableCentralCache
+            --disableCmake
+            --disableCocoapodsAnalyzer
+            --disableComposer 
+            --disableGolangDep
+            --disableGolangMod
+            --disableJar
+            --disableMixAudit
+            --disableNodeAudit
+            --disableNodeAuditCache
+            --disableNodeJS
+            --disableNugetconf
+            --disableNuspec
+            --disableOpenSSL
+            --disableOssIndex
+            --disableOssIndexCache
+            --disablePip
+            --disablePipfile
+            --disablePyDist
+            --disablePyPkg
+            --disableRetireJS
+            --disableRubygems
+            --disableSwiftPackageManagerAnalyzer
+            --dotnet
+            --enableArtifactory
+            --enableExperimental
+            --enableNexus
+            --enableRetired
+            --exclude <pattern> 
+        -f --format <format> 
+            --failOnCVSS <score>
+            --go
+        -h --help 
+            --hints
+            --junitFailOnCVSS <score> 
+        -l --log
+        -n --noupdate                 
+            --nexus <url>        
+            --nexusPass <password>   
+            --nexusUser <username>
+            --nexusUsesProxy
+            --nodeAuditSkipDevDependencies  
+            --nonProxyHosts <list>    
+        -o --out
+            --ossIndexPassword <password>   
+            --ossIndexUsername <username> 
+        -P --propertyfile
+            --prettyPrint
+            --project <name> 
+            --proxypass <pass>
+            --proxyport <port>
+            --proxyserver <server>
+            --proxyuser <user> 
+            --purge
+            --retirejsFilter <pattern>
+            --retirejsFilterNonVulnerable
+            --retireJsForceUpdate
+            --retireJsUrl <url>
+        -s --scan
+            --suppression
+            --symLink <depth>
+            --updateonly
+        -v --version
+            --zipExtensions <extensions>      
+    "
+
+
+    # Array variable storing the possible completions.
+    COMPREPLY=()
+    local cur=${COMP_WORDS[COMP_CWORD]}
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+
+    case "${prev}" in
+        -o|--out|-d|--data|--bundleAudit|--bundleAuditWorkingDirectory|--dbDriverPath|--dotnet|--go|-P|--propertyfile|--suppression|--hint|-l|--log)
+            COMPREPLY=( $(compgen -f -o default -- ${cur}) )
+            return 0
+            ;;
+        --artifactoryParallelAnalysis|--artifactoryUseProxy|--nexusUsesProxy)
+            COMPREPLY=( $(compgen -W "true false" -- ${cur}) )
+            return 0
+            ;;
+        -f|--format)
+            COMPREPLY=( $(compgen -W "HTML XML CSV JSON JUNIT ALL" ${cur}) )
+            return 0
+            ;;
+    esac
+    if [[ "$cur" == -* ]] ; then
+        # COMPREPLY=( $(compgen -W "$options" -- "$cur") )
+        COMPREPLY=( $(compgen -W "$options" -- "$cur") )
+        return 0
+    fi
+  return 0
+}
+
+complete -F _odc_completions dependency-check.sh

--- a/cli/src/main/resources/completion-for-dependency-check.sh
+++ b/cli/src/main/resources/completion-for-dependency-check.sh
@@ -125,7 +125,6 @@ _odc_completions()
             ;;
     esac
     if [[ "$cur" == -* ]] ; then
-        # COMPREPLY=( $(compgen -W "$options" -- "$cur") )
         COMPREPLY=( $(compgen -W "$options" -- "$cur") )
         return 0
     fi


### PR DESCRIPTION
Add script for completion for dependency-check.sh so we can more easily select the correct arguments. After installing `completion-for-dependency-check.sh` (using `source completion-for-dependency-check.sh`) we can list the arguments using `<tab><tab>`. The following example lists all of the `--disable*` arguments:

```bash
$ ./dependency-check.sh --disable<tab><tab>
--disableArchive                      --disableCocoapodsAnalyzer            --disableNodeAuditCache               --disablePip
--disableAssembly                     --disableComposer                     --disableNodeJS                       --disablePipfile
--disableAutoconf                     --disableGolangDep                    --disableNugetconf                    --disablePyDist
--disableBundleAudit                  --disableGolangMod                    --disableNuspec                       --disablePyPkg
--disableCentral                      --disableJar                          --disableOpenSSL                      --disableRetireJS
--disableCentralCache                 --disableMixAudit                     --disableOssIndex                     --disableRubygems
--disableCmake                        --disableNodeAudit                    --disableOssIndexCache                --disableSwiftPackageManagerAnalyzer
```

Consider adding `source <path>/completion-for-dependency-check.sh` to your .bashrc if you use ODC a lot.
