### PR TITLE
Break build on failure to download NVD datastreams (when updates are requested or autoUpdate is enabled)

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
-import java.util.Calendar;
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
 import java.net.URL;
@@ -441,7 +441,9 @@ public class NvdCveUpdater implements CachedWebDataSource {
         if (dbProperties != null && !dbProperties.isEmpty()) {
             try {
                 final int startYear = settings.getInt(Settings.KEYS.CVE_START_YEAR, 2002);
-                final int endYear = Calendar.getInstance().get(Calendar.YEAR);
+                LocalDate today = LocalDate.now();
+                final int endYear = today.getYear();
+                final int dayOfEndYear = today.getDayOfYear();
                 boolean needsFullUpdate = false;
                 for (int y = startYear; y <= endYear; y++) {
                     final long val = Long.parseLong(dbProperties.getProperty(DatabaseProperties.LAST_UPDATED_BASE + y, "0"));
@@ -465,9 +467,26 @@ public class NvdCveUpdater implements CachedWebDataSource {
                     updates.add(item);
                     if (needsFullUpdate) {
                         // no need to download each one, just use the modified timestamp
-                        for (int i = startYear; i <= endYear; i++) {
+                        for (int i = startYear; i < endYear; i++) {
                             url = String.format(baseUrl, i);
                             final NvdCveInfo entry = new NvdCveInfo(Integer.toString(i), url, modified.getLastModifiedDate());
+                            updates.add(entry);
+                        }
+                        // for endyear check metadata availability to determine inclusion when still in grace period
+                        if (dayOfEndYear < settings.getInt(Settings.KEYS.NVD_NEW_YEAR_GRACE_PERIOD, 10)) {
+                            try {
+                                url = String.format(baseUrl, endYear);
+                                final MetaProperties meta = getMetaFile(url);
+                            } catch (UpdateException ue) {
+                                if (ue.getCause() instanceof ResourceNotFoundException) {
+                                    LOGGER.warn("NVD Data for {} has not been published yet.", endYear);
+                                } else {
+                                    throw ue;
+                                }
+                            }
+                        } else {
+                            url = String.format(baseUrl, endYear);
+                            final NvdCveInfo entry = new NvdCveInfo(Integer.toString(endYear), url, modified.getLastModifiedDate());
                             updates.add(entry);
                         }
                     } else if (!DateUtil.withinDateRange(lastUpdated, now, days)) {
@@ -484,14 +503,10 @@ public class NvdCveUpdater implements CachedWebDataSource {
                                     updates.add(entry);
                                 }
                             } catch (UpdateException ex) {
-                                final Calendar date = Calendar.getInstance();
-                                final int year = date.get(Calendar.YEAR);
-                                final int month = date.get(Calendar.MONTH);
-                                final int day = date.get(Calendar.DATE);
                                 final int grace = settings.getInt(Settings.KEYS.NVD_NEW_YEAR_GRACE_PERIOD, 10);
-                                if (ex.getMessage().contains("Unable to download meta file")
-                                        && i == year && month == 0 && day < grace) {
-                                    LOGGER.warn("NVD Data for {} has not been published yet.", year);
+                                if (ex.getCause() instanceof ResourceNotFoundException
+                                        && i == endYear && dayOfEndYear < grace) {
+                                    LOGGER.warn("NVD Data for {} has not been published yet.", endYear);
                                 } else {
                                     throw ex;
                                 }

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
@@ -460,21 +460,19 @@ public class NvdCveUpdater implements CachedWebDataSource {
                 if (!needsFullUpdate && lastUpdated == modified.getLastModifiedDate()) {
                     return updates;
                 } else {
-                    final int start = settings.getInt(Settings.KEYS.CVE_START_YEAR);
-                    final int end = Calendar.getInstance().get(Calendar.YEAR);
                     final String baseUrl = settings.getString(Settings.KEYS.CVE_BASE_JSON);
                     final NvdCveInfo item = new NvdCveInfo(MODIFIED, url, modified.getLastModifiedDate());
                     updates.add(item);
                     if (needsFullUpdate) {
                         // no need to download each one, just use the modified timestamp
-                        for (int i = start; i <= end; i++) {
+                        for (int i = startYear; i <= endYear; i++) {
                             url = String.format(baseUrl, i);
                             final NvdCveInfo entry = new NvdCveInfo(Integer.toString(i), url, modified.getLastModifiedDate());
                             updates.add(entry);
                         }
                     } else if (!DateUtil.withinDateRange(lastUpdated, now, days)) {
                         final long waitTime = settings.getInt(Settings.KEYS.CVE_DOWNLOAD_WAIT_TIME, 4000);
-                        for (int i = start; i <= end; i++) {
+                        for (int i = startYear; i <= endYear; i++) {
                             try {
                                 url = String.format(baseUrl, i);
                                 Thread.sleep(waitTime);
@@ -507,8 +505,6 @@ public class NvdCveUpdater implements CachedWebDataSource {
             } catch (NumberFormatException ex) {
                 LOGGER.warn("An invalid schema version or timestamp exists in the data.properties file.");
                 LOGGER.debug("", ex);
-            } catch (InvalidSettingException ex) {
-                throw new UpdateException("The NVD CVE start year property is set to an invalid value", ex);
             }
         }
         return updates;

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
@@ -26,7 +26,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
-import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
 import java.net.URL;
@@ -441,7 +442,10 @@ public class NvdCveUpdater implements CachedWebDataSource {
         if (dbProperties != null && !dbProperties.isEmpty()) {
             try {
                 final int startYear = settings.getInt(Settings.KEYS.CVE_START_YEAR, 2002);
-                LocalDate today = LocalDate.now();
+                // for establishing the current year use the timezone where the new year starts first
+                // as from that moment on CNAs might start assigning CVEs with the new year depending
+                // on the CNA's timezone
+                ZonedDateTime today = ZonedDateTime.now().withZoneSameInstant(ZoneOffset.ofHours(14));
                 final int endYear = today.getYear();
                 final int dayOfEndYear = today.getDayOfYear();
                 boolean needsFullUpdate = false;

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/NvdCveUpdater.java
@@ -445,7 +445,7 @@ public class NvdCveUpdater implements CachedWebDataSource {
                 // for establishing the current year use the timezone where the new year starts first
                 // as from that moment on CNAs might start assigning CVEs with the new year depending
                 // on the CNA's timezone
-                ZonedDateTime today = ZonedDateTime.now().withZoneSameInstant(ZoneOffset.ofHours(14));
+                final ZonedDateTime today = ZonedDateTime.now().withZoneSameInstant(ZoneOffset.ofHours(14));
                 final int endYear = today.getYear();
                 final int dayOfEndYear = today.getDayOfYear();
                 boolean needsFullUpdate = false;

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
@@ -151,13 +151,11 @@ public class DownloadTask implements Callable<Future<ProcessTask>> {
             return val;
 
         } catch (Throwable ex) {
-            LOGGER.error("An exception occurred downloading NVD CVE - {}\nSome CVEs may not be reported. Reason: {}",
-                    nvdCveInfo.getId(), ex.getMessage());
-            LOGGER.debug("Download Task Failed", ex);
+            LOGGER.error("Error downloading NVD CVE - {} Reason: {}", nvdCveInfo.getId(), ex.getMessage());
+            throw ex;
         } finally {
             settings.cleanup(false);
         }
-        return null;
     }
 
     private boolean attemptDownload(final URL url1, boolean showLog) throws TooManyRequestsException, ResourceNotFoundException {


### PR DESCRIPTION
## Fixes Issue #3991

## Description of Change

Make the build break instead of issuing only a warning that some CVEs may not be reported when there is an error downloading one of the NVD datafeeds.

While working spotted an issue that the year roll-over grace period was not covered for the needsFullUpdate case, so I added it there. And updated the existing logic to only accept the not-found case for failed download (a `too many requests` response would also be acceptedin the grace-period with the original code)

And as I understand it CNAs are using local date to determine the year-part of a CVE, so I think we should start attempting to obtain a new year datafeed as soon as the first timezone enters the new year.

## Have test cases been added to cover the new functionality?

no, tested locally with molesting a local NVD mirror and a temporary extended new year grace period to simulate download errors and validate that a missing new year datafeed still succeeds with just a warning in the grace-period  