### PR TITLE
Prevent embedded-artifacts manifest entry triggering FPs on the embedding  jar

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -151,6 +151,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
             "bundle-vendor",
             "include-resource",
             "embed-dependency",
+            "embedded-artifacts",
             "ipojo-components",
             "ipojo-extension",
             "plugin-dependencies",


### PR DESCRIPTION
## Fixes Issue #4064 

## Description of Change

As per #4064 it appears that the embedded-artifacts MANIFEST entry can also be expected to trigger false-positives when using embedded jar bundles in e.g. the OSGi framework.

As embedded jars are already analyzed on their own when analyzing the embedding jar contents we should discard the manifest entry that lists the paths of all these embedded jars from the embedding jar evidences.

## Have test cases been added to cover the new functionality?

no, but initiator of the issue has validated that it at least resolves there false positive