### PR TITLE
Makes excludes property configurable in command line

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -911,7 +911,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * The list of artifacts (and their transitive dependencies) to exclude from
      * the check.
      */
-    @Parameter(property = "excludes")
+    @Parameter(property = "odc.excludes")
     private List<String> excludes;
 
     /**

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -911,7 +911,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * The list of artifacts (and their transitive dependencies) to exclude from
      * the check.
      */
-    @Parameter
+    @Parameter(property = "excludes")
     private List<String> excludes;
 
     /**


### PR DESCRIPTION
Makes "excludes" configurable in command line like:
mvn clean org.owasp:dependency-check-maven:check -Dodc.excludes=mygroup-1:my-jar-1,mygroup-2:my-jar-2

## Fixes Issue #
Currently to exclude a jar from the dependencies analyses in maven we have to configure the <excludes> section in the pom file. There is no way to be able to configure this exclusions in command line.

## Description of Change
Adding the property **excludes**  configurable in command line
*Please add a description of the proposed change*
Adding a property name to the existing **excludes** property allow to provided this property when executing the maven plugin in command line like:
`mvn clean org.owasp:dependency-check-maven:check
`With this change we can now use this configuration in command line like:
`mvn clean org.owasp:dependency-check-maven:check -Dodc.excludes=mygroup-1:my-jar-1,mygroup-2:my-jar-2`

## Have test cases been added to cover the new functionality?
*no*