### PR TITLE
Fix compilation error in cli

### DIFF
--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -313,7 +313,7 @@ public class App {
                         || unscoredCvss >= cvssFailScore
                         //safety net to fail on any if for some reason the above misses on 0
                         || (cvssFailScore <= 0.0f)) {
-                    float score;
+                    float score = 0.0f;
                     if (cvssV3 >= 0.0f) {
                         score = cvssV3;
                     } else if (cvssV2 >= 0.0f) {


### PR DESCRIPTION
## Description of Change

Fixup the missing initialization of the score variable in the CLI code to resolve the compilation failure (variable score might not have been initialized)

## Have test cases been added to cover the new functionality?

no