### PR TITLE
Remove FP for parseurl

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5290,5 +5290,12 @@
         <packageUrl regex="true">^pkg:maven/(?!org\.springframework/spring\-web@).*$</packageUrl>
         <cve>CVE-2016-1000027</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        FP because cpe make reference to IonicaBizau/parse-url dependency
+        ]]></notes>
+        <packageUrl regex="true">^pkg:npm/parseurl@.*$</packageUrl>
+        <cpe>cpe:/a:parse-url_project:parse-url</cpe>
+    </suppress>
     <!-- endregion -->
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5290,7 +5290,7 @@
         <packageUrl regex="true">^pkg:maven/(?!org\.springframework/spring\-web@).*$</packageUrl>
         <cve>CVE-2016-1000027</cve>
     </suppress>
-    <suppress>
+    <suppress base="true">
         <notes><![CDATA[
         FP because cpe make reference to IonicaBizau/parse-url dependency
         ]]></notes>


### PR DESCRIPTION
Remove FP for parseurl

The following CVE's are making reference to [parse-url](https://github.com/IonicaBizau/parse-url) library.

[CVE-2022-2216](https://nvd.nist.gov/vuln/detail/CVE-2022-2216)
[CVE-2022-0722](https://nvd.nist.gov/vuln/detail/CVE-2022-0722)
[CVE-2022-2217](https://nvd.nist.gov/vuln/detail/CVE-2022-2217)
[CVE-2022-2218](https://nvd.nist.gov/vuln/detail/CVE-2022-2218)

Fixes #4661