### PR TITLE
Add links to Gradle Plugin page in various docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ The dependency-check plugin can be configured using the following:
 </project>
 ```
 
+### Gradle Plugin
+
+For instructions on the use of the Gradle Plugin, please see the [dependency-check-gradle github page](http://jeremylong.github.io/DependencyCheck/dependency-check-gradle).
+
 ### Ant Task
 
 For instructions on the use of the Ant Task, please see the [dependency-check-ant github page](http://jeremylong.github.io/DependencyCheck/dependency-check-ant).

--- a/core/src/site/markdown/index.md
+++ b/core/src/site/markdown/index.md
@@ -12,5 +12,6 @@ The engine is currently exposed via:
 
 - [Command Line Tool](../dependency-check-cli/index.html)
 - [Maven Plugin](../dependency-check-maven/index.html)
+- [Gradle Plugin](../dependency-check-gradle/index.html)
 - [Ant Task](../dependency-check-ant/index.html)
 - [Jenkins Plugin](../dependency-check-jenkins/index.html)

--- a/src/site/markdown/general/hints.md
+++ b/src/site/markdown/general/hints.md
@@ -65,5 +65,6 @@ Please see the appropriate configuration option in each interfaces configuration
 
 -  [Command Line Tool](../dependency-check-cli/arguments.html)
 -  [Maven Plugin](../dependency-check-maven/configuration.html)
+-  [Gradle Plugin](../dependency-check-gradle/configuration.html)
 -  [Ant Task](../dependency-check-ant/configuration.html)
 -  [Jenkins Plugin](../dependency-check-jenkins/index.html)

--- a/src/site/markdown/general/suppression.md
+++ b/src/site/markdown/general/suppression.md
@@ -115,5 +115,6 @@ Please see the appropriate configuration option in each interfaces configuration
 
 -  [Command Line Tool](../dependency-check-cli/arguments.html)
 -  [Maven Plugin](../dependency-check-maven/configuration.html)
+-  [Gradle Plugin](../dependency-check-gradle/configuration.html)
 -  [Ant Task](../dependency-check-ant/configuration.html)
 -  [Jenkins Plugin](../dependency-check-jenkins/index.html)


### PR DESCRIPTION
## Description of Change

Wherever the documentation links to both Ant and Maven docs, also link to the Gradle Plugin docs.

## Have test cases been added to cover the new functionality?

no - this is a documentation-only change.