### PR TITLE
Correct false positive ops CPE parsing when CPE is already a well-formed CPE name

### DIFF
--- a/.github/workflows/false-positive-ops.yml
+++ b/.github/workflows/false-positive-ops.yml
@@ -160,7 +160,7 @@ jobs:
                 purl += '/' + name.replaceAll('.','\\.');
             }
             purl += '@.*$';
-            var cpe = process.env.CPE.split(':');
+            var cpe = process.env.CPE.trim().replaceAll(/^`|`$/g,'').split(':');
             var matchCpe;
             if (cpe[1] == '2.3') {
                matchcpe = 'cpe:/a:' + cpe[3] + ':' + cpe[4];
@@ -206,7 +206,7 @@ jobs:
                 purl += '/' + name.replaceAll('.','\\.');
             }
             purl += '@.*$';
-            var cpe = process.env.CPE.split(':');
+            var cpe = process.env.CPE.trim().replaceAll(/^`|`$/g,'').split(':');
             console.log(cpe);
             var matchCpe;
             if (cpe[1] == '2.3') {
@@ -253,7 +253,7 @@ jobs:
                 purl += '/' + name.replaceAll('.','\\.');
             }
             purl += '@.*$';
-            var cpe = process.env.CPE.split(':');
+            var cpe = process.env.CPE.trim().replaceAll(/^`|`$/g,'').split(':');
             var matchCpe;
             if (cpe[1] == '2.3') {
                matchcpe = 'cpe:/a:' + cpe[3] + ':' + cpe[4];


### PR DESCRIPTION
## Description of Change

Users are asked to include backticks so the CPE displays correctly, but the code doesn't remove them before trying to parse.

Previous code works fine if the CPE is in formatted string binding format (e.g `cpe:2.3:a:microsoft:internet_explorer:8.0.6001:beta:*:*:*:*:*:*`) because it ignores content of the first and last tokens, but not if it's already in WFN format without version since the product token will have a backtick in it (e.g `cpe:2.3:/a:microsoft:internet_explorer`)

Suspect that users may often enter the CPE in the WFN format (without versions) because they are translating from a suppression they already have in their own config, rather than from the formatted strings that are typically included in the reports.

Example of issue with this problem: https://github.com/jeremylong/DependencyCheck/issues/4616#issuecomment-1160612100

## Have test cases been added to cover the new functionality?

N/A