### PR TITLE
Fixup pom-hint to properly match all spring-framework components

### DIFF
--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -5,7 +5,7 @@
             <evidence type="product" source="Manifest" name="Implementation-Title" value="Spring Framework" confidence="HIGH"/>
             <evidence type="product" source="Manifest" name="Implementation-Title" value="org.springframework.core" confidence="HIGH"/>
             <evidence type="product" source="Manifest" name="Implementation-Title" value="spring-core" confidence="HIGH"/>
-            <evidence type="vendor"  source="pom"      name="groupid"              value="org\.springframework" confidence="HIGHEST"/>
+            <evidence type="vendor"  source="pom"      name="groupid"              value="org.springframework" confidence="HIGHEST"/>
         </given>
         <add>
             <evidence type="product" source="hint analyzer" name="product" value="springsource_spring_framework" confidence="HIGHEST"/>


### PR DESCRIPTION
## Fixes Issue #4415

## Description of Change

Fixup the non-regex pom hint so that it will actually match the pom groupId of the spring-framework libraries (which in modern versions have the Implementation-Title set to the project module name rather than 'Spring Framework')

## Have test cases been added to cover the new functionality?

no, tested locally with spring-tx that original hint hits for spring-tx 2.5 and fails to hit for recent spring-tx versions and the updated hint hits for both.