### PR TITLE
Extend `cpe:/a:netty:netty` suppression to all netty-tcnative modules

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -894,9 +894,9 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        Suppresses false positives per #1573.
+        Suppresses false positives per #1573, #3889 and #4065
         ]]></notes>
-        <gav regex="true">^io\.netty:netty-tcnative-boringssl-static:.*$</gav>
+        <gav regex="true">^io\.netty:netty-tcnative.*$</gav>
         <cpe regex="true">^cpe:/a:netty(_project)?:netty.*$</cpe>
     </suppress>
     <suppress base="true">
@@ -4894,11 +4894,4 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-to\-slf4j@.*$</packageUrl>
         <cpe>cpe:/a:apache:log4j</cpe>
     </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per #3889
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-tcnative\-classes@.*$</packageUrl>
-        <cpe>cpe:/a:netty:netty</cpe>
-    </suppress>	
 </suppressions>


### PR DESCRIPTION
## Fixes Issue #4065

## Description of Change

Merge the current suppressions for netty-tcnative artifactIds and extend it to hold all the artifactIds published within the netty-tcnative groupId.

## Have test cases been added to cover the new functionality?

no