### PR TITLE
Fix jackson version to use valid Jackson version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@ Copyright (c) 2012 - Jeremy Long
         <aho-corasick-double-array-trie.version>1.2.3</aho-corasick-double-array-trie.version>
         <junit.version>4.13.2</junit.version>
         <hamcrest-core.version>2.2</hamcrest-core.version>
-        <jackson.version>2.13.2</jackson.version>
+        <jackson.version>2.13.2.1</jackson.version>
         <jackson-afterburmer.version>2.13.2</jackson-afterburmer.version>
         <jmockit.version>1.49</jmockit.version>
         <mockito-core.version>4.4.0</mockito-core.version>
@@ -1093,6 +1093,11 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
                 <version>3.4.1</version>
+            </dependency>
+            <dependency><!-- Temporary upgrade to fix jackson mess up. Be certain to delete once version is fixed -->
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.13.2.20220324</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1098,6 +1098,7 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>2.13.2.20220324</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1095,8 +1095,8 @@ Copyright (c) 2012 - Jeremy Long
                 <version>3.4.1</version>
             </dependency>
             <dependency><!-- Temporary upgrade to fix jackson mess up. Be certain to delete once version is fixed -->
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
                 <version>2.13.2.20220324</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@ Copyright (c) 2012 - Jeremy Long
         <aho-corasick-double-array-trie.version>1.2.3</aho-corasick-double-array-trie.version>
         <junit.version>4.13.2</junit.version>
         <hamcrest-core.version>2.2</hamcrest-core.version>
-        <jackson.version>2.13.2.1</jackson.version>
+        <jackson.version>2.13.2</jackson.version>
         <jackson-afterburmer.version>2.13.2</jackson-afterburmer.version>
         <jmockit.version>1.49</jmockit.version>
         <mockito-core.version>4.4.0</mockito-core.version>


### PR DESCRIPTION
## Fixes Issue #
https://github.com/dependency-check/dependency-check-gradle/issues/260
https://github.com/jeremylong/DependencyCheck/issues/4280
## Description of Change
use valid jackson version

## Have test cases been added to cover the new functionality?
N/A: no new functionality. 