### PR TITLE
Support for Package.resolved on swift package manager analyzer

### DIFF
--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
@@ -17,9 +17,10 @@ import java.io.File;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 
 /**
- * Unit tests for CocoaPodsAnalyzer.
+ * Unit tests for CocoaPodsAnalyzer and SwiftPackageManagerAnalyzer.
  *
  * @author Bianca Jiang
+ * @author Jorge Mendes
  */
 public class SwiftAnalyzersTest extends BaseTest {
 
@@ -97,6 +98,7 @@ public class SwiftAnalyzersTest extends BaseTest {
     @Test
     public void testSPMSupportsFiles() {
         assertThat(spmAnalyzer.accept(new File("Package.swift")), is(true));
+        assertThat(spmAnalyzer.accept(new File("Package.resolved")), is(true));
     }
 
     /**
@@ -166,5 +168,22 @@ public class SwiftAnalyzersTest extends BaseTest {
         //TODO: when version processing is added, update the expected name.
         assertThat(result.getDisplayFileName(), equalTo("Gloss"));
         assertThat(result.getEcosystem(), equalTo(SwiftPackageManagerAnalyzer.DEPENDENCY_ECOSYSTEM));
+    }
+
+
+    @Test
+    public void testSPMResolvedAnalyzer() throws AnalysisException {
+        final Engine engine = new Engine(getSettings());
+        final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
+                "swift/spm/Package.resolved"));
+        spmAnalyzer.analyze(result, engine);
+
+        assertThat(engine.getDependencies().length, equalTo(3));
+        assertThat(engine.getDependencies()[0].getName(), equalTo("Alamofire"));
+        assertThat(engine.getDependencies()[0].getVersion(), equalTo("5.4.3"));
+        assertThat(engine.getDependencies()[1].getName(), equalTo("AlamofireImage"));
+        assertThat(engine.getDependencies()[1].getVersion(), equalTo("4.2.0"));
+        assertThat(engine.getDependencies()[2].getName(), equalTo("Facebook"));
+        assertThat(engine.getDependencies()[2].getVersion(), equalTo("9.3.0"));
     }
 }

--- a/core/src/test/resources/swift/spm/Package.resolved
+++ b/core/src/test/resources/swift/spm/Package.resolved
@@ -1,0 +1,34 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Alamofire",
+        "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
+        "state": {
+          "branch": null,
+          "revision": "f96b619bcb2383b43d898402283924b80e2c4bae",
+          "version": "5.4.3"
+        }
+      },
+      {
+        "package": "AlamofireImage",
+        "repositoryURL": "https://github.com/Alamofire/AlamofireImage",
+        "state": {
+          "branch": null,
+          "revision": "98cbb00ce0ec5fc8e52a5b50a6bfc08d3e5aee10",
+          "version": "4.2.0"
+        }
+      },
+      {
+        "package": "Facebook",
+        "repositoryURL": "https://github.com/facebook/facebook-ios-sdk",
+        "state": {
+          "branch": null,
+          "revision": "c3d367656ae8ced1149c2c6a5e6b5dd91ecad63c",
+          "version": "9.3.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/src/site/markdown/analyzers/swift.md
+++ b/src/site/markdown/analyzers/swift.md
@@ -8,4 +8,4 @@ the false negative/false positive rates are acceptable.
 OWASP dependency-check includes an analyzer that will scan the [SWIFT Package
 Manager](https://swift.org/package-manager/)'s `Package.swift` file to obtain information on the dependencies used.
 
-Files Types Scanned: [Package.swift](https://swift.org/package-manager/#example-usage)
+Files Types Scanned: [Package.swift](https://swift.org/package-manager/#example-usage), [Package.resolved](https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#resolving-versions-packageresolved-file)


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

Add support for the **Package.resolved** file type containing the dependency packages for a swift/xcode project.

## Have test cases been added to cover the new functionality?

*yes*