### PR TITLE
Fix "go list" to support vendor directory

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
@@ -205,7 +205,7 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
     }
 
     /**
-     * Launches `go list -json -m readonly all` in the given folder.
+     * Launches `go list -json -m -mod=readonly all` in the given folder.
      *
      * @param folder the working folder
      * @return a reference to the launched process
@@ -221,8 +221,7 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
         args.add("list");
         args.add("-json");
         args.add("-m");
-        args.add("-mod");
-        args.add("readonly");
+        args.add("-mod=readonly");
         args.add("all");
 
         final ProcessBuilder builder = new ProcessBuilder(args);
@@ -340,7 +339,7 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
             if (error != null) {
                 LOGGER.warn("Warnings from go {}", error);
                 if (error.contains("can't compute 'all' using the vendor directory")) {
-                    LOGGER.warn("Switching to `go list -json -m readonly`");
+                    LOGGER.warn("Switching to `go list -json -m -mod=readonly all`");
                     process.destroy();
                     analyzeDependency(dependency, engine, true);
                     return;


### PR DESCRIPTION
## Fixes Issue #
Argument passing for `go list` is broken in GolangModAnalyzer for vendor directories.

Without this patch :
```
[WARN] Warnings from go go list -m: can't compute 'all' using the vendor directory
	(Use -mod=mod or -mod=readonly to bypass.)

[WARN] Switching to `go list -json -m readonly`
[WARN] Warnings from go go list -m: module readonly: can't resolve module using the vendor directory
	(Use -mod=mod or -mod=readonly to bypass.)
```

Patched:
```
WARN] Warnings from go go list -m: can't compute 'all' using the vendor directory
	(Use -mod=mod or -mod=readonly to bypass.)

[WARN] Switching to `go list -json -m -mod=readonly all`
```
## Description of Change

The `readonly` is a parameter for `-mod` and not for the command-line.

## Have test cases been added to cover the new functionality?

*no*