### PR TITLE
add npm aliases support (#3097)

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
@@ -280,14 +280,6 @@ public class NodePackageAnalyzer extends AbstractNpmAnalyzer {
      * @return should you skip this dependency ?
      */
     public static boolean shouldSkipDependency(String name, String version, boolean optional, boolean fileExist) {
-        // some package manager can handle alias, yarn for example, but npm doesn't support it
-        if (version.startsWith("npm:")) {
-            //TODO make this an error that gets logged
-            LOGGER.warn("dependency skipped: package.json contain an alias for {} => {} npm audit doesn't "
-                    + "support aliases", name, version.replace("npm:", ""));
-            return true;
-        }
-
         if (optional && !fileExist) {
             LOGGER.warn("dependency skipped: node module {} seems optional and not installed", name);
             return true;

--- a/core/src/test/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilderTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilderTest.java
@@ -110,8 +110,10 @@ public class NpmPayloadBuilderTest {
         Assert.assertTrue(requires.containsKey("abbrev"));
         Assert.assertEquals("^1.1.1", requires.getString("abbrev"));
 
-        //local and alias need to be skipped
-        Assert.assertFalse(requires.containsKey("react-dom"));
+        //alias is not skipped
+        Assert.assertTrue(requires.containsKey("react-dom"));
+
+        //local need to be skipped
         Assert.assertFalse(requires.containsKey("fake_submodule"));
 
         Assert.assertFalse(sanitized.containsKey("lockfileVersion"));
@@ -169,8 +171,10 @@ public class NpmPayloadBuilderTest {
             Assert.assertTrue(sanitized.containsKey("dependencies"));
             Assert.assertTrue(sanitized.containsKey("requires"));
 
-            //local and alias need to be skipped
-            Assert.assertFalse(requires.containsKey("react-dom"));
+            // Alias is not skipped
+            Assert.assertTrue(requires.containsKey("react-dom"));
+
+            //local need to be skipped
             Assert.assertFalse(requires.containsKey("fake_submodule"));
         }
     }


### PR DESCRIPTION
## Fixes Issue #

#3097

## Description of Change

npm and npm audit support dependency aliases since npm 6.9.0, so those dependencies should not be ignored.

## Have test cases been added to cover the new functionality?

*no* (Not a new functionality)