### PR TITLE
Fix false CPE match for pl.allegro libraries

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5051,4 +5051,14 @@
         <packageUrl regex="true">^pkg:maven/com\.pinterest\.ktlint/ktlint-reporter-checkstyle@.*$</packageUrl>
         <cpe>cpe:/a:checkstyle:checkstyle</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4376; Allegro for Windows, formerly known as Popsy for Windows is an entirely different
+   product (by Allegro, website: allegro.be) from the pl.allegro libraries (by Allegro Tech - website allegro.tech,
+    github allegro organisation)
+
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/pl\.allegro\..*$</packageUrl>
+        <cpe>cpe:/a:allegro:allegro</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Fixes issue #4376 by suppressing the allegro:allegro CPE for all pl.allegro libraries

## Fixes Issue #4376

## Description of Change

FP Suppression for a falsely matched CPE due to similar company names.

## Have test cases been added to cover the new functionality?

no