### PR TITLE
Checking for null value from MSBuild xpath method before accessing it

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/XPathMSBuildProjectParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/XPathMSBuildProjectParser.java
@@ -69,9 +69,14 @@ public class XPathMSBuildProjectParser implements MSBuildProjectParser {
                 final NamedNodeMap attrs = node.getAttributes();
 
                 final String include = attrs.getNamedItem("Include").getNodeValue();
-                final String version = attrs.getNamedItem("Version") != null
-                        ? attrs.getNamedItem("Version").getNodeValue()
-                        : ((Node) xpath.evaluate("Version", node, XPathConstants.NODE)).getTextContent();
+                String version = null;
+                
+                if(attrs.getNamedItem("Version") != null) {
+                    version = attrs.getNamedItem("Version").getNodeValue();
+                }
+                else if(xpath.evaluate("Version", node, XPathConstants.NODE) instanceof Node) {
+                    version = ((Node) xpath.evaluate("Version", node, XPathConstants.NODE)).getTextContent();
+                }
 
                 if (include != null && version != null) {
                     final NugetPackageReference npr = new NugetPackageReference();

--- a/core/src/test/resources/msbuild/test.csproj
+++ b/core/src/test/resources/msbuild/test.csproj
@@ -13,6 +13,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging">
       <Version>6.0.0</Version>
     </PackageReference>
+    <PackageReference Include="log4net" />
+    <PackageReference Include="RestSharp">
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Checking for null value from xpath method in MSBuild project analysis before accessing its result so we don't get a NullPointerException in case of missing version element or attribute. Also added package references without version to test-project to test for this case in the future.

## Fixes Issue 
Fixed issue #4770

## Description of Change
Concerning MSBuild project analysis:
Added check if version attribute or element was found before trying to access its value (because otherwise this may result in a NullPointerException). This bug was introduced with PR https://github.com/jeremylong/DependencyCheck/pull/4678
Will no longer throw a NullPointerException on missing version element/attribute or if version was written in lower case.
Will however not interpret in any version element or attribute that was written in lower-case.
Note: This is the same behaviour as was observed before version 7.1.2, in the future it would probably be wise to check the MSBuild project file for all the elements and attributes case insensitive. But that would go beyond this bugfix.

## Have test cases been added to cover the new functionality?
Yes, PackageReferences without any version have been added to the test-project so test will fail in future if this happenes again.