### PR TITLE
Fix a performance drain due to multiple executions of the function body

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/H2Functions.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/H2Functions.java
@@ -195,6 +195,14 @@ public final class H2Functions {
 
         final SimpleResultSet ret = new SimpleResultSet();
         ret.addColumn("id", Types.INTEGER, 10, 0);
+        String url = conn.getMetaData().getURL();
+        if (url.equals("jdbc:columnlist:connection")) {
+            // Virtual Table Functions get called multiple times by H2
+            // JDBC URL jdbc:columnlist:connection indicates that H2 only wants to discover
+            // the metadata (list of result columns) of the result and is not interested in the actual
+            // execution of the function, so we should exit early with an empty resultset.
+            return ret;
+        }
 
         int vulnerabilityId = 0;
         try (PreparedStatement selectVulnerabilityId = conn.prepareStatement("SELECT id FROM VULNERABILITY CVE WHERE cve=?")) {

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/H2Functions.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/H2Functions.java
@@ -195,8 +195,8 @@ public final class H2Functions {
 
         final SimpleResultSet ret = new SimpleResultSet();
         ret.addColumn("id", Types.INTEGER, 10, 0);
-        String url = conn.getMetaData().getURL();
-        if (url.equals("jdbc:columnlist:connection")) {
+        final String url = conn.getMetaData().getURL();
+        if ("jdbc:columnlist:connection".equals(url)) {
             // Virtual Table Functions get called multiple times by H2
             // JDBC URL jdbc:columnlist:connection indicates that H2 only wants to discover
             // the metadata (list of result columns) of the result and is not interested in the actual


### PR DESCRIPTION
## Fixes Issue #4094

## Description of Change

Immediately return an empty resultset rather than performing  the function body when H2 is only interested in the list of columns that will be return on true execution.

## Have test cases been added to cover the new functionality?

no, tested locally and observed a massive improve in wall-clock processing time as well as total CPU time.