### PR TITLE
#3274 Fix false positive on atomicfu >= 0.15.0

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4322,4 +4322,11 @@
         <packageUrl regex="true">^pkg:maven/org\.mybatis\.generator/mybatis\-generator\-core@.*$</packageUrl>
         <cpe>cpe:/a:mybatis:mybatis</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        false positive per #3274 on org.jetbrains.kotlinx:atomicfu
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlinx/atomicfu@.*$</packageUrl>
+        <cpe>cpe:/a:jetbrains:kotlin</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Fixes Issue #

Fix #3274 

## Description of Change

Artifact `org.jetbrains.kotlinx:atomicfu` get attached to cpe `cpe:2.3:a:jetbrains:kotlin`, raising CVEs about kotlin versions this artifact does not import. Kotlin CVEs attached to the linked version are still raised on `kotlin-stdlib-1.4.10.jar`.

## Have test cases been added to cover the new functionality?

*no*