### PR TITLE
#3022 scan modules when mentioned as file

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1612,6 +1612,9 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
       if (pom.isFile()) {
           getLog().debug("Adding virtual dependency from pom.xml");
           d = new Dependency(pom, true);
+      } else if (prj.getFile().isFile()) {
+          getLog().debug("Adding virtual dependency from file");
+          d = new Dependency(prj.getFile(), true);
       } else {
           d = new Dependency(true);
       }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1608,17 +1608,16 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
 
     Dependency newDependency(MavenProject prj) {
       final File pom = new File(prj.getBasedir(), "pom.xml");
-      final Dependency d;
+
       if (pom.isFile()) {
           getLog().debug("Adding virtual dependency from pom.xml");
-          d = new Dependency(pom, true);
+          return new Dependency(pom, true);
       } else if (prj.getFile().isFile()) {
           getLog().debug("Adding virtual dependency from file");
-          d = new Dependency(prj.getFile(), true);
+          return new Dependency(prj.getFile(), true);
       } else {
-          d = new Dependency(true);
+          return new Dependency(true);
       }
-      return d;
     }
 
     /**

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1555,14 +1555,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                         prj.getGroupId(), prj.getArtifactId(), prj.getVersion());
                 getLog().info(String.format(infoLogTemplate,
                         displayName));
-                final File pom = new File(prj.getBasedir(), "pom.xml");
-                final Dependency d;
-                if (pom.isFile()) {
-                    getLog().debug("Adding virtual dependency from pom.xml");
-                    d = new Dependency(pom, true);
-                } else {
-                    d = new Dependency(true);
-                }
+                final Dependency d = newDependency(prj);
                 final String key = String.format("%s:%s:%s", prj.getGroupId(), prj.getArtifactId(), prj.getVersion());
                 d.setSha1sum(Checksum.getSHA1Checksum(key));
                 d.setSha256sum(Checksum.getSHA256Checksum(key));
@@ -1611,6 +1604,18 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
             }
         }
         return false;
+    }
+
+    Dependency newDependency(MavenProject prj) {
+      final File pom = new File(prj.getBasedir(), "pom.xml");
+      final Dependency d;
+      if (pom.isFile()) {
+          getLog().debug("Adding virtual dependency from pom.xml");
+          d = new Dependency(pom, true);
+      } else {
+          d = new Dependency(true);
+      }
+      return d;
     }
 
     /**

--- a/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
+++ b/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
@@ -163,6 +163,32 @@ public class BaseDependencyCheckMojoTest extends BaseTest {
       assertNull(output);
     }
 
+    @Test
+    public void should_newDependency_get_pom_declared_as_module() {
+      // Given
+      BaseDependencyCheckMojo instance = new BaseDependencyCheckMojoImpl();
+
+      new MockUp<MavenProject>() {
+        @Mock
+        public File getBasedir() {
+          return new File("src/test/resources/dir_containing_maven_poms_declared_as_modules_in_another_pom");
+        }
+
+        @Mock
+        public File getFile() {
+          return new File("src/test/resources/dir_containing_maven_poms_declared_as_modules_in_another_pom/serverlibs.pom");
+        }
+      };
+
+      String expectOutput = "serverlibs.pom";
+
+      // When
+      String output = instance.newDependency(project).getFileName();
+
+      // Then
+      assertEquals(expectOutput, output);
+    }
+
     /**
      * Implementation of ODC Mojo for testing.
      */

--- a/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
+++ b/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Tested;
@@ -32,6 +33,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.testing.stubs.ArtifactStub;
 import org.apache.maven.project.MavenProject;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -113,6 +116,51 @@ public class BaseDependencyCheckMojoTest extends BaseTest {
                 assertFalse(engine.getDependencies().length == 0);
             }
         }
+    }
+
+    @Test
+    public void should_newDependency_get_pom_from_base_dir() {
+      // Given
+      BaseDependencyCheckMojo instance = new BaseDependencyCheckMojoImpl();
+
+      new MockUp<MavenProject>() {
+        @Mock
+        public File getBasedir() {
+          return new File("src/test/resources/maven_project_base_dir");
+        }
+      };
+
+      String expectOutput = "pom.xml";
+
+      // When
+      String output = instance.newDependency(project).getFileName();
+
+      // Then
+      assertEquals(expectOutput, output);
+    }
+
+    @Test
+    public void should_newDependency_get_default_virtual_dependency() {
+      // Given
+      BaseDependencyCheckMojo instance = new BaseDependencyCheckMojoImpl();
+
+      new MockUp<MavenProject>() {
+        @Mock
+        public File getBasedir() {
+          return new File("src/test/resources/dir_without_pom");
+        }
+
+        @Mock
+        public File getFile() {
+          return new File("src/test/resources/dir_without_pom");
+        }
+      };
+
+      // When
+      String output = instance.newDependency(project).getFileName();
+
+      // Then
+      assertNull(output);
     }
 
     /**

--- a/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
+++ b/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
@@ -120,73 +120,73 @@ public class BaseDependencyCheckMojoTest extends BaseTest {
 
     @Test
     public void should_newDependency_get_pom_from_base_dir() {
-      // Given
-      BaseDependencyCheckMojo instance = new BaseDependencyCheckMojoImpl();
+        // Given
+        BaseDependencyCheckMojo instance = new BaseDependencyCheckMojoImpl();
 
-      new MockUp<MavenProject>() {
-        @Mock
-        public File getBasedir() {
-          return new File("src/test/resources/maven_project_base_dir");
-        }
-      };
+        new MockUp<MavenProject>() {
+            @Mock
+            public File getBasedir() {
+                return new File("src/test/resources/maven_project_base_dir");
+            }
+        };
 
-      String expectOutput = "pom.xml";
+        String expectOutput = "pom.xml";
 
-      // When
-      String output = instance.newDependency(project).getFileName();
+        // When
+        String output = instance.newDependency(project).getFileName();
 
-      // Then
-      assertEquals(expectOutput, output);
+        // Then
+        assertEquals(expectOutput, output);
     }
 
     @Test
     public void should_newDependency_get_default_virtual_dependency() {
-      // Given
-      BaseDependencyCheckMojo instance = new BaseDependencyCheckMojoImpl();
+        // Given
+        BaseDependencyCheckMojo instance = new BaseDependencyCheckMojoImpl();
 
-      new MockUp<MavenProject>() {
-        @Mock
-        public File getBasedir() {
-          return new File("src/test/resources/dir_without_pom");
-        }
+        new MockUp<MavenProject>() {
+            @Mock
+            public File getBasedir() {
+                return new File("src/test/resources/dir_without_pom");
+            }
 
-        @Mock
-        public File getFile() {
-          return new File("src/test/resources/dir_without_pom");
-        }
-      };
+            @Mock
+            public File getFile() {
+                return new File("src/test/resources/dir_without_pom");
+            }
+        };
 
-      // When
-      String output = instance.newDependency(project).getFileName();
+        // When
+        String output = instance.newDependency(project).getFileName();
 
-      // Then
-      assertNull(output);
+        // Then
+        assertNull(output);
     }
 
     @Test
     public void should_newDependency_get_pom_declared_as_module() {
-      // Given
-      BaseDependencyCheckMojo instance = new BaseDependencyCheckMojoImpl();
+        // Given
+        BaseDependencyCheckMojo instance = new BaseDependencyCheckMojoImpl();
 
-      new MockUp<MavenProject>() {
-        @Mock
-        public File getBasedir() {
-          return new File("src/test/resources/dir_containing_maven_poms_declared_as_modules_in_another_pom");
-        }
+        new MockUp<MavenProject>() {
+            @Mock
+            public File getBasedir() {
+                return new File("src/test/resources/dir_containing_maven_poms_declared_as_modules_in_another_pom");
+            }
 
-        @Mock
-        public File getFile() {
-          return new File("src/test/resources/dir_containing_maven_poms_declared_as_modules_in_another_pom/serverlibs.pom");
-        }
-      };
+            @Mock
+            public File getFile() {
+                return new File("src/test/resources/dir_containing_maven_poms_declared_as_modules_in_another_pom/serverlibs.pom");
+            }
+        };
 
-      String expectOutput = "serverlibs.pom";
+        String expectOutput = "serverlibs.pom";
 
-      // When
-      String output = instance.newDependency(project).getFileName();
+        // When
+        String output = instance.newDependency(project).getFileName();
 
-      // Then
-      assertEquals(expectOutput, output);
+        // Then
+        assertEquals(expectOutput, output);
     }
 
     /**

--- a/maven/src/test/resources/dir_containing_maven_poms_declared_as_modules_in_another_pom/serverlibs.pom
+++ b/maven/src/test/resources/dir_containing_maven_poms_declared_as_modules_in_another_pom/serverlibs.pom
@@ -1,0 +1,57 @@
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.owasp.dependency-check</groupId>
+    <artifactId>sample</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>sample</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <repositories>
+        <repository>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <name>staging</name>
+            <id>staging</id>
+        </repository>
+    </repositories>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <executions>
+                    <execution>
+                        <goals>check</goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <showEvidence>false</showEvidence>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <version>3.0.0.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.struts</groupId>
+            <artifactId>struts2-core</artifactId>
+            <version>2.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/src/test/resources/maven_project_base_dir/pom.xml
+++ b/maven/src/test/resources/maven_project_base_dir/pom.xml
@@ -1,0 +1,57 @@
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.owasp.dependency-check</groupId>
+    <artifactId>sample</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>sample</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <repositories>
+        <repository>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <name>staging</name>
+            <id>staging</id>
+        </repository>
+    </repositories>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <executions>
+                    <execution>
+                        <goals>check</goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <showEvidence>false</showEvidence>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <version>3.0.0.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.struts</groupId>
+            <artifactId>struts2-core</artifactId>
+            <version>2.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
## Fixes Issue #

Fix #3022 

## Description of Change

[A Maven module can be declared by pointing to an xml file](https://maven.apache.org/pom.html#aggregation-or-multi-module). Dependency check currently only handles mapping to a folder searching for a `pom.xml` inside it.

The author of the issue is getting an exception because when the module is declared by pointing already to an xml file. We instantiate the `Dependency` and don't set an `actualFilePath`. Which then generate a `NullPointerException` in `AnalysisTask.shouldAnalyze()`.

I first tried to prevent the exception there, but I ended up having to fix NPEs in multiple places. I think it goes against the principle of fail fast and can lead to potential silent non detection so I did not submit a PR with this solution. Changes can be looked here : https://github.com/nhumblot/DependencyCheck/commits/3022-fix-npe. If maintainers would like me to backport some of these commits, do not hesitate to ask for it and I will add them in this PR.

The present solution has a smaller scope, which reduce the risk of regression or weird behavior.

## Have test cases been added to cover the new functionality?

*yes*

I first started to extract method. The newly created `Dependency newDependency(MavenProject prj)` is package protected to preserve the public api of `BaseDependencyCheckMojo`. It allows to setup tests for it to cover already handled cases. I then added a test to reproduce the issue faced in #3022, and fixed it.

The proposed implementation works fine when using the steps to reproduce detailed in #3022. Instead of getting an execution error, a dependency-check report is generated.