### PR TITLE
Fix/swift package manager

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageResolvedAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageResolvedAnalyzer.java
@@ -172,7 +172,9 @@ public class SwiftPackageResolvedAnalyzer extends AbstractFileTypeAnalyzer {
                 String version = null;
                 final JsonObject state = pin.getJsonObject("state");
                 if (state != null) {
-                    version = state.getString("version");
+                    if (!state.isNull("version")) {
+                        version = state.getString("version");
+                    }
                 }
                 final Dependency dependency = createDependency(spmResolved, SPM_RESOLVED_FILE_NAME, name, version, repo);
                 engine.addDependency(dependency);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageResolvedAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageResolvedAnalyzer.java
@@ -174,6 +174,8 @@ public class SwiftPackageResolvedAnalyzer extends AbstractFileTypeAnalyzer {
                 if (state != null) {
                     if (!state.isNull("version")) {
                         version = state.getString("version");
+                    } else if (!state.isNull("branch")) {
+                        version = state.getString("branch");
                     }
                 }
                 final Dependency dependency = createDependency(spmResolved, SPM_RESOLVED_FILE_NAME, name, version, repo);


### PR DESCRIPTION
## Fixes Issue #

#3813

## Description of Change

Theres an issue with 6.5.0 where if your Swift `Package.resolved` file has packages linked by branch instead of version, `dependecy-check` will raise an exception, due to `version` returning null.

This PR resolves this by only fetching the value if it exists. 

Additionally, if `version` is empty, we should use the `branch` value instead.

## Have test cases been added to cover the new functionality?

No, I don't have dotnet and go installed

## Command line output

<details>
  <summary>After applying fix</summary>

  ```
  [INFO] Analysis Started
  [INFO] Launching: [bundle-audit, version] from /var/folders/86/1vtftp_j2rn_wdcq6232q_z80000gq/T/dctemp0b0b49f8-dffd-4a5c-8336-9440b2da2f5e
  [WARN] Warnings from bundle-audit
  [INFO] Ruby Bundle Audit Analyzer is enabled and is using bundle-audit with version details: bundler-audit 0.9.0.1
  . Note: It is necessary to manually run "bundle-audit update" occasionally to keep its database up to date.
  [INFO] Disabled org.owasp.dependencycheck.analyzer.RubyGemspecAnalyzer to avoid noisy duplicate results.
  [INFO] Disabled org.owasp.dependencycheck.analyzer.RubyGemspecAnalyzer to avoid noisy duplicate results.
  [INFO] Disabled org.owasp.dependencycheck.analyzer.RubyGemspecAnalyzer to avoid noisy duplicate results.
  [INFO] Disabled org.owasp.dependencycheck.analyzer.RubyGemspecAnalyzer to avoid noisy duplicate results.
  [INFO] Disabled org.owasp.dependencycheck.analyzer.RubyBundlerAnalyzer to avoid noisy duplicate results.
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/Commandant/Carthage/Checkouts/Nimble
  [INFO] Disabled org.owasp.dependencycheck.analyzer.RubyBundlerAnalyzer to avoid noisy duplicate results.
  [INFO] Disabled org.owasp.dependencycheck.analyzer.RubyBundlerAnalyzer to avoid noisy duplicate results.
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/Commandant/Carthage/Checkouts/Quick
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/Quick/Externals/Nimble
  [INFO] Disabled org.owasp.dependencycheck.analyzer.RubyBundlerAnalyzer to avoid noisy duplicate results.
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/Nimble
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/SourceKitten/Carthage/Checkouts/Yams
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/Quick
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/RequestKit
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/SourceKitten
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/SwiftLint
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/Yams
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/danger-swift-xcodesummary
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/octokit.swift
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app
  [INFO] Finished Ruby Bundle Audit Analyzer (4 seconds)
  [INFO] Finished File Name Analyzer (0 seconds)
  [INFO] Finished Autoconf Analyzer (0 seconds)
  [INFO] Finished CMake Analyzer (0 seconds)
  [WARN] No lock file exists - this will result in false negatives; please run `npm install --package-lock`
  [WARN] Analyzing `/Users/paulwilliamson/Developer/ios-app/.build/checkouts/swift/package.json` - however, the node_modules directory does not exist. Please run `npm install` prior to running dependency-check
  [INFO] Finished Node.js Package Analyzer (0 seconds)
  [INFO] Finished CocoaPods Package Analyzer (0 seconds)
  [INFO] Finished SWIFT Package Manager Analyzer (0 seconds)
  [INFO] Finished SWIFT Package Resolved Analyzer (0 seconds)
  [INFO] Finished Dependency Merging Analyzer (0 seconds)
  [INFO] Finished Version Filter Analyzer (0 seconds)
  [INFO] Finished Hint Analyzer (0 seconds)
  [INFO] Created CPE Index (1 seconds)
  [INFO] Finished NPM CPE Analyzer (2 seconds)
  [INFO] Created CPE Index (2 seconds)
  [INFO] Finished CPE Analyzer (6 seconds)
  [INFO] Finished False Positive Analyzer (0 seconds)
  [INFO] Finished NVD CVE Analyzer (0 seconds)
  [INFO] Finished RetireJS Analyzer (1 seconds)
  [INFO] Finished Sonatype OSS Index Analyzer (2 seconds)
  [INFO] Finished Vulnerability Suppression Analyzer (0 seconds)
  [INFO] Finished Dependency Bundling Analyzer (0 seconds)
  [INFO] Analysis Complete (19 seconds)
  [INFO] Writing report to: /Users/paulwilliamson/Developer/ios-app/./dependency-check-report.json
  [INFO] Writing report to: /Users/paulwilliamson/Developer/ios-app/./dependency-check-report.html
  ```
</details>

<details>
  <summary>Before applying fix</summary>

  ```
  [INFO] Analysis Started
  [INFO] Launching: [bundle-audit, version] from /var/folders/86/1vtftp_j2rn_wdcq6232q_z80000gq/T/dctempf732ce64-6c6e-4e0c-a63d-8006ded16e6b
  [WARN] Warnings from bundle-audit
  [INFO] Ruby Bundle Audit Analyzer is enabled and is using bundle-audit with version details: bundler-audit 0.9.0.1
  . Note: It is necessary to manually run "bundle-audit update" occasionally to keep its database up to date.
  [INFO] Disabled org.owasp.dependencycheck.analyzer.RubyBundlerAnalyzer to avoid noisy duplicate results.
  [INFO] Disabled org.owasp.dependencycheck.analyzer.RubyGemspecAnalyzer to avoid noisy duplicate results.
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/Commandant/Carthage/Checkouts/Nimble
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/Commandant/Carthage/Checkouts/Quick
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/Nimble
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/Quick
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/Quick/Externals/Nimble
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/RequestKit
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/SourceKitten/Carthage/Checkouts/Yams
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/SourceKitten
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/SwiftLint
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/Yams
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/danger-swift-xcodesummary
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app/.build/checkouts/octokit.swift
  [INFO] Launching: [bundle-audit, check, --verbose] from /Users/paulwilliamson/Developer/ios-app
  [INFO] Finished Ruby Bundle Audit Analyzer (1 seconds)
  [INFO] Finished File Name Analyzer (0 seconds)
  [INFO] Finished Autoconf Analyzer (0 seconds)
  [INFO] Finished CMake Analyzer (0 seconds)
  [WARN] No lock file exists - this will result in false negatives; please run `npm install --package-lock`
  [WARN] Analyzing `/Users/paulwilliamson/Developer/ios-app/.build/checkouts/swift/package.json` - however, the node_modules directory does not exist. Please run `npm install` prior to running dependency-check
  [INFO] Finished Node.js Package Analyzer (0 seconds)
  [INFO] Finished CocoaPods Package Analyzer (0 seconds)
  [INFO] Finished SWIFT Package Manager Analyzer (0 seconds)
  [WARN] An unexpected error occurred during analysis of '/Users/paulwilliamson/Developer/ios-app/.build/checkouts/swift/Package.resolved' (SWIFT Package Resolved Analyzer): class javax.json.JsonValueImpl cannot be cast to class javax.json.JsonString (javax.json.JsonValueImpl and javax.json.JsonString are in unnamed module of loader 'app')
  [ERROR]
  java.lang.ClassCastException: class javax.json.JsonValueImpl cannot be cast to class javax.json.JsonString (javax.json.JsonValueImpl and javax.json.JsonString are in unnamed module of loader 'app')
    at org.glassfish.json.JsonObjectBuilderImpl$JsonObjectImpl.getJsonString(JsonObjectBuilderImpl.java:252)
    at org.glassfish.json.JsonObjectBuilderImpl$JsonObjectImpl.getString(JsonObjectBuilderImpl.java:257)
    at org.owasp.dependencycheck.analyzer.SwiftPackageResolvedAnalyzer.lambda$analyzeSpmResolvedDependencies$0(SwiftPackageResolvedAnalyzer.java:175)
    at java.base/java.lang.Iterable.forEach(Iterable.java:75)
    at org.owasp.dependencycheck.analyzer.SwiftPackageResolvedAnalyzer.analyzeSpmResolvedDependencies(SwiftPackageResolvedAnalyzer.java:168)
    at org.owasp.dependencycheck.analyzer.SwiftPackageResolvedAnalyzer.analyzeDependency(SwiftPackageResolvedAnalyzer.java:139)
    at org.owasp.dependencycheck.analyzer.AbstractAnalyzer.analyze(AbstractAnalyzer.java:131)
    at org.owasp.dependencycheck.AnalysisTask.call(AnalysisTask.java:88)
    at org.owasp.dependencycheck.AnalysisTask.call(AnalysisTask.java:37)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    at java.base/java.lang.Thread.run(Thread.java:833)
  [INFO] Finished SWIFT Package Resolved Analyzer (0 seconds)
  [INFO] Finished Dependency Merging Analyzer (0 seconds)
  [INFO] Finished Version Filter Analyzer (0 seconds)
  [INFO] Finished Hint Analyzer (0 seconds)
  [INFO] Created CPE Index (1 seconds)
  [INFO] Finished NPM CPE Analyzer (1 seconds)
  [INFO] Created CPE Index (1 seconds)
  [INFO] Finished CPE Analyzer (2 seconds)
  [INFO] Finished False Positive Analyzer (0 seconds)
  [INFO] Finished NVD CVE Analyzer (0 seconds)
  [INFO] Finished RetireJS Analyzer (0 seconds)
  [INFO] Finished Sonatype OSS Index Analyzer (0 seconds)
  [INFO] Finished Vulnerability Suppression Analyzer (0 seconds)
  [INFO] Finished Dependency Bundling Analyzer (0 seconds)
  [INFO] Analysis Complete (7 seconds)
  [INFO] Writing report to: /Users/paulwilliamson/Developer/ios-app/./dependency-check-report.json
  [INFO] Writing report to: /Users/paulwilliamson/Developer/ios-app/./dependency-check-report.html
  [ERROR] class javax.json.JsonValueImpl cannot be cast to class javax.json.JsonString (javax.json.JsonValueImpl and javax.json.JsonString are in unnamed module of loader 'app')
  ```
</details>

## Example `Package.resolved`

<details>
  <summary>Package.resolved</summary>

  ```json
  {
    "object": {
      "pins": [
        {
          "package": "Commandant",
          "repositoryURL": "https://github.com/Carthage/Commandant.git",
          "state": {
            "branch": null,
            "revision": "ab68611013dec67413628ac87c1f29e8427bc8e4",
            "version": "0.17.0"
          }
        },
        {
          "package": "swift-doc",
          "repositoryURL": "https://github.com/SwiftDocOrg/swift-doc",
          "state": {
            "branch": "1.0.0-beta.4",
            "revision": "581af2fe50667ed2f49c53d26b91a8feb4531302",
            "version": null
          }
        }
      ]
    },
    "version": 1
  }
  ```
</details>

