### PR TITLE
Add suppression for jira-rest-java-client-app

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -947,6 +947,14 @@
         <cpe>cpe:/a:atlassian:jira</cpe>
         <cpe>cpe:/a:atlassian:jira_core</cpe>
     </suppress>
+    <suppress  base="true">
+        <notes><![CDATA[
+        FP per #2859
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.atlassian\.jira/jira\-rest\-java\-client\-app@.*$</packageUrl>
+        <cpe>cpe:/a:atlassian:jira</cpe>
+        <cpe>cpe:/a:atlassian:jira_core</cpe>
+    </suppress>
     <suppress base="true">
         <notes><![CDATA[
         Suppresses false positives per issue #2298


### PR DESCRIPTION
## Fixes Issue #
Fixes the same FP as in #2859 but for the  `jira-rest-java-client-app` dependency


## Description of Change
The `jira-rest-java-client-app` bundles the `jira-rest-java-client-core` which is already in the suppression file and some runtime dependencies. https://mvnrepository.com/artifact/com.atlassian.jira/jira-rest-java-client-app/5.2.2


## Have test cases been added to cover the new functionality?

*yes*