### PR TITLE
fix: prevent duplicate, non-built (reactor) virtual dependencies

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -259,7 +259,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @return the dependency added; in the case of virtual dependencies this
      * may not be the same as the dependency passed in as an argument
      */
-    public synchronized Dependency addDependency(Dependency dependency) {
+    public synchronized void addDependency(Dependency dependency) {
         if (dependency.isVirtual()) {
             for (Dependency existing : dependencies) {
                 if (existing.isVirtual()
@@ -269,13 +269,12 @@ public class Engine implements FileFilter, AutoCloseable {
                         && existing.getDisplayFileName().equals(dependency.getDisplayFileName())
                         && identifiersMatch(existing.getSoftwareIdentifiers(), dependency.getSoftwareIdentifiers())) {
                     DependencyBundlingAnalyzer.mergeDependencies(existing, dependency, null);
-                    return existing;
+                    return;
                 }
             }
         }
         dependencies.add(dependency);
         dependenciesExternalView = null;
-        return dependency;
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -252,8 +252,8 @@ public class Engine implements FileFilter, AutoCloseable {
 
     /**
      * Adds a dependency. In some cases, when adding a virtual dependency, the
-     * method will identify if the virtual dependency was previously added and
-     * if so the existing dependency will be returned.
+     * method will identify if the virtual dependency was previously added and update
+     * the existing dependency rather then adding a duplicate.
      *
      * @param dependency the dependency to add
      * @return the dependency added; in the case of virtual dependencies this

--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -256,8 +256,6 @@ public class Engine implements FileFilter, AutoCloseable {
      * the existing dependency rather then adding a duplicate.
      *
      * @param dependency the dependency to add
-     * @return the dependency added; in the case of virtual dependencies this
-     * may not be the same as the dependency passed in as an argument
      */
     public synchronized void addDependency(Dependency dependency) {
         if (dependency.isVirtual()) {


### PR DESCRIPTION
Resolves https://github.com/dependency-check/dependency-check-gradle/issues/290

The gradle plugin and maven plugin could create duplicate dependencies that would be present during the analysis phase and only be cleaned up in post-processing. This can cause large projects that do not run a build before analysis to take a very long time to complete.