### PR TITLE
Add developer debug option

### DIFF
--- a/cli/src/main/conf/unixBinTemplate
+++ b/cli/src/main/conf/unixBinTemplate
@@ -101,7 +101,15 @@ if $cygwin || $mingw; then
   [ -n "$REPO" ] && REPO=`cygpath --path --windows "$REPO"`
 fi
 
-exec "$JAVACMD" $JAVA_OPTS @EXTRA_JVM_ARGUMENTS@ \
+DEBUG=""
+for var in "$@"
+do
+if [ "$var" = "--debug" ]; then
+    DEBUG="-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000"
+fi
+done
+
+exec "$JAVACMD" $JAVA_OPTS $DEBUG @EXTRA_JVM_ARGUMENTS@ \
   -classpath "$CLASSPATH" \
   -Dapp.name="@APP_NAME@" \
   -Dapp.pid="$$" \

--- a/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
@@ -261,7 +261,7 @@ public final class CliParser {
         final Options options = new Options();
         addStandardOptions(options);
         addAdvancedOptions(options);
-//        addDeprecatedOptions(options);
+        addDeprecatedOptions(options);
         return options;
     }
 
@@ -457,18 +457,21 @@ public final class CliParser {
 
     }
 
-//    /**
-//     * Adds the deprecated command line options to the given options collection.
-//     * These are split out for purposes of not including them in the help
-//     * message. We need to add the deprecated options so as not to break
-//     * existing scripts.
-//     *
-//     * @param options a collection of command line arguments
-//     */
-//    @SuppressWarnings({"static-access", "deprecation"})
-//    private void addDeprecatedOptions(final Options options) {
-//        //all deprecated arguments have been removed (for now)
-//    }
+    /**
+     * Adds the deprecated command line options to the given options collection.
+     * These are split out for purposes of not including them in the help
+     * message. We need to add the deprecated options so as not to break
+     * existing scripts.
+     *
+     * @param options a collection of command line arguments
+     */
+    @SuppressWarnings({"static-access", "deprecation"})
+    private void addDeprecatedOptions(final Options options) {
+        //not a real option - but enables java debugging via the shell script
+        options.addOption(newOption("debug",
+                "Used to enable java debugging of the cli via dependency-check.sh."));
+    }
+
     /**
      * Determines if the 'version' command line argument was passed in.
      *
@@ -565,6 +568,7 @@ public final class CliParser {
     public boolean isYarnAuditDisabled() {
         return hasDisableOption(ARGUMENT.DISABLE_YARN_AUDIT, Settings.KEYS.ANALYZER_YARN_AUDIT_ENABLED);
     }
+
     /**
      * Returns true if the disablePnpmAudit command line argument was specified.
      *

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -2,6 +2,13 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress base="true">
         <notes><![CDATA[
+            fp per #3945 & #3943
+            ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.quarkus/quarkus\-hibernate\-orm.*$</packageUrl>
+        <cpe>cpe:/a:hibernate:hibernate_orm</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
             only log4j-core is vulnerable
             ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-(api|web)@.*$</packageUrl>


### PR DESCRIPTION
Occasionally it is helpful to attach a debugger to the CLI. This PR allows developers of ODC to add the `--debug` flag to the CLI execution to add the arguments to the JVM to suspend execution and wait for a debugger to be attached.

Additionally - because I'm unfortunately sloppy, this includes a fix for a FP also ;) 