### PR TITLE
Set the context class loader when executing ant tasks

### DIFF
--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -1892,7 +1892,7 @@ public class Check extends Update {
     //see note on `dealWithReferences()` for information on this suppression
     @SuppressWarnings("squid:RedundantThrowsDeclarationCheck")
     @Override
-    public void execute() throws BuildException {
+    protected void executeWithContextClassloader() throws BuildException {
         dealWithReferences();
         validateConfiguration();
         populateSettings();

--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Purge.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Purge.java
@@ -20,11 +20,18 @@ package org.owasp.dependencycheck.taskdefs;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+
+import org.apache.commons.jcs.JCS;
+import org.apache.commons.jcs.access.CacheAccess;
+import org.apache.commons.jcs.engine.CompositeCacheAttributes;
+import org.apache.commons.jcs.engine.behavior.ICompositeCacheAttributes;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.data.cache.DataCache;
 import org.owasp.dependencycheck.utils.Settings;
+import org.owasp.dependencycheck.xml.pom.Model;
 import org.slf4j.impl.StaticLoggerBinder;
 
 /**
@@ -105,6 +112,23 @@ public class Purge extends Task {
     }
 
     /**
+     * Sets the {@link Thread#getContextClassLoader() Thread Context Class Loader} to the one for this class, and then calls {@link #executeWithContextClassloader()}. This is done because the JCS cache needs to have the Thread Context Class Loader set to something that can resolve it's classes. Other build tools do this by default but Ant does not.
+     *
+     * @throws BuildException throws if there is a problem. See {@link #executeWithContextClassloader()} for details
+     */
+    @Override
+    public final void execute() throws BuildException {
+        ClassLoader current = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+
+            executeWithContextClassloader();
+        } finally {
+            Thread.currentThread().setContextClassLoader(current);
+        }
+    }
+
+    /**
      * Executes the dependency-check purge to delete the existing local copy of
      * the NVD CVE data.
      *
@@ -112,8 +136,7 @@ public class Purge extends Task {
      */
     //see note on `Check.dealWithReferences()` for information on this suppression
     @SuppressWarnings("squid:RedundantThrowsDeclarationCheck")
-    @Override
-    public void execute() throws BuildException {
+    protected void executeWithContextClassloader() throws BuildException {
         populateSettings();
         try (Engine engine = new Engine(Engine.Mode.EVIDENCE_PROCESSING, getSettings())) {
             engine.purge();

--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Update.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Update.java
@@ -440,7 +440,7 @@ public class Update extends Purge {
     //see note on `Check.dealWithReferences()` for information on this suppression
     @SuppressWarnings("squid:RedundantThrowsDeclarationCheck")
     @Override
-    public void execute() throws BuildException {
+    protected void executeWithContextClassloader() throws BuildException {
         populateSettings();
         try (Engine engine = new Engine(Update.class.getClassLoader(), getSettings())) {
             engine.doUpdates();


### PR DESCRIPTION
Issue: #3666

## Fixes Issue #

## Description of Change

Adds a context class loader to all the ant tasks. Other build tools set the ContextClassLoader property on the current Thread instance before calling into the plugin, ant does not.

The JCS library has some logic down in it's deserializer which finds the classloader to use. If it used the 'default' one this would work; but since it uses the Context Class Loader it fails since that classloader is something else.

## Have test cases been added to cover the new functionality?

*no*