### PR TITLE
add hive storage cve suppress CVE-2020-13949

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4666,5 +4666,12 @@
         <packageUrl regex="true">^pkg:maven/com\.nimbusds/lang\-tag@.*$</packageUrl>
         <cpe>cpe:/a:nim-lang:nim-lang</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        file name: hive-storage-api-2.8.1.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.hive/hive\-storage\-api@.*$</packageUrl>
+        <cve>CVE-2020-13949</cve>
+    </suppress>
     <!-- end cpan support -->
 </suppressions>


### PR DESCRIPTION
## Fixes Issue #3668

## Description of Change

Add suppress for false positive on library hive-storage-api on CVE-2020-13949, which is for Apache Thrift based on the description in https://nvd.nist.gov/vuln/detail/CVE-2020-13949

## Have test cases been added to cover the new functionality?

no