### PR TITLE
Fix false-positive CPE matches for spring-boot libraries

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5142,10 +5142,14 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        Suppresses false positives per #1566 and #3580.
+        Suppresses false positives per #1566, #3580 and #4617
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/.*$</packageUrl>
         <cpe>cpe:/a:vmware:spring_integration</cpe>
+        <cpe>cpe:/a:pivotal:spring_security_oauth</cpe>
+        <cpe>cpe:/a:pivotal_software:spring_security</cpe>
+        <cpe>cpe:/a:vmware:server</cpe>
+        <cpe>cpe:/a:vmware:spring_security</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[


### PR DESCRIPTION
## Fixes Issue #4617

## Description of Change

Extend the suppression for spring-boot projects to not hit other Pivotal/Spring/VMWare products

## Have test cases been added to cover the new functionality?

no; checked with a dedicated suppression file that it resolves the issues raised in #4617 