### PR TITLE
Add additional hint evidence for org.bouncycastle.bcprovider for CVE-2020-15522

### DIFF
--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -307,6 +307,7 @@
         </given>
         <add>
             <evidence type="product" source="hint analyzer" name="product" value="legion-of-the-bouncy-castle-java-crytography-api" confidence="HIGH"/>
+            <evidence type="product" source="hint analyzer" name="product" value="the_bouncy_castle_crypto_package_for_java" confidence="HIGH"/>
         </add>
     </hint>
     <hint>


### PR DESCRIPTION
## Fixes Issue #3437

## Description of Change

Add additional evidence string that is used in https://nvd.nist.gov/vuln/detail/CVE-2020-15522 for the product

## Have test cases been added to cover the new functionality?

no