### PR TITLE
Fix jetty false positives

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -2,6 +2,20 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress base="true">
         <notes><![CDATA[
+                FP in jetty as jetty-jakarta-servlet-api is identified as a low version jetty
+                ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty\-jakarta\-servlet\-api@.*$</packageUrl>
+        <cpe>cpe:/a:eclipse:jetty</cpe>
+    </suppress>	
+    <suppress base="true">
+        <notes><![CDATA[
+                FP in jetty as jetty-jakarta-servlet-api is identified as a low version jetty
+                ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty\-jakarta\-servlet\-api@.*$</packageUrl>
+        <cpe>cpe:/a:jetty:jetty</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
         FP per #3471
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-annotations@.*$</packageUrl>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -6,12 +6,6 @@
                 ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty\-jakarta\-servlet\-api@.*$</packageUrl>
         <cpe>cpe:/a:eclipse:jetty</cpe>
-    </suppress>	
-    <suppress base="true">
-        <notes><![CDATA[
-                FP in jetty as jetty-jakarta-servlet-api is identified as a low version jetty
-                ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty\-jakarta\-servlet\-api@.*$</packageUrl>
         <cpe>cpe:/a:jetty:jetty</cpe>
     </suppress>
     <suppress base="true">


### PR DESCRIPTION
## Fixes false positives in Jetty

The following false positives are reported otherwise in jetty 11.0.5, which isn't affected by these vulnerabilities.

- CVE-2009-5045
- CVE-2009-5046
- CVE-2017-7656 
- CVE-2017-7657
- CVE-2017-7658
- CVE-2017-9735
- CVE-2020-27216
- CVE-2021-28169
- CVE-2021-34428

## Description of Change

Add base suppression for jetty-jakarta-servlet-api not being jetty.

## Have test cases been added to cover the new functionality?

no