### PR TITLE
Coverity scan cid 3334550 and 318313

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/EngineVersionCheck.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/EngineVersionCheck.java
@@ -18,6 +18,7 @@
 package org.owasp.dependencycheck.data.update;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -217,8 +218,10 @@ public class EngineVersionCheck implements CachedWebDataSource {
             if (conn.getResponseCode() != 200) {
                 return null;
             }
-            final String releaseVersion = new String(IOUtils.toByteArray(conn.getInputStream()), StandardCharsets.UTF_8);
-            return releaseVersion.trim();
+            try (InputStream is = conn.getInputStream()) {
+                final String releaseVersion = new String(IOUtils.toByteArray(is), StandardCharsets.UTF_8);
+                return releaseVersion.trim();
+            }
         } catch (MalformedURLException ex) {
             LOGGER.debug("Unable to retrieve current release version of dependency-check - malformed url?");
         } catch (URLConnectionFailureException ex) {

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyMergingAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyMergingAnalyzerTest.java
@@ -245,8 +245,8 @@ public class DependencyMergingAnalyzerTest extends BaseTest {
                     break;
                 }
             }
-            dependency2.setEcosystem(Ecosystem.JAVA);
             assertNotNull("classes.jar was not found", dependency2);
+            dependency2.setEcosystem(Ecosystem.JAVA);
             DependencyMergingAnalyzer instance = new DependencyMergingAnalyzer();
             Dependency expResult = dependency1;
             Dependency result = instance.getMainAndroidDependency(dependency1, dependency2);


### PR DESCRIPTION
## Fixes Issue #

Fix Coverity issues, no GitHub issues related.

## Description of Change

Fix the following Coverity issues :
* 3334550 - by relying on the explicit assert instead of throwing a `NullPointerException`
* 318313 - by closing the `InputStream` with a try with resources

## Have test cases been added to cover the new functionality?

*no*

Sorry for not having much time to contribute lately. I hope to have more time in the near future. :slightly_smiling_face: 