### PR TITLE
fix: remove non-reproducible git entries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -489,7 +489,8 @@ Copyright (c) 2012 - Jeremy Long
                         <excludeProperty>git.build.user.*</excludeProperty>
                         <excludeProperty>git.build.host</excludeProperty>
                         <excludeProperty>git.commit.user.*</excludeProperty>
-                        <excludeProperty>git.commit.count</excludeProperty>
+                        <excludeProperty>git.tags</excludeProperty>
+                        <excludeProperty>git.total.commit.count</excludeProperty>
                     </excludeProperties>
                 </configuration>
             </plugin>


### PR DESCRIPTION

## Fixes Issue #

fixes #5026

## Description of Change

ignore 2 non-reproducible git properties

## Have test cases been added to cover the new functionality?

no, but tested with a build