### PR TITLE
#3936 Fix CVE-2021-44832 false positive for log4-api & log4j-web

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -6,6 +6,7 @@
             ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-(api|web)@.*$</packageUrl>
         <cve>CVE-2021-44228</cve>
+        <cve>CVE-2021-44832</cve>
         <cve>CVE-2021-45046</cve>
         <cve>CVE-2021-45105</cve>
     </suppress>


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

Fix #3936 by declaring CVE-2021-44832 a false positive for log4j-api & log4j-web artifacts.

## Have test cases been added to cover the new functionality?

*no*