### PR TITLE
Fixing file separator bug for unit test on windows machines

### DIFF
--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java
@@ -89,7 +89,7 @@ public class DependencyCheckPropertiesTest {
     }
 
     public Set<Class<?>> findAllClasses(String packageName) throws IOException {
-        String parsedPackageName = packageName.replaceAll("[.]", File.separator.replaceAll("\\\\","\\\\\\\\"));
+        String parsedPackageName = packageName.replaceAll("[.]", "/");
 
         Set<Class<?>> classes = new HashSet<>();
         Enumeration<URL> resources = ClassLoader.getSystemClassLoader().getResources(parsedPackageName);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java
@@ -89,7 +89,7 @@ public class DependencyCheckPropertiesTest {
     }
 
     public Set<Class<?>> findAllClasses(String packageName) throws IOException {
-        String parsedPackageName = packageName.replaceAll("[.]", File.separator);
+        String parsedPackageName = packageName.replaceAll("[.]", File.separator.replaceAll("\\\\","\\\\\\\\"));
 
         Set<Class<?>> classes = new HashSet<>();
         Enumeration<URL> resources = ClassLoader.getSystemClassLoader().getResources(parsedPackageName);


### PR DESCRIPTION
## Fixes Issue #
Fixed test for windows machines (backslash would escape a character, therefore it needs to be replaced with a double backslash if file separator is a backslash).

## Description of Change
Replacing potential backslash in File.separator property with double-backslash so it won't throw an exception on windows machines (or other OS using backslash instead of slash as path separator).

## Have test cases been added to cover the new functionality?
Technically no, because it fixes a test case itself.