### PR TITLE
Enable the Swift Resolved Analyzer 

### DIFF
--- a/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
+++ b/core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
@@ -38,6 +38,7 @@ org.owasp.dependencycheck.analyzer.ElixirMixAuditAnalyzer
 org.owasp.dependencycheck.analyzer.ComposerLockAnalyzer
 org.owasp.dependencycheck.analyzer.CocoaPodsAnalyzer
 org.owasp.dependencycheck.analyzer.SwiftPackageManagerAnalyzer
+org.owasp.dependencycheck.analyzer.SwiftPackageResolvedAnalyzer
 org.owasp.dependencycheck.analyzer.VersionFilterAnalyzer
 org.owasp.dependencycheck.analyzer.OssIndexAnalyzer
 org.owasp.dependencycheck.analyzer.PerlCpanfileAnalyzer

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -2,6 +2,13 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress base="true">
         <notes><![CDATA[
+           swift-log is not swift...
+        ]]></notes>
+        <packageUrl regex="true">^pkg:swift/swift\-log@.*$</packageUrl>
+        <cpe>cpe:/a:apple:swift</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
                 FP in jetty as jetty-jakarta-servlet-api is identified as a low version jetty
                 ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty\-jakarta\-servlet\-api@.*$</packageUrl>
@@ -1069,11 +1076,11 @@
         <cpe>cpe:/a:openid:openid_connect</cpe>
     </suppress>
     <suppress base="true">
-       <notes><![CDATA[
+        <notes><![CDATA[
        Suppresses false positives per issue #3345
        ]]></notes>
-       <packageUrl regex="true">^pkg:maven/com\.azure/azure\-core\-http\-netty@.*$</packageUrl>
-       <cpe>cpe:/a:netty:netty</cpe>
+        <packageUrl regex="true">^pkg:maven/com\.azure/azure\-core\-http\-netty@.*$</packageUrl>
+        <cpe>cpe:/a:netty:netty</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[


### PR DESCRIPTION
## Fixes Issue #3735

Apparently when the Swift Resolved Analyzer was added - we missed adding it to `core/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer` and as such it was never loaded. This PR resolve the issue and adds a suppression rule for a swift fp.