### PR TITLE
Only access/await CVE Modified processing task when it was actually submitted

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
@@ -304,9 +304,11 @@ public class NvdCveUpdater implements CachedWebDataSource {
             final Future<ProcessTask> task;
             try {
                 task = modified.get();
-                final ProcessTask last = task.get();
-                if (last.getException() != null) {
-                    throw last.getException();
+                if (task != null) {
+                    final ProcessTask last = task.get();
+                    if (last.getException() != null) {
+                        throw last.getException();
+                    }
                 }
             } catch (InterruptedException ex) {
                 LOGGER.debug("Thread was interrupted during download", ex);


### PR DESCRIPTION
CVE Modified processing task should only be accessed/awaited when CVE Modified download task actually submitted it. Fixes issue #3262

## Fixes Issue #3262

## Description of Change
Perform a non-null check on the result of the download task to ensure that an actual ProcessingTask was submitted by the DownloadTask. Otherwise skip awaiting/checking the results of the ProcessingTask.

## Have test cases been added to cover the new functionality?

No, think the condition is too hard to isolate in a concise testcase (needs a failing downloadtask for CVE Modified)