### PR TITLE
Do not verify JAR files when analyzing

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -428,7 +428,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
 
         //TODO add breakpoint on groov-all to find out why commons-cli is not added as a new dependency?
         boolean evidenceAdded = false;
-        try (JarFile jar = new JarFile(dependency.getActualFilePath())) {
+        try (JarFile jar = new JarFile(dependency.getActualFilePath(), false)) {
             //check if we are scanning in a repo directory - so the pom is adjacent to the jar
             final String repoPomName = FilenameUtils.removeExtension(dependency.getActualFilePath()) + ".pom";
             final File repoPom = new File(repoPomName);
@@ -852,7 +852,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
     protected boolean parseManifest(Dependency dependency, List<ClassNameInformation> classInformation)
             throws IOException {
         boolean foundSomething = false;
-        try (JarFile jar = new JarFile(dependency.getActualFilePath())) {
+        try (JarFile jar = new JarFile(dependency.getActualFilePath(), false)) {
             final Manifest manifest = jar.getManifest();
             if (manifest == null) {
                 if (!dependency.getFileName().toLowerCase().endsWith("-sources.jar")
@@ -1170,7 +1170,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
      */
     protected List<ClassNameInformation> collectClassNames(Dependency dependency) {
         final List<ClassNameInformation> classNames = new ArrayList<>();
-        try (JarFile jar = new JarFile(dependency.getActualFilePath())) {
+        try (JarFile jar = new JarFile(dependency.getActualFilePath(), false)) {
             final Enumeration<JarEntry> entries = jar.entries();
             while (entries.hasMoreElements()) {
                 final JarEntry entry = entries.nextElement();

--- a/core/src/test/java/org/owasp/dependencycheck/xml/pom/PomUtilsTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/pom/PomUtilsTest.java
@@ -59,11 +59,11 @@ public class PomUtilsTest extends BaseTest {
         result = PomUtils.readPom(file);
         assertEquals(expResult, result.getName());
     }
-    
+
     @Test
-    public void testReadPom_String_File() throws Exception {  
+    public void testReadPom_String_File() throws Exception {
         File fileCommonValidator = BaseTest.getResourceAsFile(this, "commons-validator-1.4.0.jar");
-        JarFile jar = new JarFile(fileCommonValidator);
+        JarFile jar = new JarFile(fileCommonValidator, false);
         String expResult = "Commons Validator";
         Model result = PomUtils.readPom("META-INF/maven/commons-validator/commons-validator/pom.xml", jar);
         assertEquals(expResult, result.getName());


### PR DESCRIPTION
## Fixes Issue #2221

Disable signature verification when analyzing JAR files. See #2221.