### PR TITLE
Fixup configuration of Nexus staging plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -768,7 +768,7 @@ Copyright (c) 2012 - Jeremy Long
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
-                    <nexusurl>https://oss.sonatype.org/</nexusurl>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Description of Change

My IDE flagged the nexusurl configuration of the staging-plugin as invalid. Research showed that it is camelCased, so it should be nexus**U**rl.
This likely will resolve the NullPointerException on main branch pipeline.

## Have test cases been added to cover the new functionality?

N/A