### PR TITLE
Reduce download threads and add sleep for NVD downloads

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
@@ -170,7 +170,7 @@ public class NvdCveUpdater implements CachedWebDataSource {
      */
     protected void initializeExecutorServices() {
         final int downloadPoolSize;
-        final int max = settings.getInt(Settings.KEYS.MAX_DOWNLOAD_THREAD_POOL_SIZE, 3);
+        final int max = settings.getInt(Settings.KEYS.MAX_DOWNLOAD_THREAD_POOL_SIZE, 1);
         if (DOWNLOAD_THREAD_POOL_SIZE > max) {
             downloadPoolSize = max;
         } else {
@@ -340,6 +340,7 @@ public class NvdCveUpdater implements CachedWebDataSource {
             final URL u = new URL(metaUrl);
             final Downloader d = new Downloader(settings);
             final String content = d.fetchContent(u, true, Settings.KEYS.CVE_USER, Settings.KEYS.CVE_PASSWORD);
+            Thread.sleep(2000);
             return new MetaProperties(content);
         } catch (MalformedURLException ex) {
             throw new UpdateException("Meta file url is invalid: " + metaUrl, ex);
@@ -351,6 +352,9 @@ public class NvdCveUpdater implements CachedWebDataSource {
             throw new UpdateException("Unable to download meta file: " + metaUrl + "; received 429 -- too many requests", ex);
         } catch (ResourceNotFoundException ex) {
             throw new UpdateException("Unable to download meta file: " + metaUrl + "; received 404 -- resource not found", ex);
+        } catch (InterruptedException ex) {
+            Thread.interrupted();
+            throw new UpdateException("The download of the meta file was interupted: " + metaUrl, ex);
         }
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
@@ -142,8 +142,8 @@ public class DownloadTask implements Callable<Future<ProcessTask>> {
                 return null;
             }
             final ProcessTask task = new ProcessTask(cveDB, this, settings);
-            Future<ProcessTask> val = this.processorService.submit(task);
-            
+            final Future<ProcessTask> val = this.processorService.submit(task);
+
             Thread.sleep(2000);
             return val;
 

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
@@ -142,7 +142,10 @@ public class DownloadTask implements Callable<Future<ProcessTask>> {
                 return null;
             }
             final ProcessTask task = new ProcessTask(cveDB, this, settings);
-            return this.processorService.submit(task);
+            Future<ProcessTask> val = this.processorService.submit(task);
+            
+            Thread.sleep(2000);
+            return val;
 
         } catch (Throwable ex) {
             LOGGER.error("An exception occurred downloading NVD CVE - {}\nSome CVEs may not be reported. Reason: {}",

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -68,7 +68,7 @@ cve.url.base.defaultFilename=nvdcve-1.1-%d.json.gz
 cve.cpe.startswith.filter=cpe:2.3:a:
 nvd.newyear.grace.period=10
 
-max.download.threads=2
+max.download.threads=1
 
 cpe.validfordays=30
 cpe.url=https://static.nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz


### PR DESCRIPTION
## Fixes Issue #3639

## Description of Change

The PR reduces the download threads to **one** and adds a `Thread.sleep(2000)` after each download to reduce the chance that ODC will cause the NVD's rate limiting to be activated.