### PR TITLE
Fix #4327 - FP on javax.ws.rs-api

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4996,4 +4996,11 @@
         <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast@(?!5\.1-BETA-1).*$</packageUrl>
         <cve>CVE-2022-0265</cve>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4327
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/javax\.ws\.rs/javax\.ws\.rs-api@.*$</packageUrl>
+        <cpe>cpe:/a:eclipse:eclipse_ide</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
* False-positive CPE match - wrongly associated CPE of Eclipse IDE

## Fixes Issue #4327 

## Description of Change

*Add `cpe:/a:eclipse:eclipse_ide` suppression for `pkg:maven/javax.ws.rs/javax.ws.rs-api@*`*

## Have test cases been added to cover the new functionality?

*No*