### PR TITLE
Jackson fixes

### DIFF
--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -381,15 +381,6 @@
     </hint>  
     <hint>
         <given>
-            <evidence type="product" source="pom" name="groupid" value="fasterxml.jackson.core"/>
-        </given>
-        <add>
-            <evidence type="product" source="hint analyzer" name="product" value="modules" confidence="HIGHEST"/>
-            <evidence type="product" source="hint analyzer" name="product" value="java8" confidence="HIGHEST"/>
-        </add>
-    </hint>
-    <hint>
-        <given>
             <evidence type="vendor" source="pom" name="groupid" value="org.cryptacular"/>
             <evidence type="vendor" source="jar" name="package name" value="cryptacular"/>
         </given>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -2360,6 +2360,13 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
+           These only apply to the jackson-dataformat-cbor sub-module
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.dataformat/jackson\-dataformat(?!\-cbor).*@.*$</packageUrl>
+        <cve>CVE-2020-28491</cve>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
             These CVE only affects jackson-dataformat-xml. See issue #517.
         ]]></notes>
         <gav regex="true">com\.fasterxml\.jackson\.dataformat:jackson(?!\-dataformat\-xml).*</gav>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -10,13 +10,6 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per #3471
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-annotations@.*$</packageUrl>
-        <cpe>cpe:/a:fasterxml:jackson-modules-java8</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
 	    FP per #3331
 	    ]]></notes>
         <packageUrl regex="true">^pkg:npm/%40babel%2Fcli@.*$</packageUrl>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -2353,6 +2353,13 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
+        jackson-dataformat-avro/cbor/ion/protobuf/smile are cpe:/a:fasterxml:jackson-dataformat-binary
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.dataformat/jackson\-dataformat\-(ion|cbor|avro|protobuf|smile)@.*$</packageUrl>
+        <cpe>cpe:/a:fasterxml:jackson-dataformat-xml</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
             These CVE only affects jackson-dataformat-xml. See issue #517.
         ]]></notes>
         <gav regex="true">com\.fasterxml\.jackson\.dataformat:jackson(?!\-dataformat\-xml).*</gav>

--- a/maven/src/it/1512-transitive-test/postbuild.groovy
+++ b/maven/src/it/1512-transitive-test/postbuild.groovy
@@ -17,16 +17,27 @@
  */
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.w3c.dom.NodeList;
+
 import java.nio.charset.Charset;
+import javax.xml.xpath.*
+import javax.xml.parsers.DocumentBuilderFactory
 
+// Check to see if jackson-databind-2.5.3.jar was identified with a known CVE - using CVE-2018-7489.
 
-// Check to see if jackson-dataformat-xml-2.4.5.jar was identified.
-//TODO change this to xpath and check for CVE-2016-3720
+def countMatches(String xml, String xpathQuery) {
+    def xpath = XPathFactory.newInstance().newXPath()
+    def builder     = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+    def inputStream = new ByteArrayInputStream( xml.bytes )
+    def records     = builder.parse(inputStream).documentElement
+    NodeList nodes       = xpath.evaluate( xpathQuery, records, XPathConstants.NODESET ) as NodeList
+    nodes.getLength();
+}
+
 String log = FileUtils.readFileToString(new File(basedir, "target/dependency-check-report.xml"), Charset.defaultCharset().name());
-int count = StringUtils.countMatches(log, "<name>CVE-2018-1000873</name>");
-if (count == 0){
-    System.out.println(String.format("jackson-dataformat-xml was not identified", count));
+int count = countMatches(log,"/analysis/dependencies/dependency[./fileName = 'jackson-databind-2.5.3.jar']/vulnerabilities/vulnerability[./name = 'CVE-2018-7489']");
+if (count != 1){
+    System.out.println(String.format("jackson-databind CVE-2018-7489 was identified %s times, expected 1", count));
     return false;
 }
 return true;

--- a/maven/src/it/629-jackson-dataformat/pom.xml
+++ b/maven/src/it/629-jackson-dataformat/pom.xml
@@ -26,42 +26,42 @@ Copyright (c) 2017 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.0</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.6.0</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>2.6.0</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.6.0</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
-            <version>2.8.9</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-ion</artifactId>
-            <version>2.8.9</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-hppc</artifactId>
-            <version>2.8.9</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-yaml-provider</artifactId>
-            <version>2.8.9</version>
+            <version>2.10.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Fixes Issue #3543, fixes issue #3505, fixes issue #3471 

## Description of Change

Rework the integration testcases for #629 and #1512 to use recent vulnerabilities to test that we don't introduce a regression on those issues (the existing tests were using a false positive CVE)
Remove invalid hint from the base-hints triggering invalid CPE linking to jackson-modules-java8 for libraries of different jackson subprojects.

## Have test cases been added to cover the new functionality?

no