### PR TITLE
Include external references from OSS Index API response in the report

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -339,7 +339,7 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
 
         // generate references to other references reported by OSS Index
         for (final String externalReference : source.getExternalReferences()) {
-            result.addReference("MISC", null, externalReference);
+            result.addReference("OSSIndex", externalReference, externalReference);
         }
 
         // attach vulnerable software details as best we can

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -337,6 +337,11 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
         // generate a reference to the vulnerability details on OSS Index
         result.addReference(REFERENCE_TYPE, source.getTitle(), source.getReference().toString());
 
+        // generate references to other references reported by OSS Index
+        for (final String externalReference : source.getExternalReferences()) {
+            result.addReference("MISC", null, externalReference);
+        }
+
         // attach vulnerable software details as best we can
         final PackageUrl purl = report.getCoordinates();
         try {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -339,7 +339,7 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
 
         // generate references to other references reported by OSS Index
         for (final String externalReference : source.getExternalReferences()) {
-            result.addReference("OSSIndex", externalReference, externalReference);
+            result.addReference("OSSIndex", externalReference.toString(), externalReference.toString());
         }
 
         // attach vulnerable software details as best we can


### PR DESCRIPTION
## Fixes Issue #
DependencyCheck report is missing references that are visible on the OSS Index vulnerability page

## Description of Change

Add externalReferences reported by OSS Index to the DependencyCheck report as well.
Relevant links:
https://github.com/OSSIndex/vulns/issues/193
https://javadoc.io/doc/org.sonatype.ossindex/ossindex-service-api/latest/index.html

## Have test cases been added to cover the new functionality?

*no*