### PR TITLE
Fix false positive FP #3471 against com.fasterxml.jackson.core/jackson-annotations

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -2,6 +2,13 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress base="true">
         <notes><![CDATA[
+        FP per #3471
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-annotations@.*$</packageUrl>
+        <cpe>cpe:/a:fasterxml:jackson-modules-java8</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
 	    FP per #3331
 	    ]]></notes>
         <packageUrl regex="true">^pkg:npm/%40babel%2Fcli@.*$</packageUrl>


### PR DESCRIPTION
Fix false positive FP #3471 against com.fasterxml.jackson.core/jackson-annotations

Reported as cpe:2.3:a:fasterxml:jackson-modules-java8 (Confidence:Low)
which causes an FP hit on CVE-2018-1000873 (circa June 2021).

julius@mergebase.com