### PR TITLE
Add engine.removeAll(Collection<Dependency>)

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -273,6 +273,16 @@ public class Engine implements FileFilter, AutoCloseable {
     }
 
     /**
+     * Removes all dependencies in the collection.
+     *
+     * @param dependencies the collection of dependencies to remove.
+     */
+    public synchronized void removeDependencies(@NotNull final Collection<Dependency> dependencies) {
+        dependencies.removeAll(dependencies);
+        dependenciesExternalView = null;
+    }
+
+    /**
      * Returns a copy of the dependencies as an array.
      *
      * @return the dependencies identified

--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -275,10 +275,10 @@ public class Engine implements FileFilter, AutoCloseable {
     /**
      * Removes all dependencies in the collection.
      *
-     * @param dependencies the collection of dependencies to remove.
+     * @param collection the collection of dependencies to remove.
      */
-    public synchronized void removeDependencies(@NotNull final Collection<Dependency> dependencies) {
-        dependencies.removeAll(dependencies);
+    public synchronized void removeDependencies(@NotNull final Collection<Dependency> collection) {
+        dependencies.removeAll(collection);
         dependenciesExternalView = null;
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractDependencyComparingAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractDependencyComparingAnalyzer.java
@@ -101,7 +101,7 @@ public abstract class AbstractDependencyComparingAnalyzer extends AbstractAnalyz
                     }
                 }
             }
-            engine.removeDepensdency(dependenciesToRemove);
+            engine.removeDependencies(dependenciesToRemove);
         }
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractDependencyComparingAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractDependencyComparingAnalyzer.java
@@ -101,7 +101,7 @@ public abstract class AbstractDependencyComparingAnalyzer extends AbstractAnalyz
                     }
                 }
             }
-            dependenciesToRemove.forEach((d) -> engine.removeDependency(d));
+            engine.removeDepensdency(dependenciesToRemove);
         }
     }
 


### PR DESCRIPTION
Minor update to use removeAll when removing dependencies from the engine's collection.