### PR TITLE
Addressing CVE-2022-33915 (log4j AWS)

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5394,4 +5394,11 @@
         <cpe>cpe:/a:vmware:spring_data_rest</cpe>
         <cpe>cpe:/a:pivotal_software:spring_data_rest</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4637
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-.*@.*$</packageUrl>
+        <cve>CVE-2022-33915</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Fixes Issue

#4637

## Description of Change

From what I understand CVE-2022-33915 is way to broad. The vulnerability appears to be only affecting AWS builds of log4j(2).

## Have test cases been added to cover the new functionality?

*yes/no*