### PR TITLE
Add new Mysql Connector java maven co-ordinates after migration

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -3109,9 +3109,9 @@
 
     <suppress base="true">
         <notes><![CDATA[
-        FP per issue #3041
+        FP per issue #3041 and #4933
         ]]></notes>
-        <packageUrl regex="true">^pkg:maven/mysql/mysql\-connector\-java@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/(mysql/mysql\-connector\-java|com\.mysql/mysql\-connector\-j)@.*$</packageUrl>
         <cpe>cpe:/a:oracle:connector%2fj</cpe>
         <cpe>cpe:/a:oracle:jdbc</cpe>
     </suppress>
@@ -3119,9 +3119,9 @@
         <notes><![CDATA[
         FP per issue #952 - instead of suppressing the whole thing, we will just
             suppress specific CVE that are for the server
-            Added additional CVE per #3509.
+            Added additional CVE per #3509 and new connector co-ordinates per #4933
         ]]></notes>
-        <gav regex="true">^(mysql:mysql-connector-java|org\.drizzle\.jdbc:drizzle-jdbc):.*$</gav>
+        <gav regex="true">^(mysql:mysql-connector-java|com\.mysql:mysql-connector-j|org\.drizzle\.jdbc:drizzle-jdbc):.*$</gav>
         <cve>CVE-2017-15945</cve>
         <cve>CVE-2018-3081</cve>
         <cve>CVE-2018-3137</cve>


### PR DESCRIPTION
## Fixes Issue #

- fixes #4933 

## Description of Change

The Mysql Connector for java is moving from `mysql:mysql-connector-java` to `com.mysql:mysql-connector-j` per  https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-31.html

You can see the first version at https://central.sonatype.dev/artifact/com.mysql/mysql-connector-j/8.0.31

This updates the existing suppressions to include the new Maven co-ordinates.

## Have test cases been added to cover the new functionality?

N/A