### PR TITLE
#3521 New OssIndexAnalyzer config options

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -50,6 +50,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -135,6 +136,7 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
         synchronized (FETCH_MUTIX) {
             if (!failed && reports == null) {
                 try {
+                    requestDelay();
                     reports = requestReports(engine.getDependencies());
                 } catch (TransportException ex) {
                     failed = true;
@@ -154,6 +156,17 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
         // skip enrichment if we failed to fetch reports
         if (!failed) {
             enrich(dependency);
+        }
+    }
+
+    /**
+     * Delays each request (thread) by the configured amount of seconds, if the configuration is present.
+     */
+    private void requestDelay() throws InterruptedException {
+        final int delay = getSettings().getInt(Settings.KEYS.ANALYZER_OSSINDEX_REQUEST_DELAY,0);
+        if(delay > 0) {
+            LOG.debug("Request delay: " + delay);
+            TimeUnit.SECONDS.sleep(delay);
         }
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/data/ossindex/OssindexClientFactory.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/ossindex/OssindexClientFactory.java
@@ -82,6 +82,9 @@ public final class OssindexClientFactory {
             config.setAuthConfiguration(auth);
         }
 
+        final int batchSize = settings.getInt(Settings.KEYS.ANALYZER_OSSINDEX_BATCH_SIZE, OssindexClientConfiguration.DEFAULT_BATCH_SIZE);
+        config.setBatchSize(batchSize);
+
         // proxy likely does not need to be configured here as we are using the
         // URLConnectionFactory#createHttpURLConnection() which automatically configures
         // the proxy on the connection.

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -682,6 +682,15 @@ public final class Settings {
          */
         public static final String ANALYZER_OSSINDEX_PASSWORD = "analyzer.ossindex.password";
         /**
+         * The properties key for the Sonatype OSS batch-size.
+         */
+        public static final String ANALYZER_OSSINDEX_BATCH_SIZE = "analyzer.ossindex.batch.size";
+        /**
+         * The properties key for the Sonatype OSS Request Delay.
+         * Amount of time in seconds to wait before executing a request against the Sonatype OSS Rest API
+         */
+        public static final String ANALYZER_OSSINDEX_REQUEST_DELAY = "analyzer.ossindex.request.delay";
+        /**
          * The properties key setting whether or not the JSON and XML reports
          * will be pretty printed.
          */


### PR DESCRIPTION
## Fixes Issue #3521

## Description of Change
Added two new config options  and request delay implementation to the OssIndexAnalyzer.

analyzer.ossindex.batch.size
Which maps to the corresponding config option in org.sonatype.ossindex.service.client.OssindexClientConfiguration

analyzer.ossindex.request.delay
Which delayes each request to the OssIndex Rest API by the configured amount of seconds.
If the configuration is present.


## Have test cases been added to cover the new functionality?
no