### PR TITLE
Use a proper parser for PyPA Core Metadata

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzer.java
@@ -36,6 +36,7 @@ import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.utils.PyPACoreMetadataParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -289,8 +290,8 @@ public class PythonDistributionAnalyzer extends AbstractFileTypeAnalyzer {
      * @param dependency the dependency being analyzed
      * @param file a reference to the manifest/properties file
      */
-    private static void collectWheelMetadata(Dependency dependency, File file) {
-        final Properties headers = getManifestProperties(file);
+    private static void collectWheelMetadata(Dependency dependency, File file) throws AnalysisException {
+        final Properties headers = PyPACoreMetadataParser.getProperties(file);
         final String version = addPropertyToEvidence(dependency, EvidenceType.VERSION, Confidence.HIGHEST, headers, "Version");
         final String name = addPropertyToEvidence(dependency, EvidenceType.VENDOR, Confidence.HIGHEST, headers, "Name");
         addPropertyToEvidence(dependency, EvidenceType.PRODUCT, Confidence.HIGHEST, headers, "Name");

--- a/core/src/main/java/org/owasp/dependencycheck/utils/PyPACoreMetadataParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/PyPACoreMetadataParser.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.utils;
+
+import org.apache.commons.lang3.StringUtils;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Properties;
+
+/**
+ * A utility class to handle Python Packaging Authority (PyPA) core metadata files. It was created based on the
+ * <a href="https://packaging.python.org/en/latest/specifications/core-metadata/">specification by PyPA</a> for
+ * version 2.2
+ */
+public class PyPACoreMetadataParser {
+
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(PyPACoreMetadataParser.class);
+
+    /**
+     * The largest major version considered by this parser
+     */
+    private static final int SUPPORTED_MAJOR_UPPERBOUND = 2;
+
+    /**
+     * The largest version of the specification considered during coding of this parser
+     */
+    private static final BigDecimal MAX_SUPPORTED_VERSION = BigDecimal.valueOf(22, 1);
+
+    /**
+     * Loads all key/value pairs from PyPA metadata specifications¶.
+     *
+     * @param file
+     *         The Wheel metadata of a Python package
+     *
+     * @return
+     */
+    public static Properties getProperties(File file) throws AnalysisException {
+        try (BufferedReader utf8Reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+            return getProperties(utf8Reader);
+        } catch (IOException | IllegalArgumentException e) {
+            throw new AnalysisException("Error parsing PyPA core-metadata file", e);
+        }
+    }
+
+    public static Properties getProperties(final BufferedReader utf8Reader) throws IOException {
+        Properties result = new Properties();
+        String line = utf8Reader.readLine();
+        StringBuilder singleHeader = null;
+        boolean inDescription = false;
+        while (line != null && !line.isEmpty()) {
+            if (inDescription && line.startsWith("       |")) {
+                singleHeader.append('\n').append(line.substring(8));
+            } else if (singleHeader != null && line.startsWith(" ")) {
+                singleHeader.append(line.substring(1));
+            } else {
+                if (singleHeader != null) {
+                    parseAndAddHeader(result, singleHeader);
+                }
+                singleHeader = new StringBuilder(line);
+                inDescription = line.startsWith("Description:");
+            }
+            line = utf8Reader.readLine();
+        }
+        if (singleHeader != null) {
+            parseAndAddHeader(result, singleHeader);
+        }
+        // ignore a body if any (description is allowed to be the message body)
+        return result;
+    }
+
+    /**
+     * Add a single metadata keyvalue pair to the metadata. When the given metadataHeader cannot be parsed as a '{@code key: value}'
+     * line a warning is emitted and the line is ignored.
+     *
+     * @param metadata
+     *         The collected metadata to which the new metadataHeader must be added
+     * @param metadataHeader
+     *         A single uncollapsed header line of the metadata
+     *
+     * @throws IllegalArgumentException
+     *         When the given metadataHeader has a key {@code Metadata-Version} and the value holds a major version that is larger
+     *         than the highest supported metadata version. As defined by the specification: <blockquote>Automated tools consuming
+     *         metadata SHOULD warn if metadata_version is greater than the highest version they support, and MUST fail if
+     *         metadata_version has a greater major version than the highest version they support (as described in PEP 440, the
+     *         major version is the value before the first dot).</blockquote>
+     */
+    private static void parseAndAddHeader(final Properties metadata, final StringBuilder metadataHeader) {
+        String[] keyValue = StringUtils.split(metadataHeader.toString(), ":", 2);
+        if (keyValue.length != 2) {
+            LOGGER.warn("Invalid mailheader format encountered in Wheel Metadata, not a \"key: value\" string");
+            return;
+        }
+        String key = keyValue[0];
+        String value = keyValue[1].trim();
+        if ("Metadata-Version".equals(key)) {
+            int majorVersion = Integer.parseInt(value.substring(0, value.indexOf('.')), 10);
+            BigDecimal version = new BigDecimal(value);
+            if (majorVersion > SUPPORTED_MAJOR_UPPERBOUND) {
+                throw new IllegalArgumentException(String.format(
+                        "Unsupported PyPA Wheel metadata. Metadata-Version " + "is '%s', largest supported major is %d", value,
+                        SUPPORTED_MAJOR_UPPERBOUND));
+            } else if (version.compareTo(MAX_SUPPORTED_VERSION) > 0 && LOGGER.isWarnEnabled()) {
+                LOGGER.warn(String.format("Wheel metadata Metadata-Version (%s) has a larger minor version than the highest known "
+                                          + "supported Metadata specification (%s) continuing with best effort", value,
+                                          MAX_SUPPORTED_VERSION));
+            }
+        }
+        metadata.setProperty(key, value);
+    }
+}

--- a/core/src/main/java/org/owasp/dependencycheck/utils/PyPACoreMetadataParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/PyPACoreMetadataParser.java
@@ -34,6 +34,8 @@ import java.util.Properties;
  * A utility class to handle Python Packaging Authority (PyPA) core metadata files. It was created based on the
  * <a href="https://packaging.python.org/en/latest/specifications/core-metadata/">specification by PyPA</a> for
  * version 2.2
+ *
+ * @author Hans Aikema
  */
 public class PyPACoreMetadataParser {
 
@@ -52,13 +54,16 @@ public class PyPACoreMetadataParser {
      */
     private static final BigDecimal MAX_SUPPORTED_VERSION = BigDecimal.valueOf(22, 1);
 
+    private PyPACoreMetadataParser() {
+        // hide constructor for utility class
+    }
     /**
      * Loads all key/value pairs from PyPA metadata specifications¶.
      *
      * @param file
-     *         The Wheel metadata of a Python package
+     *         The Wheel metadata of a Python package as a File
      *
-     * @return
+     * @return The metadata properties read from the file
      */
     public static Properties getProperties(File file) throws AnalysisException {
         try (BufferedReader utf8Reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
@@ -68,8 +73,16 @@ public class PyPACoreMetadataParser {
         }
     }
 
+    /**
+     * Loads all key/value pairs from PyPA metadata specifications¶.
+     *
+     * @param utf8Reader
+     *         The Wheel metadata of a Python package as a BufferedReader
+     *
+     * @return The metadata properties read from the utf8Reader
+     */
     public static Properties getProperties(final BufferedReader utf8Reader) throws IOException {
-        Properties result = new Properties();
+        final Properties result = new Properties();
         String line = utf8Reader.readLine();
         StringBuilder singleHeader = null;
         boolean inDescription = false;
@@ -111,16 +124,16 @@ public class PyPACoreMetadataParser {
      *         major version is the value before the first dot).</blockquote>
      */
     private static void parseAndAddHeader(final Properties metadata, final StringBuilder metadataHeader) {
-        String[] keyValue = StringUtils.split(metadataHeader.toString(), ":", 2);
+        final String[] keyValue = StringUtils.split(metadataHeader.toString(), ":", 2);
         if (keyValue.length != 2) {
             LOGGER.warn("Invalid mailheader format encountered in Wheel Metadata, not a \"key: value\" string");
             return;
         }
-        String key = keyValue[0];
-        String value = keyValue[1].trim();
+        final String key = keyValue[0];
+        final String value = keyValue[1].trim();
         if ("Metadata-Version".equals(key)) {
-            int majorVersion = Integer.parseInt(value.substring(0, value.indexOf('.')), 10);
-            BigDecimal version = new BigDecimal(value);
+            final int majorVersion = Integer.parseInt(value.substring(0, value.indexOf('.')), 10);
+            final BigDecimal version = new BigDecimal(value);
             if (majorVersion > SUPPORTED_MAJOR_UPPERBOUND) {
                 throw new IllegalArgumentException(String.format(
                         "Unsupported PyPA Wheel metadata. Metadata-Version " + "is '%s', largest supported major is %d", value,

--- a/core/src/main/java/org/owasp/dependencycheck/utils/PyPACoreMetadataParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/PyPACoreMetadataParser.java
@@ -37,7 +37,7 @@ import java.util.Properties;
  *
  * @author Hans Aikema
  */
-public class PyPACoreMetadataParser {
+public final class PyPACoreMetadataParser {
 
     /**
      * The logger.

--- a/core/src/test/java/org/owasp/dependencycheck/utils/PyPACoreMetadataParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/PyPACoreMetadataParserTest.java
@@ -1,0 +1,69 @@
+package org.owasp.dependencycheck.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+
+public class PyPACoreMetadataParserTest {
+
+    @Test
+    public void getProperties_should_throw_exception_for_too_large_major() throws IOException {
+        try {
+            PyPACoreMetadataParser.getProperties(new BufferedReader(new StringReader("Metadata-Version: 3.0")));
+            Assert.fail("Expected IllegalArgumentException for too large major in Metadata-Version");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("Unsupported PyPA Wheel metadata"));
+        }
+    }
+
+    @Test
+    public void getProperties_should_properly_parse_multiline_description() throws IOException {
+        String payload = "Metadata-Version: 1.0\r\n"
+                         + "Description: This is the first line\r\n"
+                         + "       | and this the second\r\n"
+                         + "       |\r\n"
+                         + "       | and the fourth after an empty third\r\n"
+                         + "\r\n"
+                         + "This: is the body and it is ignored. It may contain an extensive description in various formats";
+        Properties props = PyPACoreMetadataParser.getProperties(new BufferedReader(new StringReader(payload)));
+        Assert.assertEquals("1.0", props.get("Metadata-Version"));
+        Assert.assertEquals("This is the first line\n"
+                            + " and this the second\n"
+                            + "\n"
+                            + " and the fourth after an empty third", props.get("Description"));
+        Assert.assertFalse("Body was parsed as a header", props.containsKey("This"));
+    }
+
+    @Test
+    public void getProperties_should_support_colon_in_headerValue() throws IOException {
+        String payload = "Metadata-Version: 2.2\r\n"
+                         + "Description: My value contains a : colon\r\n";
+        Properties props = PyPACoreMetadataParser.getProperties(new BufferedReader(new StringReader(payload)));
+        Assert.assertEquals("2.2", props.getProperty("Metadata-Version"));
+        Assert.assertEquals("My value contains a : colon", props.getProperty("Description"));
+    }
+    @Test
+    public void getProperties_should_support_folding_in_headerValue() throws IOException {
+        String payload = "Metadata-Version: 2\r\n"
+                         + " .2\r\n"
+                         + "Description: My value\r\n"
+                         + "  contains a \r\n"
+                         + " : colon\r\n";
+        Properties props = PyPACoreMetadataParser.getProperties(new BufferedReader(new StringReader(payload)));
+        Assert.assertEquals("2.2", props.getProperty("Metadata-Version"));
+        Assert.assertEquals("My value contains a : colon", props.getProperty("Description"));
+    }
+    @Test
+    public void getProperties_should_support_newer_minors() throws IOException {
+        String payload = "Metadata-Version: 2\r\n"
+                         + " .5\r\n";
+        Properties props = PyPACoreMetadataParser.getProperties(new BufferedReader(new StringReader(payload)));
+        Assert.assertEquals("2.5", props.getProperty("Metadata-Version"));
+    }
+}


### PR DESCRIPTION
## Fixes Issue #4072

## Description of Change

Use a proper parser for the PyPA Core Metadata format to process a wheel metadata file. As indicated in the issue the java.util.Properties class is not appropriate to process the file as it is expected to be UTF-8 encoded in a format derived from the internet mail message format.
The format is using header fields for key/value metadata and allows the description to be either a multiline header field or a message body.

**DRAFT** Awaiting feedback from issue-commenters to validate that it also works IRL

## Have test cases been added to cover the new functionality?

Testcases have been added to validate some of the parsing features.