### PR TITLE
Evict corrupt datafiles from the NVD cache upon corruption detection

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/exception/CorruptedDatastreamException.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/exception/CorruptedDatastreamException.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2012 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.update.exception;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * An exception used when data corruption is detected on an NVD CVE Datastream file.
+ *
+ * @author Hans Aikema
+ */
+@ThreadSafe
+public class CorruptedDatastreamException extends Exception {
+
+    /**
+     * Create a new CorruptedDatastreamException.
+     */
+    public CorruptedDatastreamException() {
+    }
+
+    /**
+     * Create a new CorruptedDatastreamException with the specified detail message.
+     *
+     * @param message
+     *         a message for the exception.
+     */
+    public CorruptedDatastreamException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Create a new CorruptedDatastreamException with the specified cause.
+     *
+     * @param cause
+     *         the cause for the exception.
+     */
+    public CorruptedDatastreamException(final Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Create a new CorruptedDatastreamException with the specified detail message and cause.
+     *
+     * @param message
+     *         a message for the exception.
+     * @param cause
+     *         the cause for the exception.
+     */
+    public CorruptedDatastreamException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/DownloadTask.java
@@ -19,6 +19,7 @@ package org.owasp.dependencycheck.data.update.nvd;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -183,6 +184,19 @@ public class DownloadTask implements Callable<Future<ProcessTask>> {
         if (file != null && file.exists() && !file.delete()) {
             LOGGER.debug("Failed to delete first temporary file {}", file.toString());
             file.deleteOnExit();
+        }
+    }
+
+    /**
+     * Attempts to delete the files that were downloaded.
+     */
+    public void evictCorruptFileFromCache() {
+        final NvdCache cache = new NvdCache(settings);
+        try {
+            final URL url1 = new URL(nvdCveInfo.getUrl());
+            cache.evictFromCache(url1);
+        } catch (MalformedURLException e) {
+            LOGGER.debug("Ignoring Cache-eviction request for an invalid URL");
         }
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/NvdCache.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/NvdCache.java
@@ -20,6 +20,7 @@ package org.owasp.dependencycheck.data.update.nvd;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.time.Instant;
 import org.apache.commons.io.FileUtils;
 import org.owasp.dependencycheck.utils.Settings;
@@ -106,6 +107,30 @@ public class NvdCache {
             } catch (IOException ex) {
                 LOGGER.debug("Error storing nvd file in cache", ex);
             }
+        }
+    }
+
+    /**
+     * Evict a file corresponding to a URL from the cache.
+     * <br>
+     * Used to clear files from the cache that are found to be a corrupted download.
+     *
+     * @param url
+     *         the origin URL of the file that is to be evicted from the cache
+     */
+    public void evictFromCache(URL url) {
+        try {
+            final File tmp = new File(url.getPath());
+            final String filename = tmp.getName();
+            final File cache = new File(settings.getDataDirectory(), "nvdcache");
+            if (!cache.isDirectory()) {
+                return;
+            }
+            LOGGER.error("Removing file from cache for {} as a corrupted download is detected", url);
+            final File nvdFile = new File(cache, filename);
+            Files.delete(nvdFile.toPath());
+        } catch (IOException ex) {
+            LOGGER.warn("Error evicting corrupt nvd file from cache", ex);
         }
     }
 }


### PR DESCRIPTION

## Fixes Issue #4165

## Description of Change

Upon detection of corrupted downloads for the NVD data (ZIPException or premature EOF while parsing) evict the corrupt download from the nvdcache so that it will be re-downloaded on a next update attempt.

## Have test cases been added to cover the new functionality?

no, locally tested with a corrupt file in a local NVD mirror that eviction works as designed.