### PR TITLE
improve matching of update versions

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -590,7 +590,7 @@ public class CPEAnalyzer extends AbstractAnalyzer {
                 if (i instanceof PurlIdentifier) {
                     PurlIdentifier p = (PurlIdentifier) i;
                     if (cleanPackageName(p.getName()).equals(cleanPackageName(entry.getProduct()))) {
-                        isValid=true;
+                        isValid = true;
                     }
                 }
             }
@@ -600,8 +600,10 @@ public class CPEAnalyzer extends AbstractAnalyzer {
         }
         return isValid;
     }
+
     /**
      * Only returns alpha numeric characters contained in a given package name.
+     *
      * @param name the package name to cleanse
      * @return the cleansed packaage name
      */
@@ -611,6 +613,7 @@ public class CPEAnalyzer extends AbstractAnalyzer {
         }
         return name.replaceAll("[^a-zA-Z0-9]+", "");
     }
+
     /**
      * Used to determine if the EvidenceCollection contains a specific string.
      *
@@ -776,7 +779,7 @@ public class CPEAnalyzer extends AbstractAnalyzer {
                     cpeBuilder.part(Part.APPLICATION).vendor(vendor).product(product);
                     final int idx = depVersion.getVersionParts().size() - 1;
                     if (idx > 0 && depVersion.getVersionParts().get(idx)
-                            .matches("^(v|final|release|snapshot|beta|alpha|u|rc|m|20\\d\\d).*$")) {
+                            .matches("^(v|final|release|snapshot|r|b|beta|a|alpha|u|rc|sp|dev|revision|service|build|pre|p|patch|update|m|20\\d\\d).*$")) {
                         cpeBuilder.version(StringUtils.join(depVersion.getVersionParts().subList(0, idx), "."));
                         //when written - no update versions in the NVD start with v### - they all strip the v off
                         if (depVersion.getVersionParts().get(idx).matches("^v\\d.*$")) {

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/VulnerableSoftwareTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/VulnerableSoftwareTest.java
@@ -55,6 +55,7 @@ public class VulnerableSoftwareTest extends BaseTest {
 
     /**
      * Test of compareTo method, of class VulnerableSoftware.
+     *
      * @throws CpeValidationException
      */
     @Test
@@ -63,43 +64,55 @@ public class VulnerableSoftwareTest extends BaseTest {
         VulnerableSoftware obj = builder.part(Part.APPLICATION).vendor("mortbay").product("jetty").version("6.1.0").build();
         VulnerableSoftware instance = builder.part(Part.APPLICATION).vendor("mortbay").product("jetty").version("6.1").build();
         int result = instance.compareTo(obj);
-        assertTrue(result<0);
-        
+        assertTrue(result < 0);
+
         obj = builder.part(Part.APPLICATION).vendor("yahoo").product("toolbar").version("3.1.0.20130813024103").build();
         instance = builder.part(Part.APPLICATION).vendor("yahoo").product("toolbar").version("3.1.0.20130813024104").build();
         result = instance.compareTo(obj);
-        assertTrue(result>0);
+        assertTrue(result > 0);
     }
-    
+
     @Test
     public void testCompareVersionRange() throws CpeValidationException {
         VulnerableSoftwareBuilder builder = new VulnerableSoftwareBuilder();
         VulnerableSoftware instance = builder.version("2.0.0").build();
         assertTrue(instance.compareVersionRange("2.0.0"));
         assertFalse(instance.compareVersionRange("2.0.1"));
-        
+
         instance = builder.version(LogicalValue.ANY).build();
         assertTrue(instance.compareVersionRange("2.0.1"));
-        
+
         instance = builder.version(LogicalValue.NA).build();
         assertFalse(instance.compareVersionRange("2.0.1"));
-        
+
         instance = builder.version(LogicalValue.ANY).versionEndIncluding("2.0.1").build();
         assertTrue(instance.compareVersionRange("2.0.1"));
         assertFalse(instance.compareVersionRange("2.0.2"));
-        
+
         instance = builder.version(LogicalValue.ANY).versionEndExcluding("2.0.2").build();
         assertTrue(instance.compareVersionRange("2.0.1"));
         assertFalse(instance.compareVersionRange("2.0.2"));
-        
-        
+
         instance = builder.version(LogicalValue.ANY).versionStartIncluding("1.0.1").build();
         assertTrue(instance.compareVersionRange("1.0.1"));
         assertFalse(instance.compareVersionRange("1.0.0"));
-        
+
         instance = builder.version(LogicalValue.ANY).versionStartExcluding("1.0.0").build();
         assertTrue(instance.compareVersionRange("1.0.1"));
         assertFalse(instance.compareVersionRange("1.0.0"));
+    }
+
+    @Test
+    public void testcompareUpdateAttributes() throws CpeValidationException {
+
+        assertTrue(VulnerableSoftware.compareUpdateAttributes("update1", "u1"));
+        assertTrue(VulnerableSoftware.compareUpdateAttributes("u1", "update1"));
+        assertTrue(VulnerableSoftware.compareUpdateAttributes("u1", "update-1"));
+        assertTrue(VulnerableSoftware.compareUpdateAttributes("a1", "alpha1"));
+        assertTrue(VulnerableSoftware.compareUpdateAttributes("alpha-1", "alpha1"));
+        assertTrue(VulnerableSoftware.compareUpdateAttributes("b-1", "beta1"));
+        assertFalse(VulnerableSoftware.compareUpdateAttributes("a1", "beta1"));
+
     }
 
 }


### PR DESCRIPTION
## Fixes Issue #1866

Improvs matching of update versions - allowing for additional update versions to be detected and correctly matched.

## Have test cases been added to cover the new functionality?

yes