### PR TITLE
fix: automation should use conventional commits

### DIFF
--- a/.github/workflows/false-positive-approvals.yml
+++ b/.github/workflows/false-positive-approvals.yml
@@ -129,7 +129,7 @@ jobs:
                 if (err) throw err;
               });
 
-              execSync('git commit -m "' + commitComment + '" generatedSuppressions.xml;git push origin generatedSuppressions', (err, stdout, stderr) => {
+              execSync('git commit -m "fix(fp): ' + commitComment + '" generatedSuppressions.xml;git push origin generatedSuppressions', (err, stdout, stderr) => {
                 if (err) throw err;
                 console.log('committed suppression rule');
               });

--- a/pom.xml
+++ b/pom.xml
@@ -789,6 +789,7 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
+                    <scmCommentPrefix>build:</scmCommentPrefix>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                     <arguments>-Dmaven.javadoc.skip=true -DskipTests -DskipITs</arguments>
                     <updateWorkingCopyVersions>true</updateWorkingCopyVersions>


### PR DESCRIPTION
While I'm not perfect with this - I've been trying to follow conventional commits: https://www.conventionalcommits.org/en/v1.0.0/

This PR updates the release plugin to use conventional commit prefix when making commits during the release process.