### PR TITLE
Update PR Workflow

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -7,8 +7,10 @@ on:
       - '**/*.txt'
 
 jobs:
-  build:
-    name: Build dependency-check
+  test:
+    name: Build and Test
+    permissions: 
+      contents: read
     runs-on: ubuntu-latest 
     steps:
       - uses: actions/checkout@v3
@@ -17,7 +19,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository/
-          key: mvn-repo
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - uses: actions/setup-dotnet@v2
         with:
           dotnet-version: '6.0.x'
@@ -30,11 +34,41 @@ jobs:
       - uses: pnpm/action-setup@v2.2.1
         with:
           version: 6.0.2
-      - name: Build with Maven
+      - name: Test with Maven
         id: build
         run: |
-            mvn -s settings.xml clean package verify site -DreleaseTesting --no-transfer-progress --batch-mode
-            mvn se.bjurr.violations:violation-comments-to-github-maven-plugin:violation-comments --no-transfer-progress --batch-mode -DpullRequestId=${{ github.event.pull_request.number }} -DoAuth2Token=${{ secrets.GITHUB_TOKEN }}
+            mvn -s settings.xml -pl utils,core,cli,ant,archetype -am compile verify --no-transfer-progress --batch-mode
+  maven:
+    name: Regression Test Maven Plugin
+    permissions: 
+      contents: read
+    runs-on: ubuntu-latest 
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check Maven Cache
+        id: maven-cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository/
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+      - name: Set up JDK 1.8
+        id: jdk-8
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: 'zulu'
+      - uses: pnpm/action-setup@v2.2.1
+        with:
+          version: 6.0.2
+      - name: Regression Test Maven Plugin
+        id: build
+        run: |
+            mvn -s settings.xml -pl utils,core,maven -am compile verify -DtestMavenPlugin -DreleaseTesting --no-transfer-progress --batch-mode
       - name: Archive IT test logs
         id: archive-logs
         if: always()
@@ -43,15 +77,31 @@ jobs:
           name: it-test-logs
           retention-days: 7
           path: maven/target/it/**/build.log
-  semgrep:
+  audit:
     runs-on: ubuntu-latest
-    name: Check
+    permissions: 
+      contents: read
+      pull-requests: write
+    name: Audit
     steps:
       - uses: actions/checkout@v3
+      - name: Check Maven Cache
+        id: maven-cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository/
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Semgrep
         id: semgrep
-        uses: returntocorp/semgrep-action@v1
-        with:
-          config: p/r2c
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            docker run --rm -v "${PWD}:/src" returntocorp/semgrep --config "p/ci" --sarif > semgrep.sarif
+      - name: Maven Site
+        if: always()
+        run: |
+            mvn -s settings.xml package site -DskipTests=true --no-transfer-progress --batch-mode
+      - name: Publish Comments
+        if: always()
+        run: |
+            mvn se.bjurr.violations:violation-comments-to-github-maven-plugin:violation-comments --no-transfer-progress --batch-mode -DpullRequestId=${{ github.event.pull_request.number }} -DoAuth2Token=${{ secrets.GITHUB_TOKEN }}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -467,6 +467,32 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
     </dependencies>
     <profiles>
         <profile>
+            <id>TestMavenPlugin-core</id>
+            <activation>
+                <property>
+                    <name>testMavenPlugin</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>MySQL-IntegrationTest</id>
             <activation>
                 <property>

--- a/pom.xml
+++ b/pom.xml
@@ -806,7 +806,20 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>se.bjurr.violations</groupId>
                 <artifactId>violation-comments-to-github-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>se.bjurr.violations</groupId>
+                        <artifactId>violation-comments-to-github-lib</artifactId>
+                        <version>1.83.1</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>se.bjurr.violations</groupId>
+                        <artifactId>violations-lib</artifactId>
+                        <version>1.148.0</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
+                    <inherited>false</inherited>
                     <repositoryOwner>jeremylong</repositoryOwner>
                     <repositoryName>DependencyCheck</repositoryName>
                     <gitHubUrl>https://api.github.com/</gitHubUrl>
@@ -827,6 +840,12 @@ Copyright (c) 2012 - Jeremy Long
                             <reporter>Checkstyle</reporter>
                             <folder>.</folder>
                             <pattern>.*/checkstyle-result.xml$</pattern>
+                        </violation>
+                        <violation>
+                            <parser>SARIF</parser>
+                            <reporter>Sarif</reporter>
+                            <folder>.</folder>
+                            <pattern>.*/semgrep.sarif$</pattern>
                         </violation>
                     </violations>
                 </configuration>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -83,4 +83,32 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>utils</id>
+            <activation>
+                <property>
+                    <name>testMavenPlugin</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
- improve PR workflow execution time
   - split the `verify` for the `utils`, `core`, `archetype`, `ant`, and `cli` modules from the verify/release testing of the `maven plugin` so that they run in parallel.
- improve violations reporting to include semgrep findings