### PR TITLE
Fix NullPointerException

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nvd/ecosystem/CveEcosystemMapper.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvd/ecosystem/CveEcosystemMapper.java
@@ -86,6 +86,7 @@ public class CveEcosystemMapper {
         final List<DefCpeMatch> cpeEntries = cve.getConfigurations().getNodes().stream()
                 .collect(NodeFlatteningCollector.getInstance())
                 .collect(CpeMatchStreamCollector.getInstance())
+                .filter(defCpeMatch -> defCpeMatch.getCpe23Uri() != null)
                 .collect(Collectors.toList());
         if (!cpeEntries.isEmpty() && cpeEntries.size() > 1) {
             final DefCpeMatch firstMatch = cpeEntries.get(0);

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveItemOperator.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveItemOperator.java
@@ -220,6 +220,7 @@ public class CveItemOperator {
         return cve.getConfigurations().getNodes().stream()
                 .collect(NodeFlatteningCollector.getInstance())
                 .collect(CpeMatchStreamCollector.getInstance())
+                .filter(cpe -> cpe.getCpe23Uri() != null)
                 .anyMatch(cpe -> cpe.getCpe23Uri().startsWith(cpeStartsWithFilter));
     }
 }


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

Fixed a NullPointerException in

```
            final int pos = uri.indexOf(":", uri.indexOf(":", 10) + 1);
```

where `uri` is null  because some (malformed?) entries having no uri set (see [line](https://github.com/jeremylong/DependencyCheck/blob/ab5078f519adaf14d2215ec74493424d3655b37f/core/src/main/java/org/owasp/dependencycheck/data/nvd/ecosystem/CveEcosystemMapper.java#L93)).

Output and stack trace:

```
...
[INFO] Download Complete for NVD CVE - 2018  (1141 ms)
[INFO] Download Started for NVD CVE - 2020
[INFO] Processing Started for NVD CVE - 2018
[INFO] Download Complete for NVD CVE - 2019  (1224 ms)
[INFO] Download Started for NVD CVE - 2021
[INFO] Processing Started for NVD CVE - 2019
[INFO] Download Complete for NVD CVE - 2021  (958 ms)
[INFO] Processing Started for NVD CVE - 2021
[INFO] Download Complete for NVD CVE - 2020  (1757 ms)
[INFO] Processing Started for NVD CVE - 2020
[ERROR] java.util.concurrent.ExecutionException: java.lang.NullPointerException
org.owasp.dependencycheck.data.update.exception.UpdateException: java.util.concurrent.ExecutionException: java.lang.NullPointerException
	at org.owasp.dependencycheck.data.update.NvdCveUpdater.performUpdate(NvdCveUpdater.java:298)
	at org.owasp.dependencycheck.data.update.NvdCveUpdater.update(NvdCveUpdater.java:125)
	at org.owasp.dependencycheck.Engine.doUpdates(Engine.java:860)
	at org.owasp.dependencycheck.Engine.initializeAndUpdateDatabase(Engine.java:667)
	at org.owasp.dependencycheck.Engine.analyzeDependencies(Engine.java:593)
	at org.owasp.dependencycheck.App.runScan(App.java:254)
	at org.owasp.dependencycheck.App.run(App.java:186)
	at org.owasp.dependencycheck.App.main(App.java:81)
Caused by: java.util.concurrent.ExecutionException: java.lang.NullPointerException
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
	at org.owasp.dependencycheck.data.update.NvdCveUpdater.performUpdate(NvdCveUpdater.java:288)
	... 7 common frames omitted
Caused by: java.lang.NullPointerException: null
	at org.owasp.dependencycheck.data.nvd.ecosystem.UrlEcosystemMapper.getEcosystem(UrlEcosystemMapper.java:68)
	at org.owasp.dependencycheck.data.nvd.ecosystem.CveEcosystemMapper.getEcosystem(CveEcosystemMapper.java:74)
	at org.owasp.dependencycheck.data.update.nvd.NvdCveParser.parse(NvdCveParser.java:97)
	at org.owasp.dependencycheck.data.update.nvd.ProcessTask.importJSON(ProcessTask.java:139)
	at org.owasp.dependencycheck.data.update.nvd.ProcessTask.processFiles(ProcessTask.java:152)
	at org.owasp.dependencycheck.data.update.nvd.ProcessTask.call(ProcessTask.java:113)
	at org.owasp.dependencycheck.data.update.nvd.ProcessTask.call(ProcessTask.java:40)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

## Have test cases been added to cover the new functionality?

no