### PR TITLE
Chown root group (0) for OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,11 @@ RUN apk update                                                                  
             "mysql-connector-java-${MYSQL_DRIVER_VERSION}/mysql-connector-java-${MYSQL_DRIVER_VERSION}.jar" && \
     addgroup -S ${user} && adduser -S -G ${user} ${user}                                             && \
     mkdir /usr/share/dependency-check/data                                                           && \
-    chown -R ${user}:${user} /usr/share/dependency-check                                             && \
+    chown -R ${user}:0 /usr/share/dependency-check                                                   && \
+    chmod -R g=u /usr/share/dependency-check                                                         && \
     mkdir /report                                                                                    && \
-    chown -R ${user}:${user} /report                                                                 && \
+    chown -R ${user}:0 /report                                                                       && \
+    chmod -R g=u /report                                                                             && \
     apk del .build-deps
 
 ### remove any suid sgid - we don't need them


### PR DESCRIPTION
## Fixes Issue #
#2949 

## Description of Change
As per https://docs.openshift.com/enterprise/3.2/creating_images/guidelines.html, to support Arbitrary User IDs. 

For an image to support running as an arbitrary user, directories and files that may be written to by processes in the image should be owned by the root group and be read/writable by that group. Files to be executed should also have group execute permissions.

Because the container user is always a member of the root group, the container user can read and write these files. The root group does not have any special permissions (unlike the root user) so there are no security concerns with this arrangement.

## Have test cases been added to cover the new functionality?

*no*