### PR TITLE
Bump dockerfile to use a supported version of Java (latest LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.17.1-alpine AS go
 
-FROM azul/zulu-openjdk-alpine:14 AS jlink
+FROM azul/zulu-openjdk-alpine:17 AS jlink
 
 RUN "$JAVA_HOME/bin/jlink" --compress=2 --module-path /opt/java/openjdk/jmods --add-modules java.base,java.compiler,java.datatransfer,jdk.crypto.ec,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.scripting,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.unsupported --output /jlinked
 


### PR DESCRIPTION
## Fixes Issue #4760

## Description of Change

Bump the Azul java docker image on which the jlinked java runtime is built to a version of a supported Azul JRE

## Have test cases been added to cover the new functionality?

no