### PR TITLE
3620 improve doc on experimental analyzers

### DIFF
--- a/ant/src/site/markdown/configuration.md
+++ b/ant/src/site/markdown/configuration.md
@@ -92,16 +92,16 @@ artifactoryAnalyzerParallelAnalysis | Whether the Artifactory analyzer should be
 artifactoryAnalyzerUsername         | The user name (only used with API token) to connect to Artifactory instance                                | &nbsp;
 artifactoryAnalyzerApiToken         | The API token to connect to Artifactory instance, only used if the username or the API key are not defined by artifactoryAnalyzerServerId,artifactoryAnalyzerUsername or artifactoryAnalyzerApiToken | &nbsp;
 artifactoryAnalyzerBearerToken      | The bearer token to connect to Artifactory instance                                                        | &nbsp;
-pyDistributionAnalyzerEnabled       | Sets whether the [experimental](../analyzers/index.html) Python Distribution Analyzer will be used.        | true
-pyPackageAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) Python Package Analyzer will be used.             | true
-rubygemsAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used.               | true
+pyDistributionAnalyzerEnabled       | Sets whether the [experimental](../analyzers/index.html) Python Distribution Analyzer will be used. `enableExperimental` must be set to true. | true
+pyPackageAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) Python Package Analyzer will be used. `enableExperimental` must be set to true. | true
+rubygemsAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used. `enableExperimental` must be set to true. | true
 opensslAnalyzerEnabled              | Sets whether the openssl Analyzer should be used.                                                          | true
-cmakeAnalyzerEnabled                | Sets whether the [experimental](../analyzers/index.html) CMake Analyzer should be used.                    | true
-autoconfAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) autoconf Analyzer should be used.                 | true
-pipAnalyzerEnabled                  | Sets whether the [experimental](../analyzers/index.html) pip Analyzer should be used.                      | true
-pipfileAnalyzerEnabled              | Sets whether the [experimental](../analyzers/index.html) Pipfile Analyzer should be used.                  | true
-composerAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) PHP Composer Lock File Analyzer should be used.   | true
-cpanfileAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) Perl CPAN File Analyzer should be used.           | true
+cmakeAnalyzerEnabled                | Sets whether the [experimental](../analyzers/index.html) CMake Analyzer should be used. `enableExperimental` must be set to true. | true
+autoconfAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) autoconf Analyzer should be used. `enableExperimental` must be set to true. | true
+pipAnalyzerEnabled                  | Sets whether the [experimental](../analyzers/index.html) pip Analyzer should be used. `enableExperimental` must be set to true. | true
+pipfileAnalyzerEnabled              | Sets whether the [experimental](../analyzers/index.html) Pipfile Analyzer should be used. `enableExperimental` must be set to true. | true
+composerAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) PHP Composer Lock File Analyzer should be used. `enableExperimental` must be set to true. | true
+cpanfileAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) Perl CPAN File Analyzer should be used. `enableExperimental` must be set to true. | true
 nodeAnalyzerEnabled                 | Sets whether the [retired](../analyzers/index.html) Node.js Analyzer should be used.                       | true
 nodeAuditAnalyzerEnabled            | Sets whether the Node Audit Analyzer should be used. This analyzer requires an internet connection.        | true
 nodeAuditAnalyzerUseCache           | Sets whether the Node Audit Analyzer will cache results. Cached results expire after 24 hours.             | true
@@ -114,19 +114,19 @@ retirejsFilterNonVulnerable         | Configures the RetireJS Analyzer to remove
 retirejsFilter                      | A nested configuration that can be specified multple times; The regex defined is used to filter JS files based on content. | &nbsp;
 retireJsUrl                         | The URL to the Retire JS repository.                                                                       | https://raw.githubusercontent.com/Retirejs/retire.js/master/repository/jsrepository.json
 nuspecAnalyzerEnabled               | Sets whether the .NET Nuget Nuspec Analyzer will be used.                                                  | true
-nugetconfAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used. | true
-cocoapodsAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used.                | true
-mixAuditAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) Mix Audit Analyzer should be used.                | true
+nugetconfAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used. `enableExperimental` must be set to true. | true
+cocoapodsAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used. `enableExperimental` must be set to true. | true
+mixAuditAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) Mix Audit Analyzer should be used. `enableExperimental` must be set to true. | true
 mixAuditPath                        | Sets the path to the mix_audit executable; only used if mix audit analyzer is enabled and experimental analyzers are enabled.  | &nbsp;
-bundleAuditAnalyzerEnabled          | Sets whether the [experimental](../analyzers/index.html) Bundle Audit Analyzer should be used.             | true
+bundleAuditAnalyzerEnabled          | Sets whether the [experimental](../analyzers/index.html) Bundle Audit Analyzer should be used. `enableExperimental` must be set to true. | true
 bundleAuditPath                     | Sets the path to the bundle audit executable; only used if bundle audit analyzer is enabled and experimental analyzers are enabled.  | &nbsp;
-swiftPackageManagerAnalyzerEnabled  | Sets whether the [experimental](../analyzers/index.html) Swift Package Analyzer should be used.            | true
-swiftPackageResolvedAnalyzerEnabled | Sets whether the [experimental](../analyzers/index.html) Swift Package Resolved should be used.            | true
+swiftPackageManagerAnalyzerEnabled  | Sets whether the [experimental](../analyzers/index.html) Swift Package Analyzer should be used. `enableExperimental` must be set to true. | true
+swiftPackageResolvedAnalyzerEnabled | Sets whether the [experimental](../analyzers/index.html) Swift Package Resolved should be used. `enableExperimental` must be set to true. | true
 assemblyAnalyzerEnabled             | Sets whether the .NET Assembly Analyzer should be used.                                                    | true
 msbuildAnalyzerEnabled              | Sets whether the MSBuild Analyzer should be used.                                                          | true
 pathToCore                          | The path to dotnet core .NET assembly analysis on non-windows systems.                                     | &nbsp;
-golangDepEnabled                    | Sets whether or not the [experimental](../analyzers/index.html) Golang Dependency Analyzer should be used. | true
-golangModEnabled                    | Sets whether or not the [experimental](../analyzers/index.html) Goland Module Analyzer should be used; requires `go` to be installed. | true
+golangDepEnabled                    | Sets whether or not the [experimental](../analyzers/index.html) Golang Dependency Analyzer should be used. `enableExperimental` must be set to true. | true
+golangModEnabled                    | Sets whether or not the [experimental](../analyzers/index.html) Goland Module Analyzer should be used; requires `go` to be installed. `enableExperimental` must be set to true. | true
 pathToGo                            | The path to `go`.                                                                                          | &nbsp;
 
 Advanced Configuration

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -107,6 +107,7 @@ analyzer.retired.enabled=false
 
 analyzer.jar.enabled=true
 analyzer.archive.enabled=true
+analyzer.cpanfile.enabled=true
 analyzer.node.package.enabled=true
 analyzer.node.audit.enabled=true
 analyzer.yarn.audit.enabled=true
@@ -135,6 +136,7 @@ analyzer.central.enabled=true
 analyzer.nexus.enabled=false
 analyzer.cocoapods.enabled=true
 analyzer.swift.package.manager.enabled=true
+analyzer.swift.package.resolved.enabled=true
 #whether the nexus analyzer uses the proxy
 analyzer.nexus.proxy=true
 analyzer.cpe.enabled=true

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java
@@ -1,6 +1,5 @@
 package org.owasp.dependencycheck.analyzer;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -130,7 +129,6 @@ public class DependencyCheckPropertiesTest {
         return Collections.emptySet();
     }
 
-    @NotNull
     private Set<Class<?>> tryGetClasses(String packageName, BufferedReader reader) {
         return reader.lines()
                 .filter(line -> line.endsWith(".class"))
@@ -146,7 +144,6 @@ public class DependencyCheckPropertiesTest {
         }
     }
 
-    @NotNull
     private Class<?> tryGetClass(String className, String packageName) throws ClassNotFoundException {
         return Class.forName(packageName + "." + className.substring(0, className.lastIndexOf('.')));
     }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java
@@ -72,23 +72,11 @@ public class DependencyCheckPropertiesTest {
     }
 
     private boolean isAnalyzerImplementation(Class<?> clazz) {
-        if (isAnAbstractClass(clazz)) {
+        if (isAnAbstractClass(clazz) || isATestAnalyzer(clazz)) {
             return false;
         }
 
-        if (isATestAnalyzer(clazz)) {
-            return false;
-        }
-
-        Class<?> superclass = clazz.getSuperclass();
-        while (superclass != Object.class) {
-            if (extendsAbstractAnalyzer(superclass)) {
-                return true;
-            }
-            superclass = superclass.getSuperclass();
-        }
-
-        return false;
+        return AbstractAnalyzer.class.isAssignableFrom(clazz);
     }
 
     private boolean isAnAbstractClass(Class<?> clazz) {
@@ -97,10 +85,6 @@ public class DependencyCheckPropertiesTest {
 
     private boolean isATestAnalyzer(Class<?> clazz) {
         return clazz == AbstractSuppressionAnalyzerTest.AbstractSuppressionAnalyzerImpl.class;
-    }
-
-    private boolean extendsAbstractAnalyzer(Class<?> superclass) {
-        return superclass == AbstractAnalyzer.class;
     }
 
     public Set<Class<?>> findAllClasses(String packageName) throws IOException {

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java
@@ -1,0 +1,153 @@
+package org.owasp.dependencycheck.analyzer;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DependencyCheckPropertiesTest {
+
+    @Test
+    public void should_each_analyzer_have_default_enabled_property()
+            throws IOException, InstantiationException, IllegalAccessException {
+        String packageName = "org.owasp.dependencycheck.analyzer";
+        Set<Class<AbstractAnalyzer>> analyzerImplementations = findAllAnalyzerImplementations(packageName);
+
+        Set<String> analyzerEnabledSettingKeys = new HashSet<>();
+
+        for (Class<AbstractAnalyzer> analyzerClass : analyzerImplementations) {
+            AbstractAnalyzer analyzer = analyzerClass.newInstance();
+            String enabledKey = analyzer.getAnalyzerEnabledSettingKey();
+            analyzerEnabledSettingKeys.add(enabledKey);
+        }
+
+
+        Properties properties = new Properties();
+        Path propertiesPath = Paths.get("src", "main", "resources", "dependencycheck.properties");
+        try (FileInputStream fis = new FileInputStream(propertiesPath.toFile())) {
+            properties.load(fis);
+        }
+
+        Assert.assertFalse(analyzerEnabledSettingKeys.isEmpty());
+
+        Set<String> absentKeys = analyzerEnabledSettingKeys.stream()
+                .filter(key -> !properties.containsKey(key))
+                .collect(Collectors.toSet());
+
+        Assert.assertTrue(absentKeys.isEmpty());
+    }
+
+    public Set<Class<AbstractAnalyzer>> findAllAnalyzerImplementations(String packageName)
+            throws IOException {
+
+        Set<Class<?>> packageClasses = findAllClasses(packageName);
+
+        Set<Class<AbstractAnalyzer>> analyzers = new HashSet<>();
+        for (Class<?> clazz : packageClasses) {
+            if (isAnalyzerImplementation(clazz)) {
+                // We can safely cast due to call to isAnalyzerImplementation()
+                @SuppressWarnings("unchecked")
+                Class<AbstractAnalyzer> abstractAnalyzer = (Class<AbstractAnalyzer>) clazz;
+                analyzers.add(abstractAnalyzer);
+            }
+        }
+
+        return analyzers;
+    }
+
+    private boolean isAnalyzerImplementation(Class<?> clazz) {
+        if (isAnAbstractClass(clazz)) {
+            return false;
+        }
+
+        if (isATestAnalyzer(clazz)) {
+            return false;
+        }
+
+        Class<?> superclass = clazz.getSuperclass();
+        while (superclass != Object.class) {
+            if (extendsAbstractAnalyzer(superclass)) {
+                return true;
+            }
+            superclass = superclass.getSuperclass();
+        }
+
+        return false;
+    }
+
+    private boolean isAnAbstractClass(Class<?> clazz) {
+        return Modifier.isAbstract(clazz.getModifiers());
+    }
+
+    private boolean isATestAnalyzer(Class<?> clazz) {
+        return clazz == AbstractSuppressionAnalyzerTest.AbstractSuppressionAnalyzerImpl.class;
+    }
+
+    private boolean extendsAbstractAnalyzer(Class<?> superclass) {
+        return superclass == AbstractAnalyzer.class;
+    }
+
+    public Set<Class<?>> findAllClasses(String packageName) throws IOException {
+        String parsedPackageName = packageName.replaceAll("[.]", File.separator);
+
+        Set<Class<?>> classes = new HashSet<>();
+        Enumeration<URL> resources = ClassLoader.getSystemClassLoader().getResources(parsedPackageName);
+        while (resources.hasMoreElements()) {
+            URL resource = resources.nextElement();
+            classes.addAll(getClasses(resource, packageName));
+        }
+
+        return classes;
+    }
+
+    private Set<Class<?>> getClasses(URL resource, String packageName) throws IOException {
+        if (Objects.nonNull(resource)) {
+            try (InputStream is = resource.openStream();
+                 InputStreamReader isr = new InputStreamReader(is);
+                 BufferedReader reader = new BufferedReader(isr)) {
+
+                return tryGetClasses(packageName, reader);
+            }
+        }
+
+        return Collections.emptySet();
+    }
+
+    @NotNull
+    private Set<Class<?>> tryGetClasses(String packageName, BufferedReader reader) {
+        return reader.lines()
+                .filter(line -> line.endsWith(".class"))
+                .map(line -> getClass(line, packageName))
+                .collect(Collectors.toSet());
+    }
+
+    private Class<?> getClass(String className, String packageName) {
+        try {
+            return tryGetClass(className, packageName);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @NotNull
+    private Class<?> tryGetClass(String className, String packageName) throws ClassNotFoundException {
+        return Class.forName(packageName + "." + className.substring(0, className.lastIndexOf('.')));
+    }
+}

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import org.owasp.dependencycheck.dependency.EvidenceType;
@@ -190,5 +191,11 @@ public class SwiftAnalyzersTest extends BaseTest {
         assertThat(engine.getDependencies()[1].getVersion(), equalTo("4.2.0"));
         assertThat(engine.getDependencies()[2].getName(), equalTo("Facebook"));
         assertThat(engine.getDependencies()[2].getVersion(), equalTo("9.3.0"));
+    }
+
+    @Test
+    public void testIsEnabledIsTrueByDefault() {
+        assertTrue(spmAnalyzer.isEnabled());
+        assertTrue(sprAnalyzer.isEnabled());
     }
 }

--- a/maven/src/site/markdown/configuration.md
+++ b/maven/src/site/markdown/configuration.md
@@ -71,16 +71,16 @@ artifactoryAnalyzerServerId         | The id of a server defined in the settings
 artifactoryAnalyzerUsername         | The user name (only used with API token) to connect to Artifactory instance                                                                         | &nbsp;
 artifactoryAnalyzerApiToken         | The API token to connect to Artifactory instance, only used if the username or the API key are not defined by artifactoryAnalyzerServerId,artifactoryAnalyzerUsername or artifactoryAnalyzerApiToken | &nbsp;
 artifactoryAnalyzerBearerToken      | The bearer token to connect to Artifactory instance                                                                                                 | &nbsp;
-pyDistributionAnalyzerEnabled       | Sets whether the [experimental](../analyzers/index.html) Python Distribution Analyzer will be used.                                                 | true
-pyPackageAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) Python Package Analyzer will be used.                                                      | true
-rubygemsAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used.                                                        | true
+pyDistributionAnalyzerEnabled       | Sets whether the [experimental](../analyzers/index.html) Python Distribution Analyzer will be used. `enableExperimental` must be set to true.       | true
+pyPackageAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) Python Package Analyzer will be used. `enableExperimental` must be set to true.            | true
+rubygemsAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used. `enableExperimental` must be set to true.              | true
 opensslAnalyzerEnabled              | Sets whether the openssl Analyzer should be used.                                                                                                   | true
-cmakeAnalyzerEnabled                | Sets whether the [experimental](../analyzers/index.html) CMake Analyzer should be used.                                                             | true
-autoconfAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) autoconf Analyzer should be used.                                                          | true
-pipAnalyzerEnabled                  | Sets whether the [experimental](../analyzers/index.html) pip Analyzer should be used.                                                               | true
-pipfileAnalyzerEnabled              | Sets whether the [experimental](../analyzers/index.html) Pipfile Analyzer should be used.                                                           | true
-composerAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) PHP Composer Lock File Analyzer should be used.                                            | true
-cpanfileAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) Perl CPAN File Analyzer should be used.                                                    | true
+cmakeAnalyzerEnabled                | Sets whether the [experimental](../analyzers/index.html) CMake Analyzer should be used. `enableExperimental` must be set to true.                   | true
+autoconfAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) autoconf Analyzer should be used. `enableExperimental` must be set to true.                | true
+pipAnalyzerEnabled                  | Sets whether the [experimental](../analyzers/index.html) pip Analyzer should be used. `enableExperimental` must be set to true.                     | true
+pipfileAnalyzerEnabled              | Sets whether the [experimental](../analyzers/index.html) Pipfile Analyzer should be used. `enableExperimental` must be set to true.                 | true
+composerAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) PHP Composer Lock File Analyzer should be used. `enableExperimental` must be set to true.  | true
+cpanfileAnalyzerEnabled             | Sets whether the [experimental](../analyzers/index.html) Perl CPAN File Analyzer should be used. `enableExperimental` must be set to true.          | true
 yarnAuditAnalyzerEnabled            | Sets whether the Yarn Audit Analyzer should be used. This analyzer requires yarn and an internet connection.  Use `nodeAuditSkipDevDependencies` to skip dev dependencies. | true
 pathToYarn                          | The path to `yarn`.                                                                                                                                 | &nbsp;
 nodeAnalyzerEnabled                 | Sets whether the [retired](../analyzers/index.html) Node.js Analyzer should be used.                                                                | true
@@ -91,17 +91,17 @@ retireJsAnalyzerEnabled             | Sets whether the RetireJS Analyzer should 
 retirejsForceupdate                 | Sets whether the RetireJS Analyzer should update regardless of the `autoupdate` setting.                                                            | false
 retireJsUrl                         | The URL to the Retire JS repository. **Note** the file name must be `jsrepository.json`.                                                            | https://raw.githubusercontent.com/Retirejs/retire.js/master/repository/jsrepository.json
 nuspecAnalyzerEnabled               | Sets whether the .NET Nuget Nuspec Analyzer will be used.                                                                                           | true
-nugetconfAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used.                                          | true
-cocoapodsAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used.                                                         | true
-bundleAuditAnalyzerEnabled          | Sets whether the [experimental](../analyzers/index.html) Bundle Audit Analyzer should be used.                                                      | true
+nugetconfAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used. `enableExperimental` must be set to true. | true
+cocoapodsAnalyzerEnabled            | Sets whether the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used. `enableExperimental` must be set to true.               | true
+bundleAuditAnalyzerEnabled          | Sets whether the [experimental](../analyzers/index.html) Bundle Audit Analyzer should be used. `enableExperimental` must be set to true.            | true
 bundleAuditPath                     | Sets the path to the bundle audit executable; only used if bundle audit analyzer is enabled and experimental analyzers are enabled.                 | &nbsp;
-swiftPackageManagerAnalyzerEnabled  | Sets whether the [experimental](../analyzers/index.html) Swift Package Analyzer should be used.                                                     | true
-swiftPackageResolvedAnalyzerEnabled | Sets whether the [experimental](../analyzers/index.html) Swift Package Resolved should be used.                                                     | true
+swiftPackageManagerAnalyzerEnabled  | Sets whether the [experimental](../analyzers/index.html) Swift Package Analyzer should be used. `enableExperimental` must be set to true.           | true
+swiftPackageResolvedAnalyzerEnabled | Sets whether the [experimental](../analyzers/index.html) Swift Package Resolved should be used. `enableExperimental` must be set to true.           | true
 assemblyAnalyzerEnabled             | Sets whether the .NET Assembly Analyzer should be used.                                                                                             | true
 msbuildAnalyzerEnabled              | Sets whether the MSBuild Analyzer should be used.                                                                                                   | true
 pathToCore                          | The path to dotnet core .NET assembly analysis on non-windows systems.                                                                              | &nbsp;
-golangDepEnabled                    | Sets whether or not the [experimental](../analyzers/index.html) Golang Dependency Analyzer should be used.                                          | true
-golangModEnabled                    | Sets whether or not the [experimental](../analyzers/index.html) Goland Module Analyzer should be used; requires `go` to be installed.               | true
+golangDepEnabled                    | Sets whether or not the [experimental](../analyzers/index.html) Golang Dependency Analyzer should be used. `enableExperimental` must be set to true.| true
+golangModEnabled                    | Sets whether or not the [experimental](../analyzers/index.html) Goland Module Analyzer should be used; requires `go` to be installed. `enableExperimental` must be set to true. | true
 pathToGo                            | The path to `go`.                                                                                                                                   | &nbsp;
 
 RetireJS Configuration

--- a/src/site/markdown/dependency-check-gradle/configuration-aggregate.md
+++ b/src/site/markdown/dependency-check-gradle/configuration-aggregate.md
@@ -119,27 +119,27 @@ analyzers    | centralEnabled        | Sets whether Central Analyzer will be use
 analyzers    | nexusEnabled          | Sets whether Nexus Analyzer will be used (requires Nexus Pro). This analyzer is superceded by the Central Analyzer; however, you can configure this to run against a Nexus Pro installation. | true
 analyzers    | nexusUrl              | Defines the Nexus Server's web service end point (example http://domain.enterprise/service/local/). If not set the Nexus Analyzer will be disabled. | &nbsp;
 analyzers    | nexusUsesProxy        | Whether or not the defined proxy should be used when connecting to Nexus.                                         | true
-analyzers    | pyDistributionEnabled | Sets whether the [experimental](../analyzers/index.html) Python Distribution Analyzer will be used.               | true
-analyzers    | pyPackageEnabled      | Sets whether the [experimental](../analyzers/index.html) Python Package Analyzer will be used.                    | true
-analyzers    | rubygemsEnabled       | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used.                      | true
+analyzers    | pyDistributionEnabled | Sets whether the [experimental](../analyzers/index.html) Python Distribution Analyzer will be used. `experimentalEnabled` must be set to true. | true
+analyzers    | pyPackageEnabled      | Sets whether the [experimental](../analyzers/index.html) Python Package Analyzer will be used. `experimentalEnabled` must be set to true. | true
+analyzers    | rubygemsEnabled       | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used. `experimentalEnabled` must be set to true. | true
 analyzers    | opensslEnabled        | Sets whether or not the openssl Analyzer should be used.                                                          | true
 analyzers    | nuspecEnabled         | Sets whether or not the .NET Nuget Nuspec Analyzer will be used.                                                  | true
-analyzers    | nugetconfEnabled      | Sets whether or not the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used. | true
+analyzers    | nugetconfEnabled      | Sets whether or not the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used. `experimentalEnabled` must be set to true. | true
 analyzers    | assemblyEnabled       | Sets whether or not the .NET Assembly Analyzer should be used.                                                    | true
 analyzers    | msbuildEnabled        | Sets whether or not the MS Build Analyzer should be used.                                                         | true
 analyzers    | pathToDotnet          | The path to dotnet core - needed on some systems to analyze .net assemblies.                                      | &nbsp;
-analyzers    | cmakeEnabled          | Sets whether or not the [experimental](../analyzers/index.html) CMake Analyzer should be used.                    | true
-analyzers    | autoconfEnabled       | Sets whether or not the [experimental](../analyzers/index.html) autoconf Analyzer should be used.                 | true
-analyzers    | composerEnabled       | Sets whether or not the [experimental](../analyzers/index.html) PHP Composer Lock File Analyzer should be used.   | true
-analyzers    | cpanEnabled           | Sets whether or not the [experimental](../analyzers/index.html) Perl CPAN File Analyzer should be used.           | true
+analyzers    | cmakeEnabled          | Sets whether or not the [experimental](../analyzers/index.html) CMake Analyzer should be used. `experimentalEnabled` must be set to true. | true
+analyzers    | autoconfEnabled       | Sets whether or not the [experimental](../analyzers/index.html) autoconf Analyzer should be used. `experimentalEnabled` must be set to true. | true
+analyzers    | composerEnabled       | Sets whether or not the [experimental](../analyzers/index.html) PHP Composer Lock File Analyzer should be used. `experimentalEnabled` must be set to true. | true
+analyzers    | cpanEnabled           | Sets whether or not the [experimental](../analyzers/index.html) Perl CPAN File Analyzer should be used. `experimentalEnabled` must be set to true. | true
 analyzers    | nodeEnabled           | Sets whether or not the Node.js Analyzer should be used.                                                          | true
-analyzers    | cocoapodsEnabled      | Sets whether or not the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used.                | true
-analyzers    | swiftEnabled          | Sets whether or not the [experimental](../analyzers/index.html) Swift Package Manager Analyzer should be used.    | true
-analyzers    | swiftPackageResolvedEnabled | Sets whether or not the [experimental](../analyzers/index.html) Swift Package Resolved Analyzer should be used. | true
-analyzers    | bundleAuditEnabled    | Sets whether or not the [experimental](../analyzers/index.html) Ruby Bundle Audit Analyzer should be used.        | true
+analyzers    | cocoapodsEnabled      | Sets whether or not the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used. `experimentalEnabled` must be set to true. | true
+analyzers    | swiftEnabled          | Sets whether or not the [experimental](../analyzers/index.html) Swift Package Manager Analyzer should be used. `experimentalEnabled` must be set to true. | true
+analyzers    | swiftPackageResolvedEnabled | Sets whether or not the [experimental](../analyzers/index.html) Swift Package Resolved Analyzer should be used. `experimentalEnabled` must be set to true. | true
+analyzers    | bundleAuditEnabled    | Sets whether or not the [experimental](../analyzers/index.html) Ruby Bundle Audit Analyzer should be used. `experimentalEnabled` must be set to true. | true
 analyzers    | pathToBundleAudit     | The path to bundle audit.                                                                                         | &nbsp;
-analyzers    | golangDepEnabled      | Sets whether or not the [experimental](../analyzers/index.html) Golang Dependency Analyzer should be used.        | true
-analyzers    | golangModEnabled      | Sets whether or not the [experimental](../analyzers/index.html) Goland Module Analyzer should be used; requies `go` to be installed. | true
+analyzers    | golangDepEnabled      | Sets whether or not the [experimental](../analyzers/index.html) Golang Dependency Analyzer should be used. `experimentalEnabled` must be set to true. | true
+analyzers    | golangModEnabled      | Sets whether or not the [experimental](../analyzers/index.html) Goland Module Analyzer should be used; requies `go` to be installed. `experimentalEnabled` must be set to true. | true
 analyzers    | pathToGo              | The path to `go`.                                                                                                 | &nbsp;
 
 #### Additional Configuration

--- a/src/site/markdown/dependency-check-gradle/configuration.md
+++ b/src/site/markdown/dependency-check-gradle/configuration.md
@@ -103,28 +103,28 @@ analyzers    | centralEnabled        | Sets whether Central Analyzer will be use
 analyzers    | nexusEnabled          | Sets whether Nexus Analyzer will be used (requires Nexus Pro). This analyzer is superceded by the Central Analyzer; however, you can configure this to run against a Nexus Pro installation. | true
 analyzers    | nexusUrl              | Defines the Nexus Server's web service end point (example http://domain.enterprise/service/local/). If not set the Nexus Analyzer will be disabled. | &nbsp;
 analyzers    | nexusUsesProxy        | Whether or not the defined proxy should be used when connecting to Nexus.                                         | true
-analyzers    | pyDistributionEnabled | Sets whether the [experimental](../analyzers/index.html) Python Distribution Analyzer will be used.               | true
-analyzers    | pyPackageEnabled      | Sets whether the [experimental](../analyzers/index.html) Python Package Analyzer will be used.                    | true
-analyzers    | rubygemsEnabled       | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used.                      | true
+analyzers    | pyDistributionEnabled | Sets whether the [experimental](../analyzers/index.html) Python Distribution Analyzer will be used. `experimentalEnabled` must be set to true. | true
+analyzers    | pyPackageEnabled      | Sets whether the [experimental](../analyzers/index.html) Python Package Analyzer will be used. `experimentalEnabled` must be set to true. | true
+analyzers    | rubygemsEnabled       | Sets whether the [experimental](../analyzers/index.html) Ruby Gemspec Analyzer will be used. `experimentalEnabled` must be set to true. | true
 analyzers    | opensslEnabled        | Sets whether or not the openssl Analyzer should be used.                                                          | true
 analyzers    | nuspecEnabled         | Sets whether or not the .NET Nuget Nuspec Analyzer will be used.                                                  | true
-analyzers    | nugetconfEnabled      | Sets whether or not the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used. | true
+analyzers    | nugetconfEnabled      | Sets whether or not the [experimental](../analyzers/index.html) .NET Nuget packages.config Analyzer will be used. `experimentalEnabled` must be set to true. | true
 analyzers    | assemblyEnabled       | Sets whether or not the .NET Assembly Analyzer should be used.                                                    | true
 analyzers    | msbuildEnabled        | Sets whether or not the MS Build Analyzer should be used.                                                         | true
 analyzers    | pathToDotnet          | The path to dotnet core - needed on some systems to analyze .net assemblies.                                      | &nbsp;
-analyzers    | cmakeEnabled          | Sets whether or not the [experimental](../analyzers/index.html) CMake Analyzer should be used.                    | true
-analyzers    | autoconfEnabled       | Sets whether or not the [experimental](../analyzers/index.html) autoconf Analyzer should be used.                 | true
-analyzers    | composerEnabled       | Sets whether or not the [experimental](../analyzers/index.html) PHP Composer Lock File Analyzer should be used.   | true
-analyzers    | cpanEnabled           | Sets whether or not the [experimental](../analyzers/index.html) Perl CPAN File Analyzer should be used.           | true
+analyzers    | cmakeEnabled          | Sets whether or not the [experimental](../analyzers/index.html) CMake Analyzer should be used. `experimentalEnabled` must be set to true. | true
+analyzers    | autoconfEnabled       | Sets whether or not the [experimental](../analyzers/index.html) autoconf Analyzer should be used. `experimentalEnabled` must be set to true. | true
+analyzers    | composerEnabled       | Sets whether or not the [experimental](../analyzers/index.html) PHP Composer Lock File Analyzer should be used. `experimentalEnabled` must be set to true. | true
+analyzers    | cpanEnabled           | Sets whether or not the [experimental](../analyzers/index.html) Perl CPAN File Analyzer should be used. `experimentalEnabled` must be set to true. | true
 analyzers    | nodeEnabled           | Sets whether or not the Node.js Analyzer should be used.                                                          | true
-analyzers    | cocoapodsEnabled      | Sets whether or not the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used.                | true
-analyzers    | swiftEnabled          | Sets whether or not the [experimental](../analyzers/index.html) Swift Package Manager Analyzer should be used.    | true
-analyzers    | swiftPackageResolvedEnabled | Sets whether or not the [experimental](../analyzers/index.html) Swift Package Resolved Analyzer should be used. | true
-analyzers    | bundleAuditEnabled    | Sets whether or not the [experimental](../analyzers/index.html) Ruby Bundle Audit Analyzer should be used.        | true
+analyzers    | cocoapodsEnabled      | Sets whether or not the [experimental](../analyzers/index.html) Cocoapods Analyzer should be used. `experimentalEnabled` must be set to true. | true
+analyzers    | swiftEnabled          | Sets whether or not the [experimental](../analyzers/index.html) Swift Package Manager Analyzer should be used. `experimentalEnabled` must be set to true. | true
+analyzers    | swiftPackageResolvedEnabled | Sets whether or not the [experimental](../analyzers/index.html) Swift Package Resolved Analyzer should be used. `experimentalEnabled` must be set to true. | true
+analyzers    | bundleAuditEnabled    | Sets whether or not the [experimental](../analyzers/index.html) Ruby Bundle Audit Analyzer should be used. `experimentalEnabled` must be set to true. | true
 analyzers    | pathToBundleAudit     | The path to bundle audit.                                                                                         | &nbsp;
 analyzers    | retiredEnabled        | Sets whether the [retired analyzers](../analyzers/index.html) will be used. If not set to true the analyzers marked as experimental (see below) will not be used | false
-analyzers    | golangDepEnabled      | Sets whether or not the [experimental](../analyzers/index.html) Golang Dependency Analyzer should be used.        | true
-analyzers    | golangModEnabled      | Sets whether or not the [experimental](../analyzers/index.html) Goland Module Analyzer should be used; requires `go` to be installed. | true
+analyzers    | golangDepEnabled      | Sets whether or not the [experimental](../analyzers/index.html) Golang Dependency Analyzer should be used. `experimentalEnabled` must be set to true. | true
+analyzers    | golangModEnabled      | Sets whether or not the [experimental](../analyzers/index.html) Goland Module Analyzer should be used; requires `go` to be installed. `experimentalEnabled` must be set to true. | true
 analyzers    | pathToGo              | The path to `go`.                                                                                                 | &nbsp;
 
 #### Additional Configuration


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

Fix #3620 

The goal of this PR is to :
* Make it more explicit that experimental analyzers property must be enabled for an experimental analyzer to run
* Enforce analyzers keys are all listed in the `dependencycheck.properties` file to prevent any misunderstanding.

I did not updated the cli documentation because the options are disabling analyzers instead of enabling them. I thought the misunderstanding was not present in this case. Another reason is also that I couldn't come with a short but clear & explicit sentence like the other tools.

Any suggestion is welcomed. :slightly_smiling_face: 

## Have test cases been added to cover the new functionality?

*yes*