### PR TITLE
Suppress unnecessary RetireJS analyzer info logging

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzer.java
@@ -17,6 +17,7 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
+import com.esotericsoftware.minlog.Log;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.github.packageurl.PackageURLBuilder;
@@ -179,6 +180,14 @@ public class RetireJsAnalyzer extends AbstractFileTypeAnalyzer {
      */
     @Override
     protected void prepareFileTypeAnalyzer(Engine engine) throws InitializationException {
+        // RetireJS outputs a bunch of repeated output like the following for
+        // vulnerable dependencies, with little context:
+        // 
+        // INFO: Vulnerability found: jquery below 1.6.3
+        //
+        // This logging is suppressed because it isn't particularly useful, and
+        // it aligns with other analyzers that don't log such information.
+        Log.set(Log.LEVEL_WARN);
 
         File repoFile = null;
         boolean repoEmpty = false;
@@ -440,5 +449,10 @@ public class RetireJsAnalyzer extends AbstractFileTypeAnalyzer {
         } catch (IOException | DatabaseException e) {
             throw new AnalysisException(e);
         }
+    }
+
+    @Override
+    protected void closeAnalyzer() throws Exception {
+        Log.set(Log.LEVEL_INFO);
     }
 }


### PR DESCRIPTION
## Description of Change

This suppresses unnecessary RetireJS analyzer info logging that is otherwise output, e.g.

```
[dependency-check] 00:00  INFO: Vulnerability found: jquery below 1.6.3
[dependency-check] 00:00  INFO: Vulnerability found: jquery below 1.9.0b1
[dependency-check] 00:00  INFO: Vulnerability found: jquery below 1.12.0
[dependency-check] 00:00  INFO: Vulnerability found: jquery below 3.4.0
[dependency-check] 00:00  INFO: Vulnerability found: jquery below 3.5.0
[dependency-check] 00:00  INFO: Vulnerability found: jquery below 3.5.0
[dependency-check] 00:00  INFO: Vulnerability found: jquery below 1.6.3
<snip ~2000 similar lines>
[dependency-check] 00:09  INFO: Vulnerability found: handlebars below 1.0.0.beta.3
[dependency-check] 00:09  INFO: Vulnerability found: handlebars below 4.0.0
[dependency-check] 00:09  INFO: Vulnerability found: handlebars below 4.3.0
[dependency-check] 00:09  INFO: Vulnerability found: handlebars below 4.5.3
[dependency-check] 00:09  INFO: Vulnerability found: handlebars below 4.6.0
[dependency-check] 00:09  INFO: Vulnerability found: handlebars below 4.7.7
[dependency-check] Finished RetireJS Analyzer (15 seconds)
```

## Have test cases been added to cover the new functionality?

No, I'm not sure this is something of interest to test. Let me know if I'm wrong.