### PR TITLE
Bump spotbugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,8 @@ Copyright (c) 2012 - Jeremy Long
         <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
         <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-        <spotbugs.maven.plugin.version>4.5.0</spotbugs.maven.plugin.version>
+        <spotbugs.version>4.5.0</spotbugs.version>
+        <spotbugs.maven.plugin.version>4.5.0.0</spotbugs.maven.plugin.version>
         <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
 
@@ -1004,7 +1005,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-annotations</artifactId>
-                <version>${spotbugs.maven.plugin.version}</version>
+                <version>${spotbugs.version}</version>
                 <scope>compile</scope>
                 <optional>true</optional>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@ Copyright (c) 2012 - Jeremy Long
         <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
         <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-        <spotbugs.maven.plugin.version>4.4.2</spotbugs.maven.plugin.version>
+        <spotbugs.maven.plugin.version>4.5.0</spotbugs.maven.plugin.version>
         <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
 


### PR DESCRIPTION
## Replaces PR #3810 

## Description of Change

As the spotbugs-maven-plugin is semi-independently versioned from spotbugs itself we need two properties, one for the annotations version and one for the plugin

## Have test cases been added to cover the new functionality?

no (not applicable)