### PR TITLE
Use DependencyResolver instead of ArtifactResolver for dependencies

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -39,6 +39,7 @@ import org.apache.maven.reporting.MavenReportException;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Server;
 import org.apache.maven.shared.artifact.filter.resolve.PatternInclusionsFilter;
+import org.apache.maven.shared.artifact.filter.resolve.TransformableFilter;
 import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
 import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
 import org.apache.maven.shared.transfer.artifact.TransferUtils;
@@ -1317,16 +1318,16 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 } else {
                     final ArtifactCoordinate coordinate = TransferUtils.toArtifactCoordinate(dependencyNode.getArtifact());
                     try {
-                        List<org.apache.maven.model.Dependency> dependencies = project.getDependencies();
-                        List<org.apache.maven.model.Dependency> managedDependencies = project.getDependencyManagement() == null?
-                                                                                      null:
-                                                                                      project.getDependencyManagement().getDependencies();
-                        Iterable<ArtifactResult> singleResult = dependencyResolver.resolveDependencies(buildingRequest,
-                                                                                                       dependencies,
-                                                                                                       managedDependencies,
-                                                                                                       new PatternInclusionsFilter(Collections.singletonList(TransferUtils.toArtifactCoordinate(dependencyNode.getArtifact()).toString())));
+                        final List<org.apache.maven.model.Dependency> dependencies = project.getDependencies();
+                        final List<org.apache.maven.model.Dependency> managedDependencies =
+                                project.getDependencyManagement() == null ? null : project.getDependencyManagement().getDependencies();
+                        final TransformableFilter filter = new PatternInclusionsFilter(
+                                Collections.singletonList(TransferUtils.toArtifactCoordinate(dependencyNode.getArtifact()).toString()));
+                        final Iterable<ArtifactResult> singleResult =
+                                dependencyResolver.resolveDependencies(buildingRequest, dependencies, managedDependencies, filter);
+
                         if (singleResult.iterator().hasNext()) {
-                            ArtifactResult first = singleResult.iterator().next();
+                            final ArtifactResult first = singleResult.iterator().next();
                             result = first.getArtifact();
                         } else {
                             throw new DependencyNotFoundException(String.format("Failed to resolve dependency %s with "

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -38,11 +38,15 @@ import org.apache.maven.reporting.MavenReport;
 import org.apache.maven.reporting.MavenReportException;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Server;
+import org.apache.maven.shared.artifact.filter.resolve.PatternInclusionsFilter;
 import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
 import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
 import org.apache.maven.shared.transfer.artifact.TransferUtils;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
+import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResult;
+import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolver;
+import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolverException;
 import org.eclipse.aether.artifact.ArtifactType;
 import org.apache.maven.shared.artifact.filter.PatternExcludesArtifactFilter;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
@@ -165,6 +169,16 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     @SuppressWarnings("CanBeFinal")
     @Component
     private ArtifactResolver artifactResolver;
+    /**
+     * The entry point towards a Maven version independent way of resolving
+     * dependencies (handles both Maven 3.0 Sonatype and Maven 3.1+ eclipse Aether
+     * implementations). Contrary to the ArtifactResolver this resolver also takes into
+     * account the additional repositories defined in the dependency-path towards transitive
+     * dependencies.
+     */
+    @SuppressWarnings("CanBeFinal")
+    @Component
+    private DependencyResolver dependencyResolver;
 
     /**
      * The Maven Session.
@@ -1303,8 +1317,22 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 } else {
                     final ArtifactCoordinate coordinate = TransferUtils.toArtifactCoordinate(dependencyNode.getArtifact());
                     try {
-                        result = artifactResolver.resolveArtifact(buildingRequest, coordinate).getArtifact();
-                    } catch (ArtifactResolverException ex) {
+                        List<org.apache.maven.model.Dependency> dependencies = project.getDependencies();
+                        List<org.apache.maven.model.Dependency> managedDependencies = project.getDependencyManagement() == null?
+                                                                                      null:
+                                                                                      project.getDependencyManagement().getDependencies();
+                        Iterable<ArtifactResult> singleResult = dependencyResolver.resolveDependencies(buildingRequest,
+                                                                                                       dependencies,
+                                                                                                       managedDependencies,
+                                                                                                       new PatternInclusionsFilter(Collections.singletonList(TransferUtils.toArtifactCoordinate(dependencyNode.getArtifact()).toString())));
+                        if (singleResult.iterator().hasNext()) {
+                            ArtifactResult first = singleResult.iterator().next();
+                            result = first.getArtifact();
+                        } else {
+                            throw new DependencyNotFoundException(String.format("Failed to resolve dependency %s with "
+                                                                                + "dependencyResolver", coordinate));
+                        }
+                    } catch (DependencyNotFoundException | DependencyResolverException ex) {
                         getLog().debug(String.format("Aggregate : %s", aggregate));
                         boolean addException = true;
                         //CSOFF: EmptyBlock


### PR DESCRIPTION
Use Maven's DependencyResolver instead of ArtifactResolver to resolve the (potentially transitive) dependencies from the dependencyGraph

## Fixes Issue #3626

## Description of Change

Use the DependencyResolver which takes into account the additional repositories defined in the dependency-path towards transitive dependencies to resolve the dependencies from the dependency-graph.

## Have test cases been added to cover the new functionality?

no