### PR TITLE
Make NodeAuditAnalyzer skip DevDependencies in legacy mode; fixes #4491

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NodeAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NodeAuditAnalyzer.java
@@ -246,7 +246,8 @@ public class NodeAuditAnalyzer extends AbstractNpmAnalyzer {
             }
 
             // Modify the payload to meet the NPM Audit API requirements
-            final JsonObject payload = NpmPayloadBuilder.build(packageJson, dependencyMap);
+            final JsonObject payload = NpmPayloadBuilder.build(packageJson, dependencyMap,
+                    getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_SKIPDEV, false));
 
             // Submits the package payload to the nsp check service
             return getSearcher().submitPackage(payload);

--- a/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilder.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilder.java
@@ -132,10 +132,12 @@ public final class NpmPayloadBuilder {
      *
      * @param packageJson a raw package-lock.json file
      * @param dependencyMap a collection of module/version pairs that is
+     * @param skipDevDependencies whether devDependencies should be skipped
      * populated while building the payload
      * @return the JSON payload for NPN Audit
      */
-    public static JsonObject build(JsonObject packageJson, MultiValuedMap<String, String> dependencyMap) {
+    public static JsonObject build(JsonObject packageJson, MultiValuedMap<String, String> dependencyMap,
+                                   final boolean skipDevDependencies) {
         final JsonObjectBuilder payloadBuilder = Json.createObjectBuilder();
         addProjectInfo(packageJson, payloadBuilder);
 
@@ -155,6 +157,10 @@ public final class NpmPayloadBuilder {
                             .map(JsonString::getString)
                             .orElse(null);
 
+                    final boolean isDev = dep.getBoolean("dev", false);
+                    if (skipDevDependencies && isDev) {
+                        return;
+                    }
                     if (NodePackageAnalyzer.shouldSkipDependency(name, version)) {
                         return;
                     }

--- a/core/src/test/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilderTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilderTest.java
@@ -59,7 +59,7 @@ public class NpmPayloadBuilderTest {
 
         JsonObject packageJson = builder.build();
         final MultiValuedMap<String, String> dependencyMap = new HashSetValuedHashMap<>();
-        JsonObject sanitized = NpmPayloadBuilder.build(packageJson, dependencyMap);
+        JsonObject sanitized = NpmPayloadBuilder.build(packageJson, dependencyMap, false);
 
         Assert.assertTrue(sanitized.containsKey("name"));
         Assert.assertTrue(sanitized.containsKey("version"));
@@ -108,7 +108,7 @@ public class NpmPayloadBuilderTest {
 
         JsonObject packageJson = builder.build();
         final MultiValuedMap<String, String> dependencyMap = new HashSetValuedHashMap<>();
-        JsonObject sanitized = NpmPayloadBuilder.build(packageJson, dependencyMap);
+        JsonObject sanitized = NpmPayloadBuilder.build(packageJson, dependencyMap, false);
 
         Assert.assertTrue(sanitized.containsKey("name"));
         Assert.assertTrue(sanitized.containsKey("version"));
@@ -133,7 +133,7 @@ public class NpmPayloadBuilderTest {
         final MultiValuedMap<String, String> dependencyMap = new HashSetValuedHashMap<>();
         try (JsonReader jsonReader = Json.createReader(in)) {
             JsonObject packageJson = jsonReader.readObject();
-            JsonObject sanitized = NpmPayloadBuilder.build(packageJson, dependencyMap);
+            JsonObject sanitized = NpmPayloadBuilder.build(packageJson, dependencyMap, false);
 
             Assert.assertTrue(sanitized.containsKey("name"));
             Assert.assertTrue(sanitized.containsKey("version"));


### PR DESCRIPTION
## Fixes Issue #4491

## Description of Change

Honor the skipDevDependencies setting for NodeAuditAnalyzer in legacy mode so that DevDependencies are also skipped when running the cli against a zipped up node project with a disabled NodePackageAnalyzer (so that only package-lock.json is extracted)

## Have test cases been added to cover the new functionality?

No
