### PR TITLE
Resolve false negative on PostgreSQL JDBC driver

### DIFF
--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -422,5 +422,14 @@
         <add>
             <evidence type="product" source="hint analyzer" name="product" value="legion-of-the-bouncy-castle-fips-java" confidence="HIGHEST"/>
         </add>
-    </hint>  
+    </hint>
+    <hint>
+        <given>
+            <evidence type="product" source="pom" name="name" value="PostgreSQL JDBC Driver"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="postgresql_jdbc_driver" confidence="HIGHEST"/>
+            <evidence type="product" source="hint analyzer" name="product" value="pgjdbc" confidence="HIGHEST"/>
+        </add>
+    </hint>
 </hints>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -3994,108 +3994,12 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per issue #946 - instead of suppressing the whole thing, we will just
-            suppress specific CVE that are for the server
+            Original suppression as per #946 suppressed individual CVEs.
+            As per false negative #4085 Postgresql JDBC driver has two CPEs of its own, so it's proper to suppress the server CPE
+            NOTE: the additional colon in the CPE is required to not match on prefix with cpe:/a:postgresql:postgresql_jdbc_driver
         ]]></notes>
-        <gav regex="true">^(org\.)?postgresql:postgresql:.*$</gav>
-        <cve>CVE-2016-7048</cve>
-        <cve>CVE-2018-1115</cve>
-        <cve>CVE-2017-14798</cve>
-        <cve>CVE-2017-8806</cve>
-        <cve>CVE-2006-5540</cve>
-        <cve>CVE-2006-5542</cve>
-        <cve>CVE-2007-6600</cve>
-        <cve>CVE-2007-3279</cve>
-        <cve>CVE-2016-5423</cve>
-        <cve>CVE-2005-0244</cve>
-        <cve>CVE-2006-2314</cve>
-        <cve>CVE-2005-0246</cve>
-        <cve>CVE-2005-1410</cve>
-        <cve>CVE-2006-0678</cve>
-        <cve>CVE-2002-0972</cve>
-        <cve>CVE-2005-0227</cve>
-        <cve>CVE-2002-1402</cve>
-        <cve>CVE-2004-0977</cve>
-        <cve>CVE-2013-1899</cve>
-        <cve>CVE-2003-0901</cve>
-        <cve>CVE-2010-0733</cve>
-        <cve>CVE-2010-1447</cve>
-        <cve>CVE-2002-1642</cve>
-        <cve>CVE-2006-0553</cve>
-        <cve>CVE-2002-1400</cve>
-        <cve>CVE-2007-3280</cve>
-        <cve>CVE-2017-7484</cve>
-        <cve>CVE-2009-4034</cve>
-        <cve>CVE-2017-7486</cve>
-        <cve>CVE-2012-3489</cve>
-        <cve>CVE-2009-4136</cve>
-        <cve>CVE-2014-0061</cve>
-        <cve>CVE-2015-5288</cve>
-        <cve>CVE-1999-0862</cve>
-        <cve>CVE-2014-0063</cve>
-        <cve>CVE-2014-0065</cve>
-        <cve>CVE-2007-2138</cve>
-        <cve>CVE-2002-1397</cve>
-        <cve>CVE-2007-0556</cve>
-        <cve>CVE-2002-1399</cve>
-        <cve>CVE-2006-0105</cve>
-        <cve>CVE-2016-0766</cve>
-        <cve>CVE-2010-0442</cve>
-        <cve>CVE-2014-0067</cve>
-        <cve>CVE-2002-1657</cve>
-        <cve>CVE-2017-7548</cve>
-        <cve>CVE-2010-1975</cve>
-        <cve>CVE-2012-0866</cve>
-        <cve>CVE-2012-0868</cve>
-        <cve>CVE-2013-1903</cve>
-        <cve>CVE-2013-1901</cve>
-        <cve>CVE-2016-0768</cve>
-        <cve>CVE-2017-7546</cve>
-        <cve>CVE-2009-3231</cve>
-        <cve>CVE-2016-2193</cve>
-        <cve>CVE-2006-5541</cve>
-        <cve>CVE-2016-3065</cve>
-        <cve>CVE-2007-3278</cve>
-        <cve>CVE-2007-6601</cve>
-        <cve>CVE-2016-5424</cve>
-        <cve>CVE-2006-2313</cve>
-        <cve>CVE-2005-0245</cve>
-        <cve>CVE-2007-4769</cve>
-        <cve>CVE-2005-0247</cve>
-        <cve>CVE-2009-0922</cve>
-        <cve>CVE-2002-1401</cve>
-        <cve>CVE-2012-2655</cve>
-        <cve>CVE-2010-1169</cve>
-        <cve>CVE-2012-3488</cve>
-        <cve>CVE-2010-4015</cve>
-        <cve>CVE-2016-0773</cve>
-        <!--cve>CVE-2017-7485</cve>  This affects the client -->
-        <cve>CVE-2007-4772</cve>
-        <cve>CVE-2014-0060</cve>
-        <cve>CVE-2014-0062</cve>
-        <cve>CVE-2010-1170</cve>
-        <cve>CVE-2014-0064</cve>
-        <cve>CVE-2015-3165</cve>
-        <cve>CVE-2009-3229</cve>
-        <cve>CVE-2007-0555</cve>
-        <cve>CVE-2002-1398</cve>
-        <cve>CVE-2000-1199</cve>
-        <cve>CVE-2013-0255</cve>
-        <cve>CVE-2010-3433</cve>
-        <cve>CVE-2014-0066</cve>
-        <cve>CVE-2004-0547</cve>
-        <cve>CVE-2014-2669</cve>
-        <cve>CVE-2013-1900</cve>
-        <cve>CVE-2005-1409</cve>
-        <cve>CVE-2002-0802</cve>
-        <cve>CVE-2013-1902</cve>
-        <cve>CVE-2017-7547</cve>
-        <cve>CVE-2012-0867</cve>
-        <cve>CVE-2012-2143</cve>
-        <!--cve>CVE-2012-1618</cve>  this affects the JDBC -->
-        <cve>CVE-2015-5289</cve>
-        <cve>CVE-2009-3230</cve>
-        <cve>CVE-2007-6067</cve>
+        <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
+        <cpe>cpe:/a:postgresql:postgresql:</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[


### PR DESCRIPTION
## Fixes Issue #4085

## Description of Change

Added hints to support the proper linking of the postgresql JDBC driver to the 2 CPEs present in the NVD datastreams for this driver, also cleaning up the suppressions to suppress the postgresql server CPE rather than suppressing all its CVEs

## Have test cases been added to cover the new functionality?

no