### PR TITLE
Extended message as an interim fix for #2416

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/exception/ExceptionCollection.java
+++ b/core/src/main/java/org/owasp/dependencycheck/exception/ExceptionCollection.java
@@ -209,7 +209,16 @@ public class ExceptionCollection extends Exception {
     public String getMessage() {
         final StringBuilder sb = new StringBuilder(MSG);
 
-        this.exceptions.forEach((t) -> sb.append("\n\t").append(t.getMessage()));
+        this.exceptions.forEach((t) -> sb.append("\n\t").append(t.getClass().getSimpleName()).append(": ").append(ExceptionCollection.nestedCauseList(t)));
         return sb.toString();
+    }
+    private static StringBuilder nestedCauseList(Throwable t) {
+        StringBuilder sb = new StringBuilder(t.getMessage());
+        Throwable nestedCause = t.getCause();
+        while (nestedCause != null) {
+            sb.append("\n\t\tcaused by ").append(nestedCause.getClass().getSimpleName()).append(": ").append(nestedCause.getMessage());
+            nestedCause = nestedCause.getCause();
+        }
+        return sb;
     }
 }


### PR DESCRIPTION
## Fixes Issue #2416 

## Description of Change

Extend the error message of the CollectionException to get better visibility into the errors leading up to an anlysis failure.
This is the short-term fix to resolve issue 2416 pending  a more thorough look at exception handling.

## Have test cases been added to cover the new functionality?

no