### PR TITLE
#4058 Prevent NPE during race condition

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -153,12 +153,13 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
                     throw new AnalysisException("Failed to request component-reports", e);
                 }
             }
+
+            // skip enrichment if we failed to fetch reports
+            if (!failed) {
+                enrich(dependency);
+            }
         }
 
-        // skip enrichment if we failed to fetch reports
-        if (!failed) {
-            enrich(dependency);
-        }
     }
 
     /**
@@ -224,7 +225,7 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
      *
      * @param dependency the dependency to enrich
      */
-    private void enrich(final Dependency dependency) {
+    void enrich(final Dependency dependency) {
         LOG.debug("Enrich dependency: {}", dependency);
 
         for (Identifier id : dependency.getSoftwareIdentifiers()) {

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
@@ -1,6 +1,6 @@
 package org.owasp.dependencycheck.analyzer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
@@ -39,14 +39,13 @@ public class OssIndexAnalyzerTest extends BaseTest {
 
         analyzer.initialize(settings);
 
-        String expectedOutput = "https://ossindex.sonatype.org/component/pkg:maven/test/test@1.0?" +
-                "utm_source=dependency-check&utm_medium=integration&utm_content=7.0.0-SNAPSHOT";
+        String expectedOutput = "https://ossindex.sonatype.org/component/pkg:maven/test/test@1.0";
 
         // When
         analyzer.analyzeDependency(dependency, engine);
 
         // Then
-        assertEquals(identifier.getUrl(), expectedOutput);
+        assertTrue(identifier.getUrl().startsWith(expectedOutput));
     }
 
     /*

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
@@ -1,0 +1,82 @@
+package org.owasp.dependencycheck.analyzer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.dependency.Confidence;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.naming.Identifier;
+import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
+import org.owasp.dependencycheck.utils.Settings;
+
+import com.github.packageurl.MalformedPackageURLException;
+
+public class OssIndexAnalyzerTest extends BaseTest {
+
+    @Test
+    public void should_enrich_be_included_in_mutex_to_prevent_NPE()
+            throws AnalysisException, MalformedPackageURLException {
+
+        // Given
+        OssIndexAnalyzer analyzer = new SproutOssIndexAnalyzer();
+
+
+        Identifier identifier = new PurlIdentifier("maven", "test", "test", "1.0",
+                Confidence.HIGHEST);
+
+        Dependency dependency = new Dependency();
+        dependency.addSoftwareIdentifier(identifier);
+        Settings settings = getSettings();
+        Engine engine = new Engine(settings);
+        engine.setDependencies(Collections.singletonList(dependency));
+
+        analyzer.initialize(settings);
+
+        String expectedOutput = "https://ossindex.sonatype.org/component/pkg:maven/test/test@1.0?" +
+                "utm_source=dependency-check&utm_medium=integration&utm_content=7.0.0-SNAPSHOT";
+
+        // When
+        analyzer.analyzeDependency(dependency, engine);
+
+        // Then
+        assertEquals(identifier.getUrl(), expectedOutput);
+    }
+
+    /*
+     * This action is inspired by the sprout method technique displayed in
+     * "Michael Feathers - Working Effectively with Legacy code".
+     *
+     * We want to trigger a race condition between a call to
+     * OssIndexAnalyzer.closeAnalyzer() and OssIndexAnalyzer.enrich().
+     *
+     * The last method access data from the "reports" field while
+     * closeAnalyzer() erase the reference. If enrich() is not included in
+     * the "FETCH_MUTIX" synchronized statement, we can trigger a
+     * NullPointeException in a multithreaded environment, which can happen
+     * due to the usage of java.util.concurrent.Future.
+     *
+     * We want to make sure enrich() will be able to set the url of an
+     * identifier and enrich it.
+     */
+    static final class SproutOssIndexAnalyzer extends OssIndexAnalyzer {
+        @Override
+        void enrich(Dependency dependency) {
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            executor.execute(() -> {
+                try {
+                    this.closeAnalyzer();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            super.enrich(dependency);
+        }
+    }
+}


### PR DESCRIPTION
## Fixes Issue #

Fix #4058 

## Description of Change

This change prevent raising a `NullPointerException` by including the `OssIndexAnalyzer.enrich()` method into the mutex. If not, `reports.get(purl)` can cause the exception.

## Have test cases been added to cover the new functionality?

*yes*

I tried to reproduce the behavior with a unit test and succeeded to do so. On my computer with Eclipse, I was getting a test failure every time with the current test implementation and the `enrich()` call being outside of the mutex. I had to slightly alter the api by making the `enrich()` method package protected instead of private.

I also ran an analysis with the maven installed snapshot to check if we do not encounter a dead lock.

The comment added in the test try to explain the goal of the class and the test. I am not sure if it is clear enough, please do not hesitate to ask questions or indicates if you see an issue with such kind of tests.

Please take extra care while reviewing this PR, due to adding statements in a `synchronized()` block, it might slow things a little. Comments are welcomed. :slightly_smiling_face: 