### PR TITLE
Allow outputDirectory to be set from a user-property on the commandline

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -183,7 +183,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * The output directory. This generally maps to "target".
      */
     @SuppressWarnings("CanBeFinal")
-    @Parameter(defaultValue = "${project.build.directory}", required = true)
+    @Parameter(defaultValue = "${project.build.directory}", required = true, property = "outputDirectory")
     private File outputDirectory;
     /**
      * This is a reference to the &gt;reporting&lt; sections


### PR DESCRIPTION

## Fixes Issue #
1686

## Description of Change
Allow outputDirectory to be set from a user-property on the commandline using -DoutputDirectory

## Have test cases been added to cover the new functionality?

*no*