### PR TITLE
Fix for Dependencies with classifier and SNAPSHOT

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1526,7 +1526,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         }
         boolean result = Objects.equals(res.getArtifact().getGroupId(), theCoord.getGroupId());
         result &= Objects.equals(res.getArtifact().getArtifactId(), theCoord.getArtifactId());
-        result &= Objects.equals(res.getArtifact().getVersion(), theCoord.getVersion());
+        result &= Objects.equals(res.getArtifact().getBaseVersion(), theCoord.getVersion());
         result &= Objects.equals(res.getArtifact().getClassifier(), theCoord.getClassifier());
         result &= Objects.equals(res.getArtifact().getType(), theCoord.getExtension());
         return result;


### PR DESCRIPTION
Fixes issue #3786
Dependencies with a classifier and SNAPSHOT version cannot be resolved bug

## Fixes Issue #3786

## Description of Change

Since recent changes to workaround MSHARED-998 the use of the class ArtifactResult appeared in the code. While this class looks like ArtifactCoordinate, we have to take care of the `getVersion()` method because for SNAPSHOT versions it provides the timestamped result, not the 'real' version.

So I only changed the `getVersion()` by `getBaseVersion()` call for class ArtifactResult.

I have tested the change manually with a fake project and it solves the  DependencyNotFoundException as expected.

## Have test cases been added to cover the new functionality?

no, not yet, sorry...