### PR TITLE
Fix False positive on java-cfenv-boot-pivotal-scs

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -2,6 +2,14 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress base="true">
         <notes><![CDATA[
+        FP per #3073
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.pivotal\.cfenv/java\-cfenv\-boot\-pivotal\-scs@.*$</packageUrl>
+        <cpe>cpe:/a:pivotal_software:spring_boot</cpe>
+        <cpe>cpe:/a:pivotal_software:spring_framework</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
         FP per #3053
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.seleniumhq\.selenium/selenium\-opera\-driver@.*$</packageUrl>


### PR DESCRIPTION
java-cfenv-boot-pivotal-scs is being identified as 
- spring_boot 
- spring_framework 

leading to an interesting number of false positive

## Fixes Issue #
#3073

## Description of Change

Added false positive on java-cfenv-pivotal-scs in dependencycheck-base-suppression.xml for the greater good!

## Have test cases been added to cover the new functionality?

*no* / cry in unit test