### PR TITLE
Add missing jackson-core dependency to dependency-check-utils module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -943,6 +943,11 @@ Copyright (c) 2012 - Jeremy Long
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
             </dependency>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -51,6 +51,10 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Fixes Issue #
https://github.com/jeremylong/DependencyCheck/issues/2947

## Description of Change
Added missing jackson-core dependency to dependency-check-utils module

## Have test cases been added to cover the new functionality?

*no*