### PR TITLE
Make nestedCauseList safe for Throwables with a null-valued message

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/exception/ExceptionCollection.java
+++ b/core/src/main/java/org/owasp/dependencycheck/exception/ExceptionCollection.java
@@ -217,7 +217,7 @@ public class ExceptionCollection extends Exception {
     }
 
     private static StringBuilder nestedCauseList(Throwable t) {
-        final StringBuilder sb = new StringBuilder(t.getMessage());
+        final StringBuilder sb = new StringBuilder().append(t.getMessage());
         Throwable nestedCause = t.getCause();
         while (nestedCause != null) {
             sb.append("\n\t\tcaused by ").append(nestedCause.getClass().getSimpleName()).append(": ").append(nestedCause.getMessage());


### PR DESCRIPTION
## Fixes Issue #4089

## Description of Change

Initialize an empty StringBuilder and then append the message of the first throwable in order to be able to handle null-valued messages as StringBuilder is capable of appending a null-valued object, but cannot be constructed from a null-valued object.
As there is no reproducer for the (null-message) ConcurrentModificationException that was the root of the NPE I think it's wise to at least get this fix in (which strictly fixes the reported issue) and have another look at the ConcurrentModificationException when somebody manages to reproduce it.

## Have test cases been added to cover the new functionality?

no