### PR TITLE
fix reproducible build issues

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -48,7 +48,7 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                 <includes>
                     <include>completion-for-dependency-check.sh</include>
                 </includes>
-                <targetPath>${project.build.directory}/release/bin</targetPath>
+		<targetPath>../release/bin</targetPath>
             </resource>
             <resource>
                 <directory>${basedir}</directory>

--- a/core/src/main/resources/dependencycheck-cache.properties
+++ b/core/src/main/resources/dependencycheck-cache.properties
@@ -56,7 +56,7 @@ jcs.region.NODEAUDIT.elementattributes.IsLateral=false
 # AVAILABLE AUXILIARY CACHES
 jcs.auxiliary.ODC=org.apache.commons.jcs.auxiliary.disk.indexed.IndexedDiskCacheFactory
 jcs.auxiliary.ODC.attributes=org.apache.commons.jcs.auxiliary.disk.indexed.IndexedDiskCacheAttributes
-#jcs.auxiliary.ODC.attributes.DiskPath=${user.dir}/jcs_swap
+#jcs.auxiliary.ODC.attributes.DiskPath=$ {user.dir}/jcs_swap
 jcs.auxiliary.ODC.attributes.MaxPurgatorySize=10000000
 jcs.auxiliary.ODC.attributes.MaxKeySize=1000000
 jcs.auxiliary.ODC.attributes.OptimizeAtRemoveCount=300000

--- a/pom.xml
+++ b/pom.xml
@@ -488,6 +488,7 @@ Copyright (c) 2012 - Jeremy Long
                         <excludeProperty>git.build.user.*</excludeProperty>
                         <excludeProperty>git.build.host</excludeProperty>
                         <excludeProperty>git.commit.user.*</excludeProperty>
+                        <excludeProperty>git.commit.count</excludeProperty>
                     </excludeProperties>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Description of Change

fix reproducible builds issues found when rebuilding 7.0.4 release: https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/owasp/dependency-check/dependency-check-parent-7.0.4.diffoscope

there is only 1 unknown issue: why is the `HelpMojo.class` not reproduced? I have no clue yet...

at least with this PR, only 1 jar won't be successful

## Have test cases been added to cover the new functionality?

no