### PR TITLE
3038 build failure with french locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ The dependency-check plugin can be configured using the following:
 
 For instructions on the use of the Ant Task, please see the [dependency-check-ant github page](http://jeremylong.github.io/DependencyCheck/dependency-check-ant).
 
+Development Prerequisites
+-------------
+
+For installation to pass, you must have the following components installed:
+* Go: `go version` 1.12 and higher
+* Java: `java --version` 1.8.0 and higher
+* Maven: `mvn --version` 3.5.0 and higher
+
 Development Usage
 -------------
 The following instructions outline how to compile and use the current snapshot. While every intention is to maintain a stable snapshot it is recommended

--- a/ant/src/test/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTaskIT.java
+++ b/ant/src/test/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTaskIT.java
@@ -103,7 +103,11 @@ public class DependencyCheckTaskIT extends BaseDBTestCase {
         Exception exception = Assert.assertThrows(BuildException.class, () -> {
             buildFileRule.executeTarget("failCVSS");
         });
-        Assert.assertTrue(exception.getMessage().contains("One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '3.0':"));
+
+        String expectedMessage = String.format("One or more dependencies were identified with vulnerabilities that " +
+                "have a CVSS score greater than or equal to '%.1f':", 3.0f);
+
+        Assert.assertTrue(exception.getMessage().contains(expectedMessage));
     }
 
     /**


### PR DESCRIPTION
## Fixes Issue #
Fixes #3038 

## Description of Change
This pull request adds development prerequisites for newcomers and make  `DependencyCheckTaskIT.testGetFailBuildOnCVSS()` locale independant.

Feel free to provide any comments on this code changes and I will provide changes accordingly.

## Have test cases been added to cover the new functionality?
There is no new functionality in this pull request. This is just a documentation and test improvement.