### PR TITLE
#4077 Declare com.itextpdf:pdfrender as not related to cpe:/a:itextpdf:itext

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4805,4 +4805,11 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-to\-slf4j@.*$</packageUrl>
         <cpe>cpe:/a:apache:log4j</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        False positive as per #4077
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.itextpdf/pdfrender@.*$</packageUrl>
+        <cpe>cpe:/a:itextpdf:itext</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Fixes Issue #

Fix #4077 

## Description of Change

Add a suppression rule for com.itextpdf:pdfrender package.

## Have test cases been added to cover the new functionality?

*no*, just a manual test on a sample repo.