### PR TITLE
Suppress netty-tcnative-boringssl-static vs chromium_project:chromium FP

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4594,10 +4594,11 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       FP per issue #4154
+       FP per issue #4154, #4776
        ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty-tcnative-boringssl-static@.*$</packageUrl>
         <cpe>cpe:/a:chromium:chromium</cpe>
+        <cpe>cpe:/a:chromium_project:chromium</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[


### PR DESCRIPTION
## Fixes Issue

#4776 

## Description of Change

The false positive fixed with #4154 is now appearing again for the CPE "cpe:/a:chromium_project:chromium" instead of the already suppressed "cpe:/a:chromium:chromium".
