### PR TITLE
Update iOS Analysis

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -1089,7 +1089,11 @@ public class CPEAnalyzer extends AbstractAnalyzer {
             return null;
         }
         if (ecosystem != null) {
-            return entries.stream().filter(c -> c.getEcosystem() == null || c.getEcosystem().equals(ecosystem))
+            return entries.stream().filter(c
+                    -> c.getEcosystem() == null
+                    || c.getEcosystem().equals(ecosystem)
+                    //some ios CVE/CPEs are listed under native
+                    || (Ecosystem.IOS.equals(ecosystem) && Ecosystem.NATIVE.equals(c.getEcosystem())))
                     .map(c -> c.getCpe())
                     .collect(Collectors.toSet());
         }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
@@ -18,6 +18,7 @@
 package org.owasp.dependencycheck.analyzer;
 
 import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
 import com.github.packageurl.PackageURLBuilder;
 import java.io.File;
 import java.io.FileFilter;
@@ -184,6 +185,25 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
             dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
             dependency.setName(name);
             dependency.setVersion(version);
+            
+            try {
+                final PackageURLBuilder builder = PackageURLBuilder.aPackageURL().withType("cocoapods").withName(dependency.getName());
+                if (dependency.getVersion() != null) {
+                    builder.withVersion(dependency.getVersion());
+                }
+                final PackageURL purl = builder.build();
+                dependency.addSoftwareIdentifier(new PurlIdentifier(purl, Confidence.HIGHEST));
+            } catch (MalformedPackageURLException ex) {
+                LOGGER.debug("Unable to build package url for cocoapods", ex);
+                final GenericIdentifier id;
+                if (dependency.getVersion() != null) {
+                    id = new GenericIdentifier("cocoapods:" + dependency.getName() + "@" + dependency.getVersion(), Confidence.HIGHEST);
+                } else {
+                    id = new GenericIdentifier("cocoapods:" + dependency.getName(), Confidence.HIGHEST);
+                }
+                dependency.addSoftwareIdentifier(id);
+            }
+            
             final String packagePath = String.format("%s:%s", name, version);
             dependency.setPackagePath(packagePath);
             dependency.setDisplayFileName(packagePath);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
@@ -185,7 +185,7 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
             dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
             dependency.setName(name);
             dependency.setVersion(version);
-            
+
             try {
                 final PackageURLBuilder builder = PackageURLBuilder.aPackageURL().withType("cocoapods").withName(dependency.getName());
                 if (dependency.getVersion() != null) {
@@ -203,7 +203,7 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
                 }
                 dependency.addSoftwareIdentifier(id);
             }
-            
+
             final String packagePath = String.format("%s:%s", name, version);
             dependency.setPackagePath(packagePath);
             dependency.setDisplayFileName(packagePath);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
@@ -95,7 +95,7 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * The capture group #1 is the dependency name, #2 is dependency version
      */
-    private static final Pattern PODFILE_LOCK_DEPENDENCY_PATTERN = Pattern.compile("  - \"?(.*) \\((\\d+\\.\\d+\\.\\d+)\\)\"?");
+    private static final Pattern PODFILE_LOCK_DEPENDENCY_PATTERN = Pattern.compile("  - \"?(.*) \\((\\d+(\\.\\d+){0,4})\\)\"?");
 
     /**
      * Returns the FileFilter

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NvdCveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NvdCveAnalyzer.java
@@ -143,7 +143,8 @@ public class NvdCveAnalyzer extends AbstractAnalyzer {
     }
 
     /**
-     * Filters the list of vulnerabilities for the given ecosystem.
+     * Filters the list of vulnerabilities for the given ecosystem compared to
+     * the target software from the NVD.
      *
      * @param ecosystem the dependency's ecosystem
      * @param vulnerabilities the list of vulnerabilities to filter

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageManagerAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageManagerAnalyzer.java
@@ -194,7 +194,7 @@ public class SwiftPackageManagerAnalyzer extends AbstractFileTypeAnalyzer {
                 final PackageURL purl = builder.build();
                 dependency.addSoftwareIdentifier(new PurlIdentifier(purl, Confidence.HIGHEST));
             } catch (MalformedPackageURLException ex) {
-                LOGGER.debug("Unable to build package url for python", ex);
+                LOGGER.debug("Unable to build package url for swift", ex);
                 final GenericIdentifier id;
                 if (dependency.getVersion() != null) {
                     id = new GenericIdentifier("swift:" + dependency.getName() + "@" + dependency.getVersion(), Confidence.HIGHEST);


### PR DESCRIPTION
## Fixes Issues

* https://github.com/jeremylong/DependencyCheck/issues/3168
* https://github.com/jeremylong/DependencyCheck/issues/3765

## Description of Change

* For iOS dependencies allow CPE that are either `native` or `ios` - some ios related CPEs get flagged as native and thus get hidden from analysis.
* Improve the regex for matching version numbers in podfile.lock to be more flexible.