### PR TITLE
Fix FP #3470 against prometheus-kt

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4397,6 +4397,13 @@
         <cpe>cpe:/a:apache:batik</cpe>
         <cpe>cpe:/a:i18n_project:i18n</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        Library related to prometheus is being flagged as prometheus itself (#3470)
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven\/com\.github\.anti-social[.\/]prometheus-kt.*$</packageUrl>
+        <cpe>cpe:/a:prometheus:prometheus</cpe>
+    </suppress>
     
     
     <!-- begin cpan support-->


### PR DESCRIPTION
Fixes #3470

Adds a suppression so `prometheus-kt` isn't mistaken for prometheus itself. 