### PR TITLE
4499 infinite loop in cmakeanalyzer

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -174,7 +174,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
         }
         if (StringUtils.isNotBlank(contents)) {
             final HashMap<String, String> vars = new HashMap<>();
-            collectDefinedVariables(dependency, engine, contents, vars);
+            collectDefinedVariables(contents, vars);
 
             String contentsReplacer = contents;
             Matcher r = INL_VAR_REGEX.matcher(contents);
@@ -241,13 +241,10 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * Collect defined CMake variables
      *
-     * @param dependency the dependency being analyzed
-     * @param engine the dependency-check engine
      * @param contents the version information
      * @param vars map of variable replacement tokens
      */
-    private void collectDefinedVariables(Dependency dependency, Engine engine, String contents,
-            HashMap<String, String> vars) {
+    private void collectDefinedVariables(String contents, HashMap<String, String> vars) {
         final Matcher m = SET_VAR_REGEX.matcher(contents);
         int count = 0;
         while (m.find()) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -355,7 +355,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
      * @return a new map without infinite chain variables
      */
     Map<String, String> removeSelfReferences(final Map<String, String> vars) {
-        Map<String, String> resolvedVars = new HashMap<>();
+        final Map<String, String> resolvedVars = new HashMap<>();
 
         vars.forEach((key, value) -> {
             if (!isVariableSelfReferencing(vars, key)) {
@@ -367,12 +367,12 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
     }
 
     private boolean isVariableSelfReferencing(Map<String, String> vars, String key) {
-        List<String> resolutionChain = new ArrayList<>();
+        final List<String> resolutionChain = new ArrayList<>();
         resolutionChain.add(key);
 
         String nextKey = resolutionChain.get(0);
         do {
-            Matcher matcher = INL_VAR_REGEX.matcher(vars.get(nextKey));
+            final Matcher matcher = INL_VAR_REGEX.matcher(vars.get(nextKey));
             if (!matcher.find()) {
                 break;
             }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -245,9 +245,11 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
      * Collect defined CMake variables
      *
      * @param contents the version information
+     *
+     * @return a map referencing identified variables
      */
     private Map<String, String> collectDefinedVariables(String contents) {
-        Map<String, String> vars = new HashMap<>();
+        final Map<String, String> vars = new HashMap<>();
         final Matcher m = SET_VAR_REGEX.matcher(contents);
         int count = 0;
         while (m.find()) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -84,7 +84,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
      * Regex to obtain variables.
      */
     private static final Pattern SET_VAR_REGEX = Pattern.compile(
-            "^\\s*set\\s*\\(\\s*([a-zA-Z0-9_\\-]*)\\s+\"?([a-zA-Z0-9_\\-.${}]*)\"?\\s*\\)", REGEX_OPTIONS);
+            "^\\s*set\\s*\\(\\s*([a-zA-Z\\d_\\-]*)\\s+\"?([a-zA-Z\\d_\\-.${}]*)\"?\\s*\\)", REGEX_OPTIONS);
     /**
      * Regex to find inlined variables to replace them.
      */

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -177,8 +177,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
                     "Problem occurred while reading dependency file.", e);
         }
         if (StringUtils.isNotBlank(contents)) {
-            final HashMap<String, String> vars = new HashMap<>();
-            collectDefinedVariables(contents, vars);
+            final Map<String, String> vars = collectDefinedVariables(contents);
 
             String contentsReplacer = contents;
             Matcher r = INL_VAR_REGEX.matcher(contents);
@@ -246,9 +245,9 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
      * Collect defined CMake variables
      *
      * @param contents the version information
-     * @param vars map of variable replacement tokens
      */
-    private void collectDefinedVariables(String contents, HashMap<String, String> vars) {
+    private Map<String, String> collectDefinedVariables(String contents) {
+        Map<String, String> vars = new HashMap<>();
         final Matcher m = SET_VAR_REGEX.matcher(contents);
         int count = 0;
         while (m.find()) {
@@ -262,6 +261,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
             vars.put(name, value);
         }
         LOGGER.debug("Found {} matches.", count);
+        return vars;
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -261,7 +261,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
             vars.put(name, value);
         }
         LOGGER.debug("Found {} matches.", count);
-        return vars;
+        return removeSelfReferences(vars);
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzer.java
@@ -84,11 +84,11 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
      * Regex to obtain variables.
      */
     private static final Pattern SET_VAR_REGEX = Pattern.compile(
-            "^\\s*set\\s*\\(\\s*([a-zA-Z0-9_\\-]*)\\s+\"?([a-zA-Z0-9_\\-\\.\\$\\{\\}]*)\"?\\s*\\)", REGEX_OPTIONS);
+            "^\\s*set\\s*\\(\\s*([a-zA-Z0-9_\\-]*)\\s+\"?([a-zA-Z0-9_\\-.${}]*)\"?\\s*\\)", REGEX_OPTIONS);
     /**
      * Regex to find inlined variables to replace them.
      */
-    private static final Pattern INL_VAR_REGEX = Pattern.compile("(\\$\\s*\\{([^\\}]*)\\s*\\})", REGEX_OPTIONS);
+    private static final Pattern INL_VAR_REGEX = Pattern.compile("(\\$\\s*\\{([^}]*)\\s*})", REGEX_OPTIONS);
     /**
      * Regex to extract the product information.
      */
@@ -102,7 +102,7 @@ public class CMakeAnalyzer extends AbstractFileTypeAnalyzer {
      * Group 2: Version
      */
     private static final Pattern SET_VERSION = Pattern
-            .compile("^\\s*set\\s*\\(\\s*(\\w+)_version\\s+\"?([^\"\\)]*)\\s*\"?\\)", REGEX_OPTIONS);
+            .compile("^\\s*set\\s*\\(\\s*(\\w+)_version\\s+\"?([^\")]*)\\s*\"?\\)", REGEX_OPTIONS);
 
     /**
      * Detects files that can be analyzed.

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzerTest.java
@@ -218,4 +218,21 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
         // Then
         assertEquals(expectedOutput, output);
     }
+
+    /**
+     * Test the analyzer does not end up in an infinite loop when a temp
+     * variable is used to store old value and then restore it afterwards.
+     *
+     * @throws AnalysisException is thrown when an exception occurs.
+     */
+    @Test
+    public void testAnalyzeCMakeTempVariable() throws AnalysisException {
+        try (Engine engine = new Engine(getSettings())) {
+            final Dependency result = new Dependency(BaseTest.getResourceAsFile(
+                    this, "cmake/libtiff/FindDeflate.cmake"));
+            analyzer.analyze(result, engine);
+
+            assertEquals("FindDeflate.cmake", result.getFileName());
+        }
+    }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzerTest.java
@@ -28,6 +28,8 @@ import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
 import org.owasp.dependencycheck.dependency.Dependency;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -36,6 +38,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
+
 import org.owasp.dependencycheck.dependency.Evidence;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 
@@ -188,5 +191,31 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
             }
         }
         assertTrue("Expected version evidence to contain \"" + version + "\".", found);
+    }
+
+    @Test
+    public void testRemoveSelfReferences() {
+        // Given
+        Map<String, String> input = new HashMap<>();
+        input.put("Deflate_OLD_FIND_LIBRARY_PREFIXES", "${CMAKE_FIND_LIBRARY_PREFIXES}");
+        input.put("Deflate_INCLUDE_DIRS", "${Deflate_INCLUDE_DIR}");
+        input.put("Deflate_LIBRARIES", "${Deflate_LIBRARY}");
+        input.put("Deflate_MINOR_VERSION", "${Deflate_VERSION_MINOR}");
+        input.put("Deflate_VERSION_STRING", "${Deflate_MAJOR_VERSION}.${Deflate_MINOR_VERSION}");
+        input.put("CMAKE_FIND_LIBRARY_PREFIXES", "${Deflate_OLD_FIND_LIBRARY_PREFIXES}");
+        input.put("Deflate_MAJOR_VERSION", "${Deflate_VERSION_MAJOR}");
+
+        Map<String, String> expectedOutput = new HashMap<>();
+        expectedOutput.put("Deflate_INCLUDE_DIRS", "${Deflate_INCLUDE_DIR}");
+        expectedOutput.put("Deflate_LIBRARIES", "${Deflate_LIBRARY}");
+        expectedOutput.put("Deflate_MINOR_VERSION", "${Deflate_VERSION_MINOR}");
+        expectedOutput.put("Deflate_VERSION_STRING", "${Deflate_MAJOR_VERSION}.${Deflate_MINOR_VERSION}");
+        expectedOutput.put("Deflate_MAJOR_VERSION", "${Deflate_VERSION_MAJOR}");
+
+        // When
+        Map<String, String> output = analyzer.removeSelfReferences(input);
+
+        // Then
+        assertEquals(expectedOutput, output);
     }
 }

--- a/core/src/test/resources/cmake/libtiff/FindDeflate.cmake
+++ b/core/src/test/resources/cmake/libtiff/FindDeflate.cmake
@@ -1,0 +1,116 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindDeflate
+--------
+
+Find the native Deflate includes and library.
+
+IMPORTED Targets
+^^^^^^^^^^^^^^^^
+
+This module defines :prop_tgt:`IMPORTED` target ``Deflate::Deflate``, if
+Deflate has been found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+::
+
+  Deflate_INCLUDE_DIRS   - where to find deflate.h, etc.
+  Deflate_LIBRARIES      - List of libraries when using deflate.
+  Deflate_FOUND          - True if deflate found.
+
+::
+
+  Deflate_VERSION_STRING - The version of deflate found (x.y.z)
+  Deflate_VERSION_MAJOR  - The major version of deflate
+  Deflate_VERSION_MINOR  - The minor version of deflate
+
+  Debug and Release variants are found separately.
+#]=======================================================================]
+
+# Standard names to search for
+set(Deflate_NAMES deflate deflatestatic)
+set(Deflate_NAMES_DEBUG deflated deflatestaticd)
+
+find_path(Deflate_INCLUDE_DIR
+          NAMES libdeflate.h
+          PATH_SUFFIXES include)
+
+set(Deflate_OLD_FIND_LIBRARY_PREFIXES "${CMAKE_FIND_LIBRARY_PREFIXES}")
+# Library has a "lib" prefix even on Windows.
+set(CMAKE_FIND_LIBRARY_PREFIXES "lib" "")
+
+# Allow Deflate_LIBRARY to be set manually, as the location of the deflate library
+if(NOT Deflate_LIBRARY)
+  find_library(Deflate_LIBRARY_RELEASE
+               NAMES ${Deflate_NAMES}
+               PATH_SUFFIXES lib)
+  find_library(Deflate_LIBRARY_DEBUG
+               NAMES ${Deflate_NAMES_DEBUG}
+               PATH_SUFFIXES lib)
+
+  include(SelectLibraryConfigurations)
+  select_library_configurations(Deflate)
+endif()
+
+set(CMAKE_FIND_LIBRARY_PREFIXES "${Deflate_OLD_FIND_LIBRARY_PREFIXES}")
+
+unset(Deflate_NAMES)
+unset(Deflate_NAMES_DEBUG)
+unset(Deflate_OLD_FIND_LIBRARY_PREFIXES)
+
+mark_as_advanced(Deflate_INCLUDE_DIR)
+
+if(Deflate_INCLUDE_DIR AND EXISTS "${Deflate_INCLUDE_DIR}/deflate.h")
+    file(STRINGS "${Deflate_INCLUDE_DIR}/libdeflate.h" Deflate_H REGEX "^#define LIBDEFLATE_VERSION_STRING\s+\"[^\"]*\"$")
+
+    string(REGEX REPLACE "^.*Deflate_VERSION \"([0-9]+).*$" "\\1" Deflate_MAJOR_VERSION "${Deflate_H}")
+    string(REGEX REPLACE "^.*Deflate_VERSION \"[0-9]+\\.([0-9]+).*$" "\\1" Deflate_MINOR_VERSION  "${Deflate_H}")
+    set(Deflate_VERSION_STRING "${Deflate_MAJOR_VERSION}.${Deflate_MINOR_VERSION}")
+
+    set(Deflate_MAJOR_VERSION "${Deflate_VERSION_MAJOR}")
+    set(Deflate_MINOR_VERSION "${Deflate_VERSION_MINOR}")
+endif()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Deflate
+        REQUIRED_VARS Deflate_LIBRARY Deflate_INCLUDE_DIR
+        VERSION_VAR Deflate_VERSION_STRING)
+
+if(Deflate_FOUND)
+    set(Deflate_INCLUDE_DIRS ${Deflate_INCLUDE_DIR})
+
+    if(NOT Deflate_LIBRARIES)
+        set(Deflate_LIBRARIES ${Deflate_LIBRARY})
+    endif()
+
+    if(NOT TARGET Deflate::Deflate)
+        add_library(Deflate::Deflate UNKNOWN IMPORTED)
+        set_target_properties(Deflate::Deflate PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${Deflate_INCLUDE_DIRS}")
+
+        if(Deflate_LIBRARY_RELEASE)
+            set_property(TARGET Deflate::Deflate APPEND PROPERTY
+                    IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(Deflate::Deflate PROPERTIES
+                    IMPORTED_LOCATION_RELEASE "${Deflate_LIBRARY_RELEASE}")
+        endif()
+
+        if(Deflate_LIBRARY_DEBUG)
+            set_property(TARGET Deflate::Deflate APPEND PROPERTY
+                    IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(Deflate::Deflate PROPERTIES
+                    IMPORTED_LOCATION_DEBUG "${Deflate_LIBRARY_DEBUG}")
+        endif()
+
+        if(NOT Deflate_LIBRARY_RELEASE AND NOT Deflate_LIBRARY_DEBUG)
+            set_target_properties(Deflate::Deflate PROPERTIES
+                    IMPORTED_LOCATION_RELEASE "${Deflate_LIBRARY}")
+        endif()
+    endif()
+endif()


### PR DESCRIPTION
## Fixes Issue #

Fix #4499 

## Description of Change

This change prevent creating an infinite loop during variable resolution when variables references each other. For each variable, it tries to build a resolution chain to see if the initial variable ends up pointing to itself. In such case, this variable resolution is discarded as it cannot be performed.

## Have test cases been added to cover the new functionality?

*yes*, two tests based on the example displayed in the initial issue.

The first one validates the chain resolution method specifically to enforce self referencing variables are not passed to the analyzer to prevent the infinite loop.

The second one validates this new method is called during the analysis process, validating the infinite loop does not occurs.