### PR TITLE
Update golang to fix golang analyzer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine AS go
+FROM golang:1.17.1-alpine AS go
 
 FROM azul/zulu-openjdk-alpine:14 AS jlink
 


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

1.16 Golang is not compatible with latest OWASP dependency checker. Update to latest Golang version to fix it

## Have test cases been added to cover the new functionality?

no