### PR TITLE
Ignore kotlin-version from Manifest

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -154,7 +154,8 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
             "today",
             "tstamp",
             "dstamp",
-            "eclipse-sourcereferences");
+            "eclipse-sourcereferences",
+            "kotlin-version");
     /**
      * Deprecated Jar manifest attribute, that is, nonetheless, useful for
      * analysis.


### PR DESCRIPTION
## Fixes Issue #3133

## Description of Change
kotlin-version from Manifest (1.4) triggers false CPE version matching (to 1.4.0 variants) where it clearly indicates a kotlin language specification version. So kotlin-version Manifest entry should be ignored in the analysis.

## Have test cases been added to cover the new functionality?

no, verified locally with snapshot build of gradle-plugin and dependency on the library mentioned in #3133 which now gets properly indentified as a version 1.4.30 (`cpe:2.3:a:jetbrains:kotlin:1.4.30:*:*:*:*:*:*:* `)