### PR TITLE
#3282 #3283 #3284 #3285 fix false positives

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4301,4 +4301,11 @@
         <cpe>cpe:/a:kubernetes:java</cpe>
         <cpe>cpe:/a:kubernetes:kubernetes</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        false positive per #3284 on com.amazonaws:aws-java-sdk-storagegateway
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws\-java\-sdk\-storagegateway@.*$</packageUrl>
+        <cpe>cpe:/a:storage_project:storage</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4315,4 +4315,11 @@
         <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws\-java\-sdk\-sagemakerruntime@.*$</packageUrl>
         <cpe>cpe:/a:sage:sage</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        false positive per #3282 on org.mybatis.generator:mybatis-generator-core
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mybatis\.generator/mybatis\-generator\-core@.*$</packageUrl>
+        <cpe>cpe:/a:mybatis:mybatis</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4308,4 +4308,11 @@
         <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws\-java\-sdk\-storagegateway@.*$</packageUrl>
         <cpe>cpe:/a:storage_project:storage</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        false positive per #3283 on com.amazonaws:aws-java-sdk-sagemakerruntime
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws\-java\-sdk\-sagemakerruntime@.*$</packageUrl>
+        <cpe>cpe:/a:sage:sage</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4293,4 +4293,12 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.sis\.storage/sis\-.*$</packageUrl>
         <cpe>cpe:/a:storage_project:storage</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        false positive per #3285 on com.amazonaws:aws-java-sdk-eks
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws\-java\-sdk\-eks@.*$</packageUrl>
+        <cpe>cpe:/a:kubernetes:java</cpe>
+        <cpe>cpe:/a:kubernetes:kubernetes</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Fixes Issue #

Fix #3282 
Fix #3283 
FIx #3284 
Fix #3285 

## Description of Change

Add base suppression rules for `mybatis-generator-core`, `aws-java-sdk-eks`, `aws-java-sdk-storagegateway`, `aws-java-sdk-sagemakerruntime` artifacts to remove CPEs declared as false positives. Having checked the CVEs in the NVD database, I do not see correlation either

## Have test cases been added to cover the new functionality?

*no*