### PR TITLE
Make sure people use the right Java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Development Prerequisites
 -------------
 
 For installation to pass, you must have the following components installed:
-* Java: `java --version` 1.8.0 and higher
-* Maven: `mvn --version` 3.5.0 and higher
+* Java: `java -version` 1.8
+* Maven: `mvn -version` 3.5.0 and higher
 
 Tests cases require:
 * dotnet core version 3.1
@@ -203,7 +203,7 @@ docker run --rm ^
 
 Building From Source
 -------------
-To build dependency-check run the command:
+To build dependency-check (using Java 8) run the command:
 
 ```
 mvn -s settings.xml install


### PR DESCRIPTION
If one tries to compile the current branch you cannot use anything higher than Java 8. Otherwise you get a typical error like ``class file has wrong version 55.0, should be 5x.0`` if one tries with Java 11 instead of 8. 

This PR fixes that by making sure which version to use. Note: The message scrolled outside the buffer from my terminal window. Maybe Java 9  (version 53) works too but as it is not supported anymore I believe it makes sense not to recommend this version.

Also I added in the mvn command in the bottom the Java  version needed.

Also this PR fixes the supposed gnu-style ``--version`` switch which doesn't exist for Java (``-version`` works). Maven is fine with both. In order to not confuse people I changed that too though.

## Fixes Issue #

## Description of Change

*Please add a description of the proposed change*

## Have test cases been added to cover the new functionality?

*yes/no*