### PR TITLE
Restore support for RELEASE and LATEST meta-versions in dependencies

### DIFF
--- a/maven/src/it/3721-metaversion-dependencies/invoker.properties
+++ b/maven/src/it/3721-metaversion-dependencies/invoker.properties
@@ -1,0 +1,20 @@
+#
+# This file is part of dependency-check-maven.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+#
+
+# NOTE needs a -U as maven invoker builds otherwise cannot resolve RELEASE/SNAPSHOT meta-versions
+invoker.goals = -U --no-transfer-progress --batch-mode -Danalyzer.ossindex.enabled=false -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:aggregate -Dformat=XML -Dcve.startyear=2018

--- a/maven/src/it/3721-metaversion-dependencies/pom.xml
+++ b/maven/src/it/3721-metaversion-dependencies/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2017 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.owasp.test</groupId>
+    <artifactId>3721-metaversion-dependencies</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>LATEST</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/src/it/3721-metaversion-dependencies/postbuild.groovy
+++ b/maven/src/it/3721-metaversion-dependencies/postbuild.groovy
@@ -1,0 +1,48 @@
+/*
+ * This file is part of dependency-check-maven.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+
+import org.apache.commons.io.FileUtils;
+import org.w3c.dom.NodeList;
+
+import java.nio.charset.Charset;
+import javax.xml.xpath.*
+import javax.xml.parsers.DocumentBuilderFactory
+
+// Check to see if jackson-databind-2.5.3.jar was identified with a known CVE - using CVE-2018-7489.
+
+def countMatches(String xml, String xpathQuery) {
+    def xpath = XPathFactory.newInstance().newXPath()
+    def builder     = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+    def inputStream = new ByteArrayInputStream( xml.bytes )
+    def records     = builder.parse(inputStream).documentElement
+    NodeList nodes       = xpath.evaluate( xpathQuery, records, XPathConstants.NODESET ) as NodeList
+    nodes.getLength();
+}
+
+String log = FileUtils.readFileToString(new File(basedir, "target/dependency-check-report.xml"), Charset.defaultCharset().name());
+int count = countMatches(log,"/analysis/dependencies/dependency/evidenceCollected/evidence[@type='product' and ./value = 'commons-compress' and ./name = 'artifactid']");
+if (count != 1){
+    System.out.println(String.format("commons-compress was identified %s times, expected 1", count));
+    return false;
+}
+count = countMatches(log,"/analysis/dependencies/dependency/evidenceCollected/evidence[@type='product' and ./value = 'commons-pool2' and ./name = 'artifactid']");
+if (count != 1){
+    System.out.println(String.format("commons-pool2  was identified %s times, expected 1", count));
+    return false;
+}
+return true;

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1345,9 +1345,10 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                                             null);
                             result = findClassifierArtifactInAllDeps(allDeps, theCoord);
                         } else {
+                            final String versionlessFilter =
+                                    new StringBuilder(theCoord.getGroupId()).append(':').append(theCoord.getArtifactId()).append(':').append(theCoord.getExtension()).toString();
                             final TransformableFilter filter = new PatternInclusionsFilter(
-                                    Collections.singletonList(
-                                            TransferUtils.toArtifactCoordinate(dependencyNode.getArtifact()).toString()));
+                                    Collections.singletonList(versionlessFilter));
                             final Iterable<ArtifactResult> singleResult
                                     = dependencyResolver.resolveDependencies(buildingRequest, dependencies, managedDependencies,
                                             filter);

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1346,7 +1346,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                             result = findClassifierArtifactInAllDeps(allDeps, theCoord);
                         } else {
                             final String versionlessFilter =
-                                    new StringBuilder(theCoord.getGroupId()).append(':').append(theCoord.getArtifactId()).append(':').append(theCoord.getExtension()).toString();
+                                    new StringBuilder(coordinate.getGroupId()).append(':').append(coordinate.getArtifactId()).append(':').append(coordinate.getExtension()).toString();
                             final TransformableFilter filter = new PatternInclusionsFilter(
                                     Collections.singletonList(versionlessFilter));
                             final Iterable<ArtifactResult> singleResult

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@ Copyright (c) 2012 - Jeremy Long
         <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
         <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-        <spotbugs.maven.plugin.version>4.4.1</spotbugs.maven.plugin.version>
+        <spotbugs.maven.plugin.version>4.4.2</spotbugs.maven.plugin.version>
         <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
 


### PR DESCRIPTION
## Fixes Issue #3721

## Description of Change

Fix the regression that RELEASE and LATEST dependencies run into dependency not found exceptions.

## Have test cases been added to cover the new functionality?

yes