### PR TITLE
Suppress false positives for common jruby rubygems

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5403,4 +5403,18 @@
         <packageUrl regex="true">^pkg:npm/parseurl@.*$</packageUrl>
         <cpe>cpe:/a:parse-url_project:parse-url</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4648 and #4649
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/rubygems/jruby\-.*@.*$</packageUrl>
+        <cpe>cpe:/a:jruby:jruby</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4649
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/rubygems/jruby\-openssl@.*$</packageUrl>
+        <cpe>cpe:/a:openssl:openssl</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Fixes Issue 

- fixes #4648
- fixes #4649

## Description of Change

Adds suppressions for two libraries which the suppressions bot cannot handle due to use of non-standard (but common) RubyGems maven repo for use with JRuby.

These are located via JRuby uber-jars, e.g `jruby-complete-9.3.8.0.jar: readline.jar (shaded: rubygems:jruby-readline:1.3.7)` (and similar for jruby-openssl)

Dependency Check can locate the nested jar at `File Path: /go/.gradle/caches/modules-2/files-2.1/org.jruby/jruby-complete/9.3.8.0/8e11191265ab501930125081d8c21a3f55f1b8cd/jruby-complete-9.3.8.0.jar/META-INF/jruby.home/lib/ruby/stdlib/readline.jar/META-INF/maven/rubygems/jruby-readline/pom.xml`

## Have test cases been added to cover the new functionality?

N/A