### PR TITLE
Add a hint for false negative of Apache Xerces. Fixes #4389

### DIFF
--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -434,4 +434,14 @@
             <evidence type="product" source="hint analyzer" name="product" value="pgjdbc" confidence="HIGHEST"/>
         </add>
     </hint>
+    <hint>
+        <!-- false negative per issue #4389, NVD has two CPE products in active use for Apache Xerces: xerces2_java and xerces-j -->
+        <given>
+            <evidence type="product" source="pom" name="artifactId" value="xercesImpl"/>
+            <evidence type="product" source="file" name="name" value="xercesImpl"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="xerces-j" confidence="HIGHEST"/>
+        </add>
+    </hint>
 </hints>


### PR DESCRIPTION
## Fixes Issue #4389

## Description of Change

Add a hint to ensure that both CPEs in NVD for Apache Xerces get detected

## Have test cases been added to cover the new functionality?

no, locally tested with a sample project depending on xercesImpl 2.11.0 to return vulnerabilities for both CPEs