### PR TITLE
Suppress the netty CPE for all netty incubator projects

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4821,6 +4821,15 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
+        FP per #3830 - as the netty incubator projects are separate from the mainline of netty
+        it can be assumed that NVD will assign a separate CPE if there is ever a CVE registered
+        for an incubator project.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty\.incubator/.*$</packageUrl>
+        <cpe>cpe:/a:netty:netty</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
         FP because reactor-kafka from version 1.3.2 updated the kafka-clients dependency to version 2.6.1
         which does apply to the CVE
         ]]></notes>


### PR DESCRIPTION
## Fixes Issue #3830

## Description of Change

Suppress the netty CPE for all netty incubator projects. Unfortunately I did not get a response from the Netty security team, but based on other examples I think it is safe to assume that if ever a CVE would be raised for a netty-incubator library it would receive a separate CPE in the NVD.

## Have test cases been added to cover the new functionality?

no