### PR TITLE
#3270 fix quarkus false positive

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4345,4 +4345,11 @@
         <packageUrl regex="true">^pkg:maven/org\.owasp/csrfguard\-.*$</packageUrl>
         <cpe>cpe:/a:php:com_extensions</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        As per #3270 groupIds io.quarkus.security, io.quarkus.http and io.quarkus.gizmo have their own CPE and are not linked to the main quarkus:quarkus CPE
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.quarkus\.(security|gizmo|http)/.*$</packageUrl>
+        <cpe>cpe:/a:quarkus:quarkus</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Fixes Issue #

Fix #3270 

## Description of Change

Quarkus team has declared specific CPEs for quarkus:quarkus-http, quarkus:quarkus-gizmo and quarkus:quarkus-security. We should not match on the main quarkus:quarkus CPE.

As quarkus is a big project and they provided a long description of their issue with links in #3270, please do not hesitate to take the appropriate time to double check this change and be sure everything is ok.

## Have test cases been added to cover the new functionality?

*no*