### PR TITLE
Fix issue 4733. Update the mysql, mssql, postgresql and oracle initialize files.

### DIFF
--- a/core/src/main/resources/data/initialize_mssql.sql
+++ b/core/src/main/resources/data/initialize_mssql.sql
@@ -58,6 +58,8 @@ CREATE TABLE cpeEcosystemCache (vendor VARCHAR(255), product VARCHAR(255), ecosy
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('apache', 'zookeeper', 'MULTIPLE');
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('tensorflow', 'tensorflow', 'MULTIPLE');
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('scikit-learn', 'scikit-learn', 'MULTIPLE');
+INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('unicode', 'international_components_for_unicode', 'MULTIPLE');
+INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('icu-project', 'international_components_for_unicode', 'MULTIPLE');
 
 CREATE INDEX idxCwe ON cweEntry(cveid);
 CREATE INDEX idxVulnerability ON vulnerability(cve);
@@ -205,7 +207,7 @@ END;
 
 GO
 
-INSERT INTO properties(id,value) VALUES ('version','5.2');
+INSERT INTO properties(id,value) VALUES ('version','5.2.1');
 
 GO
 /**

--- a/core/src/main/resources/data/initialize_mysql.sql
+++ b/core/src/main/resources/data/initialize_mysql.sql
@@ -58,6 +58,8 @@ CREATE TABLE cpeEcosystemCache (vendor VARCHAR(255), product VARCHAR(255), ecosy
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('apache', 'zookeeper', 'MULTIPLE');
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('tensorflow', 'tensorflow', 'MULTIPLE');
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('scikit-learn', 'scikit-learn', 'MULTIPLE');
+INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('unicode', 'international_components_for_unicode', 'MULTIPLE');
+INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('icu-project', 'international_components_for_unicode', 'MULTIPLE');
 
 CREATE INDEX idxCwe ON cweEntry(cveid);
 CREATE INDEX idxVulnerability ON vulnerability(cve);
@@ -272,4 +274,4 @@ GRANT EXECUTE ON PROCEDURE dependencycheck.update_ecosystems2 TO 'dcuser';
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON dependencycheck.* TO 'dcuser';
 
-INSERT INTO properties(id, value) VALUES ('version', '5.2');
+INSERT INTO properties(id, value) VALUES ('version', '5.2.1');

--- a/core/src/main/resources/data/initialize_oracle.sql
+++ b/core/src/main/resources/data/initialize_oracle.sql
@@ -130,6 +130,8 @@ CREATE TABLE cpeEcosystemCache (vendor VARCHAR(255), product VARCHAR(255), ecosy
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('apache', 'zookeeper', 'MULTIPLE');
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('tensorflow', 'tensorflow', 'MULTIPLE');
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('scikit-learn', 'scikit-learn', 'MULTIPLE');
+INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('unicode', 'international_components_for_unicode', 'MULTIPLE');
+INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('icu-project', 'international_components_for_unicode', 'MULTIPLE');
 
 -- CREATE INDEX idxCwe ON cweEntry(cveid); -- PK automatically receives index
 -- CREATE INDEX idxVulnerability ON vulnerability(cve); -- PK automatically receives index
@@ -394,4 +396,4 @@ CREATE OR REPLACE VIEW v_update_ecosystems AS
     ON c.vendor=e.vendor
         AND c.product=e.product;
 
-INSERT INTO properties(id,value) VALUES ('version','5.2');
+INSERT INTO properties(id,value) VALUES ('version','5.2.1');

--- a/core/src/main/resources/data/initialize_postgres.sql
+++ b/core/src/main/resources/data/initialize_postgres.sql
@@ -42,6 +42,8 @@ CREATE TABLE cpeEcosystemCache (vendor VARCHAR(255), product VARCHAR(255), ecosy
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('apache', 'zookeeper', 'MULTIPLE');
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('tensorflow', 'tensorflow', 'MULTIPLE');
 INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('scikit-learn', 'scikit-learn', 'MULTIPLE');
+INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('unicode', 'international_components_for_unicode', 'MULTIPLE');
+INSERT INTO cpeEcosystemCache (vendor, product, ecosystem) VALUES ('icu-project', 'international_components_for_unicode', 'MULTIPLE');
 
 CREATE TABLE cweEntry (cveid INT, cwe VARCHAR(20),
     CONSTRAINT fkCweEntry FOREIGN KEY (cveid) REFERENCES vulnerability(id) ON DELETE CASCADE);
@@ -209,4 +211,4 @@ GRANT EXECUTE ON FUNCTION public.insert_software (INT, CHAR(1), VARCHAR(255),
 
 
 
-INSERT INTO properties(id,value) VALUES ('version','5.2');
+INSERT INTO properties(id,value) VALUES ('version','5.2.1');


### PR DESCRIPTION
## Fixes Issue #
[setting autoUpdate to false causes "Old database schema identified", but schema is up to date](https://github.com/jeremylong/DependencyCheck/issues/4733)

## The problem
In the commit, https://github.com/jeremylong/DependencyCheck/commit/811a9ebdb5f62e278612690b56836b6eb2b11389, the data.version in [core/src/main/resources/dependencycheck.properties](https://github.com/jeremylong/DependencyCheck/blob/562a4b3b5efdc496f57c0f623add5cea374461f0/core/src/main/resources/dependencycheck.properties) was updated to 5.2.1. Meanwhile, the database schema file and its version in [core/src/main/resources/data/initialize.sql](https://github.com/jeremylong/DependencyCheck/blob/562a4b3b5efdc496f57c0f623add5cea374461f0/core/src/main/resources/data/initialize.sql) was updated to 5.2.1 as well.

However, the other initialize files and their versions, like [core/src/main/resources/data/initialize_postgres.sql](https://github.com/jeremylong/DependencyCheck/blob/562a4b3b5efdc496f57c0f623add5cea374461f0/core/src/main/resources/data/initialize_postgres.sql), haven't been updated.

Therefore, when somebody installes Dependency Check by using [core/src/main/resources/data/initialize_postgres.sql](https://github.com/jeremylong/DependencyCheck/blob/562a4b3b5efdc496f57c0f623add5cea374461f0/core/src/main/resources/data/initialize_postgres.sql), and when they run the goal check, the data.version is 5.2.1, but the database schema version is 5.2. And if they configure autoUpdate to false, an exception will be thrown in the file [core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DatabaseManager.java](https://github.com/jeremylong/DependencyCheck/blob/562a4b3b5efdc496f57c0f623add5cea374461f0/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DatabaseManager.java) in the method [ensureSchemaVersion](https://github.com/jeremylong/DependencyCheck/blob/562a4b3b5efdc496f57c0f623add5cea374461f0/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DatabaseManager.java#L484), from the line [512](https://github.com/jeremylong/DependencyCheck/blob/562a4b3b5efdc496f57c0f623add5cea374461f0/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DatabaseManager.java#L512).

## Description of Change
Updated the other initialize files and their versions by studying the commit https://github.com/jeremylong/DependencyCheck/commit/811a9ebdb5f62e278612690b56836b6eb2b11389.

## Have test cases been added to cover the new functionality?
There is no functionality. Manually tested [core/src/main/resources/data/initialize_postgres.sql](https://github.com/jeremylong/DependencyCheck/blob/562a4b3b5efdc496f57c0f623add5cea374461f0/core/src/main/resources/data/initialize_postgres.sql).