### PR TITLE
CID-338792 Specify encoding of analyzer files

### DIFF
--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Modifier;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -103,7 +104,7 @@ public class DependencyCheckPropertiesTest {
     private Set<Class<?>> getClasses(URL resource, String packageName) throws IOException {
         if (Objects.nonNull(resource)) {
             try (InputStream is = resource.openStream();
-                 InputStreamReader isr = new InputStreamReader(is);
+                 InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
                  BufferedReader reader = new BufferedReader(isr)) {
 
                 return tryGetClasses(packageName, reader);


### PR DESCRIPTION
## Fixes Issue #

No github issue referenced

## Description of Change

Fix SpotBugs issue raised by Coverity scan:
```
Hi,

Please find the latest report on new defect(s) introduced to jeremylong/DependencyCheck found with Coverity Scan.

1 new defect(s) introduced to jeremylong/DependencyCheck found with Coverity Scan.


New defect(s) Reported-by: Coverity Scan
Showing 1 of 1 defect(s)


** CID 338792:  SpotBugs: Internationalization  (FB.DM_DEFAULT_ENCODING)
/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java: 106 in org.owasp.dependencycheck.analyzer.DependencyCheckPropertiesTest.getClasses(java.net.URL, java.lang.String)()


________________________________________________________________________________________________________
*** CID 338792:  SpotBugs: Internationalization  (FB.DM_DEFAULT_ENCODING)
/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java: 106 in org.owasp.dependencycheck.analyzer.DependencyCheckPropertiesTest.getClasses(java.net.URL, java.lang.String)()
100             return classes;
101         }
102     
103         private Set<Class<?>> getClasses(URL resource, String packageName) throws IOException {
104             if (Objects.nonNull(resource)) {
105                 try (InputStream is = resource.openStream();

                CID 338792:  SpotBugs: Internationalization  (FB.DM_DEFAULT_ENCODING)
                Found reliance on default encoding: new java.io.InputStreamReader(InputStream).

106                      InputStreamReader isr = new InputStreamReader(is);
107                      BufferedReader reader = new BufferedReader(isr)) {
108     
109                     return tryGetClasses(packageName, reader);
110                 }
111             }
```

## Have test cases been added to cover the new functionality?

*no*