### PR TITLE
Reduce dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -262,10 +262,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <artifactId>jsoup</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>mailapi</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
@@ -28,6 +28,7 @@ import java.io.FileNotFoundException;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Properties;
 import org.apache.commons.io.filefilter.NameFileFilter;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
 import org.apache.commons.lang3.StringUtils;
@@ -38,8 +39,6 @@ import org.owasp.dependencycheck.dependency.Dependency;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.mail.MessagingException;
-import javax.mail.internet.InternetHeaders;
 import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.ExtractionException;
 import org.owasp.dependencycheck.utils.ExtractionUtil;
@@ -291,7 +290,7 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
      * @param file a reference to the manifest/properties file
      */
     private static void collectWheelMetadata(Dependency dependency, File file) {
-        final InternetHeaders headers = getManifestProperties(file);
+        final Properties headers = getManifestProperties(file);
         final String version = addPropertyToEvidence(dependency, EvidenceType.VERSION, Confidence.HIGHEST, headers, "Version");
         final String name = addPropertyToEvidence(dependency, EvidenceType.VENDOR, Confidence.HIGHEST, headers, "Name");
         addPropertyToEvidence(dependency, EvidenceType.PRODUCT, Confidence.HIGHEST, headers, "Name");
@@ -301,14 +300,14 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
         dependency.setVersion(version);
         dependency.setPackagePath(packagePath);
         dependency.setDisplayFileName(packagePath);
-        final String url = headers.getHeader("Home-page", null);
+        final String url = headers.getProperty("Home-page", null);
         if (StringUtils.isNotBlank(url)) {
             if (UrlStringUtils.isUrl(url)) {
                 dependency.addEvidence(EvidenceType.VENDOR, METADATA, "vendor", url, Confidence.MEDIUM);
             }
         }
         addPropertyToEvidence(dependency, EvidenceType.VENDOR, Confidence.LOW, headers, "Author");
-        final String summary = headers.getHeader("Summary", null);
+        final String summary = headers.getProperty("Summary", null);
         if (StringUtils.isNotBlank(summary)) {
             JarAnalyzer.addDescription(dependency, summary, METADATA, "summary");
         }
@@ -336,8 +335,8 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
      * <code>null</code>
      */
     private static String addPropertyToEvidence(Dependency dependency, EvidenceType type, Confidence confidence,
-            InternetHeaders headers, String property) {
-        final String value = headers.getHeader(property, null);
+            Properties headers, String property) {
+        final String value = headers.getProperty(property, null);
         LOGGER.debug("Property: {}, Value: {}", property, value);
         if (StringUtils.isNotBlank(value)) {
             dependency.addEvidence(type, METADATA, property, value, confidence);
@@ -368,20 +367,20 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
      * @param manifest the manifest
      * @return the manifest entries
      */
-    private static InternetHeaders getManifestProperties(File manifest) {
-        final InternetHeaders result = new InternetHeaders();
+    private static Properties getManifestProperties(File manifest) {
+        Properties prop = new Properties();
         if (null == manifest) {
             LOGGER.debug("Manifest file not found.");
         } else {
             try (InputStream in = new BufferedInputStream(new FileInputStream(manifest))) {
-                result.load(in);
-            } catch (MessagingException | FileNotFoundException e) {
+                prop.load(in);
+            } catch (FileNotFoundException e) {
                 LOGGER.warn(e.getMessage(), e);
             } catch (IOException ex) {
                 LOGGER.warn(ex.getMessage(), ex);
             }
         }
-        return result;
+        return prop;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,6 @@ Copyright (c) 2012 - Jeremy Long
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-text.version>1.9</commons-text.version>
         <commons-jcs-core.version>2.2.1</commons-jcs-core.version>
-        <com.sun.mail.mailapi.version>1.6.5</com.sun.mail.mailapi.version>
         <aho-corasick-double-array-trie.version>1.2.2</aho-corasick-double-array-trie.version>
         <junit.version>4.13.2</junit.version>
         <hamcrest-core.version>2.2</hamcrest-core.version>
@@ -986,11 +985,6 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
                 <version>${commons-text.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.mail</groupId>
-                <artifactId>mailapi</artifactId>
-                <version>${com.sun.mail.mailapi.version}</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1158,7 +1158,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>[24.1.1,)</version>
+                <version>24.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.hankcs</groupId>


### PR DESCRIPTION
The use of `InternetHeaders` from the mailApi can be replaced with the standard Java properties file api.