### PR TITLE
Don't continue processing when there was a fatal exception in analysis

### DIFF
--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -1662,16 +1662,16 @@ public class Check extends Update {
                 }
             }
             final ExceptionCollection exceptions = callExecuteAnalysis(engine);
-
-            for (String format : getReportFormats()) {
-                engine.writeReports(getProjectName(), new File(reportOutputDirectory), format, exceptions);
-            }
-
-            if (this.failBuildOnCVSS <= 10) {
-                checkForFailure(engine.getDependencies());
-            }
-            if (this.showSummary) {
-                DependencyCheckScanAgent.showSummary(engine.getDependencies());
+            if (exceptions == null || !exceptions.isFatal()) {
+                for (String format : getReportFormats()) {
+                    engine.writeReports(getProjectName(), new File(reportOutputDirectory), format, exceptions);
+                }
+                if (this.failBuildOnCVSS <= 10) {
+                    checkForFailure(engine.getDependencies());
+                }
+                if (this.showSummary) {
+                    DependencyCheckScanAgent.showSummary(engine.getDependencies());
+                }
             }
         } catch (DatabaseException ex) {
             final String msg = "Unable to connect to the dependency-check database; analysis has stopped";


### PR DESCRIPTION
## Fixes Issue #2212

## Description of Change

Handle fatal analysis errors in Ant Check task similar to the other modules: skip the remaining processing steps. This avoids the NPE when writeReports wants to enumerate the database properties that is caused by the already closed (and nullified) database.

Seemed the safest approach to fix the NPE of #2212, but the discrepancy between the error message for update-errors and the actual behaviour of DependencyCheck remains.

## Have test cases been added to cover the new functionality?
no