### PR TITLE
Treeset performance improvements

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -85,7 +85,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
     /**
      * A list of Identifiers.
      */
-    private final Set<Identifier> vulnerabileSoftwareIdentifiers = new TreeSet<>();
+    private final Set<Identifier> vulnerableSoftwareIdentifiers = new TreeSet<>();
     /**
      * A set of identifiers that have been suppressed.
      */
@@ -434,7 +434,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * @return an unmodifiable set of vulnerability identifiers
      */
     public synchronized Set<Identifier> getVulnerableSoftwareIdentifiers() {
-        return Collections.unmodifiableSet(new TreeSet<>(this.vulnerabileSoftwareIdentifiers));
+        return Collections.unmodifiableSet(new TreeSet<>(this.vulnerableSoftwareIdentifiers));
     }
 
     /**
@@ -454,7 +454,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * @param identifiers A set of Identifiers
      */
     protected synchronized void addVulnerableSoftwareIdentifiers(Set<Identifier> identifiers) {
-        this.vulnerabileSoftwareIdentifiers.addAll(identifiers);
+        this.vulnerableSoftwareIdentifiers.addAll(identifiers);
     }
 
     /**
@@ -495,7 +495,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * @param identifier a reference to the identifier to add
      */
     public synchronized void addVulnerableSoftwareIdentifier(Identifier identifier) {
-        this.vulnerabileSoftwareIdentifiers.add(identifier);
+        this.vulnerableSoftwareIdentifiers.add(identifier);
     }
 
     /**
@@ -504,7 +504,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * @param i the identifier to remove
      */
     public synchronized void removeVulnerableSoftwareIdentifier(Identifier i) {
-        this.vulnerabileSoftwareIdentifiers.remove(i);
+        this.vulnerableSoftwareIdentifiers.remove(i);
     }
 
     /**
@@ -854,7 +854,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
                 .append(this.sha1sum, other.sha1sum)
                 .append(this.sha256sum, other.sha256sum)
                 .append(this.softwareIdentifiers, other.softwareIdentifiers)
-                .append(this.vulnerabileSoftwareIdentifiers, other.vulnerabileSoftwareIdentifiers)
+                .append(this.vulnerableSoftwareIdentifiers, other.vulnerableSoftwareIdentifiers)
                 .append(this.suppressedIdentifiers, other.suppressedIdentifiers)
                 .append(this.description, other.description)
                 .append(this.license, other.license)
@@ -883,7 +883,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
                 .append(sha1sum)
                 .append(sha256sum)
                 .append(softwareIdentifiers)
-                .append(vulnerabileSoftwareIdentifiers)
+                .append(vulnerableSoftwareIdentifiers)
                 .append(suppressedIdentifiers)
                 .append(description)
                 .append(license)

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -425,7 +425,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * @return an unmodifiable set of software identifiers
      */
     public synchronized Set<Identifier> getSoftwareIdentifiers() {
-        return Collections.unmodifiableSet(new TreeSet<>(softwareIdentifiers));
+        return Collections.unmodifiableSet(softwareIdentifiers);
     }
 
     /**
@@ -434,7 +434,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * @return an unmodifiable set of vulnerability identifiers
      */
     public synchronized Set<Identifier> getVulnerableSoftwareIdentifiers() {
-        return Collections.unmodifiableSet(new TreeSet<>(this.vulnerableSoftwareIdentifiers));
+        return Collections.unmodifiableSet(this.vulnerableSoftwareIdentifiers);
     }
 
     /**
@@ -564,7 +564,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * @return the value of suppressedIdentifiers
      */
     public synchronized Set<Identifier> getSuppressedIdentifiers() {
-        return Collections.unmodifiableSet(new TreeSet<>(this.suppressedIdentifiers));
+        return Collections.unmodifiableSet(this.suppressedIdentifiers);
     }
 
     /**
@@ -743,7 +743,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * @return the unmodifiable set of relatedDependencies
      */
     public synchronized Set<Dependency> getRelatedDependencies() {
-        return Collections.unmodifiableSet(new TreeSet<>(relatedDependencies));
+        return Collections.unmodifiableSet(relatedDependencies);
     }
 
     /**

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
@@ -155,7 +155,7 @@ public class DependencyTest extends BaseTest {
     }
 
     /**
-     * Test of getSha1sum method, of class Dependency.
+     * Test of getSha256sum method, of class Dependency.
      */
     @Test
     public void testGetSha256sum() {
@@ -178,10 +178,10 @@ public class DependencyTest extends BaseTest {
     }
 
     /**
-     * Test of setSha1sum method, of class Dependency.
+     * Test of setSha256sum method, of class Dependency.
      */
     @Test
-    public void testSetSha256um() {
+    public void testSetSha256sum() {
         String sha256sum = "test";
         Dependency instance = new Dependency();
         instance.setSha256sum(sha256sum);
@@ -189,7 +189,7 @@ public class DependencyTest extends BaseTest {
     }
 
     /**
-     * Test of getIdentifiers method, of class Dependency.
+     * Test of getSoftwareIdentifiers method, of class Dependency.
      */
     @Test
     public void testGetSoftwareIdentifiers() {
@@ -200,7 +200,7 @@ public class DependencyTest extends BaseTest {
     }
 
     /**
-     * Test of setIdentifiers method, of class Dependency.
+     * Test of addSoftwareIdentifiers method, of class Dependency.
      */
     @Test
     public void testAddSoftwareIdentifiers() {
@@ -211,10 +211,10 @@ public class DependencyTest extends BaseTest {
     }
 
     /**
-     * Test of addIdentifier method, of class Dependency.
+     * Test of addVulnerableSoftwareIdentifier method, of class Dependency.
      */
     @Test
-    public void testAddVulnerableSoftwareIIdentifier() throws Exception {
+    public void testAddVulnerableSoftwareIdentifier() throws Exception {
         CpeBuilder builder = new CpeBuilder();
         Cpe cpe = builder.part(Part.APPLICATION).vendor("apache").product("struts").version("2.1.2").build();
         CpeIdentifier id = new CpeIdentifier(cpe, Confidence.HIGHEST);


### PR DESCRIPTION
## Fixes Issue #
https://github.com/jeremylong/DependencyCheck/issues/3454, branched off of the `v6.2.2` tag.

These changes cut just under 20% off of my analysis time.

## Description of Change

Some of the instance variables in the `Dependency` class are already `TreeSet<Identifier>` objects. In a few places we return `Collections.immutableSet(new TreeSet(thingThatIsAlreadyATreeSet))`. The `new TreeSet(...)` call causes the contents of one `TreeSet` to be read into another one at a time, evaluating the `compareTo` method of the `Identifier` subclass to make sure the new `TreeSet` is in order.

The tests all pass locally but I am not certain if this behaviour is intended and that we want to return a copy of the set rather than an immutable wrapper of the set so please examine carefully.

## Have test cases been added to cover the new functionality?

No - open to suggestions, but the current test doesn't enforce that the collection is immutable or that it's a copy so I'm unsure of the intended behaviour.