### PR TITLE
Fix Semver Exception on some NPM projects

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java
@@ -23,6 +23,7 @@ import com.github.packageurl.PackageURL.StandardTypes;
 import com.github.packageurl.PackageURLBuilder;
 import com.vdurmont.semver4j.Semver;
 import com.vdurmont.semver4j.Semver.SemverType;
+import com.vdurmont.semver4j.SemverException;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.data.nodeaudit.Advisory;
 import org.owasp.dependencycheck.data.nodeaudit.NodeAuditSearch;
@@ -527,9 +528,13 @@ public abstract class AbstractNpmAnalyzer extends AbstractFileTypeAnalyzer {
             return availableVersions.iterator().next();
         }
         for (String v : availableVersions) {
-            final Semver version = new Semver(v, SemverType.NPM);
-            if (version.satisfies(versionRange)) {
-                return v;
+            try {
+                final Semver version = new Semver(v, SemverType.NPM);
+                if (version.satisfies(versionRange)) {
+                    return v;
+                }
+            } catch (SemverException ex) {
+                LOGGER.debug("invalid semver: " + v);
             }
         }
         return availableVersions.iterator().next();

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -2,6 +2,13 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress base="true">
         <notes><![CDATA[
+            fp per #3945 & #3943
+            ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.quarkus/quarkus\-hibernate\-orm.*$</packageUrl>
+        <cpe>cpe:/a:hibernate:hibernate_orm</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
             only log4j-core is vulnerable
             ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-(api|web)@.*$</packageUrl>


### PR DESCRIPTION
## Fixes Issue #3956

The fix ignores versions that cannot be parsed by semver - this is 100% acceptable as we are parsing `evidence` that may not contain valid version information.