### PR TITLE
Prevent ConcurrentModificationException on addFalseNegativeCPEs

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
@@ -414,10 +414,8 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
     private void addFalseNegativeCPEs(Dependency dependency) {
         final CpeBuilder builder = new CpeBuilder();
         //TODO move this to the hint analyzer
-        // defensive copu for #3618 as I do not have access projects with opensso / opensso_enterprise
-        // to validate that a move of rules to the hint analyzer will result in the desired effects
-        List<Identifier> currentVulnSwIds = new ArrayList<>(dependency.getVulnerableSoftwareIdentifiers());
-        currentVulnSwIds.stream()
+        List<Identifier> identifiersToAdd = new ArrayList<>();
+        dependency.getVulnerableSoftwareIdentifiers().stream()
                 .filter((i) -> (i instanceof CpeIdentifier))
                 .map(i -> (CpeIdentifier) i)
                 .forEach((i) -> {
@@ -440,10 +438,10 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
                             final CpeIdentifier newCpeId2 = new CpeIdentifier(newCpe2, i.getConfidence());
                             final CpeIdentifier newCpeId3 = new CpeIdentifier(newCpe3, i.getConfidence());
                             final CpeIdentifier newCpeId4 = new CpeIdentifier(newCpe4, i.getConfidence());
-                            dependency.addVulnerableSoftwareIdentifier(newCpeId1);
-                            dependency.addVulnerableSoftwareIdentifier(newCpeId2);
-                            dependency.addVulnerableSoftwareIdentifier(newCpeId3);
-                            dependency.addVulnerableSoftwareIdentifier(newCpeId4);
+                            identifiersToAdd.add(newCpeId1);
+                            identifiersToAdd.add(newCpeId2);
+                            identifiersToAdd.add(newCpeId3);
+                            identifiersToAdd.add(newCpeId4);
 
                         } catch (CpeValidationException ex) {
                             LOGGER.warn("Unable to add oracle and sun CPEs", ex);
@@ -454,12 +452,13 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
                             final Cpe newCpe1 = builder.part(Part.APPLICATION).vendor("apache")
                                     .product("xml_security_for_java").version(cpe.getVersion()).build();
                             final CpeIdentifier newCpeId1 = new CpeIdentifier(newCpe1, i.getConfidence());
-                            dependency.addVulnerableSoftwareIdentifier(newCpeId1);
+                            identifiersToAdd.add(newCpeId1);
                         } catch (CpeValidationException ex) {
                             LOGGER.warn("Unable to add apache xml_security_for_java CPE", ex);
                         }
                     }
                 });
+        identifiersToAdd.forEach(dependency::addVulnerableSoftwareIdentifier);
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
@@ -414,7 +414,7 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
     private void addFalseNegativeCPEs(Dependency dependency) {
         final CpeBuilder builder = new CpeBuilder();
         //TODO move this to the hint analyzer
-        List<Identifier> identifiersToAdd = new ArrayList<>();
+        final List<Identifier> identifiersToAdd = new ArrayList<>();
         dependency.getVulnerableSoftwareIdentifiers().stream()
                 .filter((i) -> (i instanceof CpeIdentifier))
                 .map(i -> (CpeIdentifier) i)

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
@@ -414,7 +414,10 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
     private void addFalseNegativeCPEs(Dependency dependency) {
         final CpeBuilder builder = new CpeBuilder();
         //TODO move this to the hint analyzer
-        dependency.getVulnerableSoftwareIdentifiers().stream()
+        // defensive copu for #3618 as I do not have access projects with opensso / opensso_enterprise
+        // to validate that a move of rules to the hint analyzer will result in the desired effects
+        List<Identifier> currentVulnSwIds = new ArrayList<>(dependency.getVulnerableSoftwareIdentifiers());
+        currentVulnSwIds.stream()
                 .filter((i) -> (i instanceof CpeIdentifier))
                 .map(i -> (CpeIdentifier) i)
                 .forEach((i) -> {


### PR DESCRIPTION
## Fixes Issue #3618

## Description of Change

Started with a defensive copy, but preferred to gather the additions in a list instead to add all of them outside the loop that iterates over the already known vulnerableSoftwareIds.
If you have a good way to test that migration of the code to the hints rulebase is properly effective feel free to dispose of this and instead fix #3618 by removing the code and move its intended effect into the base-hints rulebase as already suggested in the existing TODO comment).
Without an ability (due to lack of access to opensso libraries) that hints that I create would trigger the desired detections I felt safer to extend the code to prevent the ConcurrentModificationException.
Scanned the source-code for calls to the getVulnerableSoftwareIdentifiers() method and did not spot any other potential ConcurrentModificationException for the set returned by that method.

## Have test cases been added to cover the new functionality?

no