### PR TITLE
Remove Direct Usage of Guava

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ core/src/test/resources/nodejs/**/.gitattributes
 core/src/test/resources/nodejs/**/*.cmd
 core/src/test/resources/nodejs/**/*.jshintrc
 core/src/test/resources/nodejs/**/.travis.yml
+/cli/target/
+/ant/target/
+/maven/target/
+/archetype/target/

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -278,10 +278,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <artifactId>ossindex-service-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.moandjiezana.toml</groupId>
             <artifactId>toml4j</artifactId>
             <version>0.7.2</version>

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/ConnectionFactory.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/ConnectionFactory.java
@@ -17,12 +17,8 @@
  */
 package org.owasp.dependencycheck.data.nvdcve;
 
-import com.google.common.io.Resources;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.sql.PreparedStatement;
 import java.sql.Connection;
 import java.sql.Driver;
@@ -32,7 +28,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import javax.annotation.concurrent.ThreadSafe;
 import org.anarres.jdiagnostics.DefaultQuery;
-import org.apache.commons.io.IOUtils;
 import org.owasp.dependencycheck.utils.DBUtils;
 import org.owasp.dependencycheck.utils.DependencyVersion;
 import org.owasp.dependencycheck.utils.DependencyVersionUtil;
@@ -320,7 +315,7 @@ public final class ConnectionFactory {
         LOGGER.debug("Creating database structure");
         final String dbStructure;
         try {
-            dbStructure = getResource(DB_STRUCTURE_RESOURCE);
+            dbStructure = FileUtils.getResource(DB_STRUCTURE_RESOURCE);
 
             Statement statement = null;
             try {
@@ -337,20 +332,6 @@ public final class ConnectionFactory {
         } catch (LinkageError ex) {
             LOGGER.debug(new DefaultQuery(ex).call().toString());
         }
-    }
-
-    private String getResource(String resource) throws IOException {
-        String dbStructure;
-        try {
-            final URL url = Resources.getResource(resource);
-            dbStructure = Resources.toString(url, StandardCharsets.UTF_8);
-        } catch (IllegalArgumentException ex) {
-            LOGGER.debug("Resources.getResource(String) failed to find the DB Structure Resource", ex);
-            try (InputStream is = FileUtils.getResourceAsStream(resource)) {
-                dbStructure = IOUtils.toString(is, StandardCharsets.UTF_8);
-            }
-        }
-        return dbStructure;
     }
 
     /**
@@ -377,7 +358,7 @@ public final class ConnectionFactory {
                         + "purge command to remove the existing database");
             }
             try {
-                final String dbStructureUpdate = getResource(updateFile);
+                final String dbStructureUpdate = FileUtils.getResource(updateFile);
                 Statement statement = null;
                 try {
                     statement = conn.createStatement();

--- a/pom.xml
+++ b/pom.xml
@@ -743,6 +743,7 @@ Copyright (c) 2012 - Jeremy Long
                     <failOnError>false</failOnError>
                     <bottom>Copyright© 2012-19 Jeremy Long. All Rights Reserved.</bottom>
                     <excludes>**/generated-sources/java/**/*.java</excludes>
+                    <source>8</source>
                 </configuration>
                 <reportSets>
                     <reportSet>
@@ -1148,11 +1149,6 @@ Copyright (c) 2012 - Jeremy Long
                         <artifactId>httpcore</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>24.1.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.hankcs</groupId>

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Checksum.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Checksum.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.codec.digest.MessageDigestAlgorithms;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
When we first removed guava - we ran into issues with the Ant plugin loading resources as the method within Guava was able to identify the resources when the other method used was not. This PR enhances the other mechanism to retrieve the resources and removes the direct usage of guava.