### PR TITLE
#3790 Suppress false positive for log4j-api-kotlin

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4770,4 +4770,11 @@
         <cve>CVE-2020-13949</cve>
     </suppress>
     <!-- end cpan support -->
+    <suppress base="true">
+        <notes><![CDATA[
+        False positive as per #3790
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-api\-kotlin@.*$</packageUrl>
+        <cpe>cpe:/a:apache:log4j</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Fixes Issue #

Fix #3790 

## Description of Change

Add a suppression rule for log4j-api-kotlin package.

Sorry for not contributing a lot lately, I am focused on translating the OWASP Top 10 into French. :slightly_smiling_face: 

## Have test cases been added to cover the new functionality?

*no*, but a test has been made to confirm no more false positive is triggered after suppressing this rule => https://github.com/nhumblot/owasp-dependency-check-test-directory/tree/log4j-api-kotlin