### PR TITLE
#4078 Return a dedicated error message when sonatype returns a 403

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -144,6 +144,8 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
                         throw new AnalysisException("Invalid credentails provided for OSS Index", ex);
                     } else if (ex.getMessage() != null && ex.getMessage().endsWith("429")) {
                         throw new AnalysisException("OSS Index rate limit exceeded", ex);
+                    } else if (ex.getMessage() != null && ex.getMessage().endsWith("403")) {
+                        throw new AnalysisException("OSS Index access forbidden", ex);
                     }
                     LOG.debug("Error requesting component reports", ex);
                     throw new AnalysisException("Failed to request component-reports", ex);
@@ -210,13 +212,17 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
         });
         // only attempt if we have been able to collect some packages
         if (!packages.isEmpty()) {
-            try (OssindexClient client = OssindexClientFactory.create(getSettings())) {
+            try (OssindexClient client = newOssIndexClient()) {
                 LOG.debug("OSS Index Analyzer submitting: " + packages.toString());
                 return client.requestComponentReports(packages);
             }
         }
         LOG.warn("Unable to determine Package-URL identifiers for {} dependencies", dependencies.length);
         return Collections.emptyMap();
+    }
+
+    OssindexClient newOssIndexClient() {
+        return OssindexClientFactory.create(getSettings());
     }
 
     /**

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
@@ -19,7 +19,6 @@ import org.owasp.dependencycheck.dependency.naming.Identifier;
 import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
 import org.owasp.dependencycheck.utils.Settings;
 
-import com.github.packageurl.MalformedPackageURLException;
 import org.sonatype.goodies.packageurl.PackageUrl;
 import org.sonatype.ossindex.service.api.componentreport.ComponentReport;
 import org.sonatype.ossindex.service.client.OssindexClient;
@@ -29,10 +28,11 @@ public class OssIndexAnalyzerTest extends BaseTest {
 
     @Test
     public void should_enrich_be_included_in_mutex_to_prevent_NPE()
-            throws AnalysisException, MalformedPackageURLException {
+            throws Exception {
 
         // Given
         OssIndexAnalyzer analyzer = new SproutOssIndexAnalyzer();
+        analyzer.close();
 
 
         Identifier identifier = new PurlIdentifier("maven", "test", "test", "1.0",
@@ -87,9 +87,10 @@ public class OssIndexAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void should_analyzeDependency_return_a_dedicated_error_message_when_403_response_from_sonatype() throws MalformedPackageURLException {
+    public void should_analyzeDependency_return_a_dedicated_error_message_when_403_response_from_sonatype() throws Exception {
         // Given
         OssIndexAnalyzer analyzer = new OssIndexAnalyzerThrowing403();
+        analyzer.close();
         analyzer.initialize(getSettings());
 
         Identifier identifier = new PurlIdentifier("maven", "test", "test", "1.0",

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
@@ -32,8 +32,6 @@ public class OssIndexAnalyzerTest extends BaseTest {
 
         // Given
         OssIndexAnalyzer analyzer = new SproutOssIndexAnalyzer();
-        analyzer.close();
-
 
         Identifier identifier = new PurlIdentifier("maven", "test", "test", "1.0",
                 Confidence.HIGHEST);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
@@ -1,8 +1,11 @@
 package org.owasp.dependencycheck.analyzer;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -17,6 +20,10 @@ import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
 import org.owasp.dependencycheck.utils.Settings;
 
 import com.github.packageurl.MalformedPackageURLException;
+import org.sonatype.goodies.packageurl.PackageUrl;
+import org.sonatype.ossindex.service.api.componentreport.ComponentReport;
+import org.sonatype.ossindex.service.client.OssindexClient;
+import org.sonatype.ossindex.service.client.transport.Transport;
 
 public class OssIndexAnalyzerTest extends BaseTest {
 
@@ -76,6 +83,58 @@ public class OssIndexAnalyzerTest extends BaseTest {
                 }
             });
             super.enrich(dependency);
+        }
+    }
+
+    @Test
+    public void should_analyzeDependency_return_a_dedicated_error_message_when_403_response_from_sonatype() throws MalformedPackageURLException {
+        // Given
+        OssIndexAnalyzer analyzer = new OssIndexAnalyzerThrowing403();
+        analyzer.initialize(getSettings());
+
+        Identifier identifier = new PurlIdentifier("maven", "test", "test", "1.0",
+                Confidence.HIGHEST);
+
+        Dependency dependency = new Dependency();
+        dependency.addSoftwareIdentifier(identifier);
+        Settings settings = getSettings();
+        Engine engine = new Engine(settings);
+        engine.setDependencies(Collections.singletonList(dependency));
+
+        // When
+        AnalysisException output = new AnalysisException();
+        try {
+            analyzer.analyzeDependency(dependency, engine);
+        } catch (AnalysisException e) {
+            output = e;
+        }
+
+        // Then
+        assertEquals("OSS Index access forbidden", output.getMessage());
+    }
+
+    static final class OssIndexAnalyzerThrowing403 extends OssIndexAnalyzer {
+        @Override
+        OssindexClient newOssIndexClient() {
+            return new OssIndexClient403();
+        }
+    }
+
+    private static final class OssIndexClient403 implements OssindexClient {
+
+        @Override
+        public Map<PackageUrl, ComponentReport> requestComponentReports(List<PackageUrl> coordinates) throws Exception {
+            throw new Transport.TransportException("Unexpected response; status: 403");
+        }
+
+        @Override
+        public ComponentReport requestComponentReport(PackageUrl coordinates) throws Exception {
+            throw new Transport.TransportException("Unexpected response; status: 403");
+        }
+
+        @Override
+        public void close() throws Exception {
+
         }
     }
 }


### PR DESCRIPTION
## Fixes Issue #

Fix #4078 

## Description of Change

Handle an HTTP 403 Forbidden response from OSS Index and display an explicit error message.

## Have test cases been added to cover the new functionality?

*yes*

No change on the public API.

Comments are welcomed. :slightly_smiling_face: 

edit: I am sorry for the multiple `--force-push-with-lease`, a Maven execution on my workstation ends up in success. I will try to find why the test is failing in the CI.