### PR TITLE
Fixup XML template for related dependencies Sha256sum

### DIFF
--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -95,7 +95,7 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
                 <relatedDependency#if($related.isVirtual()) isVirtual="true"#end>
                     <fileName>$enc.xml($related.DisplayFileName)</fileName>
                     <filePath>$enc.xml($related.FilePath)</filePath>
-                    <sha256>#if(!$dependency.isVirtual())$enc.xml($dependency.Sha256sum)#end</sha256>
+                    <sha256>#if(!$related.isVirtual())$enc.xml($related.Sha256sum)#end</sha256>
                     <sha1>#if(!$related.isVirtual())$enc.xml($related.Sha1sum)#end</sha1>
                     <md5>#if(!$related.isVirtual())$enc.xml($related.Md5sum)#end</md5>
 #if($related.getSoftwareIdentifiers().size()>0)


### PR DESCRIPTION

## Fixes Issue #4559

## Description of Change

Fixup an incorrect variable reference in the template that made all relatedDependencies list the sha256 sum of the parent dependency

## Have test cases been added to cover the new functionality?

no, manually verified