### PR TITLE
Suppress FP CPEs for the spring-boot-starter-oauth2-client project

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -443,6 +443,14 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
+       False positive per #3622. Spring-boot-starter-oauth2-client gets flagged with wrong spring CPEs.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot\-starter\-oauth2\-client@.*$</packageUrl>
+        <cpe>cpe:/a:pivotal:spring_security_oauth</cpe>
+        <cpe>cpe:/a:pivotal:spring_security</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
         This suppreses additional false positives for the xstream library that occur because spring has a copy of this library.
             com.springsource.com.thoughtworks.xstream-1.3.1.jar
         ]]></notes>


### PR DESCRIPTION
## Fixes Issue #3622

## Description of Change

Add suppressions for false CPE matches that appear in the gradle-plugin.

*Note that full resolution of the issue also requires the release of an updated gradle-plugin*

## Have test cases been added to cover the new functionality?

no