### PR TITLE
golang mod fix

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModDependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModDependency.java
@@ -19,6 +19,14 @@ package org.owasp.dependencycheck.data.golang;
 
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURLBuilder;
+import com.google.common.base.Strings;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
@@ -45,6 +53,11 @@ public class GoModDependency {
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(GoModDependency.class);
     /**
+     * A list of license files we recognize.
+     */
+    private static final Set<String> LICENSE_FILES = new HashSet<String>(Arrays.asList("LICENSE", "LICENCE", "LICENSE.TXT",
+            "LICENSE.MD", "LICENCE.MD", "LICENSE.CODE", "LICENCE.CODE", "COPYING"));
+    /**
      * The module path.
      */
     private final String modulePath;
@@ -52,22 +65,26 @@ public class GoModDependency {
      * The version.
      */
     private final String version;
-
     /**
      * A Package-URL builder.
      */
     private final PackageURLBuilder packageURLBuilder;
+    /**
+     * The module Dir.
+     */
+    private final String dir;
 
     /**
      * Constructs a new GoModDependency.
      *
      * @param modulePath the module path
      * @param version the dependency version
+     * @param dir the directory that the module exists within
      */
-    GoModDependency(String modulePath, String version) {
+    GoModDependency(String modulePath, String version, String dir) {
         this.modulePath = modulePath;
         this.version = version;
-
+        this.dir = dir;
         packageURLBuilder = PackageURLBuilder.aPackageURL().withType("golang");
     }
 
@@ -126,13 +143,10 @@ public class GoModDependency {
             dep.setPackagePath(String.format("%s:%s", name, version));
         }
         dep.setFilePath(filePath);
-        dep.setSha1sum(Checksum.getSHA1Checksum(filePath));
-        dep.setSha256sum(Checksum.getSHA256Checksum(filePath));
-        dep.setMd5sum(Checksum.getMD5Checksum(filePath));
 
         if (vendor != null) {
             dep.addEvidence(EvidenceType.VENDOR, GO_MOD, "vendor", vendor, Confidence.HIGHEST);
-            dep.addEvidence(EvidenceType.VENDOR, GO_MOD, "vendor", vendor, Confidence.MEDIUM);
+            dep.addEvidence(EvidenceType.PRODUCT, GO_MOD, "vendor", vendor, Confidence.MEDIUM);
         }
         if (namespace != null && !"golang.org".equals(namespace)) {
             dep.addEvidence(EvidenceType.VENDOR, GO_MOD, "namespace", namespace, Confidence.LOW);
@@ -155,7 +169,42 @@ public class GoModDependency {
             id = new GenericIdentifier(value.toString(), Confidence.HIGH);
         }
         dep.addSoftwareIdentifier(id);
+        if (StringUtils.isNotBlank(dir)) {
+            File file = new File(dir);
+            if (file.exists()) {
+                dep.setFilePath(file.getAbsolutePath());
+                dep.setActualFilePath(file.getAbsolutePath());
+                dep.setFileName(file.getName());
+                extractLicense(dep, file);
+            }
+        }
         return dep;
+    }
+
+    /**
+     * Extracts the content of the license file into the dependency's license
+     * field.
+     *
+     *
+     * @param dependency the dependency being analyzed
+     * @param file the license file
+     */
+    private void extractLicense(Dependency dependency, File file) {
+        File[] files = file.listFiles();
+        if (files != null) {
+            for (File f : files) {
+                if (LICENSE_FILES.contains(f.getName().toUpperCase())) {
+                    try {
+                        final String license = FileUtils.readFileToString(f, Charset.forName("UTF-8"));
+                        dependency.setLicense(license);
+                        break;
+                    } catch (IOException ex) {
+                        LOGGER.debug("Error reading license file `" + file.getAbsolutePath()
+                                + "`: " + ex.getMessage(), ex);
+                    }
+                }
+            }
+        }
     }
 
     @Override

--- a/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/golang/GoModJsonParser.java
@@ -75,7 +75,11 @@ public final class GoModJsonParser {
                     if (version != null && version.startsWith("v")) {
                         version = version.substring(1);
                     }
-                    goModDependencies.add(new GoModDependency(path, version));
+                    String dir = null;
+                    if (module.getJsonString("Dir") != null ) {
+                        dir = module.getString("Dir");
+                    }
+                    goModDependencies.add(new GoModDependency(path, version, dir));
                 });
             }
         } catch (JsonParsingException jsonpe) {

--- a/core/src/test/java/org/owasp/dependencycheck/data/golang/GoModJsonParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/golang/GoModJsonParserTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.*;
  * @author jeremy
  */
 public class GoModJsonParserTest {
-    
+
     String issue2891 = "{\n"
             + "	\"Path\": \"cloud.google.com/go\",\n"
             + "	\"Version\": \"v0.26.0\",\n"
@@ -765,6 +765,18 @@ public class GoModJsonParserTest {
             + "	\"Time\": \"2019-01-02T05:43:23Z\",\n"
             + "	\"Indirect\": true,\n"
             + "	\"GoMod\": \"/Users/me/go/pkg/mod/cache/download/honnef.co/go/tools/@v/v0.0.0-20190102054323-c2f93a96b099.mod\"\n"
+            + "}\n"
+            + "{\n"
+            + " \"Path\": \"github.com/Microsoft/hcsshim\",\n"
+            + " \"Version\": \"v0.8.7\",\n"
+            + " \"Replace\": {\n"
+            + " \"Path\": \"github.com/Microsoft/hcsshim\",\n"
+            + " \"Version\": \"v0.8.8-0.20200421182805-c3e488f0d815\",\n"
+            + " \"Time\": \"2020-04-21T18:28:05Z\",\n"
+            + " \"GoMod\": \"/Users/me/go/pkg/mod/cache/download/github.com/!microsoft/hcsshim/@v/v0.8.8-0.20200421182805-c3e488f0d815.mod\"\n"
+            + "},\n"
+            + "	\"Indirect\": true,\n"
+            + "\"GoMod\": \"/Users/me/go/pkg/mod/cache/download/github.com/!microsoft/hcsshim/@v/v0.8.8-0.20200421182805-c3e488f0d815.mod\"\n"
             + "}\n";
 
     /**
@@ -775,6 +787,6 @@ public class GoModJsonParserTest {
         InputStream inputStream = new ByteArrayInputStream(issue2891.getBytes());
         List<GoModDependency> expResult = null;
         List<GoModDependency> result = GoModJsonParser.process(inputStream);
-        assertEquals(95, result.size());
+        assertEquals(96, result.size());
     }
 }

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/JsonArrayFixingInputStreamTest.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/JsonArrayFixingInputStreamTest.java
@@ -92,6 +92,18 @@ public class JsonArrayFixingInputStreamTest {
             + "	\"Time\": \"2017-12-14T13:08:43Z\",\n"
             + "	\"Indirect\": true,\n"
             + "	\"GoMod\": \"/Users/jeremy/go/pkg/mod/cache/download/golang.org/x/text/@v/v0.3.0.mod\"\n"
+            + "}\n"
+            + "{\n"
+            + " \"Path\": \"github.com/Microsoft/hcsshim\",\n"
+            + " \"Version\": \"v0.8.7\",\n"
+            + " \"Replace\": {\n"
+            + " \"Path\": \"github.com/Microsoft/hcsshim\",\n"
+            + " \"Version\": \"v0.8.8-0.20200421182805-c3e488f0d815\",\n"
+            + " \"Time\": \"2020-04-21T18:28:05Z\",\n"
+            + " \"GoMod\": \"/Users/me/go/pkg/mod/cache/download/github.com/!microsoft/hcsshim/@v/v0.8.8-0.20200421182805-c3e488f0d815.mod\"\n"
+            + "},\n"
+            + "	\"Indirect\": true,\n"
+            + "\"GoMod\": \"/Users/me/go/pkg/mod/cache/download/github.com/!microsoft/hcsshim/@v/v0.8.8-0.20200421182805-c3e488f0d815.mod\"\n"
             + "}\n";
 
     @BeforeClass
@@ -189,7 +201,7 @@ public class JsonArrayFixingInputStreamTest {
                 JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             try (JsonReader reader = Json.createReader(instance)) {
                 final JsonArray modules = reader.readArray();
-                assertEquals(7, modules.size());
+                assertEquals(8, modules.size());
             }
         }
     }
@@ -283,6 +295,16 @@ public class JsonArrayFixingInputStreamTest {
             boolean result = instance.markSupported();
             assertFalse(result);
         }
+    }
+
+    @Test
+    public void testIsWhiteSpace() throws Exception {
+        JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(null);
+        assertFalse(instance.isWhiteSpace((byte)'a'));
+        assertTrue(instance.isWhiteSpace((byte)'\n'));
+        assertTrue(instance.isWhiteSpace((byte)'\t'));
+        assertTrue(instance.isWhiteSpace((byte)'\r'));
+        assertTrue(instance.isWhiteSpace((byte)' '));
     }
 
 }


### PR DESCRIPTION
## Fixes Issue #

-  Json parsing issues where I have `{ ` inside  the `go list -m -json`  result, eg: 

```
{         "Path": "github.com/Microsoft/hcsshim",
        "Version": "v0.8.7",
        "Replace": {
                "Path": "github.com/Microsoft/hcsshim",
                "Version": "v0.8.8-0.20200421182805-c3e488f0d815",
                "Time": "2020-04-21T18:28:05Z",
                "GoMod": "/xxxxxx/go/pkg/mod/cache/download/github.com/!microsoft/hcsshim/@v/v0.8.8-0.20200421182805-c3e488f0d815.mod"
        },         "Indirect": true,
        "GoMod": "/xxxxxx/pkg/mod/cache/download/github.com/!microsoft/hcsshim/@v/v0.8.8-0.20200421182805-c3e488f0d815.mod" }

``` 

- Add `declared-license` into the dependencies.

- Correct the `FilePath` , 'FileName`,'ActualFilePath` for the found go modules from the `Dir`

- Respect `analyzer.golang.path` in `dependencycheck.properties`  as 1st priority and backward to default if we have no such setting. 

.