### PR TITLE
Update htmlReport.vsl

### DIFF
--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -910,7 +910,7 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                         </div>
                     #if($dependency.getVulnerabilities().size()>0)
                     #set($cnt=$cnt+1)
-                    <h4 id="header$cnt" class="subsectionheader expandable collaspablesubsection white">Published Vulnerabilities</h4>
+                    <h4 id="header$cnt" class="subsectionheader collapsed collaspablesubsection white">Published Vulnerabilities</h4>
                     <div id="content$cnt" class="subsectioncontent standardsubsection">
                         #foreach($vuln in $dependency.getVulnerabilities(true))
                             #set($vsctr=$vsctr+1)
@@ -1078,7 +1078,7 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                                 </div>
                             #if($dependency.getSuppressedVulnerabilities().size()>0)
                             #set($cnt=$cnt+1)
-                            <h4 id="header$cnt" class="subsectionheader expandable collaspablesubsection white">Suppressed Vulnerabilities</h4>
+                            <h4 id="header$cnt" class="subsectionheader collapsed collaspablesubsection white">Suppressed Vulnerabilities</h4>
                             <div id="content$cnt" class="subsectioncontent standardsubsection">
                                 #foreach($vuln in $dependency.getSuppressedVulnerabilities(true))
                                     #set($vsctr=$vsctr+1)


### PR DESCRIPTION
## Fixes Issue #

After the page is rendered, a wrong class on "Published Vulnerabilities" causes inconsistency with the click effect.

## Description of Change

Update htmlReport.vsl

- before fixed:
![image](https://user-images.githubusercontent.com/38951157/180693254-522ba2d6-71e8-4920-83ff-71b6fe72bc98.png)

- fixed:
![image](https://user-images.githubusercontent.com/38951157/180693350-bffd1f20-aee2-4095-897f-1f3cd763b5d1.png)

## Have test cases been added to cover the new functionality?

yes
