### PR TITLE
Add java-vendor to the ignored manifest entries; fixes #3845

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -131,6 +131,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
             "importpackage",
             "import-template",
             "importtemplate",
+            "java-vendor",
             "export-template",
             "exporttemplate",
             "ignorepackage",


### PR DESCRIPTION
## Fixes Issue #3845

## Description of Change

As observed in issue 3845 random libraries that have "Oracle" as (proprietary) java-vendor property in MANIFEST.MF will lead to libraries being wrongly linked to the Oracle database server when the other properties do not yield a good CPE candidate. As java-vendor will typically neither refer to the product that a jar belongs to nor its vendor, but rather to the technology-stack on which it was built we should ignore it as evidence.

## Have test cases been added to cover the new functionality?

no; validated that the FP of 3845 no longer surfaces