### PR TITLE
Ensure tests don't error out when building on Java > 1.8

### DIFF
--- a/maven/src/it/846-site-plugin/pom.xml
+++ b/maven/src/it/846-site-plugin/pom.xml
@@ -56,7 +56,7 @@ Copyright (c) 2017 The OWASP Foundation. All Rights Reserved.
         <plugins>
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.6</version>
+                <version>3.7</version>
                 <configuration>
                     <reportPlugins>
                         <plugin>

--- a/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
+++ b/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
@@ -63,8 +63,17 @@ public class BaseDependencyCheckMojoTest extends BaseTest {
      */
     public boolean canRun() {
         String version = System.getProperty("java.version");
-        int length = version.indexOf('.', version.indexOf('.') + 1);
-        version = version.substring(0, length);
+        int firstDot = version.indexOf('.');
+        if (firstDot < 0) {
+            // new java.version format, so Java 9 or above
+            return false;
+        }
+        int secondDot = version.indexOf('.', firstDot+1);
+        if (secondDot < 0) {
+            // new java.version format, so Java 9 or above
+            return false;
+        }
+        version = version.substring(0, secondDot);
 
         double v = Double.parseDouble(version);
         return v == 1.7;


### PR DESCRIPTION
## Fixes Issue #3541

## Description of Change

Update the version detection procedure to work with the JEP-223 java versions
Update the site-plugin in the integrationtest to a version that is compatible with JEP-223 java versions

## Have test cases been added to cover the new functionality?

no, existing testcases have been modified to run as intended with Java versions > 8