### PR TITLE
Spring vendor fixes

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -606,9 +606,6 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
         }
 
         final String originalGroupID = groupid;
-        if (groupid != null && (groupid.startsWith("org.") || groupid.startsWith("com."))) {
-            groupid = groupid.substring(4);
-        }
 
         if ((artifactid == null || artifactid.isEmpty()) && parentArtifactId != null && !parentArtifactId.isEmpty()) {
             artifactid = parentArtifactId;

--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -115,17 +115,6 @@
     </hint>
     <hint>
         <given>
-            <evidence type="product" source="Manifest" name="Bundle-Name" value="Spring Security Core" confidence="MEDIUM"/>
-            <evidence type="product" source="pom" name="artifactid" value="spring-security-core" confidence="HIGH"/>	
-        </given>
-        <add>
-            <evidence type="product" source="hint analyzer" name="product" value="springsource_spring_framework" confidence="HIGHEST"/>
-            <evidence type="vendor" source="hint analyzer" name="vendor" value="SpringSource" confidence="HIGHEST"/>
-            <evidence type="vendor" source="hint analyzer" name="vendor" value="vmware" confidence="HIGHEST"/>
-        </add>
-    </hint>
-    <hint>
-        <given>
             <evidence type="vendor" source="composer.lock" name="vendor" value="symfony" confidence="HIGHEST"/>
         </given>
         <add>

--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -49,6 +49,16 @@
     </hint>
     <hint>
         <given>
+            <evidence regex="true" type="vendor" source="gradle" name="groupid" value="org\.springframework.*" confidence="HIGHEST"/>
+        </given>
+        <add>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="SpringSource" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="vmware" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="pivotal software" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
             <evidence regex="true" type="vendor" source="pom" name="groupid" value="org\.hibernate.*" confidence="HIGHEST"/>
         </given>
         <add>

--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -5,7 +5,7 @@
             <evidence type="product" source="Manifest" name="Implementation-Title" value="Spring Framework" confidence="HIGH"/>
             <evidence type="product" source="Manifest" name="Implementation-Title" value="org.springframework.core" confidence="HIGH"/>
             <evidence type="product" source="Manifest" name="Implementation-Title" value="spring-core" confidence="HIGH"/>
-            <evidence type="vendor"  source="pom"      name="groupid"              value="springframework" confidence="HIGHEST"/>
+            <evidence type="vendor"  source="pom"      name="groupid"              value="org\.springframework" confidence="HIGHEST"/>
         </given>
         <add>
             <evidence type="product" source="hint analyzer" name="product" value="springsource_spring_framework" confidence="HIGHEST"/>
@@ -67,7 +67,7 @@
     </hint>
     <hint>
         <given>
-            <evidence regex="true" type="vendor" source="pom" name="groupid" value="hibernate" />
+            <evidence regex="true" type="vendor" source="pom" name="groupid" value="org\.hibernate" />
         </given>
         <add>
             <evidence type="product" source="hint analyzer" name="product" value="orm" confidence="HIGHEST"/>
@@ -286,7 +286,7 @@
     <hint>
         <given>
             <evidence type="vendor" source="Manifest" name="Implementation-Vendor-Id" value="org.primefaces" confidence="MEDIUM"/>
-            <evidence type="vendor" source="pom" name="groupid" value="primefaces" confidence="HIGHEST"/>
+            <evidence type="vendor" source="pom" name="groupid" value="org.primefaces" confidence="HIGHEST"/>
         </given>
         <add>
             <evidence type="vendor" source="hint analyzer" name="vendor" value="primetek" confidence="HIGHEST"/>
@@ -329,7 +329,8 @@
     </hint>
     <hint>
         <given>
-            <evidence type="vendor" source="pom" name="groupid" value="zeroturnaround"/>
+            <evidence type="vendor" source="pom" name="groupid" value="com.zeroturnaround"/>
+            <evidence type="vendor" source="pom" name="groupid" value="org.zeroturnaround"/>
         </given>
         <add>
             <evidence type="vendor" source="hint analyzer" name="vendor" value="jrebel" confidence="HIGHEST"/>
@@ -345,7 +346,7 @@
     </hint>
     <hint>
         <given>
-            <evidence type="vendor" source="pom" name="groupid" value="datomic"/>
+            <evidence type="vendor" source="pom" name="groupid" value="com.datomic"/>
         </given>
         <add>
             <evidence type="vendor" source="hint analyzer" name="vendor" value="cognitect" confidence="HIGHEST"/>
@@ -372,7 +373,7 @@
     </hint>
     <hint>
         <given>
-            <evidence type="vendor" source="pom" name="groupid" value="quartz-scheduler"/>
+            <evidence type="vendor" source="pom" name="groupid" value="org.quartz-scheduler"/>
         </given>
         <add>
             <evidence type="vendor" source="hint analyzer" name="vendor" value="softwareag" confidence="HIGHEST"/>
@@ -380,7 +381,7 @@
     </hint>  
     <hint>
         <given>
-            <evidence type="product" source="pom" name="groupid" value="fasterxml.jackson.core"/>
+            <evidence type="product" source="pom" name="groupid" value="com.fasterxml.jackson.core"/>
         </given>
         <add>
             <evidence type="product" source="hint analyzer" name="product" value="modules" confidence="HIGHEST"/>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -417,6 +417,16 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
+            This suppresses false positives identified on spring projects that are separate projects side-by-side with the Spring Framework
+            project that have springframework in the groupid where NVD is known to have separate products in the CPE dictionary.
+        ]]></notes>
+        <gav regex="true">^org\.springframework\.(amqp|batch|boot|cloud|data|integration|ldap|security|social|webflow|ws).*$</gav>
+        <cpe>cpe:/a:vmware:spring_framework</cpe>
+        <cpe>cpe:/a:pivotal_software:spring_framework</cpe>
+        <cpe>cpe:/a:springsource:spring_framework</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
        Don't flag specific CVEs for spring framework related components (i.e. org.springframework.data).
        ]]></notes>
         <gav regex="true">^org\.springframework\..*$</gav>


### PR DESCRIPTION
## Fixes Issue #3494
## Fixes Issue #3522 

## Description of Change

Fix JarAnalyzer to make existing base-hints match
Add base-hint to make gradle plugin match for Spring-projects that use gradle for the build
Update suppressions to avoid false positives with the improved vendor-assignment for Spring.io binaries
Fix an erroneous base-hint (Spring-security is not part of Spring-framework)

## Have test cases been added to cover the new functionality?

no