### PR TITLE
#4219 cpe:/a:liquibase:liquibase is a false positive for liquibase-sessionlock

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4947,4 +4947,11 @@
         <packageUrl regex="true">^pkg:maven/io\.quarkus/quarkus\-apache\-httpclient@.*$</packageUrl>
         <cpe>cpe:/a:apache:httpclient</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4219
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.github\.blagerweij/liquibase-sessionlock@.*$</packageUrl>
+        <cpe>cpe:/a:liquibase:liquibase</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Fixes Issue #

Fix #4219

## Description of Change

Declare `cpe:/a:liquibase:liquibase` as a false positive for `com.github.blagerweij:liquibase-sessionlock`.

## Have test cases been added to cover the new functionality?

*no*, but a manual test to validate the good behavior of the suppression rule has been performed on a sample repository.