### PR TITLE
Exclude node_modules from Maven's scan path

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1594,6 +1594,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 mixedLangSet.addInclude("go.mod");
                 mixedLangSet.addInclude("yarn.lock");
                 mixedLangSet.addInclude("pnpm-lock.yaml");
+                mixedLangSet.addExclude("/node_modules/");
             } catch (IOException ex) {
                 if (exCol == null) {
                     exCol = new ExceptionCollection();


### PR DESCRIPTION
## Fixes Issue #4972

99% positive the error reported in #4972 is due to how file sets work with Maven. Other places in the code we filter out scanning the node_modules directory - filtering here should prevent the reported error regarding yarn.