### PR TITLE
Parse for Dart SDK version

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/DartAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/DartAnalyzer.java
@@ -137,6 +137,8 @@ public class DartAnalyzer extends AbstractFileTypeAnalyzer {
         Iterator<Map.Entry<String, JsonNode>> devDependencies = rootNode.get("dev_dependencies").fields();
         addYamlDependenciesToEngine(devDependencies, yamlFile, engine);
 
+        String dartVersion = rootNode.get("environment").get("sdk").textValue();
+        addYamlDartDependencyToEngine(dartVersion, yamlFile, engine);
     }
 
     private void analyzeLockFileDependencies(Dependency lockFileDependency, Engine engine) throws AnalysisException {
@@ -152,6 +154,15 @@ public class DartAnalyzer extends AbstractFileTypeAnalyzer {
         }
 
         addLockFileDependenciesToEngine(lockFile, engine, rootNode);
+        addLockFileDartVersionToEngine(lockFile, engine, rootNode);
+    }
+
+    private void addLockFileDartVersionToEngine(File file, Engine engine, JsonNode rootNode) throws AnalysisException {
+        String dartVersion = rootNode.get("sdks").get("dart").textValue();
+        String minimumVersion = extractMinimumVersion(dartVersion);
+
+        engine.addDependency(
+                createDependencyFromNameAndVersion(file, "dart_software_development_kit", minimumVersion));
     }
 
     private void addLockFileDependenciesToEngine(File file, Engine engine, JsonNode rootNode) throws AnalysisException {
@@ -194,6 +205,13 @@ public class DartAnalyzer extends AbstractFileTypeAnalyzer {
                     createDependencyFromNameAndVersion(file, name, version)
             );
         }
+    }
+
+    private void addYamlDartDependencyToEngine(String dartVersion, File file, Engine engine) throws AnalysisException {
+        String minimumVersion = extractMinimumVersion(dartVersion);
+
+        engine.addDependency(
+                createDependencyFromNameAndVersion(file, "dart_software_development_kit", minimumVersion));
     }
 
     private Dependency createDependencyFromNameAndVersion(File file, String name, String version) throws AnalysisException {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/DartAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/DartAnalyzer.java
@@ -137,8 +137,7 @@ public class DartAnalyzer extends AbstractFileTypeAnalyzer {
         Iterator<Map.Entry<String, JsonNode>> devDependencies = rootNode.get("dev_dependencies").fields();
         addYamlDependenciesToEngine(devDependencies, yamlFile, engine);
 
-        String dartVersion = rootNode.get("environment").get("sdk").textValue();
-        addYamlDartDependencyToEngine(dartVersion, yamlFile, engine);
+        addYamlDartDependencyToEngine(rootNode, yamlFile, engine);
     }
 
     private void analyzeLockFileDependencies(Dependency lockFileDependency, Engine engine) throws AnalysisException {
@@ -207,7 +206,8 @@ public class DartAnalyzer extends AbstractFileTypeAnalyzer {
         }
     }
 
-    private void addYamlDartDependencyToEngine(String dartVersion, File file, Engine engine) throws AnalysisException {
+    private void addYamlDartDependencyToEngine(JsonNode rootNode, File file, Engine engine) throws AnalysisException {
+        String dartVersion = rootNode.get("environment").get("sdk").textValue();
         String minimumVersion = extractMinimumVersion(dartVersion);
 
         engine.addDependency(

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DartAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DartAnalyzerTest.java
@@ -90,12 +90,13 @@ public class DartAnalyzerTest extends BaseTest {
                 "dart/pubspec.lock"));
         dartAnalyzer.analyze(result, engine);
 
-        assertThat(engine.getDependencies().length, equalTo(4));
+        assertThat(engine.getDependencies().length, equalTo(5));
 
         Dependency dependency1 = engine.getDependencies()[0];
         Dependency dependency2 = engine.getDependencies()[1];
         Dependency dependency3 = engine.getDependencies()[2];
         Dependency dependency4 = engine.getDependencies()[3];
+        Dependency dependency5 = engine.getDependencies()[4];
 
         assertThat(dependency1.getName(), equalTo("_fe_analyzer_shared"));
         assertThat(dependency1.getVersion(), equalTo("40.0.0"));
@@ -116,6 +117,9 @@ public class DartAnalyzerTest extends BaseTest {
 
         assertThat(dependency4.getName(), equalTo("collection"));
         assertThat(dependency4.getVersion(), equalTo("1.16.0"));
+
+        assertThat(dependency5.getName(), equalTo("dart_software_development_kit"));
+        assertThat(dependency5.getVersion(), equalTo("2.17.0"));
     }
 
     @Test
@@ -125,7 +129,7 @@ public class DartAnalyzerTest extends BaseTest {
                 "dart/pubspec.yaml"));
         dartAnalyzer.analyze(result, engine);
 
-        assertThat(engine.getDependencies().length, equalTo(6));
+        assertThat(engine.getDependencies().length, equalTo(7));
 
         Dependency dependency1 = engine.getDependencies()[0];
         Dependency dependency2 = engine.getDependencies()[1];
@@ -133,6 +137,7 @@ public class DartAnalyzerTest extends BaseTest {
         Dependency dependency4 = engine.getDependencies()[3];
         Dependency dependency5 = engine.getDependencies()[4];
         Dependency dependency6 = engine.getDependencies()[5];
+        Dependency dependency7 = engine.getDependencies()[6];
 
         assertThat(dependency1.getName(), equalTo("auto_size_text"));
         assertThat(dependency1.getVersion(), equalTo("3.0.0"));
@@ -175,6 +180,9 @@ public class DartAnalyzerTest extends BaseTest {
                 assertThat(identifier.getValue(), equalTo("pkg:pub/flutter_test"));
             }
         }
+
+        assertThat(dependency7.getName(), equalTo("dart_software_development_kit"));
+        assertThat(dependency7.getVersion(), equalTo("2.17.0"));
     }
 
     @Test


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

`DartAnalyzer` now also parses the dependency files for the Dart SDK version, not only for the included dependencies´ version.

## Have test cases been added to cover the new functionality?

yes