### PR TITLE
Report CRITICAL (CVSSv3) or HIGH (CVSSv2) when highest-ranking CVSS-scored and unscored vulnerabilities are both present

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
@@ -416,17 +416,72 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
     }
 
     /**
-     * Compares two vulnerabilities.
+     * Compares two vulnerabilities.<br>
+     * Natural order of vulnerabilities is defined as decreasing in severity and alphabetically by name for equal severity.
+     * This way the most severe issues are listed first in a sorted list.
+     *
+     * This uses a best-effort ordering for severity as the variety of sources do not guarantee a consistent availability of
+     * standardized severity scores.<br>
+     * <ol>
+     * <li>When both vulnerabilities have an associated CVSSv3 severity their base score is used for comparison.</li>
+     * <li>When both have an associated CVSSv2 severity their score values are compared.</li>
+     * <li>When the vulnerabilities each have a CVVS severity, but one uses V3 and the other V2 the V3 baseScore and V2 score are
+     * used to compare the two.</li>
+     * <li>When one of the vulnerabilities has an unscored value it is only considered to be more severe when the other vulnerability
+     * does not fall into the highest ranking CVSS score (preferring the score of CVSSv3 for the other vulnerability when both V2
+     * and V3 are available.</li>
+     * <li>When both vulnerabilities have an unscored severity the vulnerabilities are merely ordered by name (to ensure a
+     * repeatable sequence for sorted lists as the unscored vulnerabilities have non-formalized severities that cannot be
+     * reliably compared.</li>
+     * </ol>
      *
      * @param o a vulnerability to be compared
      * @return a negative integer, zero, or a positive integer as this object is
-     * less than, equal to, or greater than the specified vulnerability
+     * less (more severe) than , equal to, or greater (less severe) than  the specified vulnerability
      */
     @Override
     public int compareTo(@NotNull Vulnerability o) {
-        return new CompareToBuilder()
+        final CompareToBuilder builder = new CompareToBuilder();
+        appendBestEffortSeverityComparison( o, builder );
+        return builder
                 .append(this.name, o.name)
                 .toComparison();
+
+    }
+
+    /**
+     * Appends a best-effort comparison for the severity component of both vulnerabilities to the
+     * compareToBuilder using a high-to-low severity natural order.
+     *
+     * @param o The other vulnerability for the compareTo method
+     * @param builder The CompareToBuilder under construction
+     * @see #compareTo(Vulnerability) For a detailed description of the comparison strategy for severity.
+     */
+    private void appendBestEffortSeverityComparison( @NotNull Vulnerability o, @NotNull CompareToBuilder builder )
+    {
+        if (this.cvssV3 != null && o.cvssV3 != null) {
+            builder.append(o.cvssV3.getBaseScore(), this.cvssV3.getBaseScore());
+        } else if (this.cvssV2 != null && o.cvssV2 != null) {
+            builder.append(o.cvssV2.getScore(), this.cvssV2.getScore());
+        } else if (this.cvssV3 != null) {
+            if (o.cvssV2 != null) {
+                builder.append(o.cvssV2.getScore(), this.cvssV3.getBaseScore());
+            } else {
+                builder.append(8.99f, this.cvssV3.getBaseScore());
+            }
+        } else if (this.cvssV2 != null) {
+            if (o.cvssV3 != null) {
+                builder.append(o.cvssV3.getBaseScore(), this.cvssV2.getScore());
+            } else {
+                builder.append(6.99f, this.cvssV2.getScore());
+            }
+        } else {
+            if (o.cvssV3 != null) {
+                builder.append(o.cvssV3.getBaseScore(), 8.99f);
+            } else if (o.cvssV2 != null) {
+                builder.append(o.cvssV2.getScore(), 6.99f);
+            }
+        }
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
@@ -442,11 +442,8 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
     @Override
     public int compareTo(@NotNull Vulnerability o) {
         final CompareToBuilder builder = new CompareToBuilder();
-        appendBestEffortSeverityComparison( o, builder );
-        return builder
-                .append(this.name, o.name)
-                .toComparison();
-
+        appendBestEffortSeverityComparison(o, builder);
+        return builder.append(this.name, o.name).toComparison();
     }
 
     /**
@@ -457,8 +454,7 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
      * @param builder The CompareToBuilder under construction
      * @see #compareTo(Vulnerability) For a detailed description of the comparison strategy for severity.
      */
-    private void appendBestEffortSeverityComparison( @NotNull Vulnerability o, @NotNull CompareToBuilder builder )
-    {
+    private void appendBestEffortSeverityComparison(@NotNull Vulnerability o, @NotNull CompareToBuilder builder) {
         if (this.cvssV3 != null && o.cvssV3 != null) {
             builder.append(o.cvssV3.getBaseScore(), this.cvssV3.getBaseScore());
         } else if (this.cvssV2 != null && o.cvssV2 != null) {

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
@@ -458,6 +458,7 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
      *
      * @see SeverityUtil#estimatedSortAdjustedCVSSv3(String)
      * @see SeverityUtil#sortAdjustedCVSSv3BaseScore(float)
+     * @return A float value that allows for best-effort sorting on vulnerability severity
      */
     private float bestEffortSeverityLevelForSorting() {
         if (this.cvssV3 != null) {
@@ -475,10 +476,10 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
      * @return The string to display in the report, clarifying for unrecognized unscored severities that critical is assumed.
      */
     public String getHighestSeverityText() {
-        if(this.cvssV3 != null) {
+        if (this.cvssV3 != null) {
             return this.cvssV3.getBaseSeverity();
         }
-        if(this.cvssV2 != null) {
+        if (this.cvssV2 != null) {
             return this.cvssV2.getSeverity();
         }
         return SeverityUtil.unscoredToSeveritytext(this.unscoredSeverity);

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.jetbrains.annotations.NotNull;
+import org.owasp.dependencycheck.utils.SeverityUtil;
 
 /**
  * Contains the information about a vulnerability.
@@ -419,65 +420,68 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
      * Compares two vulnerabilities.<br>
      * Natural order of vulnerabilities is defined as decreasing in severity and alphabetically by name for equal severity.
      * This way the most severe issues are listed first in a sorted list.
-     *
-     * This uses a best-effort ordering for severity as the variety of sources do not guarantee a consistent availability of
-     * standardized severity scores.<br>
-     * <ol>
-     * <li>When both vulnerabilities have an associated CVSSv3 severity their base score is used for comparison.</li>
-     * <li>When both have an associated CVSSv2 severity their score values are compared.</li>
-     * <li>When the vulnerabilities each have a CVVS severity, but one uses V3 and the other V2 the V3 baseScore and V2 score are
-     * used to compare the two.</li>
-     * <li>When one of the vulnerabilities has an unscored value it is only considered to be more severe when the other vulnerability
-     * does not fall into the highest ranking CVSS score (preferring the score of CVSSv3 for the other vulnerability when both V2
-     * and V3 are available.</li>
-     * <li>When both vulnerabilities have an unscored severity the vulnerabilities are merely ordered by name (to ensure a
-     * repeatable sequence for sorted lists as the unscored vulnerabilities have non-formalized severities that cannot be
-     * reliably compared.</li>
-     * </ol>
+     * <br>
+     * This uses a {@link #bestEffortSeverityLevelForSorting() best-effort ordering} for severity as the variety of sources do
+     * not guarantee a consistent availability of standardized severity scores. The bestEffort severity level estimation will use
+     * CVSSv3 baseScore for comparison when available on both sides. If any of the vulnerabilities does not have a CVSSv3 score
+     * the sort order may be off, but it will be consistent.
+     * <br>
+     * The ranking (high to low) of severity can be informally represented as
+     * {@code &lt;CVSSv3 critical> >> &lt;Unscored recognized critical> >>
+     *     &lt;Unscored unrecognized (assumed Critical)> >> &lt;Score-based comparison for high-or-lower scoring severities with
+     *     recognized unscored severities taking the lower bound of the comparable CVSSv3 range>  }
      *
      * @param o a vulnerability to be compared
      * @return a negative integer, zero, or a positive integer as this object is
-     * less (more severe) than , equal to, or greater (less severe) than  the specified vulnerability
+     * less than , equal to, or greater than the specified vulnerability
+     * @see #bestEffortSeverityLevelForSorting()
      */
     @Override
     public int compareTo(@NotNull Vulnerability o) {
-        final CompareToBuilder builder = new CompareToBuilder();
-        appendBestEffortSeverityComparison(o, builder);
-        return builder.append(this.name, o.name).toComparison();
+        return new CompareToBuilder()
+                .append(o.bestEffortSeverityLevelForSorting(), this.bestEffortSeverityLevelForSorting())
+                .append(this.name, o.name)
+                .toComparison();
     }
 
     /**
-     * Appends a best-effort comparison for the severity component of both vulnerabilities to the
-     * compareToBuilder using a high-to-low severity natural order.
+     * Compute a best-effort score for the severity of a vulnerability for the purpose of sorting.
+     *<br>
+     * Note that CVSSv2 and CVSSv3 scores are essentially uncomparable. For the purpose of sorting we nevertheless
+     * treat them comparable, with an exception for the 9.0-10.0 range. For that entire range CVSSv3 is scoring more severe than
+     * CVSSv2, so that the 'CRITICAL' severity is retained to be reported as the highest severity after sorting on
+     * descending severity.
+     *<br>
+     * For vulnerabilities not scored with a CVSS score we estimate a score from the severity text. For textual severities
+     * assumed or sementically confirmed to be of a critical nature we assign a value in between the highest CVSSv2 HIGH and
+     * the lowest CVSSv3 CRITICAL severity level.
      *
-     * @param o The other vulnerability for the compareTo method
-     * @param builder The CompareToBuilder under construction
-     * @see #compareTo(Vulnerability) For a detailed description of the comparison strategy for severity.
+     * @see SeverityUtil#estimatedSortAdjustedCVSSv3(String)
+     * @see SeverityUtil#sortAdjustedCVSSv3BaseScore(float)
      */
-    private void appendBestEffortSeverityComparison(@NotNull Vulnerability o, @NotNull CompareToBuilder builder) {
-        if (this.cvssV3 != null && o.cvssV3 != null) {
-            builder.append(o.cvssV3.getBaseScore(), this.cvssV3.getBaseScore());
-        } else if (this.cvssV2 != null && o.cvssV2 != null) {
-            builder.append(o.cvssV2.getScore(), this.cvssV2.getScore());
-        } else if (this.cvssV3 != null) {
-            if (o.cvssV2 != null) {
-                builder.append(o.cvssV2.getScore(), this.cvssV3.getBaseScore());
-            } else {
-                builder.append(8.99f, this.cvssV3.getBaseScore());
-            }
-        } else if (this.cvssV2 != null) {
-            if (o.cvssV3 != null) {
-                builder.append(o.cvssV3.getBaseScore(), this.cvssV2.getScore());
-            } else {
-                builder.append(6.99f, this.cvssV2.getScore());
-            }
-        } else {
-            if (o.cvssV3 != null) {
-                builder.append(o.cvssV3.getBaseScore(), 8.99f);
-            } else if (o.cvssV2 != null) {
-                builder.append(o.cvssV2.getScore(), 6.99f);
-            }
+    private float bestEffortSeverityLevelForSorting() {
+        if (this.cvssV3 != null) {
+            return SeverityUtil.sortAdjustedCVSSv3BaseScore(this.cvssV3.getBaseScore());
         }
+        if (this.cvssV2 != null) {
+            return this.cvssV2.getScore();
+        }
+        return SeverityUtil.estimatedSortAdjustedCVSSv3(this.unscoredSeverity);
+    }
+
+    /**
+     * The report text to use for highest severity when this issue is ranked highest.
+     *
+     * @return The string to display in the report, clarifying for unrecognized unscored severities that critical is assumed.
+     */
+    public String getHighestSeverityText() {
+        if(this.cvssV3 != null) {
+            return this.cvssV3.getBaseSeverity();
+        }
+        if(this.cvssV2 != null) {
+            return this.cvssV2.getSeverity();
+        }
+        return SeverityUtil.unscoredToSeveritytext(this.unscoredSeverity);
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/utils/SeverityUtil.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/SeverityUtil.java
@@ -66,6 +66,13 @@ public final class SeverityUtil {
         }
     }
 
+    /**
+     * Converts a textual severity to the text that should be used to signal
+     * it in a report.
+     * @param severity The textual unscored severity
+     * @return The severity when properly recognized, otherwise the severity extended with a remark that it was not recognized and
+     *  assumed to represent a critical severity.
+     */
     public static String unscoredToSeveritytext(final String severity) {
         switch (Severity.forUnscored(severity)) {
             case CRITICAL:
@@ -135,13 +142,41 @@ public final class SeverityUtil {
      */
     public static float sortAdjustedCVSSv3BaseScore(final float cvssV3BaseScore) {
         if (cvssV3BaseScore >= 9.0f) {
-            return cvssV3BaseScore+1.3f;
+            return cvssV3BaseScore + 1.3f;
         }
         return cvssV3BaseScore;
     }
 
+    /**
+     * An enum to translate unscored severity texts to a severity level of a defined set of severities.
+     * Allows for re-use of the text-to-severity mapping in multiple helper methods.
+     */
     private enum Severity {
-        CRITICAL, ASSUMED_CRITICAL, HIGH, MEDIUM, LOW, INFO;
+        /**
+         * A severity level for textual values that should be regarded as accompanying a critical severity vulnerability
+         */
+        CRITICAL,
+        /**
+         * A severity level for textual values that are not recognized and therefor assumed to be accompanying a critical severity
+         * vulnerability
+         */
+        ASSUMED_CRITICAL,
+        /**
+         * A severity level for textual values that should be regarded as accompanying a high severity vulnerability
+         */
+        HIGH,
+        /**
+         * A severity level for textual values that should be regarded as accompanying a medium severity vulnerability
+         */
+        MEDIUM,
+        /**
+         * A severity level for textual values that should be regarded as accompanying a low severity vulnerability
+         */
+        LOW,
+        /**
+         * A severity level for textual values that should be regarded as accompanying a vulnerability of informational nature
+         */
+        INFO;
 
         public static Severity forUnscored(String value) {
             switch (value == null ? "none" : value.toLowerCase()) {

--- a/core/src/main/java/org/owasp/dependencycheck/utils/SeverityUtil.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/SeverityUtil.java
@@ -17,12 +17,20 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Utility to estimate severity level scores.
  *
  * @author Jeremy Long
  */
 public final class SeverityUtil {
+
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(SeverityUtil.class);
 
     /**
      * Private constructor for a utility class.
@@ -55,6 +63,105 @@ public final class SeverityUtil {
             case "none":
             default:
                 return 3.9f;
+        }
+    }
+
+    public static String unscoredToSeveritytext(final String severity) {
+        switch (Severity.forUnscored(severity)) {
+            case CRITICAL:
+            case HIGH:
+            case MEDIUM:
+            case LOW:
+            case INFO:
+                return severity;
+            case ASSUMED_CRITICAL:
+            default:
+                final String sevText;
+                if ("0.0".equals(severity)) {
+                    sevText = "Unknown";
+                } else {
+                    sevText = severity;
+                }
+                return sevText + " (not recognized; assumed to be critical)";
+        }
+    }
+
+    /**
+     * Creates an estimated sort-adjusted CVSSv3 score for an unscored textual severity.
+     * For recognized severities below critical it returns a value at the lower bound of the CVSSv3 baseScore for that severity.
+     * For recognized critical severities it returns a score in-between the upper bound of the HIGH CVSSv2 score and the lowest
+     * sort-adjusted CVSSv3 critical score, so that unscored critical vulnerabilties are ordered in between CRITICAL scored CVSSv3
+     * rated vulnerabilities and HIGH-scored CVSSv2 rated vulnerabilities.
+     * For unrecognized severities it returns a score in-between the top HIGH CVSSv2 score and the estimatedSortAdjustedCVSSv3
+     * score for an unscored severity recognized as critical, so that recognized critical will win over unrecognized severities
+     * while unrecognized severities are assumed to be of a critical nature.
+     *
+     * @param severity The textual severity, may be null
+     * @return A float that can be used to numerically sort vulnerabilities in approximated severity (highest float represents
+     * highest severity).
+     * @see #sortAdjustedCVSSv3BaseScore(float)
+     */
+    public static float estimatedSortAdjustedCVSSv3(final String severity) {
+        switch (Severity.forUnscored(severity)) {
+            case CRITICAL:
+                return 10.2f;
+            case HIGH:
+                return 7.0f;
+            case MEDIUM:
+                return 4.0f;
+            case LOW:
+                return 0.1f;
+            case INFO:
+                return 0.0f;
+            case ASSUMED_CRITICAL:
+            default:
+                SeverityUtil.LOGGER.debug("Unrecognized unscored textual severity: {}, assuming critical score as worst-case "
+                                           + "estimate for sorting",
+                                           severity);
+                return 10.1f;
+        }
+    }
+
+    /**
+     * Compute an adjusted CVSSv3 baseScore that ensures that CRITICAL CVSSv3 scores will win over HIGH CVSSv2 and CRITICAL
+     * unscored severities to allow for a best-effort sorting that enables the report to list a reliable 'highest severity'
+     * in the report.
+     *
+     * @param cvssV3BaseScore The cvssV3 baseScore severity of a vulnerability
+     * @return The cvssV3 baseScore, adjusted if necessary in order to guarantee that CVSSv3 CRITICAL scores will rate higher than
+     * CVSSv2 HIGH, unscored critical severities and unscored unrecognized severities (which are assumed for sorting to be of a
+     * critical nature)
+     * @see #estimatedSortAdjustedCVSSv3(String)
+     */
+    public static float sortAdjustedCVSSv3BaseScore(final float cvssV3BaseScore) {
+        if (cvssV3BaseScore >= 9.0f) {
+            return cvssV3BaseScore+1.3f;
+        }
+        return cvssV3BaseScore;
+    }
+
+    private enum Severity {
+        CRITICAL, ASSUMED_CRITICAL, HIGH, MEDIUM, LOW, INFO;
+
+        public static Severity forUnscored(String value) {
+            switch (value == null ? "none" : value.toLowerCase()) {
+            case "critical":
+                return CRITICAL;
+            case "high":
+                return HIGH;
+            case "moderate":
+            case "medium":
+                return MEDIUM;
+            case "info":
+            case "informational":
+                return INFO;
+            case "low":
+            case "unknown":
+            case "none":
+                return LOW;
+            default:
+                return ASSUMED_CRITICAL;
+            }
         }
     }
 }

--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -766,17 +766,10 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                             ## with a set sorted approximately on descending severity
                             #if ($severestVuln.cvssV3)
                                 #set($cveImpact=$severestVuln.cvssV3.baseScore)
-                                #set($cveSeverity=$enc.html($severestVuln.cvssV3.baseSeverity))
                             #elseif ($severestVuln.cvssV2)
                                 #set($cveImpact=$severestVuln.cvssV2.score)
-                                #set($cveSeverity=$enc.html($severestVuln.cvssV2.severity))
-                            #elseif ($vuln.unscoredSeverity)
-                                #if($vuln.unscoredSeverity.equals("0.0"))
-                                    #set($cveSeverity="Unknown")
-                                #else
-                                    #set($cveSeverity=$enc.html($vuln.unscoredSeverity))
-                                #end
                             #end
+                            #set($cveSeverity=$enc.html($severestVuln.highestSeverityText))
                         #end
                         #set($sortValue=$cveImpact*10)
                         <td data-sort-value="$sortValue">$cveSeverity</td>

--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -760,20 +760,17 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                         #end</td>
                         #set($cveImpact=-1)
                         #set($cveSeverity="&nbsp;")
-                        #foreach($vuln in $dependency.getVulnerabilities())
+                        #if($dependency.getVulnerabilities().size()>0)
+                            #set($severestVuln=$dependency.getVulnerabilities(true).iterator().next())
                             ## yes - we are mixing v2 and v3...  no consistency in data so doing the best we can
-                            #if ($vuln.cvssV3)
-                                #if ($cveImpact<$vuln.cvssV3.baseScore)
-                                    #set($cveImpact=$vuln.cvssV3.baseScore)
-                                    #set($cveSeverity=$enc.html($vuln.cvssV3.baseSeverity))
-                                #end
-                            #elseif ($vuln.cvssV2)
-                                #if ($cveImpact<$vuln.cvssV2.score)
-                                    #set($cveImpact=$vuln.cvssV2.score)
-                                    #set($cveSeverity=$enc.html($vuln.cvssV2.severity))
-                                #end
-                            #end
-                            #if ($vuln.unscoredSeverity)
+                            ## with a set sorted approximately on descending severity
+                            #if ($severestVuln.cvssV3)
+                                #set($cveImpact=$severestVuln.cvssV3.baseScore)
+                                #set($cveSeverity=$enc.html($severestVuln.cvssV3.baseSeverity))
+                            #elseif ($severestVuln.cvssV2)
+                                #set($cveImpact=$severestVuln.cvssV2.score)
+                                #set($cveSeverity=$enc.html($severestVuln.cvssV2.severity))
+                            #elseif ($vuln.unscoredSeverity)
                                 #if($vuln.unscoredSeverity.equals("0.0"))
                                     #set($cveSeverity="Unknown")
                                 #else

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzerIT.java
@@ -157,9 +157,16 @@ public class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
                     "ruby/vulnerable/gems/sinatra/Gemfile.lock"));
             analyzer.analyze(result, engine);
             Dependency dependency = engine.getDependencies()[0];
-            Vulnerability vulnerability = dependency.getVulnerabilities(true).iterator().next();
-            assertEquals(5.0f, vulnerability.getCvssV2().getScore(), 0.0);
-
+            boolean found =false;
+            for (Vulnerability vulnerability : dependency.getVulnerabilities()) {
+                if ("CVE-2015-3225".equals(vulnerability.getName())) {
+                    found = true;
+                    // validate that the score is from NVD rather than translated from the Bundle Audit severity text
+                    assertEquals(5.0f, vulnerability.getCvssV2().getScore(), 0.0);
+                    break;
+                }
+            }
+            assertTrue("CVE-2015-3225 was not found among the vulnerabilities",found);
         } catch (InitializationException | DatabaseException | AnalysisException | UpdateException e) {
             LOGGER.warn("Exception setting up RubyBundleAuditAnalyzer. Make sure Ruby gem bundle-audit is installed. You may also need to set property \"analyzer.bundle.audit.path\".");
             Assume.assumeNoException("Exception setting up RubyBundleAuditAnalyzer; bundle audit may not be installed, or property \"analyzer.bundle.audit.path\" may not be set.", e);

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/VulnerabilityTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/VulnerabilityTest.java
@@ -18,15 +18,21 @@
 package org.owasp.dependencycheck.dependency;
 
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
 import us.springett.parsers.cpe.exceptions.CpeValidationException;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TreeSet;
+
 /**
- *
- * @author Jens Hausherr
+ * @author Jens Hausherr, Hans Aikema
  */
 public class VulnerabilityTest extends BaseTest {
 
@@ -44,4 +50,162 @@ public class VulnerabilityTest extends BaseTest {
 
         assertEquals(2, obj.getVulnerableSoftware().size());
     }
+
+    /**
+     * Test of compareTo
+     */
+    @Test
+    public void compareTo_proper_sorting() {
+        // vulnerabilities take a name in reverse alphabetical order of expected sorting sequence
+        // this way we ensure that the validated sorting was indeed due to the decreasing order of
+        // severity and not by coincidence due to equal severity + alphabetical order on name.
+        // as equals() takes only name for comparison we need to make names unique for an easy equals()
+        // comparison of the result
+
+        Vulnerability cvssV3OnlyCritHigh = new Vulnerability("Z most severe");
+        cvssV3OnlyCritHigh.setCvssV3(new CvssV3("AV", "AC", "PR", "UI", "SC", "C", "I", "A", 10.0f, "CRITICAL"));
+
+        Vulnerability cvssV3Only90 = new Vulnerability("Y 2nd most severe");
+        cvssV3Only90.setCvssV3(new CvssV3("AV", "AC", "PR", "UI", "SC", "C", "I", "A", 9.0f, "CRITICAL"));
+
+        Vulnerability unscoredCritical = new Vulnerability("X 3rd most severe");
+        unscoredCritical.setUnscoredSeverity("Critical");
+
+        Vulnerability unscoredAssumedCritical = new Vulnerability("W 4th most severe");
+        unscoredAssumedCritical.setUnscoredSeverity("Foobar");
+
+        Vulnerability cvssV2Only10_0 = new Vulnerability("V 5th most severe");
+        cvssV2Only10_0.setCvssV2(new CvssV2(10.0f, "AV", "AC", "AU", "C", "I", "A", "HIGH"));
+
+        Vulnerability cvssV2Only99 = new Vulnerability("U 6th most severe");
+        final CvssV2 cvssV2_99 = new CvssV2(9.9f, "AV", "AC", "AU", "C", "I", "A", "HIGH");
+        cvssV2Only99.setCvssV2(cvssV2_99);
+
+        Vulnerability cvssV2Only90 = new Vulnerability("T 7th most severe");
+        final CvssV2 cvssV2_90 = new CvssV2(9.0f, "AV", "AC", "AU", "C", "I", "A", "HIGH");
+        cvssV2Only90.setCvssV2(cvssV2_90);
+
+        Vulnerability cvssV3_89v2_90 = new Vulnerability("SA 8th most severe, alphabetical first");
+        final CvssV3 cvssV3_89 = new CvssV3("AV", "AC", "PR", "UI", "SC", "C", "I", "A", 8.9f, "HIGH");
+        cvssV3_89v2_90.setCvssV3(cvssV3_89);
+        cvssV3_89v2_90.setCvssV2(cvssV2_90);
+
+        Vulnerability cvssV3_89v2_99 = new Vulnerability("SB 8th most severe, alphabetical second");
+        cvssV3_89v2_99.setCvssV3(cvssV3_89);
+        cvssV3_89v2_99.setCvssV2(cvssV2_99);
+
+        Vulnerability cvssV3_80v2_99 = new Vulnerability("R 9th most severe");
+        cvssV3_80v2_99.setCvssV3(new CvssV3("AV", "AC", "PR", "UI", "SC", "C", "I", "A", 8.0f, "HIGH"));
+        cvssV3_80v2_99.setCvssV2(cvssV2_99);
+
+        Vulnerability unscoredHigh = new Vulnerability("Q 10th most severe");
+        unscoredHigh.setUnscoredSeverity("hIGH");
+
+        Vulnerability v3Medium69 = new Vulnerability("P 11th most severe");
+        v3Medium69.setCvssV3(new CvssV3("AV", "AC", "PR", "UI", "SC", "C", "I", "A", 6.9f, "MEDIUM"));
+
+        Vulnerability unscoredMedium = new Vulnerability("O 12th most severe");
+        unscoredMedium.setUnscoredSeverity("meDiUm");
+
+
+        assertTrue("V2 HIGH 9.9 to V2 HIGH 9.0, 9.9 should be most severe", cvssV2Only99.compareTo(cvssV2Only90) < 0);
+        assertTrue("V2 HIGH 9.9 to V3 CRIT 9.0 should make V3 9.0 should be most severe to retain the CRITICAL rating",
+                   cvssV3Only90.compareTo(cvssV2Only99) < 0);
+        assertTrue("V3 CRIT 9.9 to V3 CRIT 9.0, 9.9 should be most severe", cvssV3OnlyCritHigh.compareTo(cvssV3Only90) < 0);
+        assertTrue("V3 CRIT 9.0 to V3 HIGH 8.0 V2 HIGH 9.9, V3 9.0 should be most severe",
+                   cvssV3Only90.compareTo(cvssV3_80v2_99) < 0);
+        assertTrue("CVSS v3 CRITICAL should be smaller (more severe) than unscored critical",
+                   cvssV3Only90.compareTo(unscoredCritical) < 0);
+        assertTrue("unscored critical should be smaller (more severe) than CVSS v2 HIGH 10.0 should be larger (less severe)",
+                   unscoredCritical.compareTo(cvssV2Only10_0) < 0);
+        assertTrue("CVSS v3 CRITICAL should be smaller (more severe) than unscored assumed critical",
+                   cvssV3Only90.compareTo(unscoredAssumedCritical) < 0);
+        assertTrue("Unscored CRITICAL should be smaller (more severe) than unscored assumed critical",
+                   unscoredCritical.compareTo(unscoredAssumedCritical) < 0);
+        assertTrue("unscored assumed critical should be smaller (more severe) than CVSS v2 HIGH 10.0",
+                   unscoredAssumedCritical.compareTo(cvssV2Only10_0) < 0);
+        assertTrue("unscored assumed critical should be smaller (more severe) CVSS v2 9.9 v3 8.0 (HIGH)",
+                   unscoredAssumedCritical.compareTo(cvssV3_80v2_99) < 0);
+        assertTrue("CVSS v3 score should be considered over V2 score; alphabetical sort determines final sequence",
+                   cvssV3_89v2_90.compareTo(cvssV3_89v2_99) < 0);
+        assertTrue("CVSS v3 medium top-range score should be smaller (more severe) than unscored medium",
+                   v3Medium69.compareTo(unscoredMedium) < 0);
+
+        List<Vulnerability> vulns = Arrays.asList(cvssV2Only99, cvssV2Only90, cvssV3Only90, cvssV3OnlyCritHigh, cvssV3_80v2_99,
+                                                  cvssV2Only10_0, cvssV3_89v2_90,
+                                                  cvssV3_89v2_99, unscoredHigh, v3Medium69, unscoredCritical, unscoredMedium, unscoredAssumedCritical);
+        vulns.sort(Vulnerability::compareTo);
+        List<String> expectedStartLetters = Arrays.asList("Z", "Y", "X", "W", "V", "U", "T", "SA", "SB", "R", "Q", "P", "O");
+
+        for (int i = 0; i < vulns.size(); i++) {
+            assertTrue("Expected start:" + expectedStartLetters.get(i) + " encountered start: " + vulns.get(i).getName()
+                                                                                                       .substring(0, 2),
+                       vulns.get(i).getName().startsWith(expectedStartLetters.get(i)));
+        }
+        testSortStabilityForPermutations(vulns);
+    }
+
+    /**
+     * Sorts the offered list of vulnerabilities four times starting with the vulnerabilities arranged in differente sequences
+     * before sorting to check that sorting is stable for permutations of input sequence.<br> The input array is added to a
+     * sortedSet in four different sequences: all elements in delivered order, all elements in reverse of the deliverd order, all
+     * odd elements in sequence followed by even elements in sequence, all even elements in sequence followed by the odd
+     * elements.<br> It is then validated that regardless of the sequence of adding vulnerabilties the final sort is the same.
+     *
+     * @param vulnerabilities
+     *         A list of vulnerabilities to check for stable sorting behaviour
+     */
+    private void testSortStabilityForPermutations(final List<Vulnerability> vulnerabilities) {
+        int vulCount = vulnerabilities.size();
+        boolean oddHasOneMore = (vulCount % 2) != 0;
+
+        int oddEvenEvenStartIdx = oddHasOneMore ? (vulCount / 2) + 1 : vulCount / 2;
+        int evenOddOddStartIdx = vulCount / 2;
+
+        int[] indexSequential = new int[vulCount];
+        int[] indexOddEven = new int[vulCount];
+        int[] indexEvenOdd = new int[vulCount];
+        int[] indexReversed = new int[vulCount];
+        for (int i = 0; i < vulnerabilities.size(); i++) {
+            indexSequential[i] = i;
+            indexReversed[vulCount - i - 1] = i;
+            if (i % 2 == 0) {
+                indexOddEven[i / 2] = i;
+                indexEvenOdd[(i / 2) + evenOddOddStartIdx] = i;
+            } else {
+                indexOddEven[oddEvenEvenStartIdx + (i / 2)] = i;
+                indexEvenOdd[i / 2] = i;
+            }
+        }
+
+        List<int[]> permutations = new ArrayList<>();
+        permutations.add(indexReversed);
+        permutations.add(indexOddEven);
+        permutations.add(indexEvenOdd);
+        permutations.add(indexSequential);
+
+        TreeSet<Vulnerability> prev = new TreeSet<>();
+        TreeSet<Vulnerability> current = new TreeSet<>();
+        int[] prevPermutation = null;
+        for (int[] permutation : permutations) {
+            if (prev.isEmpty()) {
+                prevPermutation = permutation;
+                for (Integer ix : permutation) {
+                    prev.add(vulnerabilities.get(ix));
+                }
+            }
+            for (Integer ix : permutation) {
+                current.add(vulnerabilities.get(ix));
+            }
+            assertPermutationSortedEqual(prev.toArray(new Vulnerability[0]), current.toArray(new Vulnerability[0]), permutation,
+                                         prevPermutation);
+        }
+    }
+
+    private void assertPermutationSortedEqual(final Vulnerability[] prev, final Vulnerability[] current, final int[] permutation,
+                                              final int[] prevPermutation) {
+        assertArrayEquals(String.format("Differently sorted for permutation '%s' versus '%s'", Arrays.toString(prevPermutation),
+                                        Arrays.toString(permutation)), prev, current);
+    }
+
 }


### PR DESCRIPTION
## Fixes Issue #4112, Fixes Issue #4186

## Description of Change

### Draft status
Draft proposal, still work-in-progress with only the HTML report updated to have a base for further discussion on the approach.

Change the vulnerability natural order to take severity into account, with any unscored issue considered to be at the top of the second-highest rating when comparing to CVSS-scored vulnerabilities (so that they only are considered 'more sever' if the CVSS-score is not in the highest severity category.
This prevents a scenario where the highest scoring vulnerabilty is reported as 'unknown' while there are known vulnerabilities of the highest category.

It influences the sorting in the reports (which was up to now purely alphabetical on vulnerability name), so it should land in a new major version release as we know that there are teams out there relying on the sorting to perform a balanced-read comparison between builds to not re-alert on already alerted vulnerabilities for a subsequent build.

## Have test cases been added to cover the new functionality?

not yet, intend to add tests for the compareTo of Vulnerability before finalizing the PR