### PR TITLE
Let Dependabot check for docker image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+     ignore:
+      # stay .net 3.1
+      - dependency-name: "mcr.microsoft.com/dotnet/runtime"
+        versions:
+          - "5.x"
+          - "6.x"


### PR DESCRIPTION



## Description of Change

This should take care of opening PRs against the Dockerfile if an upstream image is bumped

## Have test cases been added to cover the new functionality?

*no*


A a side note, not sure what is special about `azul/zulu-openjdk-alpine:14` is seems that was last updated 2 months ago, while other versions have seen updates.