### PR TITLE
Matching Strategy - Product Names & Major Version Numbers

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -39,7 +39,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.map.AbstractReferenceMap.HARD;
 import static org.apache.commons.collections.map.AbstractReferenceMap.SOFT;
-import org.apache.commons.lang3.StringUtils;
 import org.owasp.dependencycheck.analyzer.exception.LambdaExceptionWrapper;
 import org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException;
 import org.owasp.dependencycheck.data.nvd.json.BaseMetricV2;
@@ -129,7 +128,6 @@ public final class CveDB implements AutoCloseable {
      */
     private boolean isOracle = false;
 
-
     /**
      * The enumeration value names must match the keys of the statements in the
      * statement bundles "dbStatements*.properties".
@@ -203,10 +201,6 @@ public final class CveDB implements AutoCloseable {
          * Key for SQL Statement.
          */
         SELECT_VENDOR_PRODUCT_LIST,
-        /**
-         * Key for SQL Statement.
-         */
-        SELECT_SIMPLE_CPE_SEARCH,
         /**
          * Key for SQL Statement.
          */
@@ -510,49 +504,6 @@ public final class CveDB implements AutoCloseable {
         return cpe;
     }
 
-    
-    public synchronized Set<Pair<String,String>> simpleCPESearch(String vendor, String product, String majorVersion) {
-        final Set<Pair<String, String>> data = new HashSet<>();
-        ResultSet rs = null;
-        try {
-            final PreparedStatement ps = getPreparedStatement(SELECT_SIMPLE_CPE_SEARCH);
-            if (ps == null) {
-                throw new SQLException("Database query does not exist in the resource bundle: " + SELECT_VENDOR_PRODUCT_LIST);
-            }
-             String vendorSearch = vendor.replace("-","_");
-            if (StringUtils.countMatches(vendorSearch, '.')>1) {
-                String[] parts = vendorSearch.split("\\.");
-                if ("org".equals(parts[0]) || "com".equals(parts[0])) {
-                    vendorSearch = parts[1];
-                }
-            }
-            final String productSearch = product.replace("-","_");
-            
-            ps.setString(1, vendorSearch);
-            ps.setString(2, productSearch);
-            
-            ps.setString(3, vendorSearch + "_project");
-            ps.setString(4, productSearch);
-            
-            ps.setString(5, vendorSearch);
-            ps.setString(6, productSearch + majorVersion);
-            
-            ps.setString(7, vendorSearch + "_project");
-            ps.setString(8, productSearch + majorVersion);
-            
-            rs = ps.executeQuery();
-            while (rs.next()) {
-                data.add(new Pair<>(rs.getString(1), rs.getString(2)));
-            }
-        } catch (SQLException ex) {
-            final String msg = "An unexpected SQL Exception occurred; please see the verbose log for more details.";
-            throw new DatabaseException(msg, ex);
-        } finally {
-            DBUtils.closeResultSet(rs);
-        }
-        return data;
-    }
-    
     /**
      * Returns the entire list of vendor/product combinations.
      *

--- a/core/src/main/resources/data/dbStatements.properties
+++ b/core/src/main/resources/data/dbStatements.properties
@@ -41,7 +41,6 @@ DELETE_PROPERTY=DELETE FROM properties WHERE id = ?
 UPDATE_ECOSYSTEM=UPDATE cpeEntry e SET e.ecosystem=(SELECT cpeEcosystemCache.ecosystem FROM cpeEcosystemCache WHERE cpeEcosystemCache.vendor=e.vendor AND cpeEcosystemCache.product=e.product AND e.ecosystem IS NULL AND cpeEcosystemCache.ecosystem<>'MULTIPLE') WHERE e.ecosystem IS NULL;
 UPDATE_ECOSYSTEM2=UPDATE cpeEntry e SET e.ecosystem=null WHERE e.ecosystem IS NOT NULL AND EXISTS(SELECT * FROM cpeEcosystemCache WHERE cpeEcosystemCache.vendor=e.vendor AND cpeEcosystemCache.product=e.product AND cpeEcosystemCache.ecosystem='MULTIPLE');
 
-SELECT_SIMPLE_CPE_SEARCH=SELECT DISTINCT VENDOR, PRODUCT FROM CPEENTRY WHERE PART='a' AND ((REPLACE(VENDOR,'-','_')=? AND REPLACE(PRODUCT,'-','_')=?) OR (REPLACE(VENDOR,'-','_')=? AND REPLACE(PRODUCT,'-','_')=?) OR (REPLACE(VENDOR,'-','_')=? AND REPLACE(PRODUCT,'-','_')=?) OR (REPLACE(VENDOR,'-','_')=? AND REPLACE(PRODUCT,'-','_')=?))
 #the following two statements are unused and are only referenced in dead code
 #DELETE_UNUSED_DICT_CPE=DELETE FROM cpeEntry WHERE dictionaryEntry=true AND id NOT IN (SELECT cpeEntryId FROM software)
 #ADD_DICT_CPE=MERGE INTO cpeEntry (cpe, vendor, product, dictionaryEntry) KEY(cpe) VALUES(?,?,?,true)


### PR DESCRIPTION
## Fixes Issue #3193 and #3183

With 6.1.2 a new matching strategy was introduced that slowed down dependency-check. This PR removes the original implementation and improves the existing matching strategy to account for the fact that CPE product names may include the major version number.