### PR TITLE
False positive FP #3509 against mysql/mysql-connector-java (CVE-2017-15945)

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -3191,8 +3191,10 @@
         <notes><![CDATA[
         FP per issue #952 - instead of suppressing the whole thing, we will just
             suppress specific CVE that are for the server
+            Added additional CVE per #3509.
         ]]></notes>
         <gav regex="true">^(mysql:mysql-connector-java|org\.drizzle\.jdbc:drizzle-jdbc):.*$</gav>
+        <cve>CVE-2017-15945</cve>
         <cve>CVE-2018-3081</cve>
         <cve>CVE-2018-3137</cve>
         <cve>CVE-2018-3145</cve>


### PR DESCRIPTION
Reported as `cpe:2.3:a:mysql:mysql` (Confidence:Highest) - the MySql
backend database engine - which causes an FP hit on CVE-2017-15945
(circa July 2021) - since mysql/mysql-connector-java is just the
JDBC driver and not the entire MySQL database.

Suppression done as `<cve>` match rather than `<cpe>` match.

## Fixes Issue #

#3509 

## Description of Change

Adds `<cve>` entry to core/src/main/resources/dependencycheck-base-suppression.xml following in the tradition of many other mysql-connector-java FP suppressions.

## Have test cases been added to cover the new functionality?

no
