### PR TITLE
Surpress FPs for cryptomator libraries. Fixes #4177

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4861,7 +4861,7 @@
         <notes><![CDATA[
             Supress FP in cryptomator libraries, because linked CVE-2022-25366 only affects end user application. (#4177)
             ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.cryptomator/.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.cryptomator/(?!cryptomator).*$</packageUrl>
         <cpe>cpe:/a:cryptomator:cryptomator</cpe>
     </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4857,4 +4857,11 @@
 	<packageUrl regex="true">^pkg:maven/com\.ibm\.etcd/etcd\-java@.*$</packageUrl>
 	<cpe>cpe:/a:etcd:etcd</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+            Supress FP in cryptomator libraries, because linked CVE-2022-25366 only affects end user application. (#4177)
+            ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.cryptomator/.*$</packageUrl>
+        <cpe>cpe:/a:cryptomator:cryptomator</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Fixes Issue #4177

## Description of Change

Due to [CVE-2022-25366](https://nvd.nist.gov/vuln/detail/CVE-2022-25366), dependency-check reports via its maven plugin every Cryptomator library as vulnerable, even though only the end user application is affected. This PR supresses these FPs by supressing any maven artifact of `org.cryptomator/*` for `cpe:/a:cryptomator:cryptomator`.

## Have test cases been added to cover the new functionality?

no, only tested locally.