### PR TITLE
Suppress icu4j FP, prevent future false-negatives on icu4j

### DIFF
--- a/core/src/main/resources/data/initialize.sql
+++ b/core/src/main/resources/data/initialize.sql
@@ -40,6 +40,8 @@ CREATE TABLE cpeEcosystemCache (vendor VARCHAR(255), product VARCHAR(255), ecosy
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('apache', 'zookeeper', 'MULTIPLE');
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('tensorflow', 'tensorflow', 'MULTIPLE');
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('scikit-learn', 'scikit-learn', 'MULTIPLE');
+INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('unicode', 'international_components_for_unicode', 'MULTIPLE');
+INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('icu-project', 'international_components_for_unicode', 'MULTIPLE');
 
 CREATE INDEX idxCwe ON cweEntry(cveid);
 CREATE INDEX idxVulnerability ON vulnerability(cve);
@@ -53,4 +55,4 @@ CREATE ALIAS update_vulnerability FOR "org.owasp.dependencycheck.data.nvdcve.H2F
 CREATE ALIAS insert_software FOR "org.owasp.dependencycheck.data.nvdcve.H2Functions.insertSoftware";
 
 CREATE TABLE properties (id varchar(50) PRIMARY KEY, `value` varchar(500));
-INSERT INTO properties(id, `value`) VALUES ('version', '5.2');
+INSERT INTO properties(id, `value`) VALUES ('version', '5.2.1');

--- a/core/src/main/resources/data/upgrade_5.2.sql
+++ b/core/src/main/resources/data/upgrade_5.2.sql
@@ -1,0 +1,4 @@
+UPDATE cpeEcosystemCache set ecosystem='MULTIPLE' where vendor = 'icu-project' and product = 'international_components_for_unicode';
+INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('unicode', 'international_components_for_unicode', 'MULTIPLE');
+
+UPDATE Properties SET `value`='5.2.1' WHERE ID='version';

--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -233,9 +233,22 @@
             <evidence type="vendor" source="hint analyzer" name="vendor" value="oracle" confidence="HIGHEST"/>
         </add>
     </hint>
+    <hint>
+        <given>
+            <evidence type="product" name="artifactId" value="icu4j"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="international_components_for_unicode"
+                      confidence="HIGHEST"/>
+        </add>
+    </hint>
     <vendorDuplicatingHint value="sun" duplicate="oracle"/>	
     <vendorDuplicatingHint value="oracle" duplicate="sun"/>
-    
+    <vendorDuplicatingHint value="icu4j" duplicate="unicode"/>
+    <vendorDuplicatingHint value="icu4j" duplicate="icu-project"/>
+    <vendorDuplicatingHint value="unicode" duplicate="icu-project"/>
+    <vendorDuplicatingHint value="icu-project" duplicate="unicode"/>
+
     <!--additional hints from community-->
     <hint>
         <given>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -2776,10 +2776,37 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        False positive per issue #851 and #1073
+        False positive per issue #851 and #1073 and #4414;
+        the CVEs listed are in the C++ part of the ICU project (and are currently all CVEs listed
+        against ICU project; nevertheless we should not suppress the CPE itself to avoid false negatives
+        when the CVE is in the icu4j (cpe:2.3:a:icu-project:international_components_for_unicode:*:*:*:*:*:java:*:*
+        / cpe:2.3:a:unicode:international_components_for_unicode:*:*:*:*:*:java:*:*) CPE
+        cpe cpe:/a:unicode:unicode is the unicode specification
         ]]></notes>
-        <gav regex="true">^com\.ibm\.icu:icu4j:.*$</gav>
-        <cpe regex="true">cpe:/a:icu[_-]project:international[_-]components[_-]for[_-]unicode:.*</cpe>
+        <packageUrl regex="true">^pkg:maven/com\.ibm\.icu/icu4j@.*$</packageUrl>
+        <cve>CVE-2020-21913</cve>
+        <cve>CVE-2014-9654</cve>
+        <cve>CVE-2014-9911</cve>
+        <cve>CVE-2016-6293</cve>
+        <cve>CVE-2016-7415</cve>
+        <cve>CVE-2017-14952</cve>
+        <cve>CVE-2017-17484</cve>
+        <cve>CVE-2015-5922</cve>
+        <cve>CVE-2007-4771</cve>
+        <cve>CVE-2020-10531</cve>
+        <cve>CVE-2011-4599</cve>
+        <cve>CVE-2014-7923</cve>
+        <cve>CVE-2014-7926</cve>
+        <cve>CVE-2014-7940</cve>
+        <cve>CVE-2014-8146</cve>
+        <cve>CVE-2014-8147</cve>
+        <cve>CVE-2017-7867</cve>
+        <cve>CVE-2017-7868</cve>
+        <cve>CVE-2007-4770</cve>
+        <cve>CVE-2017-15396</cve>
+        <cve>CVE-2017-15422</cve>
+        <cpe>cpe:/a:apple:java</cpe>
+        <cpe>cpe:/a:unicode:unicode:</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -21,7 +21,7 @@ data.file_name=odc.mv.db
 ### if you increment the DB version then you must increment the database file path
 ### in the mojo.properties, task.properties (maven and ant respectively), and
 ### the gradle PurgeDataExtension.
-data.version=5.2
+data.version=5.2.1
 
 #The analysis timeout in minutes
 odc.analysis.timeout=180


### PR DESCRIPTION
## Fixes Issue #4144

## Description of Change

While looking at fixing #4144 I discovered that there was an ineffective generic CPE suppression for the ICU CPE which in my view should be abandoned, because the NVD will categorize icu4j in that same CPE.
Ecosystem magic detection set the ICU to ecosystem native, while the ICU CPE has multiple ecosystems, as the same project produces both icu4c and icu4j.
So I've used icu4j v2.6.1 to evaluate all true FPs for icu4j (which for now are all CVEs discovered by ODC) to suppress them CVE by CVE and made sure that the various icu4j versions match up to the proper CPE.

## Have test cases been added to cover the new functionality?

no, checked the reported icu4j, the oldest  icu4j in maven central and a couple of in-between versions for proper CPE match-up (and absence of FPs in the report)