### PR TITLE
Remove an unneeded not effective hardcoded spring suppressions

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzer.java
@@ -137,41 +137,10 @@ public class FalsePositiveAnalyzer extends AbstractAnalyzer {
     protected void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
         removeJreEntries(dependency);
         removeBadMatches(dependency);
-        removeBadSpringMatches(dependency);
         removeWrongVersionMatches(dependency);
         removeSpuriousCPE(dependency);
         removeDuplicativeEntriesFromJar(dependency, engine);
         addFalseNegativeCPEs(dependency);
-    }
-
-    /**
-     * Removes inaccurate matches on springframework CPEs.
-     *
-     * @param dependency the dependency to test for and remove known inaccurate
-     * CPE matches
-     */
-    private void removeBadSpringMatches(Dependency dependency) {
-        String mustContain = null;
-        for (Identifier i : dependency.getSoftwareIdentifiers()) {
-            if (i.getValue() != null && i.getValue().startsWith("org.springframework.")) {
-                final int endPoint = i.getValue().indexOf(':', 19);
-                if (endPoint >= 0) {
-                    mustContain = i.getValue().substring(19, endPoint).toLowerCase();
-                    break;
-                }
-            }
-        }
-        if (mustContain != null) {
-            final Set<Identifier> removalSet = new HashSet<>();
-            for (Identifier i : dependency.getVulnerableSoftwareIdentifiers()) {
-                if (i.getValue() != null
-                        && i.getValue().startsWith("cpe:/a:springsource:")
-                        && !i.getValue().toLowerCase().contains(mustContain)) {
-                    removalSet.add(i);
-                }
-            }
-            removalSet.forEach(dependency::removeVulnerableSoftwareIdentifier);
-        }
     }
 
     /**


### PR DESCRIPTION
## Fixes Issue #4354

## Description of Change

Remove the hardcoded removal of bad CPE matches for Spring-libraries that according to my analysis appears to already be ineffective in the current codebase.
It's intention is to suppress spring_framework CPE, which is already covered by the suppression-rule added in e094c63292fab1433d18ae463d2c0690d699612a to resolve various FPs caused by the not-removed CPE of spring_framework for non-framework spring libraries.

## Have test cases been added to cover the new functionality?

no