### PR TITLE
#3068 False positive on spring-session-hazelcast

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4271,4 +4271,12 @@
         <packageUrl regex="true">^pkg:maven/org\.mybatis\.spring\.boot/mybatis\-spring\-boot.*$</packageUrl>
         <cpe>cpe:/a:mybatis:mybatis</cpe>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        false positive per #3068 on spring-session-hazelcast
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.session/spring\-session\-hazelcast@.*$</packageUrl>
+        <cpe>cpe:/a:hazelcast:hazelcast</cpe>
+        <cpe>cpe:/a:pivotal_software:spring_security</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4271,7 +4271,7 @@
         <packageUrl regex="true">^pkg:maven/org\.mybatis\.spring\.boot/mybatis\-spring\-boot.*$</packageUrl>
         <cpe>cpe:/a:mybatis:mybatis</cpe>
     </suppress>
-    <suppress>
+    <suppress base="true">
         <notes><![CDATA[
         false positive per #3068 on spring-session-hazelcast
         ]]></notes>


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

Add suppression rule. Fix #3068 

`cpe:/a:pivotal_software:spring_security` also had to be excluded. After suppressing the hazelcast one, dependency check raise CVE-2018-1258 related to https://github.com/jeremylong/DependencyCheck/issues/1827

## Have test cases been added to cover the new functionality?

*no*