### PR TITLE
Generalize the suppression for Spring Boot related libraries

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -720,10 +720,11 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        Suppresses false positives per #1566.
+        Suppresses false positives per #1566 and #3580.
         ]]></notes>
-        <gav regex="true">^org\.springframework\.boot:spring-boot:.*$</gav>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/.*$</packageUrl>
         <cpe>cpe:/a:springsource:spring_framework</cpe>
+        <cpe>cpe:/a:vmware:spring_integration</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[


### PR DESCRIPTION
## Fixes Issue #3580

## Description of Change
Generalize (and convert to packageurl format) the existing suppression rule that suppresses false-positive CPEs for spring-boot subprojects.

## Have test cases been added to cover the new functionality?

no