### PR TITLE
Suppress CVE-2022-31569

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5394,4 +5394,11 @@
         <cpe>cpe:/a:vmware:spring_data_rest</cpe>
         <cpe>cpe:/a:pivotal_software:spring_data_rest</cpe>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+    Suppress CVE-2022-31569 completely since RipudamanKaushikDal/projects are examples and does not contain consumable releases.
+    ]]></notes>
+        <packageUrl regex="true">^pkg:.*$</packageUrl>
+        <cve>CVE-2022-31569</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Suppress CVE-2022-31569 completely since RipudamanKaushikDal/projects are examples and does not contain consumable releases. Fixes #4675

## Fixes Issue #
4675

## Description of Change

Suppress CVE-2022-31569 completely since RipudamanKaushikDal/projects are examples and does not contain consumable releases. Fixes #4675

## Have test cases been added to cover the new functionality?

no