### PR TITLE
Add npm Version Range Checks

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -213,8 +213,8 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java
@@ -513,12 +513,21 @@ public abstract class AbstractNpmAnalyzer extends AbstractFileTypeAnalyzer {
         return searcher;
     }
 
+    /**
+     * Give an NPM version range and a collection of versions, this method
+     * attempts to select a specific version from the collection that is in the
+     * range.
+     *
+     * @param versionRange the version range to evaluate
+     * @param availableVersions the collection of possible versions to select
+     * @return
+     */
     public static String determineVersionFromMap(String versionRange, Collection<String> availableVersions) {
-        if (availableVersions.size()==1) {
+        if (availableVersions.size() == 1) {
             return availableVersions.iterator().next();
         }
-        for (String v : availableVersions){
-            Semver version = new Semver(v, SemverType.NPM);
+        for (String v : availableVersions) {
+            final Semver version = new Semver(v, SemverType.NPM);
             if (version.satisfies(versionRange)) {
                 return v;
             }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java
@@ -520,7 +520,7 @@ public abstract class AbstractNpmAnalyzer extends AbstractFileTypeAnalyzer {
      *
      * @param versionRange the version range to evaluate
      * @param availableVersions the collection of possible versions to select
-     * @return
+     * @return the selected range from the versionRange
      */
     public static String determineVersionFromMap(String versionRange, Collection<String> availableVersions) {
         if (availableVersions.size() == 1) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java
@@ -513,7 +513,7 @@ public abstract class AbstractNpmAnalyzer extends AbstractFileTypeAnalyzer {
         return searcher;
     }
 
-    public String determineVersionFromMap(String versionRange, Collection<String> availableVersions) {
+    public static String determineVersionFromMap(String versionRange, Collection<String> availableVersions) {
         if (availableVersions.size()==1) {
             return availableVersions.iterator().next();
         }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NodeAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NodeAuditAnalyzer.java
@@ -30,15 +30,15 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.json.Json;
 import javax.json.JsonException;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.owasp.dependencycheck.analyzer.exception.SearchException;
 import org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException;
 import org.owasp.dependencycheck.data.nvd.ecosystem.Ecosystem;
@@ -140,7 +140,8 @@ public class NodeAuditAnalyzer extends AbstractNpmAnalyzer {
         }
         final File packageJson = new File(packageLock.getParentFile(), "package.json");
         final List<Advisory> advisories;
-        final Map<String, String> dependencyMap = new HashMap<>();
+        final MultiValuedMap<String, String> dependencyMap = new HashSetValuedHashMap<>();
+        //final Map<String, String> dependencyMap = new HashMap<>();
         if (packageJson.isFile()) {
             advisories = analyzePackage(packageLock, packageJson, dependency, dependencyMap);
         } else {
@@ -170,7 +171,7 @@ public class NodeAuditAnalyzer extends AbstractNpmAnalyzer {
      * submitting the npm audit API payload
      */
     private List<Advisory> analyzePackage(final File lockFile, final File packageFile,
-            Dependency dependency, Map<String, String> dependencyMap)
+            Dependency dependency, MultiValuedMap<String, String> dependencyMap)
             throws AnalysisException {
         try {
             final JsonReader packageReader = Json.createReader(FileUtils.openInputStream(packageFile));
@@ -227,7 +228,7 @@ public class NodeAuditAnalyzer extends AbstractNpmAnalyzer {
      * @throws AnalysisException thrown when there is an error creating or
      * submitting the npm audit API payload
      */
-    private List<Advisory> legacyAnalysis(final File file, Dependency dependency, Map<String, String> dependencyMap)
+    private List<Advisory> legacyAnalysis(final File file, Dependency dependency, MultiValuedMap<String, String> dependencyMap)
             throws AnalysisException {
 
         try (JsonReader jsonReader = Json.createReader(FileUtils.openInputStream(file))) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PnpmAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PnpmAuditAnalyzer.java
@@ -43,9 +43,9 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 
 @ThreadSafe
 public class PnpmAuditAnalyzer extends AbstractNpmAnalyzer {
@@ -89,7 +89,7 @@ public class PnpmAuditAnalyzer extends AbstractNpmAnalyzer {
             return;
         }
         final List<Advisory> advisories;
-        final Map<String, String> dependencyMap = new HashMap<>();
+        final MultiValuedMap<String, String> dependencyMap = new HashSetValuedHashMap<>();
         advisories = analyzePackage(packageLock, dependency);
         try {
             processResults(advisories, engine, dependency, dependencyMap);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzer.java
@@ -23,15 +23,15 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.json.Json;
 import javax.json.JsonException;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -102,7 +102,7 @@ public class YarnAuditAnalyzer extends AbstractNpmAnalyzer {
         }
         final File packageJson = new File(packageLock.getParentFile(), "package.json");
         final List<Advisory> advisories;
-        final Map<String, String> dependencyMap = new HashMap<>();
+        final MultiValuedMap<String, String> dependencyMap = new HashSetValuedHashMap<>();
         advisories = analyzePackage(packageLock, packageJson, dependency, dependencyMap);
         try {
             processResults(advisories, engine, dependency, dependencyMap);
@@ -276,7 +276,7 @@ public class YarnAuditAnalyzer extends AbstractNpmAnalyzer {
      * submitting the npm audit API payload
      */
     private List<Advisory> analyzePackage(final File lockFile, final File packageFile,
-            Dependency dependency, Map<String, String> dependencyMap)
+            Dependency dependency, MultiValuedMap<String, String> dependencyMap)
             throws AnalysisException {
         try {
             final Boolean skipDevDependencies = getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_SKIPDEV, false);

--- a/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilder.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilder.java
@@ -17,6 +17,7 @@
  */
 package org.owasp.dependencycheck.data.nodeaudit;
 
+import com.esotericsoftware.minlog.Log;
 import org.owasp.dependencycheck.analyzer.NodePackageAnalyzer;
 
 import java.util.Map;
@@ -28,6 +29,7 @@ import javax.json.JsonObjectBuilder;
 import javax.json.JsonString;
 import javax.json.JsonValue;
 import javax.annotation.concurrent.ThreadSafe;
+import org.apache.commons.collections4.MultiValuedMap;
 
 /**
  * Class used to create the payload to submit to the NPM Audit API service.
@@ -56,7 +58,7 @@ public final class NpmPayloadBuilder {
      * @return the npm audit API payload
      */
     public static JsonObject build(JsonObject lockJson, JsonObject packageJson,
-            Map<String, String> dependencyMap, boolean skipDevDependencies) {
+            MultiValuedMap<String, String> dependencyMap, boolean skipDevDependencies) {
         final JsonObjectBuilder payloadBuilder = Json.createObjectBuilder();
         addProjectInfo(packageJson, payloadBuilder);
 
@@ -132,7 +134,7 @@ public final class NpmPayloadBuilder {
      * populated while building the payload
      * @return the JSON payload for NPN Audit
      */
-    public static JsonObject build(JsonObject packageJson, Map<String, String> dependencyMap) {
+    public static JsonObject build(JsonObject packageJson, MultiValuedMap<String, String> dependencyMap) {
         final JsonObjectBuilder payloadBuilder = Json.createObjectBuilder();
         addProjectInfo(packageJson, payloadBuilder);
 
@@ -215,7 +217,7 @@ public final class NpmPayloadBuilder {
      * @param dependencyMap the collection of child dependencies
      * @return the dependencies structure needed for the npm audit API payload
      */
-    private static JsonObject buildDependencies(JsonObject dep, Map<String, String> dependencyMap) {
+    private static JsonObject buildDependencies(JsonObject dep, MultiValuedMap<String, String> dependencyMap) {
         final JsonObjectBuilder depBuilder = Json.createObjectBuilder();
         depBuilder.add("version", dep.getString("version"));
 

--- a/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilder.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilder.java
@@ -17,7 +17,6 @@
  */
 package org.owasp.dependencycheck.data.nodeaudit;
 
-import com.esotericsoftware.minlog.Log;
 import org.owasp.dependencycheck.analyzer.NodePackageAnalyzer;
 
 import java.util.Map;

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzerIT.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2021 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.analyzer;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.data.nodeaudit.Advisory;
+import org.owasp.dependencycheck.data.nodeaudit.NodeAuditSearch;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.Vulnerability;
+
+/**
+ *
+ * @author jeremy long
+ */
+public class AbstractNpmAnalyzerIT {
+    
+
+    /**
+     * Test of determineVersionFromMap method, of class AbstractNpmAnalyzer.
+     */
+    @Test
+    public void testDetermineVersionFromMap() {
+        String versionRange = ">2.1.1 <5.0.1";
+        Collection<String> availableVersions = new ArrayList<>();
+        availableVersions.add("2.0.2");
+        availableVersions.add("5.0.2");
+        availableVersions.add("10.1.0");
+        availableVersions.add("8.1.0");
+        availableVersions.add("5.1.0");
+        availableVersions.add("7.1.0");
+        availableVersions.add("3.0.0");
+        availableVersions.add("2.0.0");
+        AbstractNpmAnalyzer instance = new AbstractNpmAnalyzerImpl();
+        String expResult = "3.0.0";
+        String result = instance.determineVersionFromMap(versionRange, availableVersions);
+        assertEquals(expResult, result);
+    }
+
+    public class AbstractNpmAnalyzerImpl extends AbstractNpmAnalyzer {
+
+        @Override
+        protected FileFilter getFileFilter() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        protected void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        protected String getAnalyzerEnabledSettingKey() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getName() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public AnalysisPhase getAnalysisPhase() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+    }
+    
+}

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzerIT.java
@@ -17,34 +17,16 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.io.FileFilter;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-import org.apache.commons.collections4.MultiValuedMap;
-import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
-import org.owasp.dependencycheck.Engine;
-import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
-import org.owasp.dependencycheck.data.nodeaudit.Advisory;
-import org.owasp.dependencycheck.data.nodeaudit.NodeAuditSearch;
-import org.owasp.dependencycheck.dependency.Dependency;
-import org.owasp.dependencycheck.dependency.Vulnerability;
 
 /**
  *
  * @author jeremy long
  */
 public class AbstractNpmAnalyzerIT {
-    
 
     /**
      * Test of determineVersionFromMap method, of class AbstractNpmAnalyzer.
@@ -65,7 +47,7 @@ public class AbstractNpmAnalyzerIT {
         String result = AbstractNpmAnalyzer.determineVersionFromMap(versionRange, availableVersions);
         assertEquals(expResult, result);
     }
-    
+
     @Test
     public void testDetermineVersionFromMap_1() {
         String versionRange = ">2.1.1 <5.0.1";
@@ -75,7 +57,7 @@ public class AbstractNpmAnalyzerIT {
         String result = AbstractNpmAnalyzer.determineVersionFromMap(versionRange, availableVersions);
         assertEquals(expResult, result);
     }
-    
+
     @Test
     public void testDetermineVersionFromMap_2() {
         String versionRange = ">2.1.1 <5.0.1";

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzerIT.java
@@ -61,38 +61,29 @@ public class AbstractNpmAnalyzerIT {
         availableVersions.add("7.1.0");
         availableVersions.add("3.0.0");
         availableVersions.add("2.0.0");
-        AbstractNpmAnalyzer instance = new AbstractNpmAnalyzerImpl();
         String expResult = "3.0.0";
-        String result = instance.determineVersionFromMap(versionRange, availableVersions);
+        String result = AbstractNpmAnalyzer.determineVersionFromMap(versionRange, availableVersions);
         assertEquals(expResult, result);
     }
-
-    public class AbstractNpmAnalyzerImpl extends AbstractNpmAnalyzer {
-
-        @Override
-        protected FileFilter getFileFilter() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-        }
-
-        @Override
-        protected void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-        }
-
-        @Override
-        protected String getAnalyzerEnabledSettingKey() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-        }
-
-        @Override
-        public String getName() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-        }
-
-        @Override
-        public AnalysisPhase getAnalysisPhase() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-        }
+    
+    @Test
+    public void testDetermineVersionFromMap_1() {
+        String versionRange = ">2.1.1 <5.0.1";
+        Collection<String> availableVersions = new ArrayList<>();
+        availableVersions.add("10.1.0");
+        String expResult = "10.1.0";
+        String result = AbstractNpmAnalyzer.determineVersionFromMap(versionRange, availableVersions);
+        assertEquals(expResult, result);
     }
     
+    @Test
+    public void testDetermineVersionFromMap_2() {
+        String versionRange = ">2.1.1 <5.0.1";
+        Collection<String> availableVersions = new ArrayList<>();
+        availableVersions.add("2.0.2");
+        availableVersions.add("5.0.2");
+        String expResult = "2.0.2";
+        String result = AbstractNpmAnalyzer.determineVersionFromMap(versionRange, availableVersions);
+        assertEquals(expResult, result);
+    }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzerIT.java
@@ -31,7 +31,7 @@ public class YarnAuditAnalyzerIT extends BaseTest {
                     found = true;
                     assertTrue(result.getEvidence(EvidenceType.VENDOR).toString().contains("uglify-js"));
                     assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("uglify-js"));
-                    assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains("3.12.4"));
+                    assertTrue("Unable to find version 2.4.24: " + result.getEvidence(EvidenceType.VERSION).toString(), result.getEvidence(EvidenceType.VERSION).toString().contains("2.4.24"));
                     assertTrue(result.isVirtual());
                 }
             }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzerIT.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2021 Jeremy Long. All Rights Reserved.
+ */
 package org.owasp.dependencycheck.analyzer;
 
 import org.junit.Assume;
@@ -15,7 +32,7 @@ public class YarnAuditAnalyzerIT extends BaseTest {
 
     @Test
     public void testAnalyzePackageYarn() throws AnalysisException, InitializationException, InvalidSettingException {
-        
+
         //Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_YARN_AUDIT_ENABLED), is(true));
         try (Engine engine = new Engine(getSettings())) {
             YarnAuditAnalyzer analyzer = new YarnAuditAnalyzer();

--- a/core/src/test/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilderTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilderTest.java
@@ -28,6 +28,8 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonReader;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 
 import org.owasp.dependencycheck.BaseTest;
 
@@ -53,7 +55,7 @@ public class NpmPayloadBuilderTest {
                 );
 
         JsonObject packageJson = builder.build();
-        Map<String, String> dependencyMap = new HashMap<>();
+        final MultiValuedMap<String, String> dependencyMap = new HashSetValuedHashMap<>();
         JsonObject sanitized = NpmPayloadBuilder.build(packageJson, dependencyMap);
 
         Assert.assertTrue(sanitized.containsKey("name"));
@@ -98,7 +100,7 @@ public class NpmPayloadBuilderTest {
                 );
 
         JsonObject packageJson = builder.build();
-        Map<String, String> dependencyMap = new HashMap<>();
+        final MultiValuedMap<String, String> dependencyMap = new HashSetValuedHashMap<>();
         JsonObject sanitized = NpmPayloadBuilder.build(packageJson, dependencyMap);
 
         Assert.assertTrue(sanitized.containsKey("name"));
@@ -121,7 +123,7 @@ public class NpmPayloadBuilderTest {
     @Test
     public void testSanitizePackage() {
         InputStream in = BaseTest.getResourceAsStream(this, "nodeaudit/package-lock.json");
-        Map<String, String> dependencyMap = new HashMap<>();
+        final MultiValuedMap<String, String> dependencyMap = new HashSetValuedHashMap<>();
         try (JsonReader jsonReader = Json.createReader(in)) {
             JsonObject packageJson = jsonReader.readObject();
             JsonObject sanitized = NpmPayloadBuilder.build(packageJson, dependencyMap);
@@ -144,7 +146,7 @@ public class NpmPayloadBuilderTest {
     public void testPayloadWithLockAndPackage() {
         InputStream lock = BaseTest.getResourceAsStream(this, "nodeaudit/package-lock.json");
         InputStream json = BaseTest.getResourceAsStream(this, "nodeaudit/package.json");
-        Map<String, String> dependencyMap = new HashMap<>();
+        final MultiValuedMap<String, String> dependencyMap = new HashSetValuedHashMap<>();
         try (JsonReader jsonReader = Json.createReader(json); JsonReader lockReader = Json.createReader(lock)) {
             JsonObject packageJson = jsonReader.readObject();
             JsonObject lockJson =    lockReader.readObject();
@@ -161,8 +163,6 @@ public class NpmPayloadBuilderTest {
 
             Assert.assertFalse(sanitized.containsKey("lockfileVersion"));
             Assert.assertFalse(sanitized.containsKey("random"));
-
-
 
             Assert.assertTrue(sanitized.containsKey("name"));
             Assert.assertTrue(sanitized.containsKey("version"));

--- a/pom.xml
+++ b/pom.xml
@@ -1167,9 +1167,9 @@ Copyright (c) 2012 - Jeremy Long
                 <version>${maven-reporting-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>${commons-collections.version}</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>4.4</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.velocity</groupId>


### PR DESCRIPTION
## Fixes Issue #3893

If multiple versions of a library existed when analyzing the npm audit results - dependency-check did not consider if multiple versions of a library existed in the `package-lock.json` file. This PR corrects the behavior and does version range checking to ensure the vulnerable version is selected.

## Have test cases been added to cover the new functionality?

yes