### PR TITLE
Filter out the reactorprojects in the dependencies for the MSHARED-998 workaround attempting to resolve a dependency with a classifier

### DIFF
--- a/maven/src/it/3730-classifier-in-dependency-aggregate/childOne/pom.xml
+++ b/maven/src/it/3730-classifier-in-dependency-aggregate/childOne/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2017 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.owasp.test</groupId>
+        <artifactId>3730-classifier-in-dependency-aggregate</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>3730-classifier-in-dependency-aggregate-childOne</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>no_aop</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.owasp.test</groupId>
+            <artifactId>3730-classifier-in-dependency-aggregate-childTwo</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/src/it/3730-classifier-in-dependency-aggregate/childTwo/pom.xml
+++ b/maven/src/it/3730-classifier-in-dependency-aggregate/childTwo/pom.xml
@@ -25,4 +25,11 @@ Copyright (c) 2017 Jeremy Long. All Rights Reserved.
     </parent>
     <artifactId>3730-classifier-in-dependency-aggregate-childTwo</artifactId>
     <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>classes</classifier>
+        </dependency>
+    </dependencies>
 </project>

--- a/maven/src/it/3730-classifier-in-dependency-aggregate/childTwo/pom.xml
+++ b/maven/src/it/3730-classifier-in-dependency-aggregate/childTwo/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2017 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.owasp.test</groupId>
+        <artifactId>3730-classifier-in-dependency-aggregate</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>3730-classifier-in-dependency-aggregate-childTwo</artifactId>
+    <packaging>jar</packaging>
+</project>

--- a/maven/src/it/3730-classifier-in-dependency-aggregate/invoker.properties
+++ b/maven/src/it/3730-classifier-in-dependency-aggregate/invoker.properties
@@ -1,0 +1,19 @@
+#
+# This file is part of dependency-check-maven.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+#
+
+invoker.goals = --no-transfer-progress --batch-mode -Danalyzer.ossindex.enabled=false -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:aggregate -Dformat=XML -Dcve.startyear=2018

--- a/maven/src/it/3730-classifier-in-dependency-aggregate/pom.xml
+++ b/maven/src/it/3730-classifier-in-dependency-aggregate/pom.xml
@@ -35,6 +35,12 @@ Copyright (c) 2017 Jeremy Long. All Rights Reserved.
                 <classifier>no_aop</classifier>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>com.google.inject</groupId>
+                <artifactId>guice</artifactId>
+                <classifier>classes</classifier>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/maven/src/it/3730-classifier-in-dependency-aggregate/pom.xml
+++ b/maven/src/it/3730-classifier-in-dependency-aggregate/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2017 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.owasp.test</groupId>
+    <artifactId>3730-classifier-in-dependency-aggregate</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>childOne</module>
+        <module>childTwo</module>
+    </modules>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.inject</groupId>
+                <artifactId>guice</artifactId>
+                <version>4.2.2</version>
+                <classifier>no_aop</classifier>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/maven/src/it/3730-classifier-in-dependency-aggregate/pom.xml
+++ b/maven/src/it/3730-classifier-in-dependency-aggregate/pom.xml
@@ -38,6 +38,7 @@ Copyright (c) 2017 Jeremy Long. All Rights Reserved.
             <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
+                <version>4.2.2</version>
                 <classifier>classes</classifier>
                 <scope>provided</scope>
             </dependency>

--- a/maven/src/it/3730-classifier-in-dependency-aggregate/postbuild.groovy
+++ b/maven/src/it/3730-classifier-in-dependency-aggregate/postbuild.groovy
@@ -1,0 +1,43 @@
+/*
+ * This file is part of dependency-check-maven.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+
+import org.apache.commons.io.FileUtils;
+import org.w3c.dom.NodeList;
+
+import java.nio.charset.Charset;
+import javax.xml.xpath.*
+import javax.xml.parsers.DocumentBuilderFactory
+
+// Check to see if jackson-databind-2.5.3.jar was identified with a known CVE - using CVE-2018-7489.
+
+def countMatches(String xml, String xpathQuery) {
+    def xpath = XPathFactory.newInstance().newXPath()
+    def builder     = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+    def inputStream = new ByteArrayInputStream( xml.bytes )
+    def records     = builder.parse(inputStream).documentElement
+    NodeList nodes       = xpath.evaluate( xpathQuery, records, XPathConstants.NODESET ) as NodeList
+    nodes.getLength();
+}
+
+String log = FileUtils.readFileToString(new File(basedir, "target/dependency-check-report.xml"), Charset.defaultCharset().name());
+int count = countMatches(log,"/analysis/dependencies/dependency[./fileName = 'guice-4.2.2-no_aop.jar']");
+if (count != 1){
+    System.out.println(String.format("google guice no_aop was identified %s times, expected 1", count));
+    return false;
+}
+return true;

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/AggregateMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/AggregateMojo.java
@@ -73,7 +73,7 @@ public class AggregateMojo extends BaseDependencyCheckMojo {
             final ExceptionCollection ex = scanArtifacts(childProject, engine, true);
             if (ex != null) {
                 if (exCol == null) {
-                    exCol = ex;
+                    exCol = new ExceptionCollection();
                 }
                 exCol.getExceptions().addAll(ex.getExceptions());
                 if (ex.isFatal()) {

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/AggregateMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/AggregateMojo.java
@@ -73,9 +73,10 @@ public class AggregateMojo extends BaseDependencyCheckMojo {
             final ExceptionCollection ex = scanArtifacts(childProject, engine, true);
             if (ex != null) {
                 if (exCol == null) {
-                    exCol = new ExceptionCollection();
+                    exCol = ex;
+                } else {
+                    exCol.getExceptions().addAll(ex.getExceptions());
                 }
-                exCol.getExceptions().addAll(ex.getExceptions());
                 if (ex.isFatal()) {
                     exCol.setFatal(true);
                     final String msg = String.format("Fatal exception(s) analyzing %s", childProject.getName());

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1476,6 +1476,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * dependencies
      * @param theCoord The ArtifactCoordinate of the artifact-with-classifier we
      * intended to resolve
+     * @param project The project in whose context resolution was attempted
      * @return the resolved artifact matching with {@code theCoord}
      * @throws DependencyNotFoundException Not expected to be thrown, but will
      * be thrown if {@code theCoord} could not be found within {@code allDeps}

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1346,7 +1346,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                             final Iterable<ArtifactResult> allDeps
                                     = dependencyResolver.resolveDependencies(buildingRequest, nonReactorDependencies, managedDependencies,
                                             null);
-                            result = findClassifierArtifactInAllDeps(allDeps, theCoord);
+                            result = findClassifierArtifactInAllDeps(allDeps, theCoord, project);
                         } else {
                             final TransformableFilter filter = new PatternInclusionsFilter(
                                     Collections.singletonList(
@@ -1489,7 +1489,8 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * @throws DependencyNotFoundException Not expected to be thrown, but will
      * be thrown if {@code theCoord} could not be found within {@code allDeps}
      */
-    private Artifact findClassifierArtifactInAllDeps(final Iterable<ArtifactResult> allDeps, final ArtifactCoordinate theCoord)
+    private Artifact findClassifierArtifactInAllDeps(final Iterable<ArtifactResult> allDeps, final ArtifactCoordinate theCoord,
+                                                     final MavenProject project)
             throws DependencyNotFoundException {
         Artifact result = null;
         for (final ArtifactResult res : allDeps) {
@@ -1500,7 +1501,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         }
         if (result == null) {
             throw new DependencyNotFoundException(String.format("Expected dependency not found in resolved artifacts for "
-                    + "dependency %s", theCoord));
+                    + "dependency %s of project-artifact %s", theCoord, project.getArtifactId()));
         }
         return result;
     }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1349,8 +1349,8 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                                 if (result == null) {
                                     throw new DependencyNotFoundException(
                                             String.format("Failed to resolve dependency %s with dependencyResolver for "
-                                                          + "project-artifact %s", coordinate, project.getArtifactId())
-                                            , dre);
+                                                          + "project-artifact %s", coordinate, project.getArtifactId()),
+                                            dre);
                                 }
                             }
                         } else {

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/Mshared998Util.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/Mshared998Util.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 
 public final class Mshared998Util {
     /**
-     * Empty constructor to prevent instantiation of utility-class
+     * Empty constructor to prevent instantiation of utility-class.
      */
     private Mshared998Util() {
     }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/Mshared998Util.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/Mshared998Util.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of dependency-check-maven.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2021 Jeremy Long. All Rights Reserved.
+ */
 package org.owasp.dependencycheck.maven;
 
 import org.apache.maven.RepositoryUtils;
@@ -10,7 +27,7 @@ import org.eclipse.aether.resolution.DependencyResult;
 
 import java.util.Objects;
 
-public class Mshared998Util {
+public final class Mshared998Util {
     /**
      * Empty constructor to prevent instantiation of utility-class
      */
@@ -28,8 +45,8 @@ public class Mshared998Util {
                                                          final ArtifactCoordinate coordinate) {
         Artifact result = null;
         if (dre.getCause() instanceof DependencyResolutionException) {
-            DependencyResolutionException adre = (DependencyResolutionException) dre.getCause();
-            DependencyResult dependencyResult = adre.getResult();
+            final DependencyResolutionException adre = (DependencyResolutionException) dre.getCause();
+            final DependencyResult dependencyResult = adre.getResult();
             if (dependencyResult != null) {
                 for (ArtifactResult artifactResult : dependencyResult.getArtifactResults()) {
                     if (matchesCoordinate(artifactResult, coordinate)) {
@@ -52,7 +69,7 @@ public class Mshared998Util {
         if (artifactResult.getArtifact() == null) {
             return false;
         } else {
-            org.eclipse.aether.artifact.Artifact artifact = artifactResult.getArtifact();
+            final org.eclipse.aether.artifact.Artifact artifact = artifactResult.getArtifact();
             boolean result = Objects.equals(artifact.getGroupId(), coordinate.getGroupId());
             result &= Objects.equals(artifact.getArtifactId(), coordinate.getArtifactId());
             result &= Objects.equals(artifact.getVersion(), coordinate.getVersion());

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/Mshared998Util.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/Mshared998Util.java
@@ -1,0 +1,64 @@
+package org.owasp.dependencycheck.maven;
+
+import org.apache.maven.RepositoryUtils;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
+import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolverException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.resolution.DependencyResult;
+
+import java.util.Objects;
+
+public class Mshared998Util {
+    /**
+     * Empty constructor to prevent instantiation of utility-class
+     */
+    private Mshared998Util() {
+    }
+
+    /**
+     * Find the artifact for the given coordinate among the available succesfull resolution attempts contained within the
+     * DependencyResolverException
+     * @param dre The DependencyResolverException that might have embedded successful resolution results
+     * @param coordinate The coordinates of the artifact we're interested in
+     * @return The resolved artifact matching {@code coordinate} or {@code null} if not found
+     */
+    public static Artifact findArtifactInAetherDREResult(final DependencyResolverException dre,
+                                                         final ArtifactCoordinate coordinate) {
+        Artifact result = null;
+        if (dre.getCause() instanceof DependencyResolutionException) {
+            DependencyResolutionException adre = (DependencyResolutionException) dre.getCause();
+            DependencyResult dependencyResult = adre.getResult();
+            if (dependencyResult != null) {
+                for (ArtifactResult artifactResult : dependencyResult.getArtifactResults()) {
+                    if (matchesCoordinate(artifactResult, coordinate)) {
+                        result = RepositoryUtils.toArtifact(artifactResult.getArtifact());
+                        break;
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Checks whether the given ArtifactResult contains an artifact that matches the coordinate
+     * @param artifactResult The ArtifactResult to inspect
+     * @param coordinate The coordinate to match with
+     * @return {@code true} when the artifactresult contains an artifact that matches the coordinate on GAV_C_E,
+     * false otherwise.
+     */    private static boolean matchesCoordinate(final ArtifactResult artifactResult, final ArtifactCoordinate coordinate) {
+        if (artifactResult.getArtifact() == null) {
+            return false;
+        } else {
+            org.eclipse.aether.artifact.Artifact artifact = artifactResult.getArtifact();
+            boolean result = Objects.equals(artifact.getGroupId(), coordinate.getGroupId());
+            result &= Objects.equals(artifact.getArtifactId(), coordinate.getArtifactId());
+            result &= Objects.equals(artifact.getVersion(), coordinate.getVersion());
+            result &= Objects.equals(artifact.getClassifier(), coordinate.getClassifier());
+            result &= Objects.equals(artifact.getExtension(), coordinate.getExtension());
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## Fixes Issue #3730

## Description of Change

Remove the reactorProjects from the dependencies offered to the ArtifactResolver when trying to resolve dependencies with classifiers in the work-around for MSHARED-998

## Have test cases been added to cover the new functionality?

yes, a test-case similar to the project in the issue has been added to the integration-tests to avoid a regression in the future