### PR TITLE
Set length of versionEndExcluding, versionEndIncluding, versionStartExcluding and versionStartIncluding to 60

### DIFF
--- a/core/src/main/resources/data/initialize.sql
+++ b/core/src/main/resources/data/initialize.sql
@@ -28,8 +28,8 @@ CREATE TABLE cpeEntry (id INT auto_increment PRIMARY KEY, part CHAR(1), vendor V
 version VARCHAR(255), update_version VARCHAR(255), edition VARCHAR(255), lang VARCHAR(20), sw_edition VARCHAR(255), 
 target_sw VARCHAR(255), target_hw VARCHAR(255), other VARCHAR(255), ecosystem VARCHAR(255));
 
-CREATE TABLE software (cveid INT, cpeEntryId INT, versionEndExcluding VARCHAR(50), versionEndIncluding VARCHAR(50), 
-                       versionStartExcluding VARCHAR(50), versionStartIncluding VARCHAR(50), vulnerable BOOLEAN
+CREATE TABLE software (cveid INT, cpeEntryId INT, versionEndExcluding VARCHAR(60), versionEndIncluding VARCHAR(60),
+                       versionStartExcluding VARCHAR(60), versionStartIncluding VARCHAR(60), vulnerable BOOLEAN
     , CONSTRAINT fkSoftwareCve FOREIGN KEY (cveid) REFERENCES vulnerability(id) ON DELETE CASCADE
     , CONSTRAINT fkSoftwareCpeProduct FOREIGN KEY (cpeEntryId) REFERENCES cpeEntry(id));
 
@@ -53,4 +53,4 @@ CREATE ALIAS update_vulnerability FOR "org.owasp.dependencycheck.data.nvdcve.H2F
 CREATE ALIAS insert_software FOR "org.owasp.dependencycheck.data.nvdcve.H2Functions.insertSoftware";
 
 CREATE TABLE properties (id varchar(50) PRIMARY KEY, value varchar(500));
-INSERT INTO properties(id, value) VALUES ('version', '5.1');
+INSERT INTO properties(id, value) VALUES ('version', '5.2');

--- a/core/src/main/resources/data/upgrade_5.0.sql
+++ b/core/src/main/resources/data/upgrade_5.0.sql
@@ -2,4 +2,4 @@ UPDATE cpeecosystemcache SET ecosystem='MULTIPLE' WHERE vendor='tensorflow' AND 
 
 UPDATE cpeecosystemcache SET ecosystem='MULTIPLE' WHERE vendor='scikit-learn' AND product='scikit-learn';
 
-UPDATE Properties SET value='5.2' WHERE ID='version';
+UPDATE Properties SET value='5.1' WHERE ID='version';

--- a/core/src/main/resources/data/upgrade_5.0.sql
+++ b/core/src/main/resources/data/upgrade_5.0.sql
@@ -2,4 +2,4 @@ UPDATE cpeecosystemcache SET ecosystem='MULTIPLE' WHERE vendor='tensorflow' AND 
 
 UPDATE cpeecosystemcache SET ecosystem='MULTIPLE' WHERE vendor='scikit-learn' AND product='scikit-learn';
 
-UPDATE Properties SET value='5.1' WHERE ID='version';
+UPDATE Properties SET value='5.2' WHERE ID='version';

--- a/core/src/main/resources/data/upgrade_5.1.sql
+++ b/core/src/main/resources/data/upgrade_5.1.sql
@@ -1,0 +1,6 @@
+ALTER TABLE software ALTER COLUMN versionEndExcluding SET DATA TYPE VARCHAR(60);
+ALTER TABLE software ALTER COLUMN versionEndIncluding SET DATA TYPE VARCHAR(60);
+ALTER TABLE software ALTER COLUMN versionStartExcluding SET DATA TYPE VARCHAR(60);
+ALTER TABLE software ALTER COLUMN versionStartIncluding SET DATA TYPE VARCHAR(60);
+
+UPDATE Properties SET value='5.2' WHERE ID='version'; 

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -21,7 +21,7 @@ data.file_name=odc.mv.db
 ### if you increment the DB version then you must increment the database file path
 ### in the mojo.properties, task.properties (maven and ant respectively), and
 ### the gradle PurgeDataExtension.
-data.version=5.1
+data.version=5.2
 
 #The analysis timeout in minutes
 odc.analysis.timeout=180


### PR DESCRIPTION
## Fixes Issue #
See issue https://github.com/jeremylong/DependencyCheck/issues/3483
closes #3483 

## Description of Change

Set length of columns `versionEndExcluding`, `versionEndIncluding`, `versionStartExcluding` and `versionStartIncluding` to `60`
Set schema version to `5.2`

## Have test cases been added to cover the new functionality?

no