### PR TITLE
Suppress FP CPE for Spring Cloud Dataflow REST artifacts

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5325,4 +5325,12 @@
         <packageUrl regex="true">^pkg:maven/io\.swagger/.*$</packageUrl>
         <cpe>cpe:/a:http-swagger_project:http-swagger</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issues #4581, #4582
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.cloud/spring-cloud-dataflow-rest-.*$</packageUrl>
+        <cpe>cpe:/a:vmware:spring_data_rest</cpe>
+        <cpe>cpe:/a:pivotal_software:spring_data_rest</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Adds suppressions to prevent Spring Cloud Dataflow REST artifacts to be mistaken with Spring Data REST.

Fixes #4581 and #4582.