### PR TITLE
Work-around for MSHARED-998 until it's resolved and we can upgrade to a newer transfer-utils

### DIFF
--- a/maven/src/it/3679-classifier-in-dependency/invoker.properties
+++ b/maven/src/it/3679-classifier-in-dependency/invoker.properties
@@ -1,0 +1,19 @@
+#
+# This file is part of dependency-check-maven.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+#
+
+invoker.goals = --no-transfer-progress --batch-mode -Danalyzer.ossindex.enabled=false -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:check -Dformat=XML -Dcve.startyear=2018

--- a/maven/src/it/3679-classifier-in-dependency/pom.xml
+++ b/maven/src/it/3679-classifier-in-dependency/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2017 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.owasp.test</groupId>
+    <artifactId>3679-classifier-dependency</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>4.2.2</version>
+            <classifier>no_aop</classifier>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/src/it/3679-classifier-in-dependency/postbuild.groovy
+++ b/maven/src/it/3679-classifier-in-dependency/postbuild.groovy
@@ -1,0 +1,43 @@
+/*
+ * This file is part of dependency-check-maven.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+
+import org.apache.commons.io.FileUtils;
+import org.w3c.dom.NodeList;
+
+import java.nio.charset.Charset;
+import javax.xml.xpath.*
+import javax.xml.parsers.DocumentBuilderFactory
+
+// Check to see if jackson-databind-2.5.3.jar was identified with a known CVE - using CVE-2018-7489.
+
+def countMatches(String xml, String xpathQuery) {
+    def xpath = XPathFactory.newInstance().newXPath()
+    def builder     = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+    def inputStream = new ByteArrayInputStream( xml.bytes )
+    def records     = builder.parse(inputStream).documentElement
+    NodeList nodes       = xpath.evaluate( xpathQuery, records, XPathConstants.NODESET ) as NodeList
+    nodes.getLength();
+}
+
+String log = FileUtils.readFileToString(new File(basedir, "target/dependency-check-report.xml"), Charset.defaultCharset().name());
+int count = countMatches(log,"/analysis/dependencies/dependency[./fileName = 'guice-2.4.4-no_aop.jar']");
+if (count != 1){
+    System.out.println(String.format("google guice no_aop was identified %s times, expected 1", count));
+    return false;
+}
+return true;

--- a/maven/src/it/3679-classifier-in-dependency/postbuild.groovy
+++ b/maven/src/it/3679-classifier-in-dependency/postbuild.groovy
@@ -35,7 +35,7 @@ def countMatches(String xml, String xpathQuery) {
 }
 
 String log = FileUtils.readFileToString(new File(basedir, "target/dependency-check-report.xml"), Charset.defaultCharset().name());
-int count = countMatches(log,"/analysis/dependencies/dependency[./fileName = 'guice-2.4.4-no_aop.jar']");
+int count = countMatches(log,"/analysis/dependencies/dependency[./fileName = 'guice-4.2.2-no_aop.jar']");
 if (count != 1){
     System.out.println(String.format("google guice no_aop was identified %s times, expected 1", count));
     return false;

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1332,7 +1332,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                         final ArtifactCoordinate theCoord = TransferUtils.toArtifactCoordinate(dependencyNode.getArtifact());
                         if (theCoord.getClassifier() != null) {
                             // This would trigger NPE when using the filter - MSHARED-998
-                            getLog().debug("Expensive lookup as workaround for MSHARED-998 for "+theCoord);
+                            getLog().debug("Expensive lookup as workaround for MSHARED-998 for " + theCoord);
                             final Iterable<ArtifactResult> allDeps =
                                     dependencyResolver.resolveDependencies(buildingRequest, dependencies, managedDependencies,
                                                                            null);
@@ -1453,7 +1453,14 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         return exCol;
     }
 
-    /** Utility method for a work-around to MSHARED-998 */
+    /**
+     * Utility method for a work-around to MSHARED-998
+     * @param allDeps The Iterable of the resolved artifacts for all dependencies
+     * @param theCoord The ArtifactCoordinate of the artifact-with-classifier we intended to resolve
+     * @return the resolved artifact matching with {@code theCoord}
+     * @throws DependencyNotFoundException Not expected to be thrown, but will be thrown if {@code theCoord} could not be
+     * found within {@code allDeps}
+     */
     private Artifact findClassifierArtifactInAllDeps(final Iterable<ArtifactResult> allDeps, final ArtifactCoordinate theCoord)
             throws DependencyNotFoundException {
         Artifact result = null;
@@ -1470,7 +1477,12 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         return result;
     }
 
-    /** Utility method for a work-around to MSHARED-998 */
+    /**
+     * Utility method for a work-around to MSHARED-998
+     * @param res A single ArtifactResult obtained from the DependencyResolver
+     * @param theCoord The coordinates of the Artifact that we try to find
+     * @return {@code true} when theCoord is non-null and matches with the artifact of res
+     */
     private boolean sameArtifact(final ArtifactResult res, final ArtifactCoordinate theCoord) {
         if (res == null || res.getArtifact() == null || theCoord == null) {
             return false;

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1454,13 +1454,18 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     }
 
     /** Utility method for a work-around to MSHARED-998 */
-    private Artifact findClassifierArtifactInAllDeps(final Iterable<ArtifactResult> allDeps, final ArtifactCoordinate theCoord) {
+    private Artifact findClassifierArtifactInAllDeps(final Iterable<ArtifactResult> allDeps, final ArtifactCoordinate theCoord)
+            throws DependencyNotFoundException {
         Artifact result = null;
         for (final ArtifactResult res : allDeps) {
             if (sameArtifact(res, theCoord)) {
                 result = res.getArtifact();
                 break;
             }
+        }
+        if (result == null) {
+            throw new DependencyNotFoundException(String.format("Expected dependency not found in resolved artifacts for "
+                                                                + "dependency %s", theCoord));
         }
         return result;
     }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -87,6 +87,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -1328,17 +1329,29 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                         final List<org.apache.maven.model.Dependency> dependencies = project.getDependencies();
                         final List<org.apache.maven.model.Dependency> managedDependencies =
                                 project.getDependencyManagement() == null ? null : project.getDependencyManagement().getDependencies();
-                        final TransformableFilter filter = new PatternInclusionsFilter(
-                                Collections.singletonList(TransferUtils.toArtifactCoordinate(dependencyNode.getArtifact()).toString()));
-                        final Iterable<ArtifactResult> singleResult =
-                                dependencyResolver.resolveDependencies(buildingRequest, dependencies, managedDependencies, filter);
-
-                        if (singleResult.iterator().hasNext()) {
-                            final ArtifactResult first = singleResult.iterator().next();
-                            result = first.getArtifact();
+                        final ArtifactCoordinate theCoord = TransferUtils.toArtifactCoordinate(dependencyNode.getArtifact());
+                        if (theCoord.getClassifier() != null) {
+                            // This would trigger NPE when using the filter - MSHARED-998
+                            getLog().debug("Expensive lookup as workaround for MSHARED-998 for "+theCoord);
+                            final Iterable<ArtifactResult> allDeps =
+                                    dependencyResolver.resolveDependencies(buildingRequest, dependencies, managedDependencies,
+                                                                           null);
+                            result = findClassifierArtifactInAllDeps(allDeps, theCoord);
                         } else {
-                            throw new DependencyNotFoundException(String.format("Failed to resolve dependency %s with "
-                                                                                + "dependencyResolver", coordinate));
+                            final TransformableFilter filter = new PatternInclusionsFilter(
+                                    Collections.singletonList(
+                                            TransferUtils.toArtifactCoordinate(dependencyNode.getArtifact()).toString()));
+                            final Iterable<ArtifactResult> singleResult =
+                                    dependencyResolver.resolveDependencies(buildingRequest, dependencies, managedDependencies,
+                                                                           filter);
+
+                            if (singleResult.iterator().hasNext()) {
+                                final ArtifactResult first = singleResult.iterator().next();
+                                result = first.getArtifact();
+                            } else {
+                                throw new DependencyNotFoundException(String.format("Failed to resolve dependency %s with "
+                                                                                    + "dependencyResolver", coordinate));
+                            }
                         }
                     } catch (DependencyNotFoundException | DependencyResolverException ex) {
                         getLog().debug(String.format("Aggregate : %s", aggregate));
@@ -1438,6 +1451,31 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
             }
         }
         return exCol;
+    }
+
+    /** Utility method for a work-around to MSHARED-998 */
+    private Artifact findClassifierArtifactInAllDeps(final Iterable<ArtifactResult> allDeps, final ArtifactCoordinate theCoord) {
+        Artifact result = null;
+        for (final ArtifactResult res : allDeps) {
+            if (sameArtifact(res, theCoord)) {
+                result = res.getArtifact();
+                break;
+            }
+        }
+        return result;
+    }
+
+    /** Utility method for a work-around to MSHARED-998 */
+    private boolean sameArtifact(final ArtifactResult res, final ArtifactCoordinate theCoord) {
+        if (res == null || res.getArtifact() == null || theCoord == null) {
+            return false;
+        }
+        boolean result = Objects.equals(res.getArtifact().getGroupId(), theCoord.getGroupId());
+        result &= Objects.equals(res.getArtifact().getArtifactId(), theCoord.getArtifactId());
+        result &= Objects.equals(res.getArtifact().getVersion(), theCoord.getVersion());
+        result &= Objects.equals(res.getArtifact().getClassifier(), theCoord.getClassifier());
+        result &= Objects.equals(res.getArtifact().getType(), theCoord.getExtension());
+        return result;
     }
 
     /**


### PR DESCRIPTION
## Fixes Issue #3679

## Description of Change

As a temporary work-around do not apply a filter to artifact-resolution when resolving for a DependencyNode that uses a `<classifier>` which would lead to a NullPointerException deep down in maven's internal logic.

## Have test cases been added to cover the new functionality?

yes, an integration testcase has been added that triggers the error with the old codebase and succeeds with the workaround.