### PR TITLE
Generalize the spark-sketch suppression from 2.10 to other versions

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -1793,7 +1793,7 @@
         <notes><![CDATA[
         Suppresses false positives per #1961. spark-sketch is not sketch - an vector drawing tool.
         ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.spark/spark\-sketch_2\.10@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.spark/spark\-sketch_2\.\d+@.*$</packageUrl>
         <cpe>cpe:/a:sketch:sketch</cpe>
     </suppress>
     <suppress base="true">


### PR DESCRIPTION
## Fixes Issue #3641

## Description of Change

Generalize the spark-sketch suppression from 2.10 to other versions (e.g 2.12 as raised in #3641)

## Have test cases been added to cover the new functionality?

no