### PR TITLE
Alternative enhancement of the JUnit report

### DIFF
--- a/core/src/main/resources/templates/junitReport.vsl
+++ b/core/src/main/resources/templates/junitReport.vsl
@@ -87,7 +87,17 @@
                 #foreach($ref in $vuln.getReferences())
                     #if($ref.url)$enc.xml($ref.name): $enc.xml($ref.url)#end
                 #end]]>#end</system-out>
-            <system-err>location: $enc.xml($dependency.FilePath)</system-err>
+            #set($referencedProjects="")
+            #set($projectReferenced=false)
+            #foreach($ref in $dependency.projectReferences)
+                #if($projectReferenced)
+                    #set($referencedProjects="$referencedProjects, $ref")
+                #else
+                    #set($referencedProjects="$ref")
+                    #set($projectReferenced=true)
+                #end
+            #end
+            <system-err>location: $enc.xml($dependency.FilePath), project-references: [ $enc.xml($referencedProjects) ]</system-err>
         </testcase>
         #end
         #foreach($vuln in $dependency.getSuppressedVulnerabilities())

--- a/core/src/main/resources/templates/junitReport.vsl
+++ b/core/src/main/resources/templates/junitReport.vsl
@@ -54,7 +54,7 @@
                 #end
             #end
         #end
-    <testsuite failures="$failed" id="$suiteId" name="$enc.xml($dependency.FilePath)" package="$enc.xml($dependency.DisplayFileName)" skipped="$skipped" tests="$testCount" timestamp="$scanDateJunit">
+        <testsuite failures="$failed" errors="0" time="0" id="$suiteId" name="$enc.xml($dependency.FilePath)" package="$enc.xml($dependency.DisplayFileName)" skipped="$skipped" tests="$testCount" timestamp="$scanDateJunit">
         #if($dependency.getVulnerabilities().size()==0 && $dependency.getSuppressedVulnerabilities().size()==0)
             <testcase classname="dependency-check" name="$enc.xml($dependency.DisplayFileName)"/>
         #end


### PR DESCRIPTION
## Fixes Issue #4469

## Description of Change

An alternative implementation to the one proposed in #4476 which in my view better fits the way we use the JUnit report format for reporting on vulnerabilities.
It extends the `stderr` location data with the project references rather than including the project reference in the vulnerability (which, besides being ugly in my view) would not cleanly work for an aggreggate scan that has multiple sources).
Just like the #4476 it also resolves the missing required attributes that in the current reports make the xUnit Jenkins plugin break on XSD violations.

## Have test cases been added to cover the new functionality?

no, screenshots of sample results where added in a [comment](https://github.com/jeremylong/DependencyCheck/issues/4469#issuecomment-1166324079) in the resolved issue