### PR TITLE
Remove direct usage of guava

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -274,10 +274,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <artifactId>jackson-module-afterburner</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.h3xstream.retirejs</groupId>
             <artifactId>retirejs-core</artifactId>
         </dependency>

--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -17,7 +17,6 @@
  */
 package org.owasp.dependencycheck;
 
-import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.jcs.JCS;
@@ -52,6 +51,7 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -1220,7 +1220,7 @@ public class Engine implements FileFilter, AutoCloseable {
         /**
          * The analysis phases included in the mode.
          */
-        private final ImmutableList<AnalysisPhase> phases;
+        private final List<AnalysisPhase> phases;
 
         /**
          * Constructs a new mode.
@@ -1230,11 +1230,7 @@ public class Engine implements FileFilter, AutoCloseable {
          */
         Mode(boolean databaseRequired, AnalysisPhase... phases) {
             this.databaseRequired = databaseRequired;
-            //must use Guava 11.0.1 API as of 3/30/2019 due to Jenkins compatability issues
-            //this.phases = Arrays.stream(phases).collect(ImmutableList.toImmutableList());
-            this.phases = new ImmutableList.Builder<AnalysisPhase>()
-                    .add(phases)
-                    .build();
+            this.phases = Collections.unmodifiableList(Arrays.asList(phases));
         }
 
         /**
@@ -1251,7 +1247,7 @@ public class Engine implements FileFilter, AutoCloseable {
          *
          * @return the phases for this mode
          */
-        public ImmutableList<AnalysisPhase> getPhases() {
+        public List<AnalysisPhase> getPhases() {
             return phases;
         }
     }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
@@ -17,7 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import com.google.common.io.ByteStreams;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileFilter;
@@ -45,6 +44,7 @@ import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2Utils;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipUtils;
+import org.apache.commons.compress.utils.IOUtils;
 
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
@@ -580,7 +580,7 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
             throw new AnalysisException(msg);
         }
         try (FileOutputStream fos = new FileOutputStream(file)) {
-            ByteStreams.copy(input, fos);
+            IOUtils.copy(input, fos);
         } catch (FileNotFoundException ex) {
             LOGGER.debug("", ex);
             final String msg = String.format("Unable to find file '%s'.", file.getName());
@@ -603,7 +603,7 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
     private void decompressFile(CompressorInputStream inputStream, File outputFile) throws ArchiveExtractionException {
         LOGGER.debug("Decompressing '{}'", outputFile.getPath());
         try (FileOutputStream out = new FileOutputStream(outputFile)) {
-            ByteStreams.copy(inputStream, out);
+            IOUtils.copy(inputStream, out);
         } catch (IOException ex) {
             LOGGER.debug("", ex);
             throw new ArchiveExtractionException(ex);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
@@ -18,7 +18,6 @@
 package org.owasp.dependencycheck.analyzer;
 
 import com.github.packageurl.MalformedPackageURLException;
-import com.google.common.base.Strings;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -150,7 +149,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
                 processReader.readAll();
 
                 final String errorOutput = processReader.getError();
-                if (!Strings.isNullOrEmpty(errorOutput)) {
+                if (!StringUtils.isEmpty(errorOutput)) {
                     LOGGER.warn("Error from GrokAssembly: {}", errorOutput);
                 }
                 final int exitValue = proc.exitValue();
@@ -365,7 +364,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
             try (ProcessReader processReader = new ProcessReader(p)) {
                 processReader.readAll();
                 final String error = processReader.getError();
-                if (p.exitValue() != 1 || !Strings.isNullOrEmpty(error)) {
+                if (p.exitValue() != 1 || !StringUtils.isEmpty(error)) {
                     LOGGER.warn("An error occurred with the .NET AssemblyAnalyzer, please see the log for more details.");
                     LOGGER.debug("GrokAssembly.dll is not working properly");
                     grokAssembly = null;

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ElixirMixAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ElixirMixAuditAnalyzer.java
@@ -17,8 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.nvdcve.CveDB;
@@ -35,7 +33,9 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.owasp.dependencycheck.processing.MixAuditProcessor;
 import org.owasp.dependencycheck.utils.processing.ProcessReader;
 
@@ -105,7 +105,7 @@ public class ElixirMixAuditAnalyzer extends AbstractFileTypeAnalyzer {
         // `mix_audit --version` command and seeing whether or not it succeeds (if it returns with an exit value of 0)
         final Process process;
         try {
-            final List<String> mixAuditArgs = ImmutableList.of("--version");
+            final List<String> mixAuditArgs = Arrays.asList("--version");
             process = launchMixAudit(getSettings().getTempDirectory(), mixAuditArgs);
         } catch (AnalysisException ae) {
             setEnabled(false);
@@ -123,7 +123,7 @@ public class ElixirMixAuditAnalyzer extends AbstractFileTypeAnalyzer {
             exitValue = process.exitValue();
 
             if (exitValue != 0) {
-                if (Strings.isNullOrEmpty(processReader.getError())) {
+                if (StringUtils.isEmpty(processReader.getError())) {
                     LOGGER.warn("Unexpected exit value from mix_audit process and error stream unexpectedly not ready to capture error details. "
                             + "Disabling {}. Exit value was: {}", ANALYZER_NAME, exitValue);
                     setEnabled(false);
@@ -135,7 +135,7 @@ public class ElixirMixAuditAnalyzer extends AbstractFileTypeAnalyzer {
                     throw new InitializationException("Unexpected exit value from bundle-audit process.");
                 }
             } else {
-                if (Strings.isNullOrEmpty(processReader.getOutput())) {
+                if (StringUtils.isEmpty(processReader.getOutput())) {
                     LOGGER.warn("mix_audit input stream unexpectedly not ready to capture version details. Disabling {}", ANALYZER_NAME);
                     setEnabled(false);
                     throw new InitializationException("mix_audit input stream unexpectedly not ready to capture version details.");
@@ -246,7 +246,7 @@ public class ElixirMixAuditAnalyzer extends AbstractFileTypeAnalyzer {
     protected void analyzeDependency(Dependency dependency, Engine engine)
             throws AnalysisException {
         final File parentFile = dependency.getActualFile().getParentFile();
-        final List<String> mixAuditArgs = ImmutableList.of("--format", "json");
+        final List<String> mixAuditArgs = Arrays.asList("--format", "json");
 
         final Process process = launchMixAudit(parentFile, mixAuditArgs);
         final int exitValue;

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzer.java
@@ -17,7 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import com.google.common.base.Strings;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileFilter;
@@ -33,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.owasp.dependencycheck.data.nvd.ecosystem.Ecosystem;
 import org.owasp.dependencycheck.processing.GoModProcessor;
 import org.owasp.dependencycheck.utils.processing.ProcessReader;
@@ -272,13 +272,13 @@ public class GolangModAnalyzer extends AbstractFileTypeAnalyzer {
                         throw new InitializationException(String.format("Go executable not found. Disabling %s: %s", ANALYZER_NAME, exitValue));
                     case possiblyGoTooOldExitValue:
                         final String error = processReader.getError();
-                        if (Strings.isNullOrEmpty(error)) {
+                        if (!StringUtils.isEmpty(error)) {
+                            if (error.contains("unknown subcommand \"mod\"")) {
+                                LOGGER.warn("Your version of `go` does not support modules. Disabling {}. Error: `{}`", ANALYZER_NAME, error);
+                                throw new InitializationException("Go version does not support modules.");
+                            }
                             LOGGER.warn("An error occurred calling `go` - no output could be read. Disabling {}.", ANALYZER_NAME);
                             throw new InitializationException("Error calling `go` - no output could be read.");
-                        }
-                        if (error.contains("unknown subcommand \"mod\"")) {
-                            LOGGER.warn("Your version of `go` does not support modules. Disabling {}. Error: `{}`", ANALYZER_NAME, error);
-                            throw new InitializationException("Go version does not support modules.");
                         }
                     // fall through
                     default:

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -20,7 +20,6 @@ package org.owasp.dependencycheck.analyzer;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.github.packageurl.PackageURLBuilder;
-import com.google.common.io.ByteStreams;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileFilter;
@@ -54,6 +53,7 @@ import java.util.zip.ZipEntry;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.h2.util.IOUtils;
 import org.jsoup.Jsoup;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
@@ -559,7 +559,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
         }
         try (InputStream input = jar.getInputStream(entry);
                 FileOutputStream fos = new FileOutputStream(file)) {
-            ByteStreams.copy(input, fos);
+            IOUtils.copy(input, fos);
         } catch (IOException ex) {
             LOGGER.warn("An error occurred reading '{}' from '{}'.", path, jar.getName());
             LOGGER.error("", ex);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzer.java
@@ -20,7 +20,6 @@ package org.owasp.dependencycheck.analyzer;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.github.packageurl.PackageURLBuilder;
-import com.google.common.io.ByteStreams;
 import com.h3xstream.retirejs.repo.JsLibrary;
 import com.h3xstream.retirejs.repo.JsLibraryResult;
 import com.h3xstream.retirejs.repo.JsVulnerability;
@@ -64,6 +63,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.io.IOUtils;
 
 /**
  * The RetireJS analyzer uses the manually curated list of vulnerabilities from
@@ -276,7 +276,7 @@ public class RetireJsAnalyzer extends AbstractFileTypeAnalyzer {
     @Override
     public void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
         try (InputStream fis = new FileInputStream(dependency.getActualFile())) {
-            final byte[] fileContent = ByteStreams.toByteArray(fis);
+            final byte[] fileContent = IOUtils.toByteArray(fis);
             final ScannerFacade scanner = new ScannerFacade(jsRepository);
             final List<JsLibraryResult> results;
             try {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
@@ -17,12 +17,12 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -204,7 +204,7 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
         }
         String bundleAuditVersionDetails = null;
         try {
-            final List<String> bundleAuditArgs = ImmutableList.of("version");
+            final List<String> bundleAuditArgs = Arrays.asList("version");
             final Process process = launchBundleAudit(getSettings().getTempDirectory(), bundleAuditArgs);
             try (ProcessReader processReader = new ProcessReader(process)) {
                 processReader.readAll();
@@ -275,7 +275,7 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
             needToDisableGemspecAnalyzer = false;
         }
         final File parentFile = dependency.getActualFile().getParentFile();
-        final List<String> bundleAuditArgs = ImmutableList.of("check", "--verbose");
+        final List<String> bundleAuditArgs = Arrays.asList("check", "--verbose");
 
         final Process process = launchBundleAudit(parentFile, bundleAuditArgs);
         try (BundlerAuditProcessor processor = new BundlerAuditProcessor(dependency, engine);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzer.java
@@ -17,7 +17,6 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import com.google.common.base.Strings;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -36,6 +35,7 @@ import javax.json.JsonReader;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.analyzer.exception.SearchException;
@@ -189,7 +189,7 @@ public class YarnAuditAnalyzer extends AbstractNpmAnalyzer {
                 processReader.readAll();
                 final String errOutput = processReader.getError();
 
-                if (!Strings.isNullOrEmpty(errOutput) && !EXPECTED_ERROR.equals(errOutput)) {
+                if (!StringUtils.isEmpty(errOutput) && !EXPECTED_ERROR.equals(errOutput)) {
                     LOGGER.debug("Process Error Out: {}", errOutput);
                     LOGGER.debug("Process Out: {}", processReader.getOutput());
                 }

--- a/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearch.java
@@ -46,7 +46,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.google.common.base.Objects;
 
 /**
  * Class of methods to search Artifactory for hashes and determine Maven GAV
@@ -253,7 +252,7 @@ public class ArtifactorySearch {
             }
 
             if (nextToken.isStructStart()) {
-                if (nextToken == com.fasterxml.jackson.core.JsonToken.START_ARRAY && Objects.equal("results", parser.currentName())) {
+                if (nextToken == com.fasterxml.jackson.core.JsonToken.START_ARRAY && "results".equals(parser.currentName())) {
                     return true;
                 } else {
                     parser.skipChildren();

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/ConnectionFactory.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/ConnectionFactory.java
@@ -17,11 +17,9 @@
  */
 package org.owasp.dependencycheck.data.nvdcve;
 
-import com.google.common.io.Resources;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.sql.PreparedStatement;
 import java.sql.Connection;
@@ -342,10 +340,10 @@ public final class ConnectionFactory {
     private String getResource(String resource) throws IOException {
         String dbStructure;
         try {
-            final URL url = Resources.getResource(resource);
-            dbStructure = Resources.toString(url, StandardCharsets.UTF_8);
-        } catch (IllegalArgumentException ex) {
-            LOGGER.debug("Resources.getResource(String) failed to find the DB Structure Resource", ex);
+            LOGGER.debug("Attempting to find " + resource);
+            dbStructure = IOUtils.resourceToString(resource, StandardCharsets.UTF_8);
+        } catch (IOException ex) {
+            LOGGER.debug("IOUtils.resourceToString(String) failed to find the DB Structure Resource", ex);
             try (InputStream is = FileUtils.getResourceAsStream(resource)) {
                 dbStructure = IOUtils.toString(is, StandardCharsets.UTF_8);
             }

--- a/core/src/main/java/org/owasp/dependencycheck/data/ossindex/ODCConnectionTransport.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/ossindex/ODCConnectionTransport.java
@@ -17,8 +17,6 @@
  */
 package org.owasp.dependencycheck.data.ossindex;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -37,6 +35,10 @@ import org.sonatype.ossindex.service.client.transport.UserAgentSupplier;
  */
 public class ODCConnectionTransport extends HttpUrlConnectionTransport {
 
+    /**
+     * The authorization header.
+     */
+    private static final String AUTHORIZATION = "Authorization";
     /**
      * The OSS Index client configuration.
      */
@@ -59,8 +61,8 @@ public class ODCConnectionTransport extends HttpUrlConnectionTransport {
      */
     public ODCConnectionTransport(Settings settings, OssindexClientConfiguration config, UserAgentSupplier userAgent) {
         super(userAgent);
-        this.userAgent = checkNotNull(userAgent);
-        this.configuration = checkNotNull(config);
+        this.userAgent = userAgent;
+        this.configuration = config;
         connectionFactory = new URLConnectionFactory(settings);
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/EngineVersionCheck.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/EngineVersionCheck.java
@@ -17,13 +17,13 @@
  */
 package org.owasp.dependencycheck.data.update;
 
-import com.google.common.io.ByteStreams;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.concurrent.ThreadSafe;
+import org.apache.commons.io.IOUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.data.nvdcve.CveDB;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
@@ -217,7 +217,7 @@ public class EngineVersionCheck implements CachedWebDataSource {
             if (conn.getResponseCode() != 200) {
                 return null;
             }
-            final String releaseVersion = new String(ByteStreams.toByteArray(conn.getInputStream()), StandardCharsets.UTF_8);
+            final String releaseVersion = new String(IOUtils.toByteArray(conn.getInputStream()), StandardCharsets.UTF_8);
             return releaseVersion.trim();
         } catch (MalformedURLException ex) {
             LOGGER.debug("Unable to retrieve current release version of dependency-check - malformed url?");

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/cpe/CpeEcosystemCache.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/cpe/CpeEcosystemCache.java
@@ -17,9 +17,9 @@
  */
 package org.owasp.dependencycheck.data.update.cpe;
 
-import com.google.common.base.Strings;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 import org.owasp.dependencycheck.data.update.nvd.NvdCveParser;
 import org.owasp.dependencycheck.utils.Pair;
 import org.slf4j.Logger;
@@ -69,7 +69,7 @@ public final class CpeEcosystemCache {
         final String current = cache.get(key);
         String result = null;
         if (current == null) {
-            if (!Strings.isNullOrEmpty(identifiedEcosystem)) {
+            if (!StringUtils.isEmpty(identifiedEcosystem)) {
                 cache.put(key, identifiedEcosystem);
                 changed.put(key, identifiedEcosystem);
                 result = identifiedEcosystem;

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -19,7 +19,6 @@ package org.owasp.dependencycheck.dependency;
 
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
-import com.google.common.base.Strings;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
@@ -39,6 +38,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import org.apache.commons.lang3.StringUtils;
 
 import org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException;
 import org.owasp.dependencycheck.dependency.naming.CpeIdentifier;
@@ -542,9 +542,8 @@ public class Dependency extends EvidenceCollection implements Serializable {
                 }
             }
         }
-        if (!found && !Strings.isNullOrEmpty(mavenArtifact.getGroupId())
-                && !Strings.isNullOrEmpty(mavenArtifact.getArtifactId())
-                && !Strings.isNullOrEmpty(mavenArtifact.getVersion())) {
+        if (!found && !StringUtils.isAnyEmpty(mavenArtifact.getGroupId(),
+                mavenArtifact.getArtifactId(), mavenArtifact.getVersion())) {
             try {
                 LOGGER.debug("Adding new maven identifier {}", mavenArtifact);
                 final PackageURL p = new PackageURL("maven", mavenArtifact.getGroupId(),

--- a/core/src/main/java/org/owasp/dependencycheck/utils/ExtractionUtil.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/ExtractionUtil.java
@@ -17,7 +17,6 @@
  */
 package org.owasp.dependencycheck.utils;
 
-import com.google.common.io.ByteStreams;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -34,6 +33,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+import org.apache.commons.io.IOUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.analyzer.exception.ArchiveExtractionException;
@@ -120,7 +120,7 @@ public final class ExtractionUtil {
                             throw new ExtractionException(msg);
                         }
                         try (FileOutputStream fos = new FileOutputStream(file)) {
-                            ByteStreams.copy(zis, fos);
+                            IOUtils.copy(zis, fos);
                         } catch (FileNotFoundException ex) {
                             LOGGER.debug("", ex);
                             final String msg = String.format("Unable to find file '%s'.", file.getName());
@@ -181,7 +181,7 @@ public final class ExtractionUtil {
                         throw new ExtractionException("Archive contains a file that would be extracted outside of the target directory.");
                     }
                     try (FileOutputStream fos = new FileOutputStream(file)) {
-                        ByteStreams.copy(zis, fos);
+                        IOUtils.copy(zis, fos);
                     } catch (FileNotFoundException ex) {
                         LOGGER.debug("", ex);
                         final String msg = String.format("Unable to find file '%s'.", file.getName());
@@ -294,7 +294,7 @@ public final class ExtractionUtil {
                 createParentFile(file);
 
                 try (FileOutputStream fos = new FileOutputStream(file)) {
-                    ByteStreams.copy(input, fos);
+                    IOUtils.copy(input, fos);
                 } catch (FileNotFoundException ex) {
                     LOGGER.debug("", ex);
                     final String msg = String.format("Unable to find file '%s'.", file.getName());
@@ -348,7 +348,7 @@ public final class ExtractionUtil {
         try (FileInputStream fis = new FileInputStream(gzip);
                 GZIPInputStream cin = new GZIPInputStream(fis);
                 FileOutputStream out = new FileOutputStream(newFile)) {
-            ByteStreams.copy(cin, out);
+            IOUtils.copy(cin, out);
         } finally {
             if (gzip.isFile() && !org.apache.commons.io.FileUtils.deleteQuietly(gzip)) {
                 LOGGER.debug("Failed to delete temporary file when extracting 'gz' {}", gzip.toString());
@@ -380,7 +380,7 @@ public final class ExtractionUtil {
                 ZipInputStream cin = new ZipInputStream(fis);
                 FileOutputStream out = new FileOutputStream(newFile)) {
             cin.getNextEntry();
-            ByteStreams.copy(cin, out);
+            IOUtils.copy(cin, out);
         } finally {
             if (zip.isFile() && !org.apache.commons.io.FileUtils.deleteQuietly(zip)) {
                 LOGGER.debug("Failed to delete temporary file when extracting 'zip' {}", zip.toString());

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,6 @@ Copyright (c) 2012 - Jeremy Long
         <groovy-all.version>2.4.21</groovy-all.version>
         <gmavenplus-plugin.version>1.12.1</gmavenplus-plugin.version>
         <com.h3xstream.retirejs.core.version>3.0.2</com.h3xstream.retirejs.core.version>
-        <com.google.guava.version>30.1-jre</com.google.guava.version>
         
         <!--necassary for some IDEs to be able to execute test cases (Netbeans)-->
         <surefireArgLine />
@@ -1045,9 +1044,9 @@ Copyright (c) 2012 - Jeremy Long
                 <version>${apache.lucene.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${com.google.guava.version}</version>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.15</version>
             </dependency>
             <dependency>
                 <groupId>com.h3xstream.retirejs</groupId>

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
@@ -157,10 +157,12 @@ public final class FileUtils {
      */
     @Nullable
     public static InputStream getResourceAsStream(@NotNull String resource) {
-        final ClassLoader classLoader = FileUtils.class.getClassLoader();
-        final InputStream inputStream = classLoader != null
-                ? classLoader.getResourceAsStream(resource)
-                : ClassLoader.getSystemResourceAsStream(resource);
+        final InputStream inputStream = Thread.currentThread()
+                .getContextClassLoader().getResourceAsStream(resource);
+//        final ClassLoader classLoader = FileUtils.class.getClassLoader();
+//        final InputStream inputStream = classLoader != null
+//                ? classLoader.getResourceAsStream(resource)
+//                : ClassLoader.getSystemResourceAsStream(resource);
 
         if (inputStream == null) {
             try {


### PR DESCRIPTION
Partial fix for #3010

In most cases where ODC used guava an existing apache commons equivalent was already included. Guava is still a transitive dependency - but we have limited its usage greatly.