### PR TITLE
Fix NullPointerException in FileUtils

### DIFF
--- a/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.UUID;
 
 import org.jetbrains.annotations.NotNull;
@@ -180,9 +181,15 @@ public final class FileUtils {
      */
     public static File getResourceAsFile(final String resource) {
         final ClassLoader classLoader = FileUtils.class.getClassLoader();
-        final String path = classLoader != null
-                ? classLoader.getResource(resource).getFile()
-                : ClassLoader.getSystemResource(resource).getFile();
+        String path = null;
+        if (classLoader != null) {
+            URL url = classLoader.getResource(resource);
+            if (url != null) {
+                path = url.getFile();
+            }
+        } else {
+            path = ClassLoader.getSystemResource(resource).getFile();
+        }
 
         if (path == null) {
             return new File(resource);


### PR DESCRIPTION
## Fixes Issue #

Fixes problem with a NullPointerException.

Stacktrace is as following:
```
Exception in thread "main" java.lang.NullPointerException
	at org.owasp.dependencycheck.utils.FileUtils.getResourceAsFile(FileUtils.java:184)
	at org.owasp.dependencycheck.data.nvdcve.ConnectionFactory.updateSchema(ConnectionFactory.java:375)
	at org.owasp.dependencycheck.data.nvdcve.ConnectionFactory.ensureSchemaVersion(ConnectionFactory.java:445)
	at org.owasp.dependencycheck.data.nvdcve.ConnectionFactory.ensureSchemaVersion(ConnectionFactory.java:447)
	at org.owasp.dependencycheck.data.nvdcve.ConnectionFactory.initialize(ConnectionFactory.java:193)
	at org.owasp.dependencycheck.data.nvdcve.ConnectionFactory.getConnection(ConnectionFactory.java:234)
	at org.owasp.dependencycheck.data.nvdcve.CveDB.open(CveDB.java:269)
	at org.owasp.dependencycheck.data.nvdcve.CveDB.<init>(CveDB.java:239)
	at org.owasp.dependencycheck.Engine.openDatabase(Engine.java:969)
	at org.owasp.dependencycheck.Engine.doUpdates(Engine.java:845)
	at org.owasp.dependencycheck.Engine.initializeAndUpdateDatabase(Engine.java:662)
	at org.owasp.dependencycheck.Engine.analyzeDependencies(Engine.java:592)
	at org.owasp.dependencycheck.App.runScan(App.java:255)
	at org.owasp.dependencycheck.App.run(App.java:187)
	at org.owasp.dependencycheck.App.main(App.java:82)
```

## Description of Change

Fixes an access to a NullPointer that occurs after switching from DependencyCheck 5 to 6.
There's another null check necessary.

## Have test cases been added to cover the new functionality?

no