### PR TITLE
Added support for msbuild version tags in addition to attributes. 

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/XPathMSBuildProjectParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/XPathMSBuildProjectParser.java
@@ -68,14 +68,16 @@ public class XPathMSBuildProjectParser implements MSBuildProjectParser {
                 final Node node = nodeList.item(i);
                 final NamedNodeMap attrs = node.getAttributes();
 
-                final Node include = attrs.getNamedItem("Include");
-                final Node version = attrs.getNamedItem("Version");
+                final String include = attrs.getNamedItem("Include").getNodeValue();
+                final String version = attrs.getNamedItem("Version") != null
+                        ? attrs.getNamedItem("Version").getNodeValue()
+                        : ((Node) xpath.evaluate("Version", node, XPathConstants.NODE)).getTextContent();
 
                 if (include != null && version != null) {
                     final NugetPackageReference npr = new NugetPackageReference();
 
-                    npr.setId(include.getNodeValue());
-                    npr.setVersion(version.getNodeValue());
+                    npr.setId(include);
+                    npr.setVersion(version);
 
                     packages.add(npr);
                 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzerTest.java
@@ -75,7 +75,7 @@ public class MSBuildProjectAnalyzerTest extends BaseTest {
             analyzer.setEnabled(true);
             analyzer.analyze(toScan, engine);
 
-            assertEquals("3 dependencies should be found", 3, engine.getDependencies().length);
+            assertEquals("4 dependencies should be found", 4, engine.getDependencies().length);
 
             int foundCount = 0;
 
@@ -101,10 +101,17 @@ public class MSBuildProjectAnalyzerTest extends BaseTest {
                     assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("AspNetCore"));
                     assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("AspNetCore.All"));
                     assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains("2.0.5"));
+                } else if ("Microsoft.Extensions.Logging".equals(result.getName())) {
+                    foundCount++;
+                    assertTrue(result.getEvidence(EvidenceType.VENDOR).toString().contains("Microsoft"));
+                    assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("Microsoft.Extensions.Logging"));
+                    assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("Extensions"));
+                    assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("Extensions.Logging"));
+                    assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains("6.0.0"));
                 }
             }
 
-            assertEquals("3 expected dependencies should be found", 3, foundCount);
+            assertEquals("4 expected dependencies should be found", 4, foundCount);
         }
     }
 }

--- a/core/src/test/resources/msbuild/test.csproj
+++ b/core/src/test/resources/msbuild/test.csproj
@@ -6,8 +6,13 @@
 
   <ItemGroup>
     <PackageReference Include="Humanizer" Version="2.2.0" />
-    <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
+    <PackageReference Include="JetBrains.Annotations">
+      <Version>11.1.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging">
+      <Version>6.0.0</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Fixes Issue #
Resolves #4417
## Description of Change

This PR adds support for MSBuild project files that store NuGet version information as a sub tag instead of an attribute.
Both cases are supported by Microsoft and may exist simultaneously, so this is needed to effectively scan MSBuild projects.

The code works by first evaluating whether the attribute exists, and if it doesn't, it will use the sub tag.

See file core/src/test/resources/msbuild/test.csproj or #4417 for examples of the MSBuild project format.

## Have test cases been added to cover the new functionality?

Yes, one test case was modified and another added to verify that this works as intended. All tests are passing.