### PR TITLE
Support Package.swift version 2 Specification

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageResolvedAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageResolvedAnalyzer.java
@@ -163,8 +163,10 @@ public class SwiftPackageResolvedAnalyzer extends AbstractFileTypeAnalyzer {
             switch(fileVersion) {
                 case 1:
                     analyzeSpmResolvedDependenciesV1(spmResolved, engine, file);
+                    break;
                 case 2:
                     analyzeSpmResolvedDependenciesV2(spmResolved, engine, file);
+                    break;
                 default:
                     return;
             }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageResolvedAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageResolvedAnalyzer.java
@@ -158,12 +158,12 @@ public class SwiftPackageResolvedAnalyzer extends AbstractFileTypeAnalyzer {
         try (InputStream in = FileUtils.openInputStream(spmResolved.getActualFile());
                 JsonReader resolved = Json.createReader(in)) {
             final JsonObject file = resolved.readObject();
-            final String fileVersion = file.getString("version");
+            final int fileVersion = file.getInt("version");
 
             switch(fileVersion) {
-                case "1":
+                case 1:
                     analyzeSpmResolvedDependenciesV1(spmResolved, engine, file);
-                case "2":
+                case 2:
                     analyzeSpmResolvedDependenciesV2(spmResolved, engine, file);
                 default:
                     return;

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
@@ -178,7 +178,7 @@ public class SwiftAnalyzersTest extends BaseTest {
     }
 
     @Test
-    public void testSPMResolvedAnalyzer() throws AnalysisException {
+    public void testSPMResolvedAnalyzerV1() throws AnalysisException {
         final Engine engine = new Engine(getSettings());
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "swift/spm/Package.resolved"));
@@ -190,6 +190,22 @@ public class SwiftAnalyzersTest extends BaseTest {
         assertThat(engine.getDependencies()[1].getName(), equalTo("AlamofireImage"));
         assertThat(engine.getDependencies()[1].getVersion(), equalTo("4.2.0"));
         assertThat(engine.getDependencies()[2].getName(), equalTo("Facebook"));
+        assertThat(engine.getDependencies()[2].getVersion(), equalTo("9.3.0"));
+    }
+
+    @Test
+    public void testSPMResolvedAnalyzerV2() throws AnalysisException {
+        final Engine engine = new Engine(getSettings());
+        final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
+                "swift/spmV2/Package.resolved"));
+        sprAnalyzer.analyze(result, engine);
+
+        assertThat(engine.getDependencies().length, equalTo(3));
+        assertThat(engine.getDependencies()[0].getName(), equalTo("alamofire"));
+        assertThat(engine.getDependencies()[0].getVersion(), equalTo("5.4.3"));
+        assertThat(engine.getDependencies()[1].getName(), equalTo("alamofireimage"));
+        assertThat(engine.getDependencies()[1].getVersion(), equalTo("4.2.0"));
+        assertThat(engine.getDependencies()[2].getName(), equalTo("facebook"));
         assertThat(engine.getDependencies()[2].getVersion(), equalTo("9.3.0"));
     }
 

--- a/core/src/test/resources/swift/spmV2/Package.resolved
+++ b/core/src/test/resources/swift/spmV2/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "f96b619bcb2383b43d898402283924b80e2c4bae",
+        "version" : "5.4.3"
+      }
+    },
+    {
+      "identity" : "alamofireimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/AlamofireImage",
+      "state" : {
+        "revision" : "98cbb00ce0ec5fc8e52a5b50a6bfc08d3e5aee10",
+        "version" : "4.2.0"
+      }
+    },
+    {
+      "identity" : "facebook",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/facebook-ios-sdk",
+      "state" : {
+        "revision": "c3d367656ae8ced1149c2c6a5e6b5dd91ecad63c",
+        "version": "9.3.0"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

With the recent release of Swift 5.6 there is a new specification for the Package.resolved dependencies file. This PR aims to support the new spec on the analyzer since the structure of the file has changed.

## Have test cases been added to cover the new functionality?

*yes*