### PR TITLE
Add extra CPE pattern for existing suppressions

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -1243,7 +1243,7 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per #2553
+        FP per #2554
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.alpn/alpn\-api@.*$</packageUrl>
         <cpe>cpe:/a:jetty:jetty</cpe>
@@ -1253,7 +1253,7 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per #2554
+        FP per #2553
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty\-reactive\-httpclient@.*$</packageUrl>
         <cpe>cpe:/a:jetty:jetty</cpe>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -1249,6 +1249,7 @@
         <cpe>cpe:/a:jetty:jetty</cpe>
         <cpe>cpe:/a:eclipse:jetty</cpe>
         <cpe>cpe:/a:mortbay_jetty:jetty</cpe>
+        <cpe>cpe:/a:mortbay:jetty</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
@@ -1258,6 +1259,7 @@
         <cpe>cpe:/a:jetty:jetty</cpe>
         <cpe>cpe:/a:eclipse:jetty</cpe>
         <cpe>cpe:/a:mortbay_jetty:jetty</cpe>
+        <cpe>cpe:/a:mortbay:jetty</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[


### PR DESCRIPTION
Fixes #3475

Includes the CPE pattern `cpe:/a:mortbay:jetty` in existing exclusions added for #2553 and #2554. Also fixed the issue references as they got swapped somehow!