### PR TITLE
add yarn.lock to mixedLangSet to enable yarnAuditAnalyzer

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1587,6 +1587,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 mixedLangSet.addInclude("Gopkg.lock");
                 mixedLangSet.addInclude("go.mod");
                 mixedLangSet.addInclude("yarn.lock");
+                mixedLangSet.addInclude("pnpm-lock.yaml");
             } catch (IOException ex) {
                 if (exCol == null) {
                     exCol = new ExceptionCollection();

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1586,6 +1586,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 mixedLangSet.addInclude("npm-shrinkwrap.json");
                 mixedLangSet.addInclude("Gopkg.lock");
                 mixedLangSet.addInclude("go.mod");
+                mixedLangSet.addInclude("yarn.lock");
             } catch (IOException ex) {
                 if (exCol == null) {
                     exCol = new ExceptionCollection();


### PR DESCRIPTION
yarnAuditAnalyzer cannot be enabled if we don't have yarn.lock is added to mixedLangSet.

## Fixes Issue #
[cannot enable yarnAudit for maven plugin ](https://github.com/jeremylong/DependencyCheck/issues/4201)

## Description of Change

add yarn.lock to mixedLangSet to let yarnAuditAnalyzer can be enabled in the maven plugin

*Please add a description of the proposed change*
add   `mixedLangSet.addInclude("yarn.lock"); ` to `BaseDependencyCheckMojo.java`

## Have test cases been added to cover the new functionality?

*no*  our company have used this fixed version for 3 months.