### PR TITLE
Filter rules at execution instead of at load

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
@@ -123,7 +123,7 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer imple
         if (rules.isEmpty()) {
             return;
         }
-        rules.list().forEach((rule) -> {
+        rules.list().stream().filter(r-> !this.filter(r)).forEach((rule) -> {
             rule.process(dependency);
         });
     }
@@ -171,7 +171,7 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer imple
             if (in == null) {
                 throw new SuppressionParseException("Suppression rules `" + BASE_SUPPRESSION_FILE + "` could not be found");
             }
-            ruleList = parser.parseSuppressionRules(in, this);
+            ruleList = parser.parseSuppressionRules(in, null);
         } catch (SAXException | IOException ex) {
             throw new SuppressionParseException("Unable to parse the base suppression data file", ex);
         }
@@ -246,7 +246,7 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer imple
                     throw new SuppressionParseException(msg);
                 }
                 try {
-                    list.addAll(parser.parseSuppressionRules(file, this));
+                    list.addAll(parser.parseSuppressionRules(file, null));
                 } catch (SuppressionParseException ex) {
                     LOGGER.warn("Unable to parse suppression xml file '{}'", file.getPath());
                     LOGGER.warn(ex.getMessage());


### PR DESCRIPTION
## Fixes the failure of the jackson integrationtest

## Description of Change

Filter the rules at execution time instead of at load time so that the SuppressionRules singleton holds the rules for both CPESuppressionAnalyzer and VulnerabilitySuppressionAnalyzer.

## Have test cases been added to cover the new functionality?

no