### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,12 @@ on:
       - '**/*.md'
       - '**/*.txt'
 
+permissions: {}
 jobs:
   build:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+
     name: Build dependency-check
     runs-on: ubuntu-latest 
     steps:
@@ -106,6 +110,9 @@ jobs:
           coverage-reports: utils/target/jacoco-results/jacoco.xml,core/target/jacoco-results/jacoco.xml,maven/target/jacoco-results/jacoco.xml,ant/target/jacoco-results/jacoco.xml,cli/target/jacoco-results/jacoco.xml
 
   docker:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+
     name: Build and Test Docker
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/false-positive-approvals.yml
+++ b/.github/workflows/false-positive-approvals.yml
@@ -4,8 +4,13 @@ on:
   issue_comment:
     types: [ created ]
 
+permissions: {}
 jobs:
   update_suppression:
+    permissions:
+      contents: write # to push changes in repo (jamesives/github-pages-deploy-action)
+      issues: write
+
     name: Update Suppression Rules
     if: ${{ !github.event.issue.pull_request && 
       contains(github.event.issue.labels.*.name, 'FP Report') && 

--- a/.github/workflows/purge-cache.yml
+++ b/.github/workflows/purge-cache.yml
@@ -2,6 +2,9 @@ name: Purge Cache
 
 on: workflow_dispatch
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build:
     name: Purge GitHub Cache


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.