### PR TITLE
#3868 Suppress log4j-api & log4j-to-slf4j false positive

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4854,4 +4854,18 @@
         <packageUrl regex="true">^pkg:maven/nginx\-clojure/nginx\-clojure@.*$</packageUrl>
         <cpe>cpe:/a:nginx:nginx</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        False positive as per #3868
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-api@.*$</packageUrl>
+        <cpe>cpe:/a:apache:log4j</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        False positive as per #3868
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-to\-slf4j@.*$</packageUrl>
+        <cpe>cpe:/a:apache:log4j</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4858,13 +4858,6 @@
         <notes><![CDATA[
         False positive as per #3868
         ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-api@.*$</packageUrl>
-        <cpe>cpe:/a:apache:log4j</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        False positive as per #3868
-        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-to\-slf4j@.*$</packageUrl>
         <cpe>cpe:/a:apache:log4j</cpe>
     </suppress>


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

Fix #3868 

`log4j-api` & `log4j-to-slf4j` are identified as vulnerable to CVE-2021-44228.

[More explanations on why these two dependencies should be declared as false positive](https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot).

## Have test cases been added to cover the new functionality?

No automated test but a manual verification of these FPs not being raised on a compiled snapshot has been performed.