### PR TITLE
fix snapshot publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-        run: mvn -s settings.xml -Prelease clean package verify source:jar javadoc:jar gpg:sign deploy -DreleaseTesting --no-transfer-progress --batch-mode -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} -e -X
+        run: mvn -s settings.xml -Prelease clean package verify source:jar javadoc:jar gpg:sign deploy -DreleaseTesting --no-transfer-progress --batch-mode -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
       - name: Archive IT test logs
         id: archive-logs
         uses: actions/upload-artifact@v2

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -28,6 +28,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <description>dependency-check-maven is a Maven Plugin that uses dependency-check-core to detect publicly disclosed vulnerabilities associated with the project's dependencies. The plugin will generate a report listing the dependency, any identified Common Platform Enumeration (CPE) identifiers, and the associated Common Vulnerability and Exposure (CVE) entries.</description>
     <inceptionYear>2013</inceptionYear>
     <properties>
+        <!-- upgrading has caused publishing errors -->
         <version.maven-plugin-plugin>3.6.1</version.maven-plugin-plugin>
     </properties>
     <scm>


### PR DESCRIPTION
## Fixes Issue https://github.com/jeremylong/DependencyCheck/issues/3854

## Description of Change
revert maven-plugin-plugin bump and put in a note that new version may cause an issue when publishing the snapshot builds.