### PR TITLE
update central search url

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -534,7 +534,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
                                 && mavenArtifact.getGroupId().equals(id.getNamespace())) {
                             found = true;
                             i.setConfidence(Confidence.HIGHEST);
-                            final String url = "http://search.maven.org/#search|ga|1|1%3A%22" + this.getSha1sum() + "%22";
+                            final String url = "https://search.maven.org/search?q=1:" + this.getSha1sum();
                             i.setUrl(url);
                             //i.setUrl(mavenArtifact.getArtifactUrl());
                             LOGGER.debug("Already found identifier {}. Confidence set to highest", i.getValue());


### PR DESCRIPTION
## Fixes Issue #
None

## Description of Change

Fixes the search of maven central when generating a html report.
Example, current url's generated
http://search.maven.org/#search|ga|1|1%3A%22c592b500269bfde36096641b01238a8350f8aa31%22
Gets automatically redirected to
https://search.maven.org/search?q=1:c592b500269bfde36096641b01238a8350f8aa31

## Have test cases been added to cover the new functionality?

no