### PR TITLE
Use later version of Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM azul/zulu-openjdk-alpine:14 AS jlink
 
 RUN "$JAVA_HOME/bin/jlink" --compress=2 --module-path /opt/java/openjdk/jmods --add-modules java.base,java.compiler,java.datatransfer,jdk.crypto.ec,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.scripting,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.unsupported --output /jlinked
 
-FROM mcr.microsoft.com/dotnet/runtime:3.1-alpine3.12
+FROM mcr.microsoft.com/dotnet/runtime:3.1-alpine3.14
 
 ARG VERSION
 ARG POSTGRES_DRIVER_VERSION=42.2.19


### PR DESCRIPTION
Updated `mcr.microsoft.com/dotnet/runtime:3.1-alpine3.12` to `mcr.microsoft.com/dotnet/runtime:3.1-alpine3.14`. Listed here: https://hub.docker.com/_/microsoft-dotnet-runtime

## Fixes Issue #
#3165 

## Description of Change
Updated `mcr.microsoft.com/dotnet/runtime:3.1-alpine3.12` to `mcr.microsoft.com/dotnet/runtime:3.1-alpine3.14`.

(Change is alpine 3.12 to 3.14)

## Have test cases been added to cover the new functionality?

no