### PR TITLE
VERSIONENDEXCLUDING database field length (50) is too short to fit value

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -1048,10 +1048,10 @@ public final class CveDB implements AutoCloseable {
                         cveItemConverter.extractEcosystem(baseEcosystem, parsedCpe));
 
                 addNullableStringParameter(insertSoftware, 13, ecosystem);
-                addNullableStringParameter(insertSoftware, 14, parsedCpe.getVersionEndExcluding());
-                addNullableStringParameter(insertSoftware, 15, parsedCpe.getVersionEndIncluding());
-                addNullableStringParameter(insertSoftware, 16, parsedCpe.getVersionStartExcluding());
-                addNullableStringParameter(insertSoftware, 17, parsedCpe.getVersionStartIncluding());
+                addNullableStringParameter(insertSoftware, 14, parsedCpe.getVersionEndExcluding() != null && parsedCpe.getVersionEndExcluding().length() > 50 ? parsedCpe.getVersionEndExcluding().substring(0, 50) : parsedCpe.getVersionEndExcluding());
+                addNullableStringParameter(insertSoftware, 15, parsedCpe.getVersionEndIncluding() != null && parsedCpe.getVersionEndIncluding().length() > 50 ? parsedCpe.getVersionEndIncluding().substring(0, 50) : parsedCpe.getVersionEndIncluding());
+                addNullableStringParameter(insertSoftware, 16, parsedCpe.getVersionStartExcluding() != null && parsedCpe.getVersionStartExcluding().length() > 50 ? parsedCpe.getVersionStartExcluding().substring(0, 50) : parsedCpe.getVersionStartExcluding());
+                addNullableStringParameter(insertSoftware, 17, parsedCpe.getVersionStartIncluding() != null && parsedCpe.getVersionStartIncluding().length() > 50 ? parsedCpe.getVersionStartIncluding().substring(0, 50) : parsedCpe.getVersionStartIncluding());
                 insertSoftware.setBoolean(18, parsedCpe.isVulnerable());
 
                 if (isBatchInsertEnabled()) {


### PR DESCRIPTION
# Fixes Issue #
https://github.com/jeremylong/DependencyCheck/issues/3483, NVD Updater would crash on Setting CVE_CPE_STARTS_WITH_FILTER set to 'cpe:2.3:'
closes #3483 

## Description of Change

Since the field `VERSIONENDEXCLUDING` is only 50 characters long, the updater fails since it attempts to insert the string `dh_ipc-ack-themis_eng_p_v2.400.0000.14.r.20170713.bin` (more details see issue #3483).

Since this only happens once for the entire database, I made it so that the string gets cropped to 50 characters if it happens to be longer than 50 characters.

I tried this out and now the updater runs fine without errors when updating with the setting `CVE_CPE_STARTS_WITH_FILTER` set to `cpe:2.3:` or more specifically `cpe:2.3:o`.

## Have test cases been added to cover the new functionality?

no