### PR TITLE
#4293 Handle dependency with unspecified version to prevent NPE when scanning a lock file

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
@@ -37,6 +37,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.json.Json;
 import javax.json.JsonException;
@@ -282,7 +283,7 @@ public class NodePackageAnalyzer extends AbstractNpmAnalyzer {
      */
     public static boolean shouldSkipDependency(String name, String version, boolean optional, boolean fileExist) {
         // some package manager can handle alias, yarn for example, but npm doesn't support it
-        if (version.startsWith("npm:")) {
+        if (Objects.nonNull(version) && version.startsWith("npm:")) {
             //TODO make this an error that gets logged
             LOGGER.warn("dependency skipped: package.json contain an alias for {} => {} npm audit doesn't "
                     + "support aliases", name, version.replace("npm:", ""));
@@ -296,7 +297,7 @@ public class NodePackageAnalyzer extends AbstractNpmAnalyzer {
 
         // this seems to produce crash sometimes, I need to tests
         // using a local node_module is not supported by npm audit, it crash
-        if (version.startsWith("file:")) {
+        if (Objects.nonNull(version) && version.startsWith("file:")) {
             LOGGER.warn("dependency skipped: package.json contain an local node_module for {} seems to be "
                     + "located {} npm audit doesn't support locally referenced modules",
                     name, version.replace("file:", ""));

--- a/core/src/test/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilderTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilderTest.java
@@ -18,8 +18,6 @@
 package org.owasp.dependencycheck.data.nodeaudit;
 
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -52,6 +50,11 @@ public class NpmPayloadBuilderTest {
                                                 .add("integrity", "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==")
                                                 .add("dev", true)
                                 )
+                                .add("node_modules/jest-resolve",
+                                        Json.createObjectBuilder()
+                                                .add("dev", true)
+                                                .add("optional", true)
+                                                .add("peer", true))
                 );
 
         JsonObject packageJson = builder.build();
@@ -63,9 +66,13 @@ public class NpmPayloadBuilderTest {
         Assert.assertTrue(sanitized.containsKey("dependencies"));
         Assert.assertTrue(sanitized.containsKey("requires"));
 
+        JsonObject dependencies = sanitized.getJsonObject("dependencies");
+        Assert.assertTrue(dependencies.containsKey("node_modules/jest-resolve"));
+
         JsonObject requires = sanitized.getJsonObject("requires");
         Assert.assertTrue(requires.containsKey("abbrev"));
         Assert.assertEquals("^1.1.1", requires.getString("abbrev"));
+        Assert.assertEquals("*", requires.getString("node_modules/jest-resolve"));
 
         Assert.assertFalse(sanitized.containsKey("lockfileVersion"));
         Assert.assertFalse(sanitized.containsKey("random"));


### PR DESCRIPTION
## Fixes Issue #

Fix #4293 

## Description of Change

Prevent a `NullPointerException` during lock file scan. This change handle the case where a version might not be specified for a dependency.

## Have test cases been added to cover the new functionality?

*yes*, one unit test has been modified to reproduce the NPE.

With the proposed changes, the package-json.zip file provided by the OP is analyzed without any issue and output an html report.

NB : I contributed for over a year to this project. I'll gladly take more responsibility in it if the maintainers wish to by inviting me to join as a collaborator. I think I may be able to assist the maintainers in the issue triage and management. 🙂