### PR TITLE
#3594 Suppress false positive for com.nimbusds:lang-tag

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4651,5 +4651,12 @@
         <cve>CVE-2008-0660</cve>
         <cve>CVE-2014-6392</cve>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        False positive as per #3594
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.nimbusds/lang\-tag@.*$</packageUrl>
+        <cpe>cpe:/a:nim-lang:nim-lang</cpe>
+    </suppress>
     <!-- end cpan support -->
 </suppressions>


### PR DESCRIPTION
## Fixes Issue #
Fix #3594 

## Description of Change
Add a suppression for `com.nimbusds:lang-tag`. cpe `cpe:/a:nim-lang:nim-lang` is linked to https://github.com/nim-lang.

## Have test cases been added to cover the new functionality?

*no*