### PR TITLE
#4217 apache-httpclient false positive on quarkus-apache-httpclient

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4940,4 +4940,11 @@
         <packageUrl regex="true">^pkg:maven/org\.cryptomator/(?!cryptomator).*$</packageUrl>
         <cpe>cpe:/a:cryptomator:cryptomator</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP because quarkus-apache-httpclient is a wrapper of apache-httpclient with different version as per #4217
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.quarkus/quarkus\-apache\-httpclient@.*$</packageUrl>
+        <cpe>cpe:/a:apache:httpclient</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Fixes Issue #

Fix #4217 

## Description of Change

Declares `cpe:/a:apache:httpclient` as a false positive for `io.quarkus:quarkus-apache-httpclient`

## Have test cases been added to cover the new functionality?

*no*, a manual test has been performed on a demo repository to make sure the CVE is fixed.