### PR TITLE
Do a null-check for a list that in practice appears to be Nullable

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -339,9 +339,12 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
         result.addReference(REFERENCE_TYPE, source.getTitle(), source.getReference().toString());
 
         // generate references to other references reported by OSS Index
-        source.getExternalReferences().forEach(externalReference -> {
-            result.addReference("OSSIndex", externalReference.toString(), externalReference.toString());
-        });
+        if (source.getExternalReferences() != null) {
+            // issue 3707 demonstrated that this can ocassionally be null while not marked @Nullable in the API library
+            source.getExternalReferences().forEach(externalReference -> {
+                result.addReference("OSSIndex", externalReference.toString(), externalReference.toString());
+            });
+        }
 
         // attach vulnerable software details as best we can
         final PackageUrl purl = report.getCoordinates();


### PR DESCRIPTION
## Fixes Issue #3709

## Description of Change

Add a null-check for a field that in practice has been shown to be `@Nullable` despite not being annotated as such in a library that marks other properties clearly as `@Nullable`

## Have test cases been added to cover the new functionality?

No, as even the original case by now no longer appears to fire a test-case cannot be made that would reliably have a null-valued externalReferences