### PR TITLE
Updating Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ FROM mcr.microsoft.com/dotnet/core/runtime:3.1-alpine
 ARG VERSION
 ARG POSTGRES_DRIVER_VERSION=42.2.6
 ARG MYSQL_DRIVER_VERSION=8.0.17
+ARG UID=1000
+ARG GID=1000
 
 ENV user=dependencycheck
 ENV JAVA_HOME=/opt/jdk
@@ -31,7 +33,7 @@ RUN apk update                                                                  
     curl -Ls "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-${MYSQL_DRIVER_VERSION}.tar.gz" \
         | tar -xz --directory "/usr/share/dependency-check/plugins" --strip-components=1 --no-same-owner \
             "mysql-connector-java-${MYSQL_DRIVER_VERSION}/mysql-connector-java-${MYSQL_DRIVER_VERSION}.jar" && \
-    addgroup -S ${user} && adduser -S -G ${user} ${user}                                             && \
+    addgroup -S -g ${GID} ${user} && adduser -S -D -u ${UID} -G ${user} ${user}                      && \
     mkdir /usr/share/dependency-check/data                                                           && \
     chown -R ${user}:0 /usr/share/dependency-check                                                   && \
     chmod -R g=u /usr/share/dependency-check                                                         && \
@@ -42,7 +44,7 @@ RUN apk update                                                                  
 
 ### remove any suid sgid - we don't need them
 RUN find / -perm +6000 -type f -exec chmod a-s {} \;
-USER ${user}
+USER ${UID}
 
 VOLUME ["/src", "/report"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM golang:1.14-alpine AS go
 
-FROM azul/zulu-openjdk-alpine:14 AS jlink
+FROM azul/zulu-openjdk-alpine:15 AS jlink
 
 RUN "$JAVA_HOME/bin/jlink" --compress=2 --module-path /opt/java/openjdk/jmods --add-modules java.base,java.compiler,java.datatransfer,jdk.crypto.ec,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.scripting,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.unsupported --output /jlinked
 
-FROM mcr.microsoft.com/dotnet/core/runtime:3.1-alpine
+FROM mcr.microsoft.com/dotnet/runtime:3.1-alpine
 
 ARG VERSION
 ARG POSTGRES_DRIVER_VERSION=42.2.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM azul/zulu-openjdk-alpine:15 AS jlink
 
 RUN "$JAVA_HOME/bin/jlink" --compress=2 --module-path /opt/java/openjdk/jmods --add-modules java.base,java.compiler,java.datatransfer,jdk.crypto.ec,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.scripting,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.unsupported --output /jlinked
 
-FROM mcr.microsoft.com/dotnet/runtime:3.1-alpine
+FROM mcr.microsoft.com/dotnet/runtime:5.0-alpine3.12
 
 ARG VERSION
 ARG POSTGRES_DRIVER_VERSION=42.2.6


### PR DESCRIPTION
## Fixes Issue #
CVE-2021-23839
CVE-2021-23840
CVE-2021-23841
CVE-2021-22883
CVE-2021-22884
## Description of Change ##

Updated Dockerfiles to be the latest version as they are vulnerable.

`mcr.microsoft.com/dotnet/core/runtime:3.1-alpine` has had its repo name changed see - [#issue-739991219](https://github.com/dotnet/dotnet-docker/issues/2375#issue-739991219)

I have updated`3.1-alpine` to be `5.0-alpine3.12` as they both continue to use `Alpine 3.12` as their [OS](https://hub.docker.com/_/microsoft-dotnet-runtime).


## Have test cases been added to cover the new functionality?

no