### PR TITLE
Update Suppression File

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5418,4 +5418,215 @@
         <packageUrl regex="true">^pkg:maven/rubygems/jruby\-openssl@.*$</packageUrl>
         <cpe>cpe:/a:openssl:openssl</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4852
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-kickstart@.*$</packageUrl>
+        <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4803
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/net\.sourceforge\.htmlunit/htmlunit-cssparser@.*$</packageUrl>
+        <cpe>cpe:/a:htmlunit_project:htmlunit</cpe>
+    </suppress>
+
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4853
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-servlet@.*$</packageUrl>
+        <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4859
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.apollographql\.federation/federation-graphql-java-support@.*$</packageUrl>
+        <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4851
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.graphql-java/graphql-java-extended-scalars@.*$</packageUrl>
+        <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4860
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.apollographql\.federation/federation-graphql-java-support-api@.*$</packageUrl>
+        <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4862
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.github\.graphql-java/graphql-java-annotations@.*$</packageUrl>
+        <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4863
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.graphql-java/java-dataloader@.*$</packageUrl>
+        <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4854
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-tools@.*$</packageUrl>
+        <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4806
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.vaadin\.addon/easyuploads@.*$</packageUrl>
+        <cpe>cpe:/a:vaadin:vaadin</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4790
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback-classic@.*$</packageUrl>
+        <cpe>cpe:/a:qos:slf4j</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4781
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.microprofile\.config/microprofile-config-api@.*$</packageUrl>
+        <cpe>cpe:/a:payara:payara</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4777
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.james/apache-mime4j@.*$</packageUrl>
+        <cpe>cpe:/a:apache:james</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4755
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.postgresql/r2dbc-postgresql@.*$</packageUrl>
+        <cpe>cpe:/a:postgresql:postgresql</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4754
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mockito/mockito-junit-jupiter@.*$</packageUrl>
+        <cpe>cpe:/a:junit:junit4</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4735
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.robolectric/junit@.*$</packageUrl>
+        <cpe>cpe:/a:junit:junit4</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4729
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.openhtmltopdf/openhtmltopdf-jsoup-dom-converter@.*$</packageUrl>
+        <cpe>cpe:/a:jsoup:jsoup</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4728
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.vladsch\.flexmark/flexmark-ext-xwiki-macros@.*$</packageUrl>
+        <cpe>cpe:/a:xwiki:xwiki</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4727
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.vladsch\.flexmark/flexmark-ext-macros@.*$</packageUrl>
+        <cpe>cpe:/a:processing:processing</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4726
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jfrog\.artifactory\.client/artifactory-java-client-api@.*$</packageUrl>
+        <cpe>cpe:/a:jfrog:artifactory</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4897
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-annotation-processing-gradle@.*$</packageUrl>
+        <cpe>cpe:/a:processing:processing</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4900
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.testcontainers/mysql@.*$</packageUrl>
+        <cpe>cpe:/a:mysql:mysql</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4899
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mariadb/r2dbc-mariadb@.*$</packageUrl>
+        <cpe>cpe:/a:mariadb:mariadb</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4898
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.testcontainers/mariadb@.*$</packageUrl>
+        <cpe>cpe:/a:mariadb:mariadb</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4907
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/net\.minidev/accessors-smart@.*$</packageUrl>
+        <cpe>cpe:/a:json-smart_project:json-smart-v1</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4721
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.camel/camel-activemq@.*$</packageUrl>
+        <cpe>cpe:/a:apache:activemq</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4652
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jruby\.rack/jruby-rack@.*$</packageUrl>
+        <cpe>cpe:/a:jruby:jruby</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4647
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jruby/dirgra@.*$</packageUrl>
+        <cpe>cpe:/a:jruby:jruby</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4932
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.datasketches/datasketches-java@.*$</packageUrl>
+        <cpe>cpe:/a:sketch:sketch</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4962
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.github\.pagehelper/pagehelper-spring-boot-starter@.*$</packageUrl>
+        <cpe>cpe:/a:pagehelper_project:pagehelper</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Update the base suppression file from the `generatedSuppressions` branch to prepare for the 7.3.1 release.
- Delineator added to `generatedSuppressions.xml`:  https://github.com/jeremylong/DependencyCheck/pull/new/updateSuppressions
- Intent is to delete these entries from the generated suppressions once 7.3.1 is no longer supported.

The purpose of this is to keep the base suppression file current - even when users do not utilize the hosted suppression file (some run ODC in an offline mode).