### PR TITLE
Suppress FP for etcd-java

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4850,5 +4850,11 @@
         <packageUrl regex="true">^pkg:maven/(?!org\.apache\.james/).*$</packageUrl>
         <cpe>cpe:/a:apache:james</cpe>
     </suppress>
-
+    <suppress base="true">
+	<notes><![CDATA[
+	FP because cpe make reference to a GO library
+	]]></notes>
+	<packageUrl regex="true">^pkg:maven/com\.ibm\.etcd/etcd\-java@.*$</packageUrl>
+	<cpe>cpe:/a:etcd:etcd</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Remove FP for etcd-java

the following CVE's are making reference to [io.etcd](https://github.com/etcd-io/etcd) library based on GO.

[CVE-2020-15106](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-15106)
[CVE-2020-15112](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-15112)
[CVE-2020-15113](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-15113)