### PR TITLE
Fix syntax of false-positive-approvals.yml

### DIFF
--- a/.github/workflows/false-positive-approvals.yml
+++ b/.github/workflows/false-positive-approvals.yml
@@ -38,7 +38,7 @@ jobs:
             })
             
             let botComments = comments.filter(comment => 
-              comment.user.login == 'github-actions' && 
+              comment.user.login === 'github-actions' && 
               comment.body.includes('<suppress base="true">') &&
               comment.body.includes('Suppression rule:')
             )
@@ -70,8 +70,8 @@ jobs:
             let previousReportNotes = '';
 
             for (r of rules.suppress) {
-              if (proposedRule.suppress.packageUrl == r.packageUrl &&
-                  proposedRule.suppress.cpe == r.cpe) {
+              if (proposedRule.suppress.packageUrl === r.packageUrl &&
+                  proposedRule.suppress.cpe === r.cpe) {
                     found = true;
                     previousReportNotes = r.notes.trim();
                     break;

--- a/.github/workflows/false-positive-approvals.yml
+++ b/.github/workflows/false-positive-approvals.yml
@@ -10,9 +10,9 @@ jobs:
     if: ${{ !github.event.issue.pull_request && 
       contains(github.event.issue.labels.*.name, 'FP Report') && 
       contains(github.event.comment.body,'approved') &&
-      (github.event.comment.user.login === 'jeremylong') ||
-      github.event.comment.user.login === 'aikebah') || 
-      github.event.comment.user.login === 'nhumblot'))  }}
+      (github.event.comment.user.login == 'jeremylong') ||
+      github.event.comment.user.login == 'aikebah') || 
+      github.event.comment.user.login == 'nhumblot'))  }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
             })
             
             let botComments = comments.filter(comment => 
-              comment.user.login === 'github-actions' && 
+              comment.user.login == 'github-actions' && 
               comment.body.includes('<suppress base="true">') &&
               comment.body.includes('Suppression rule:')
             )
@@ -70,8 +70,8 @@ jobs:
             let previousReportNotes = '';
 
             for (r of rules.suppress) {
-              if (proposedRule.suppress.packageUrl === r.packageUrl &&
-                  proposedRule.suppress.cpe === r.cpe) {
+              if (proposedRule.suppress.packageUrl == r.packageUrl &&
+                  proposedRule.suppress.cpe == r.cpe) {
                     found = true;
                     previousReportNotes = r.notes.trim();
                     break;


### PR DESCRIPTION
Replace `===` by `==` as github actions doesn't have a strict-type equals [operator] (https://docs.github.com/en/actions/learn-github-actions/expressions#operators)

## Description of Change

Fixup the syntax of the comparisons as strict-type-equals operator `===` is non-existent in github actions workflow expressions

