### PR TITLE
#3271 Fix false positive on org.apache.sis.storage

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4279,4 +4279,11 @@
         <cpe>cpe:/a:hazelcast:hazelcast</cpe>
         <cpe>cpe:/a:pivotal_software:spring_security</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        false positive per #3271 on org.apache.sis.storage
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.sis\.storage/sis\-.*$</packageUrl>
+        <cpe>cpe:/a:storage_project:storage</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/test/java/org/owasp/dependencycheck/resources/DependencyCheckBaseSuppressionTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/resources/DependencyCheckBaseSuppressionTest.java
@@ -2,6 +2,7 @@ package org.owasp.dependencycheck.resources;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -22,7 +23,7 @@ public class DependencyCheckBaseSuppressionTest {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 
-        Path path = Path.of("src", "main", "resources", "dependencycheck-base-suppression.xml");
+        Path path = Paths.get("src", "main", "resources", "dependencycheck-base-suppression.xml");
         Document document = factory.newDocumentBuilder().parse(path.toFile());
         document.getDocumentElement().normalize();
 

--- a/core/src/test/java/org/owasp/dependencycheck/resources/DependencyCheckBaseSuppressionTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/resources/DependencyCheckBaseSuppressionTest.java
@@ -1,0 +1,46 @@
+package org.owasp.dependencycheck.resources;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+public class DependencyCheckBaseSuppressionTest {
+
+    @Test
+    public void testAllSuppressionsHaveBaseAttribute() throws ParserConfigurationException, SAXException, IOException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+        Path path = Path.of("src", "main", "resources", "dependencycheck-base-suppression.xml");
+        Document document = factory.newDocumentBuilder().parse(path.toFile());
+        document.getDocumentElement().normalize();
+
+        NodeList nodes = document.getElementsByTagName("suppress");
+
+        int numberOfSuppressTagsWithoutBaseTrueAttribute = 0;
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+
+            if (node.getNodeType() == Node.ELEMENT_NODE) {
+                Element element = (Element) node;
+
+                if (!"true".equalsIgnoreCase(element.getAttribute("base"))) {
+                    numberOfSuppressTagsWithoutBaseTrueAttribute++;
+                }
+            }
+        }
+
+        Assert.assertEquals(0, numberOfSuppressTagsWithoutBaseTrueAttribute);
+    }
+}


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

Fix #3271. Fix false positive report on `org.apache.sis.storage` artifacts. Issue author claims `sis-netcdf` & `sis-storage` are impacted but more artifacts are concerned. A test on [`sis-earth-observation`](https://mvnrepository.com/artifact/org.apache.sis.storage/sis-earth-observation/1.0) also raises an alert. As the cpe looks not at all related to this groupId, a wildcard has been performed on the end of the regex.

## Have test cases been added to cover the new functionality?

*yes*

Following my mistake in #3068 where I forgot the `base="true"` attribute, I created a unit test that parse `dependencycheck-base-suppression.xml` and make sure this attribute is always set. This will help contributors and maintainers to prevent commiting a non base suppression in the file.