### PR TITLE
fix(FP): Several false positive resolutions not supported by our automation

### DIFF
--- a/core/src/main/resources/data/dbEcosystemCacheUpdates.sql
+++ b/core/src/main/resources/data/dbEcosystemCacheUpdates.sql
@@ -1,2 +1,2 @@
-UPDATE cpeEcosystemCache set ecosystem='MULTIPLE' where vendor = 'apache' and product = 'hadoop';
-UPDATE cpeEcosystemCache set ecosystem='MULTIPLE' where vendor = 'apache' and product = 'ranger';
+UPDATE cpeEcosystemCache set ecosystem='MULTIPLE' where vendor = 'apache' and product = 'hadoop' and ecosystem != 'MULTIPLE';
+UPDATE cpeEcosystemCache set ecosystem='MULTIPLE' where vendor = 'apache' and product = 'ranger' and ecosystem != 'MULTIPLE';

--- a/core/src/main/resources/data/dbEcosystemCacheUpdates.sql
+++ b/core/src/main/resources/data/dbEcosystemCacheUpdates.sql
@@ -1,1 +1,2 @@
 UPDATE cpeEcosystemCache set ecosystem='MULTIPLE' where vendor = 'apache' and product = 'hadoop';
+UPDATE cpeEcosystemCache set ecosystem='MULTIPLE' where vendor = 'apache' and product = 'ranger';

--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -457,4 +457,13 @@
             <evidence type="product" source="hint analyzer" name="product" value="xerces-j" confidence="HIGHEST"/>
         </add>
     </hint>
+    <hint>
+        <!-- false negative per issue #4930 -->
+        <given>
+            <evidence type="product" source="pom" name="parent-artifactid" value="parquet"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="parquet-mr" confidence="HIGH"/>
+        </add>
+    </hint>
 </hints>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -296,8 +296,8 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4160
-   ]]></notes>
+        FP per issue #4160
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/.*vertx-pg-client@.*$</packageUrl>
         <cpe>cpe:/a:postgresql:postgresql</cpe>
     </suppress>
@@ -812,7 +812,7 @@
     <suppress base="true">
         <notes><![CDATA[
         Suppresses false positive per #3827 - this library is not the github.com/containers/storage project
-   ]]></notes>
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.smallrye/smallrye\-context\-propagation\-storage@.*$</packageUrl>
         <cpe>cpe:/a:storage_project:storage</cpe>
     </suppress>
@@ -1410,8 +1410,8 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       FP per #2571
-       ]]></notes>
+        FP per #2571
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast\-client\-protocol@.*$</packageUrl>
         <cpe>cpe:/a:hazelcast:hazelcast</cpe>
     </suppress>
@@ -2253,8 +2253,8 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4310
-   ]]></notes>
+        FP per issue #4310
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/.*$</packageUrl>
         <cpe>cpe:/a:eclipse:eclipse_ide</cpe>
     </suppress>
@@ -2333,7 +2333,7 @@
     <suppress base="true">
         <notes><![CDATA[
             These CVEs only affect jackson-dataformat-xml. See issue #517, #751, and #792.
-      ]]></notes>
+        ]]></notes>
         <gav regex="true">(org\.codehaus\.jackson|com\.fasterxml\.jackson\.(core|module|datatype|jaxrs)):jackson.*</gav>
         <cve>CVE-2016-3720</cve>
         <cve>CVE-2016-7051</cve>
@@ -2348,14 +2348,14 @@
     <suppress base="true">
         <notes><![CDATA[
         jackson-dataformat-avro/cbor/ion/protobuf/smile are cpe:/a:fasterxml:jackson-dataformat-binary
-   ]]></notes>
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.dataformat/jackson\-dataformat\-(ion|cbor|avro|protobuf|smile)@.*$</packageUrl>
         <cpe>cpe:/a:fasterxml:jackson-dataformat-xml</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
            These only apply to the jackson-dataformat-cbor sub-module
-   ]]></notes>
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.dataformat/jackson\-dataformat(?!\-cbor).*@.*$</packageUrl>
         <cve>CVE-2020-28491</cve>
     </suppress>
@@ -2386,16 +2386,16 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       False positives on python.
-       ]]></notes>
+        False positives on python.
+        ]]></notes>
         <filePath regex="true">.*__init__\.py$</filePath>
         <cpe>cpe:/a:shim:shim</cpe>
         <cpe>cpe:/a:python:python</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       False positives per #1314.
-       ]]></notes>
+        False positives per #1314.
+        ]]></notes>
         <filePath regex="true">.*PKG-INFO$</filePath>
         <cpe>cpe:/a:nodejs:nodejs</cpe>
         <cpe>cpe:/a:nodejs:node.js</cpe>
@@ -2409,8 +2409,8 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       Bouncy Castle Time Stamp Protocol is not related to openpgp.
-       ]]></notes>
+        Bouncy Castle Time Stamp Protocol is not related to openpgp.
+        ]]></notes>
         <gav regex="true">^org\.bouncycastle:bctsp.*$</gav>
         <cpe>cpe:/a:openpgp:openpgp</cpe>
         <cpe>cpe:/a:pgp:openpgp</cpe>
@@ -2418,8 +2418,8 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       Apache XML Graphics is used by Batik - but should not be identified as batik.
-       ]]></notes>
+        Apache XML Graphics is used by Batik - but should not be identified as batik.
+        ]]></notes>
         <gav regex="true">^org\.apache\.xmlgraphics:xmlgraphics-commons:.*$</gav>
         <cpe>cpe:/a:apache:batik</cpe>
     </suppress>
@@ -4581,30 +4581,30 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       FP per issue #4140, 4256
-       ]]></notes>
+        FP per issue #4140, 4256
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.aspectj/aspectj.*@.*$</packageUrl>
         <cpe>cpe:/a:vmware:tools</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       FP per issue #4149
-       ]]></notes>
+        FP per issue #4149
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.kafka/kafka-log4j-appender@.*$</packageUrl>
         <cpe>cpe:/a:apache:log4j</cpe>
         <cpe>cpe:/a:apache:kafka</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       FP per issue #4156
-       ]]></notes>
+        FP per issue #4156
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.lightbend\.akka\.management/akka-management-cluster-bootstrap_2\.13@.*$</packageUrl>
         <cpe>cpe:/a:akka:akka</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       FP per issue #4154, #4776
-       ]]></notes>
+        FP per issue #4154, #4776
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty-tcnative-boringssl-static@.*$</packageUrl>
         <cpe>cpe:/a:chromium:chromium</cpe>
         <cpe>cpe:/a:chromium_project:chromium</cpe>
@@ -4655,7 +4655,7 @@
     <suppress base="true">
         <notes><![CDATA[
           log4cats-core_2.13-2.2.0.jar FPs #4295
-   ]]></notes>
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.typelevel/log4cats\-core_2\.13@.*$</packageUrl>
         <cpe>cpe:/a:davenport:davenport</cpe>
         <cpe>cpe:/a:protonmail:protonmail</cpe>
@@ -4663,35 +4663,35 @@
     <suppress base="true">
         <notes><![CDATA[
           FP CPE match per #4289
-   ]]></notes>
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.bouncycastle/bc\-fips@.*$</packageUrl>
         <cpe>cpe:/a:bouncycastle:legion-of-the-bouncy-castle:</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
         FP per issue #4239 - jackson-jaxrs (jackson-jaxrs-json-provider) is not jackson-databind
-   ]]></notes>
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson-jaxrs@.*$</packageUrl>
         <cpe>cpe:/a:fasterxml:jackson-databind</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4228
-   ]]></notes>
+        FP per issue #4228
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.minio/minio@.*$</packageUrl>
         <cpe>cpe:/a:minio:minio</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4227 simple-xml-safe is a security-patched fork of the unmaintained simple-xml
-   ]]></notes>
+        FP per issue #4227 simple-xml-safe is a security-patched fork of the unmaintained simple-xml
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.carrotsearch\.thirdparty/simple-xml-safe@.*$</packageUrl>
         <cpe>cpe:/a:simplexml_project:simplexml</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
         FP per issue #4208 suppress CVE for explicit version as CPE 'update' field is not supported and CVE is only for the 5.1 beta-1
-   ]]></notes>
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast@(?!5\.1-BETA-1).*$</packageUrl>
         <cve>CVE-2022-0265</cve>
     </suppress>
@@ -4704,22 +4704,22 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4316
-   ]]></notes>
+        FP per issue #4316
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/ch\.qos\.reload4j/reload4j@.*$</packageUrl>
         <cpe>cpe:/a:apache:log4j</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4317
-   ]]></notes>
+        FP per issue #4317
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.mattbertolini/liquibase-slf4j@.*$</packageUrl>
         <cpe>cpe:/a:liquibase:liquibase</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4344
-   ]]></notes>
+        FP per issue #4344
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.pinterest\.ktlint/ktlint-reporter-checkstyle@.*$</packageUrl>
         <cpe>cpe:/a:checkstyle:checkstyle</cpe>
     </suppress>
@@ -4755,46 +4755,46 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       FP per issue #4427; struts-legacy is a very minimal subset of 2 generic utility classes
-       split off from strutsv1, not the struts framework itself
-   ]]></notes>
+            FP per issue #4427; struts-legacy is a very minimal subset of 2 generic utility classes
+            split off from strutsv1, not the struts framework itself
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/struts/struts-legacy@.*$</packageUrl>
         <cpe>cpe:/a:apache:struts</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4386
-   ]]></notes>
+        FP per issue #4386
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/(org\.apache\.)?ant/ant\-apache\-log4j@.*$</packageUrl>
         <cpe>cpe:/a:apache:ant</cpe>
         <cpe>cpe:/a:apache:log4j</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4382
-   ]]></notes>
+        FP per issue #4382
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.swagger\.codegen\.v3/swagger-codegen-generators@.*$</packageUrl>
         <cpe>cpe:/a:swagger:swagger-codegen</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4168; as we lack support for the target_sw field suppress the CVE of the python agent
-   ]]></notes>
+        FP per issue #4168; as we lack support for the target_sw field suppress the CVE of the python agent
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/co\.elastic\.apm/apm-agent.*$</packageUrl>
         <cve>CVE-2019-7617</cve>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4061; also added firebird which suffers from a similar FP
-   ]]></notes>
+        FP per issue #4061; also added firebird which suffers from a similar FP
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.flywaydb/.*$</packageUrl>
         <cpe>cpe:/a:mysql:mysql</cpe>
         <cpe>cpe:/a:firebird:firebird</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4016; ratpack-pac4j is neither pac4j nor ratpack, but a bridge library with its own release schedule
-   ]]></notes>
+        FP per issue #4016; ratpack-pac4j is neither pac4j nor ratpack, but a bridge library with its own release schedule
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.pac4j/ratpack\-pac4j@.*$</packageUrl>
         <cpe>cpe:/a:pac4j:pac4j</cpe>
         <cpe>cpe:/a:ratpack:ratpack</cpe>
@@ -4802,29 +4802,29 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4440
-   ]]></notes>
+        FP per issue #4440
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.activemq/activeio\-core@.*$</packageUrl>
         <cpe>cpe:/a:apache:activemq</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4445
-   ]]></notes>
+        FP per issue #4445
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.rxtx/rxtx@.*$</packageUrl>
         <cpe>cpe:/a:gnu:parallel</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4465
-   ]]></notes>
+        FP per issue #4465
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.iq80\.snappy/snappy@.*$</packageUrl>
         <cpe>cpe:/a:electrum:electrum</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4462, #4463, #4464; akka management modules are separate from akka core (and from the non-core akka HTTP modules)
-   ]]></notes>
+        FP per issue #4462, #4463, #4464; akka management modules are separate from akka core (and from the non-core akka HTTP modules)
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.lightbend\.akka\.management/akka\-.*@.*$</packageUrl>
         <cpe>cpe:/a:akka:akka</cpe>
         <cpe>cpe:/a:lightbend:akka</cpe>
@@ -4833,53 +4833,53 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4461 akka management discovery modules are separate from akka core
-   ]]></notes>
+        FP per issue #4461 akka management discovery modules are separate from akka core
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.lightbend\.akka\.discovery/akka\-.*@.*$</packageUrl>
         <cpe>cpe:/a:akka:akka</cpe>
         <cpe>cpe:/a:lightbend:akka</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4442; Eclipse Orbit is bundling thirdparty libraries as OSGI bundle, so org.eclipse.jetty.orbit libs
-   should not be linked to Jetty
-   ]]></notes>
+        FP per issue #4442; Eclipse Orbit is bundling thirdparty libraries as OSGI bundle, so org.eclipse.jetty.orbit libs
+        should not be linked to Jetty
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.orbit/.*$</packageUrl>
         <cpe>cpe:/a:jetty:jetty</cpe>
         <cpe>cpe:/a:eclipse:jetty</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4439
-   ]]></notes>
+        FP per issue #4439
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.google\.cloud/spring-cloud-gcp-starter-sql-postgresql@.*$</packageUrl>
         <cpe>cpe:/a:postgresql:postgresql</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4435; Sarif4k is not the Kotlin static analyzer Detekt
-   ]]></notes>
+        FP per issue #4435; Sarif4k is not the Kotlin static analyzer Detekt
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.github\.detekt\.sarif4k/sarif4k@.*$</packageUrl>
         <cpe>cpe:/a:detekt:detekt</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4263; prince-java-wrapper is an independently versioned wrapper to call the princeXML binary
-   ]]></notes>
+        FP per issue #4263; prince-java-wrapper is an independently versioned wrapper to call the princeXML binary
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.princexml/prince-java-wrapper@.*$</packageUrl>
         <cpe>cpe:/a:princexml:princexml</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4487,    FP per issue #4551
-   ]]></notes>
+        FP per issue #4487,    FP per issue #4551
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.google\.(?!code\.gson).*/.*gson.*$</packageUrl>
         <cpe>cpe:/a:google:gson</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4490; Datastax driver for Cassandra is not part of the Cassandra project
-   ]]></notes>
+        FP per issue #4490; Datastax driver for Cassandra is not part of the Cassandra project
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.datastax\.cassandra/cassandra-driver-core@.*$</packageUrl>
         <cpe>cpe:/a:apache:cassandra</cpe>
     </suppress>
@@ -4925,69 +4925,69 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4514
-   ]]></notes>
+        FP per issue #4514
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.axis2/axis2-xmlbeans@.*$</packageUrl>
         <cpe>cpe:/a:apache:xmlbeans</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4518; http-swagger is a SwagGo Go-librarie, not one of the swagger.io libraries
-   ]]></notes>
+        FP per issue #4518; http-swagger is a SwagGo Go-librarie, not one of the swagger.io libraries
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.swagger/.*$</packageUrl>
         <cpe>cpe:/a:http-swagger_project:http-swagger</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4560. Tomcat jakartaee-migration utility is other project than Apache Tomcat itself
-   ]]></notes>
+        FP per issue #4560. Tomcat jakartaee-migration utility is other project than Apache Tomcat itself
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat/jakartaee-migration@.*$</packageUrl>
         <cpe>cpe:/a:apache:tomcat</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4554; archiver_project:archiver is a go-module, not the NPM package
-   ]]></notes>
+        FP per issue #4554; archiver_project:archiver is a go-module, not the NPM package
+        ]]></notes>
         <packageUrl regex="true">^pkg:npm/archiver@.*$</packageUrl>
         <cpe>cpe:/a:archiver_project:archiver</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4540
-   ]]></notes>
+        FP per issue #4540
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/tyrex/tyrex@.*$</packageUrl>
         <cpe>cpe:/a:sun:j2ee</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
         FP per issue #4524; Zipkin Brave-aws is not the Brave desktop browser
-   ]]></notes>
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.zipkin\.aws/brave-propagation-aws@.*$</packageUrl>
         <cpe>cpe:/a:brave:brave</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
             FP per issue #4205;
-   ]]></notes>
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.quarkus/quarkus-micrometer-registry-prometheus@.*$</packageUrl>
         <cpe>cpe:/a:prometheus:prometheus</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
             FP per issue #3888;
-   ]]></notes>
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.activemq/activemq\-artemis\-native@.*$</packageUrl>
         <cpe>cpe:/a:apache:activemq</cpe>
         <cpe>cpe:/a:apache:activemq_artemis</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       Spring-framework libraries always have groupId org.springframework with no further extension, so suppress the
-       spring_framework CPE on other Spring libraries
-       Fixes FPs of #4364, #4363, #4362, 4353, #4351, #4350, #4349
-       Also replaces pre-existing suppressions of Spring-framework for #1566, #3580, #3749, #3738, #1027, #1328, #1921,
-       #642, #700, #3579, #1399, #1060
-       ]]></notes>
+        Spring-framework libraries always have groupId org.springframework with no further extension, so suppress the
+        spring_framework CPE on other Spring libraries
+        Fixes FPs of #4364, #4363, #4362, 4353, #4351, #4350, #4349
+        Also replaces pre-existing suppressions of Spring-framework for #1566, #3580, #3749, #3738, #1027, #1328, #1921,
+        #642, #700, #3579, #1399, #1060
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\..*$</packageUrl>
         <cpe>cpe:/a:springsource:spring_framework</cpe>
         <cpe>cpe:/a:pivotal:spring_framework</cpe>
@@ -4998,8 +4998,8 @@
     <!-- region Spring-security suppressions -->
     <suppress base="true">
         <notes><![CDATA[
-       False positive per #3622, #4561. Spring-boot-starter-oauth2-client gets flagged with wrong spring CPEs.
-   ]]></notes>
+        False positive per #3622, #4561. Spring-boot-starter-oauth2-client gets flagged with wrong spring CPEs.
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot\-starter\-oauth2\-client@.*$</packageUrl>
         <cpe>cpe:/a:pivotal:spring_security_oauth</cpe>
         <cpe>cpe:/a:pivotal:spring_security</cpe>
@@ -5059,8 +5059,8 @@
 
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4576; spring-security-saml2-core is an (end-of-life) extension project separate from spring-security https://github.com/spring-projects/spring-security-saml
-   ]]></notes>
+        FP per issue #4576; spring-security-saml2-core is an (end-of-life) extension project separate from spring-security https://github.com/spring-projects/spring-security-saml
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.security\.extensions/spring-security-saml2-core@.*$</packageUrl>
         <cpe>cpe:/a:saml_project:saml</cpe>
         <cpe>cpe:/a:vmware:spring_security</cpe>
@@ -5088,8 +5088,8 @@
 
     <suppress base="true">
         <notes><![CDATA[
-       Supress false positives per issue #1872, #4577
-       ]]></notes>
+        Supress false positives per issue #1872, #4577
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.security\.oauth/spring-security-oauth2@.*$</packageUrl>
         <cpe>cpe:/a:pivotal_software:spring_security</cpe>
         <cpe>cpe:/a:vmware:spring_security</cpe>
@@ -5132,7 +5132,7 @@
     <suppress base="true">
         <notes><![CDATA[
         FP per issue #3811
-   ]]></notes>
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.ws/spring\-ws\-security@.*$</packageUrl>
         <cpe>cpe:/a:vmware:spring_security</cpe>
         <cpe>cpe:/a:pivotal_software:spring_security</cpe>
@@ -5141,8 +5141,8 @@
     <!-- region Spring suppressions -->
     <suppress base="true">
         <notes><![CDATA[
-   FP per issues #4581, #4582
-   ]]></notes>
+        FP per issues #4581, #4582
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.cloud/spring-cloud-dataflow-rest-.*$</packageUrl>
         <cpe>cpe:/a:vmware:spring_data_rest</cpe>
         <cpe>cpe:/a:pivotal_software:spring_data_rest</cpe>
@@ -5178,10 +5178,10 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       False positive per #1513. Spring-boot-starter-data-rest is not data-rest (however, it does
+        False positive per #1513. Spring-boot-starter-data-rest is not data-rest (however, it does
            depend on spring-data-rest so the actual library will get flagged instead of the "boot" version
            being flagged as spring-data-rest with the wrong version number)
-       ]]></notes>
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring-boot-starter-data-rest@.*$</packageUrl>
         <cpe>cpe:/a:pivotal_software:spring_data_rest</cpe>
         <cpe>cpe:/a:pivotal_software:spring_boot</cpe>
@@ -5301,8 +5301,8 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       spring ldap cleanup per issue #1060
-       ]]></notes>
+        spring ldap cleanup per issue #1060
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.ldap/spring-ldap-core@.*$</packageUrl>
         <cpe>cpe:/a:net-ldap_project:net-ldap</cpe>
     </suppress>
@@ -5323,20 +5323,20 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       FP per issue #4152
-       ]]></notes>
+        FP per issue #4152
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.cloud/spring-cloud-kubernetes-fabric8-config@.*$</packageUrl>
         <cpe>cpe:/a:vmware:spring_cloud_config</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4509; Issue is in spring-web and will only be fixed by Spring in their next major release.
-   So suppressing it for the spring-framework components other than spring-web is an appropriate
-   exception to the basic policy of not micromanaging spring_framework vulnerabilities by library
-   in our suppressions.
-   https://github.com/spring-projects/spring-framework/issues/25379 (deprecation only in current 5.x versions)
-   https://github.com/spring-projects/spring-framework/commit/5822f1bf85b94fd15f9829914b065b1c61910c7d (removal in 6.0.0-M1)
-   ]]></notes>
+        FP per issue #4509; Issue is in spring-web and will only be fixed by Spring in their next major release.
+        So suppressing it for the spring-framework components other than spring-web is an appropriate
+        exception to the basic policy of not micromanaging spring_framework vulnerabilities by library
+        in our suppressions.
+        https://github.com/spring-projects/spring-framework/issues/25379 (deprecation only in current 5.x versions)
+        https://github.com/spring-projects/spring-framework/commit/5822f1bf85b94fd15f9829914b065b1c61910c7d (removal in 6.0.0-M1)
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/(?!org\.springframework/spring\-web@).*$</packageUrl>
         <cve>CVE-2016-1000027</cve>
     </suppress>
@@ -5725,168 +5725,168 @@
     <suppress base="true">
         <notes><![CDATA[
            FP per issue https://github.com/jeremylong/DependencyCheck/issues/5060
-       ]]></notes>
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.msgpack/.*@.*$</packageUrl>
         <cpe>cpe:/a:messagepack_project:messagepack</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #5038
-   ]]></notes>
+        FP per issue #5038
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.locationtech\.spatial4j/spatial4j@.*$</packageUrl>
         <cpe>cpe:/a:pro_search:pro_search</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #5037
-   ]]></notes>
+        FP per issue #5037
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.ko-sys\.av/airac@.*$</packageUrl>
         <cpe>cpe:/a:keybase:keybase</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #5027
-   ]]></notes>
+        FP per issue #5027
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/software\.aws\.rds/aws-mysql-jdbc@.*$</packageUrl>
         <cpe>cpe:/a:mysql:mysql</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #5024
-   ]]></notes>
+        FP per issue #5024
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/net\.openhft/chronicle-wire@.*$</packageUrl>
         <cpe>cpe:/a:wire:wire</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #5022
-   ]]></notes>
+        FP per issue #5022
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.zendesk/mysql-binlog-connector-java@.*$</packageUrl>
         <cpe>cpe:/a:mysql:mysql</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #5021
-   ]]></notes>
+        FP per issue #5021
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.debezium/debezium-connector-mysql@.*$</packageUrl>
         <cpe>cpe:/a:mysql:mysql</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4944
-   ]]></notes>
+        FP per issue #4944
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase-zookeeper@.*$</packageUrl>
         <cpe>cpe:/a:apache:zookeeper</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4949
-   ]]></notes>
+        FP per issue #4949
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.curioswitch\.curiostack/protobuf-jackson@.*$</packageUrl>
         <cpe>cpe:/a:grpc:grpc</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #5014
-   ]]></notes>
+        FP per issue #5014
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.ejbca\.cvc/cert-cvc@.*$</packageUrl>
         <cpe>cpe:/a:primekey:ejbca</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4952
-   ]]></notes>
+        FP per issue #4952
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.twill/twill-zookeeper@.*$</packageUrl>
         <cpe>cpe:/a:apache:zookeeper</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4948
-   ]]></notes>
+        FP per issue #4948
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.opentracing\.contrib/opentracing-grpc@.*$</packageUrl>
         <cpe>cpe:/a:grpc:grpc</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4947
-   ]]></notes>
+        FP per issue #4947
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.pf4j/pf4j@.*$</packageUrl>
         <cpe>cpe:/a:sonatype:nexus</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4946
-   ]]></notes>
+        FP per issue #4946
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.iceberg/iceberg-hive-metastore@.*$</packageUrl>
         <cpe>cpe:/a:apache:hive</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4942
-   ]]></notes>
+        FP per issue #4942
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase-hadoop-compat@.*$</packageUrl>
         <cpe>cpe:/a:apache:hadoop</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4941
-   ]]></notes>
+        FP per issue #4941
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.flink/flink-rpc-akka-loader@.*$</packageUrl>
         <cpe>cpe:/a:akka:akka</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4940
-   ]]></notes>
+        FP per issue #4940
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.flink/flink-hadoop-fs@.*$</packageUrl>
         <cpe>cpe:/a:apache:hadoop</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4931
-   ]]></notes>
+        FP per issue #4931
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.azure\.resourcemanager/azure-resourcemanager-appplatform@.*$</packageUrl>
         <cpe>cpe:/a:microsoft:platform_sdk</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4720
-   ]]></notes>
+        FP per issue #4720
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.clojure/data\.priority-map@.*$</packageUrl>
         <cpe>cpe:/a:priority-software:priority</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4693
-   ]]></notes>
+        FP per issue #4693
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.zipkin\.reporter2/zipkin-reporter@.*$</packageUrl>
         <cpe>cpe:/a:pki-core_project:pki-core</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4692
-   ]]></notes>
+        FP per issue #4692
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.zipkin\.zipkin2/zipkin@.*$</packageUrl>
         <cpe>cpe:/a:pki-core_project:pki-core</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4669
-   ]]></notes>
+        FP per issue #4669
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.junit\.jupiter/junit-jupiter-engine@.*$</packageUrl>
         <cpe>cpe:/a:fan_platform_project:fan_platform</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #5017
-   ]]></notes>
+        FP per issue #5017
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.google\.api\.grpc/grpc-google-iam-v1@.*$</packageUrl>
         <cpe>cpe:/a:grpc:grpc</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4681
-   ]]></notes>
+        FP per issue #4681
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws-java-sdk-prometheus@.*$</packageUrl>
         <cpe>cpe:/a:prometheus:prometheus</cpe>
     </suppress>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5674,4 +5674,11 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.ranger/ranger\-hive\-plugin@.*$</packageUrl>
         <cpe>cpe:/a:apache:hive</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP CPE match per issue #4945
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.hive/hive\-hbase\-handler@.*$</packageUrl>
+        <cpe>cpe:/a:apache:hbase</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5688,4 +5688,12 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase\-server@.*$</packageUrl>
         <cpe>cpe:/a:apache:http_server</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #2575, #4820
+        ]]></notes>
+        <packageUrl regex="true">^pkg:cocoapods/GoogleUtilities%2FAppDelegateSwizzler@.*$</packageUrl>
+        <cpe>cpe:/a:app_project:app</cpe>
+        <cpe>cpe:/a:delegate:delegate</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5666,4 +5666,11 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.twill/twill\-yarn@.*$</packageUrl>
         <cpe>cpe:/a:apache:hadoop</cpe>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        FP per issue #4950
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.ranger/ranger\-hive\-plugin@.*$</packageUrl>
+        <cpe>cpe:/a:apache:hive</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5654,8 +5654,8 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-   FP per issue #4953 regex to match both hive-spark-client and the historical spark-client artifactIds
-   ]]></notes>
+        FP per issue #4953 regex to match both hive-spark-client and the historical spark-client artifactIds
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.hive/.*spark\-client@.*$</packageUrl>
         <cpe>cpe:/a:apache:spark</cpe>
     </suppress>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5666,7 +5666,7 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.twill/twill\-yarn@.*$</packageUrl>
         <cpe>cpe:/a:apache:hadoop</cpe>
     </suppress>
-    <suppress>
+    <suppress base="true">
         <notes><![CDATA[
         FP per issue #4950
         ]]></notes>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5708,4 +5708,18 @@
         <cpe>cpe:/a:vmware:server</cpe>
         <cpe>cpe:/a:vmware:vmware_server</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4667
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/tailrecursion/cljs\-priority\-map@.*$</packageUrl>
+        <cpe>cpe:/a:priority-software:priority</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4667
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.clojure/data\.priority\-map@.*$</packageUrl>
+        <cpe>cpe:/a:priority-software:priority</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5659,4 +5659,11 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.hive/.*spark\-client@.*$</packageUrl>
         <cpe>cpe:/a:apache:spark</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4951
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.twill/twill\-yarn@.*$</packageUrl>
+        <cpe>cpe:/a:apache:hadoop</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5722,4 +5722,172 @@
         <packageUrl regex="true">^pkg:maven/org\.clojure/data\.priority\-map@.*$</packageUrl>
         <cpe>cpe:/a:priority-software:priority</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+           FP per issue https://github.com/jeremylong/DependencyCheck/issues/5060
+       ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.msgpack/.*@.*$</packageUrl>
+        <cpe>cpe:/a:messagepack_project:messagepack</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5038
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.locationtech\.spatial4j/spatial4j@.*$</packageUrl>
+        <cpe>cpe:/a:pro_search:pro_search</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5037
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.ko-sys\.av/airac@.*$</packageUrl>
+        <cpe>cpe:/a:keybase:keybase</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5027
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/software\.aws\.rds/aws-mysql-jdbc@.*$</packageUrl>
+        <cpe>cpe:/a:mysql:mysql</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5024
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/net\.openhft/chronicle-wire@.*$</packageUrl>
+        <cpe>cpe:/a:wire:wire</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5022
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.zendesk/mysql-binlog-connector-java@.*$</packageUrl>
+        <cpe>cpe:/a:mysql:mysql</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5021
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.debezium/debezium-connector-mysql@.*$</packageUrl>
+        <cpe>cpe:/a:mysql:mysql</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4944
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase-zookeeper@.*$</packageUrl>
+        <cpe>cpe:/a:apache:zookeeper</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4949
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.curioswitch\.curiostack/protobuf-jackson@.*$</packageUrl>
+        <cpe>cpe:/a:grpc:grpc</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5014
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.ejbca\.cvc/cert-cvc@.*$</packageUrl>
+        <cpe>cpe:/a:primekey:ejbca</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4952
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.twill/twill-zookeeper@.*$</packageUrl>
+        <cpe>cpe:/a:apache:zookeeper</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4948
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.opentracing\.contrib/opentracing-grpc@.*$</packageUrl>
+        <cpe>cpe:/a:grpc:grpc</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4947
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.pf4j/pf4j@.*$</packageUrl>
+        <cpe>cpe:/a:sonatype:nexus</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4946
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.iceberg/iceberg-hive-metastore@.*$</packageUrl>
+        <cpe>cpe:/a:apache:hive</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4942
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase-hadoop-compat@.*$</packageUrl>
+        <cpe>cpe:/a:apache:hadoop</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4941
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.flink/flink-rpc-akka-loader@.*$</packageUrl>
+        <cpe>cpe:/a:akka:akka</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4940
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.flink/flink-hadoop-fs@.*$</packageUrl>
+        <cpe>cpe:/a:apache:hadoop</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4931
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.azure\.resourcemanager/azure-resourcemanager-appplatform@.*$</packageUrl>
+        <cpe>cpe:/a:microsoft:platform_sdk</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4720
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.clojure/data\.priority-map@.*$</packageUrl>
+        <cpe>cpe:/a:priority-software:priority</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4693
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.zipkin\.reporter2/zipkin-reporter@.*$</packageUrl>
+        <cpe>cpe:/a:pki-core_project:pki-core</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4692
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.zipkin\.zipkin2/zipkin@.*$</packageUrl>
+        <cpe>cpe:/a:pki-core_project:pki-core</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4669
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.junit\.jupiter/junit-jupiter-engine@.*$</packageUrl>
+        <cpe>cpe:/a:fan_platform_project:fan_platform</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5017
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.api\.grpc/grpc-google-iam-v1@.*$</packageUrl>
+        <cpe>cpe:/a:grpc:grpc</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4681
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws-java-sdk-prometheus@.*$</packageUrl>
+        <cpe>cpe:/a:prometheus:prometheus</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5681,4 +5681,11 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.hive/hive\-hbase\-handler@.*$</packageUrl>
         <cpe>cpe:/a:apache:hbase</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4943
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase\-server@.*$</packageUrl>
+        <cpe>cpe:/a:apache:http_server</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5638,4 +5638,11 @@
         <packageUrl regex="true">^pkg:maven/com\.github\.pagehelper/pagehelper-spring-boot-starter@.*$</packageUrl>
         <cpe>cpe:/a:pagehelper_project:pagehelper</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue#4999
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.opentracing\.contrib/opentracing\-elasticsearch.*@.*$</packageUrl>
+        <cpe>cpe:/a:elasticsearch:elasticsearch</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5696,4 +5696,16 @@
         <cpe>cpe:/a:app_project:app</cpe>
         <cpe>cpe:/a:delegate:delegate</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4737, adding two more false CPE matches that were not yet reported
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-oauth2\-authorization\-server@.*$</packageUrl>
+        <cpe>cpe:/a:pivotal:spring_security_oauth</cpe>
+        <cpe>cpe:/a:pivotal_software:spring_security</cpe>
+        <cpe>cpe:/a:pivotal_software:spring_security_oauth</cpe>
+        <cpe>cpe:/a:vmware:spring_security</cpe>
+        <cpe>cpe:/a:vmware:server</cpe>
+        <cpe>cpe:/a:vmware:vmware_server</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5652,4 +5652,11 @@
         <packageUrl regex="true">^pkg:maven/com\.otaliastudios/zoomlayout@.*$</packageUrl>
         <cpe>cpe:/a:zoom:zoom</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #4953 regex to match both hive-spark-client and the historical spark-client artifactIds
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.hive/.*spark\-client@.*$</packageUrl>
+        <cpe>cpe:/a:apache:spark</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5645,4 +5645,11 @@
         <packageUrl regex="true">^pkg:maven/io\.opentracing\.contrib/opentracing\-elasticsearch.*@.*$</packageUrl>
         <cpe>cpe:/a:elasticsearch:elasticsearch</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #4984
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.otaliastudios/zoomlayout@.*$</packageUrl>
+        <cpe>cpe:/a:zoom:zoom</cpe>
+    </suppress>
 </suppressions>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5044,6 +5044,7 @@
         <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring-security-jwt.*$</packageUrl>
         <cpe>cpe:/a:vmware:springsource_spring_security</cpe>
         <cpe>cpe:/a:vmware:spring_security</cpe>
+        <cpe>cpe:/a:pivotal_software:spring_security</cpe>
         <cpe>cpe:/a:security-framework_project:security-framework</cpe>
     </suppress>
     <suppress base="true">


### PR DESCRIPTION
## Fixes Multiple FP Issues:
* fixes Issue #4999
* fixes Issue #4984
* fixes issue #4953
* fixes issue #4950 (including resolving the false-negatives for the proper ranger CPE (which was native in ecoSystemCache/cpeEntry)
* fixes issue #5073
* fixes issue #5045
* fixes issue #4827
* fixes issue #4945
* fixes issue #4943
* fixes issue #4820 
* fixes issue #4930
* fixes issue #4737
* fixes issue #4667

## Description of Change

Adds suppressions that fp-ops was not capable of generating and integrates the automatically generated suppressions up to now. Includes a code-fix for the ecosystem-cache (#5073)

## Have test cases been added to cover the new functionality?

no