### PR TITLE
OSSIndexAnalyzer rate limiting exceeded message

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -142,6 +142,8 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
                     failed = true;
                     if (ex.getMessage() != null && ex.getMessage().endsWith("401")) {
                         throw new AnalysisException("Invalid credentails provided for OSS Index", ex);
+                    } else if (ex.getMessage() != null && ex.getMessage().endsWith("429")) {
+                        throw new AnalysisException("OSS Index rate limit exceeded", ex);
                     }
                     LOG.debug("Error requesting component reports", ex);
                     throw new AnalysisException("Failed to request component-reports", ex);


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

I added a dedicated error message in case the rate limit of OSSIndex was exceeded. 

## Have test cases been added to cover the new functionality?

no