### PR TITLE
Add suppressions for io.awspring, ref #3241

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-   <suppress>
+   <suppress base="true">
         <notes><![CDATA[
 	    FP per #3241
 	    ]]></notes>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+   <suppress>
+        <notes><![CDATA[
+	    FP per #3241
+	    ]]></notes>
+        <gav regex="true">^io\.awspring\.cloud:spring-cloud-.*$</gav>
+        <cpe>cpe:/a:pivotal_software:spring_framework</cpe>
+        <cpe>cpe:/a:pivotal_software:spring_framework</cpe>
+        <cpe>cpe:/a:context_project:context</cpe>
+   </suppress>
    <suppress base="true">
         <notes><![CDATA[
         FP per #3230


### PR DESCRIPTION
## Fixes Issue #3241

## Description of Change

Suppress false positives on the io.awspring libraries, since they were moved from org.springframework.

Similar to the existing suppression for org.springframework [here](https://github.com/jeremylong/DependencyCheck/blob/df6384c30c832e1149555e68b8615e5c00f9d528/core/src/main/resources/dependencycheck-base-suppression.xml#L2446-L2454), this covers those libraries that have now been moved into a new package, io.awspring

## Have test cases been added to cover the new functionality?

No