### PR TITLE
Suppress FP CPE matching for apache james

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4842,4 +4842,13 @@
         <cpe>cpe:/a:apache:tomcat</cpe>
         <cpe>cpe:/a:apache_tomcat:apache_tomcat</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+            Suppress many FPs in apache projects that have james in the (developer) evidences now triggering apache james
+            #4123, #4128, #4132, #4136, #4137, #4138, #4145, #4146
+            ]]></notes>
+        <packageUrl regex="true">^pkg:maven/(?!org\.apache\.james/).*$</packageUrl>
+        <cpe>cpe:/a:apache:james</cpe>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
## Fixes #4123, Fixes #4128, Fixes #4132, Fixes #4136, Fixes #4137, Fixes #4138, Fixes #4145, Fixes #4146

## Description of Change

Add a generic regex suppression of Apache James if the packageUrl is not within the groupId of Apache James

## Have test cases been added to cover the new functionality?

no, locally verified that the reported cases are suppressed and `pkg:maven/org.apache.james/james-server-core@3.6.0` remains linked to the CPE