### PR TITLE
Merge identical virtual dependencies into one

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/DependencyMergingAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/DependencyMergingAnalyzer.java
@@ -121,6 +121,13 @@ public class DependencyMergingAnalyzer extends AbstractDependencyComparingAnalyz
                 mergeDependencies(nextDependency, dependency, dependenciesToRemove);
                 return true; //since we merged into the next dependency - skip forward to the next in mainIterator
             }
+        } else if ((main = getMainVirtualDependency(dependency, nextDependency)) != null) {
+            if (main == dependency) {
+                mergeDependencies(dependency, nextDependency, dependenciesToRemove);
+            } else {
+                mergeDependencies(nextDependency, dependency, dependenciesToRemove);
+                return true; //since we merged into the next dependency - skip forward to the next in mainIterator
+            }
         }
         //CSON: InnerAssignment
         return false;
@@ -296,6 +303,29 @@ public class DependencyMergingAnalyzer extends AbstractDependencyComparingAnalyz
             if (dependency1.isVirtual()) {
                 return dependency2;
             }
+            return dependency1;
+        }
+        return null;
+    }
+
+    /**
+     * Determines which of the virtual dependencies should be considered the primary.
+     *
+     * @param dependency1
+     *         the first virtual dependency to compare
+     * @param dependency2
+     *         the second virtual dependency to compare
+     *
+     * @return the first virtual dependency (or {code null} if they are not to be considered mergeable virtual dependencies)
+     */
+    protected Dependency getMainVirtualDependency(Dependency dependency1, Dependency dependency2) {
+        if (dependency1.isVirtual() && dependency2.isVirtual()
+            && dependency1.getName() != null && dependency2.getName() != null
+            && dependency1.getVersion() != null && dependency2.getVersion() != null
+            && dependency1.getActualFilePath() != null && dependency2.getActualFilePath() != null
+            && dependency1.getName().equals(dependency2.getName())
+            && dependency1.getVersion().equals(dependency2.getVersion())
+            && dependency1.getActualFilePath().equals(dependency2.getActualFilePath())) {
             return dependency1;
         }
         return null;

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -808,6 +808,11 @@ public class Dependency extends EvidenceCollection implements Serializable {
                     + "https://github.com/jeremylong/DependencyCheck/issues/172");
             LOGGER.debug("this: {}", this);
             LOGGER.debug("dependency: {}", dependency);
+        } else if (NAME_COMPARATOR.compare(this, dependency) == 0) {
+            LOGGER.debug("Attempted to add the same dependency as this, likely due to merging identical dependencies "
+                         + "obtained from different modules");
+            LOGGER.debug("this: {}", this);
+            LOGGER.debug("dependency: {}", dependency);
         } else if (!relatedDependencies.add(dependency)) {
             LOGGER.debug("Failed to add dependency, likely due to referencing the same file as another dependency in the set.");
             LOGGER.debug("this: {}", this);

--- a/maven/src/it/3944-multimodule-virtual-duplication/invoker.properties
+++ b/maven/src/it/3944-multimodule-virtual-duplication/invoker.properties
@@ -1,0 +1,19 @@
+#
+# This file is part of dependency-check-maven.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+#
+
+invoker.goals = --no-transfer-progress --batch-mode -Danalyzer.ossindex.enabled=false -Danalyzer.central.enabled=false ${project.groupId}:${project.artifactId}:${project.version}:aggregate -Dformat=XML -Dcve.startyear=2018

--- a/maven/src/it/3944-multimodule-virtual-duplication/lib/pom.xml
+++ b/maven/src/it/3944-multimodule-virtual-duplication/lib/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.owasp.test.aggregate.issue-3944</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>lib</artifactId>
+    <packaging>jar</packaging>
+</project>

--- a/maven/src/it/3944-multimodule-virtual-duplication/lib2/pom.xml
+++ b/maven/src/it/3944-multimodule-virtual-duplication/lib2/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.owasp.test.aggregate.issue-3944</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>lib2</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.owasp.test.aggregate.issue-3944</groupId>
+            <artifactId>lib</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/src/it/3944-multimodule-virtual-duplication/lib3/pom.xml
+++ b/maven/src/it/3944-multimodule-virtual-duplication/lib3/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.owasp.test.aggregate.issue-3944</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>lib3</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.owasp.test.aggregate.issue-3944</groupId>
+            <artifactId>lib</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/src/it/3944-multimodule-virtual-duplication/lib4/pom.xml
+++ b/maven/src/it/3944-multimodule-virtual-duplication/lib4/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.owasp.test.aggregate.issue-3944</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>lib4</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.owasp.test.aggregate.issue-3944</groupId>
+            <artifactId>lib</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/src/it/3944-multimodule-virtual-duplication/pom.xml
+++ b/maven/src/it/3944-multimodule-virtual-duplication/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2018 Jeremy Long. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.owasp.test.aggregate.issue-3944</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>lib</module>
+        <module>lib2</module>
+        <module>lib3</module>
+        <module>lib4</module>
+    </modules>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.owasp.test.aggregate.issue-3944</groupId>
+                <artifactId>lib</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/maven/src/it/3944-multimodule-virtual-duplication/postbuild.groovy
+++ b/maven/src/it/3944-multimodule-virtual-duplication/postbuild.groovy
@@ -1,0 +1,43 @@
+/*
+ * This file is part of dependency-check-maven.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
+ */
+
+import org.apache.commons.io.FileUtils;
+import org.w3c.dom.NodeList;
+
+import java.nio.charset.Charset;
+import javax.xml.xpath.*
+import javax.xml.parsers.DocumentBuilderFactory
+
+// Check to see if lib-1.0.0-SNAPSHOT.jar was added to the report only once as a virtual dependency.
+
+def countMatches(String xml, String xpathQuery) {
+    def xpath = XPathFactory.newInstance().newXPath()
+    def builder     = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+    def inputStream = new ByteArrayInputStream( xml.bytes )
+    def records     = builder.parse(inputStream).documentElement
+    NodeList nodes       = xpath.evaluate( xpathQuery, records, XPathConstants.NODESET ) as NodeList
+    nodes.getLength();
+}
+
+String log = FileUtils.readFileToString(new File(basedir, "target/dependency-check-report.xml"), Charset.defaultCharset().name());
+int count = countMatches(log,"/analysis/dependencies/dependency[./fileName = 'org.owasp.test.aggregate.issue-3944:lib:1.0.0-SNAPSHOT']");
+if (count != 1){
+    System.out.println(String.format("virtual dependency lib 1.0.0-SNAPSHOT was identified %s times, expected 1", count));
+    return false;
+}
+return true;


### PR DESCRIPTION
## Fixes Issue #3944

## Description of Change

Merge identical virtual dependencies (same name / version / actualfilepath ) into a single dependency in the DependencyMergingAnalyzer

While merging dependencies do not add a dependency identical to `this` to the related dependencies

Make the virtual dependencies stemming from the maven plugin register the project in which context it was found

## Have test cases been added to cover the new functionality?

yes, new integration testcase