### PR TITLE
Order of operations for Process.waitFor()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
         - JDK="JDK8"
       script:
         - if [ ! -z "$TRAVIS_TAG" ]; then 
-            travis_wait 60 mvn -s settings.xml install site site:stage -DreleaseTesting -Danalyzer.node.package.enabled=false -Danalyzer.node.audit.enabled=false; 
+            travis_wait 60 mvn -X -s settings.xml install site site:stage -DreleaseTesting -Danalyzer.node.package.enabled=false -Danalyzer.node.audit.enabled=false; 
           else 
             travis_wait 60 mvn -X -s settings.xml install -DreleaseTesting -Danalyzer.node.package.enabled=false -Danalyzer.node.audit.enabled=false; 
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
         - if [ ! -z "$TRAVIS_TAG" ]; then 
             travis_wait 60 mvn -s settings.xml install site site:stage -DreleaseTesting -Danalyzer.node.package.enabled=false -Danalyzer.node.audit.enabled=false; 
           else 
-            travis_wait 60 mvn -s settings.xml install -DreleaseTesting -Danalyzer.node.package.enabled=false -Danalyzer.node.audit.enabled=false; 
+            travis_wait 60 mvn -X -s settings.xml install -DreleaseTesting -Danalyzer.node.package.enabled=false -Danalyzer.node.audit.enabled=false; 
           fi
 
 after_success:

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
@@ -365,7 +365,7 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
                 }
             }
         } catch (IOException ioe) {
-            LOGGER.warn("go mod failure", ioe);
+            LOGGER.info("go mod failure", ioe);
         }
         return process;
     }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
@@ -348,15 +348,15 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
 
     private Process evaluateProcessErrorStream(Process process, File directory) throws AnalysisException, InterruptedException {
         try {
-            LOGGER.info("closing output stream");
-            process.getOutputStream().close();
             String error = null;
             try (InputStream errorStream = process.getErrorStream()) {
                 if (errorStream.available() > 0) {
                     error = IOUtils.toString(errorStream, StandardCharsets.UTF_8.name());
                 }
             }
+            LOGGER.info("closing error stream");
             process.getErrorStream().close();
+            LOGGER.info("error stream closed:" + error);
             if (error != null) {
                 LOGGER.warn("Warnings from go {}", error);
                 if (error.contains("can't compute 'all' using the vendor directory")) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
@@ -190,13 +190,10 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
 
         final List<String> args = new ArrayList<>();
         args.add(getGo());
-//        args.add("list");
-//        args.add("-json");
-//        args.add("-m");
-//        args.add("all");
-        args.add("mod");
-        args.add("edit");
+        args.add("list");
         args.add("-json");
+        args.add("-m");
+        args.add("all");
 
         final ProcessBuilder builder = new ProcessBuilder(args);
         builder.directory(folder);
@@ -360,7 +357,7 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
             }
             process.getErrorStream().close();
             if (error.length() > 0) {
-                LOGGER.warn("Warnings from go {}", error.toString());
+                LOGGER.error("Warnings from go {}", error.toString());
                 if (error.indexOf("can't compute 'all' using the vendor directory") >= 0) {
                     LOGGER.warn("Switching to `go list -json -m readonly`");
                     return evaluateProcessErrorStream(launchGoListReadonly(directory), directory);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
@@ -346,7 +346,7 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
 
     private Process evaluateProcessErrorStream(Process process, File directory) throws AnalysisException, InterruptedException {
         try {
-            process.getOutputStream().close();
+            //process.getOutputStream().close();
             final StringBuilder error = new StringBuilder();
             if (process.getErrorStream().available() > 0) {
                 try (BufferedReader errReader = new BufferedReader(new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8))) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
@@ -331,6 +331,8 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
                         -> engine.addDependency(goDep.toDependency(dependency))
                 );
             }
+            process.getInputStream().close();
+            process.getErrorStream().close();
             process.waitFor();
             exitValue = process.exitValue();
             if (exitValue < 0 || exitValue > 1) {
@@ -354,9 +356,6 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
                     error = IOUtils.toString(errorStream, StandardCharsets.UTF_8.name());
                 }
             }
-            LOGGER.info("closing error stream");
-            process.getErrorStream().close();
-            LOGGER.info("error stream closed:" + error);
             if (error != null) {
                 LOGGER.warn("Warnings from go {}", error);
                 if (error.contains("can't compute 'all' using the vendor directory")) {
@@ -365,7 +364,7 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
                 }
             }
         } catch (IOException ioe) {
-            LOGGER.info("go mod failure", ioe);
+            LOGGER.warn("go mod failure", ioe);
         }
         return process;
     }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
@@ -320,7 +320,7 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
 
         Process process = launchGoListAll(parentFile);
         try {
-
+            process.waitFor(500, TimeUnit.MILLISECONDS);
             process = evaluateProcessErrorStream(process, parentFile);
 
             GoModJsonParser.process(process.getInputStream()).forEach(goDep

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
@@ -324,7 +324,7 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
         Process process = launchGoListAll(parentFile);
         try {
             process = evaluateProcessErrorStream(process, parentFile);
-
+            process.waitFor();
             GoModJsonParser.process(process.getInputStream()).forEach(goDep
                     -> engine.addDependency(goDep.toDependency(dependency))
             );

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
@@ -348,6 +348,7 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
 
     private Process evaluateProcessErrorStream(Process process, File directory) throws AnalysisException, InterruptedException {
         try {
+            LOGGER.info("closing output stream");
             process.getOutputStream().close();
             String error = null;
             try (InputStream errorStream = process.getErrorStream()) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
@@ -342,9 +342,11 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
     private Process evaluateProcessErrorStream(Process process, File directory) throws AnalysisException, InterruptedException {
         try {
             final StringBuilder error = new StringBuilder();
-            try (BufferedReader errReader = new BufferedReader(new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8))) {
-                while (errReader.ready()) {
-                    error.append(errReader.readLine());
+            if (process.getErrorStream().available() > 0) {
+                try (BufferedReader errReader = new BufferedReader(new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8))) {
+                    while (errReader.ready()) {
+                        error.append(errReader.readLine());
+                    }
                 }
             }
             if (error.length() > 0) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
@@ -320,7 +320,7 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
 
         Process process = launchGoListAll(parentFile);
         try {
-            process.waitFor(500, TimeUnit.MILLISECONDS);
+            process.waitFor(1000, TimeUnit.MILLISECONDS);
             process = evaluateProcessErrorStream(process, parentFile);
 
             GoModJsonParser.process(process.getInputStream()).forEach(goDep

--- a/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
@@ -62,25 +62,22 @@ public final class GoModJsonParser {
      * results of `go mod`
      */
     public static List<GoModDependency> process(InputStream inputStream) throws AnalysisException {
-        LOGGER.debug("Beginning go.mod processing");
+        LOGGER.info("Beginning go.mod processing");
+        //LOGGER.debug("Beginning go.mod processing");
         List<GoModDependency> goModDependencies = new ArrayList<>();
         try (JsonArrayFixingInputStream jsonStream = new JsonArrayFixingInputStream(inputStream)) {
-//            String array = IOUtils.toString(inputStream, UTF_8);
-//            array = array.trim().replace("}", "},");
-//            array = "[" + array.substring(0, array.length() - 1) + "]";
-//
-//            JsonReader reader = Json.createReader(new StringReader(array));
+            LOGGER.info("input streeam available: " + jsonStream.available());
             JsonReaderFactory factory = Json.createReaderFactory(null);
             try (JsonReader reader = factory.createReader(jsonStream, java.nio.charset.StandardCharsets.UTF_8)) {
                 final JsonArray modules = reader.readArray();
-                for (JsonObject module : modules.getValuesAs(JsonObject.class)) {
+                modules.getValuesAs(JsonObject.class).forEach((module) -> {
                     final String path = module.getString("Path");
                     String version = module.getString("Version", null);
                     if (version != null && version.startsWith("v")) {
                         version = version.substring(1);
                     }
                     goModDependencies.add(new GoModDependency(path, version));
-                }
+                });
             }
         } catch (JsonParsingException jsonpe) {
             throw new AnalysisException("Error parsing stream", jsonpe);

--- a/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
@@ -31,10 +31,12 @@ import javax.json.JsonReader;
 import javax.json.stream.JsonParsingException;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import javax.json.JsonReaderFactory;
 import javax.json.stream.JsonParserFactory;
+import org.apache.commons.io.IOUtils;
 import org.owasp.dependencycheck.utils.JsonArrayFixingInputStream;
 
 /**
@@ -64,6 +66,13 @@ public final class GoModJsonParser {
     public static List<GoModDependency> process(InputStream inputStream) throws AnalysisException {
         LOGGER.info("Beginning go.mod processing");
         //LOGGER.debug("Beginning go.mod processing");
+        try {
+            String text = IOUtils.toString(inputStream, StandardCharsets.UTF_8.name());
+            LOGGER.info("stream text: " + text);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+
         List<GoModDependency> goModDependencies = new ArrayList<>();
         try (JsonArrayFixingInputStream jsonStream = new JsonArrayFixingInputStream(inputStream)) {
             LOGGER.info("input streeam available: " + jsonStream.available());

--- a/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
@@ -62,12 +62,10 @@ public final class GoModJsonParser {
      * results of `go mod`
      */
     public static List<GoModDependency> process(InputStream inputStream) throws AnalysisException {
-        LOGGER.info("Beginning go.mod processing");
-        //LOGGER.debug("Beginning go.mod processing");
+        LOGGER.debug("Beginning go.mod processing");
 
         List<GoModDependency> goModDependencies = new ArrayList<>();
         try (JsonArrayFixingInputStream jsonStream = new JsonArrayFixingInputStream(inputStream)) {
-            LOGGER.info("input streeam available: " + jsonStream.available());
             JsonReaderFactory factory = Json.createReaderFactory(null);
             try (JsonReader reader = factory.createReader(jsonStream, java.nio.charset.StandardCharsets.UTF_8)) {
                 final JsonArray modules = reader.readArray();

--- a/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
@@ -33,6 +33,8 @@ import javax.json.stream.JsonParsingException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import javax.json.JsonReaderFactory;
+import javax.json.stream.JsonParserFactory;
 import org.owasp.dependencycheck.utils.JsonArrayFixingInputStream;
 
 /**
@@ -68,7 +70,8 @@ public final class GoModJsonParser {
 //            array = "[" + array.substring(0, array.length() - 1) + "]";
 //
 //            JsonReader reader = Json.createReader(new StringReader(array));
-            try (JsonReader reader = Json.createReader(jsonStream)) {
+            JsonReaderFactory factory = Json.createReaderFactory(null);
+            try (JsonReader reader = factory.createReader(jsonStream, java.nio.charset.StandardCharsets.UTF_8)) {
                 final JsonArray modules = reader.readArray();
                 for (JsonObject module : modules.getValuesAs(JsonObject.class)) {
                     final String path = module.getString("Path");

--- a/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
@@ -18,9 +18,9 @@
 package org.owasp.dependencycheck.data.golang;
 
 import java.io.IOException;
-import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.json.Json;
@@ -28,15 +28,13 @@ import javax.json.JsonArray;
 import javax.json.JsonException;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
+import javax.json.JsonReaderFactory;
 import javax.json.stream.JsonParsingException;
 
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import javax.json.JsonReaderFactory;
-import javax.json.stream.JsonParserFactory;
-import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.utils.JsonArrayFixingInputStream;
 
 /**
@@ -66,12 +64,6 @@ public final class GoModJsonParser {
     public static List<GoModDependency> process(InputStream inputStream) throws AnalysisException {
         LOGGER.info("Beginning go.mod processing");
         //LOGGER.debug("Beginning go.mod processing");
-        try {
-            String text = IOUtils.toString(inputStream, StandardCharsets.UTF_8.name());
-            LOGGER.info("stream text: " + text);
-        } catch (IOException ex) {
-            throw new RuntimeException(ex);
-        }
 
         List<GoModDependency> goModDependencies = new ArrayList<>();
         try (JsonArrayFixingInputStream jsonStream = new JsonArrayFixingInputStream(inputStream)) {


### PR DESCRIPTION
## Fixes Issue #2934

The code needs to read from the streams prior to calling `waitFor()` otherwise `go` may hang because the stream buffers are full and need to be read before it can output more data.