### PR TITLE
Bump ossindex-service-client to 1.8.1 to resolve #3709

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1168,7 +1168,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>org.sonatype.ossindex</groupId>
                 <artifactId>ossindex-service-client</artifactId>
-                <version>1.8.0</version>
+                <version>1.8.1</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
## Fixes Issue #3709

## Description of Change

OSSIndex team was fast to patch the potential null-return by a guaranteed list return, so upgrading the library is better that redoing the null-check in our code. Replaces #3711 .

## Have test cases been added to cover the new functionality?

no