### PR TITLE
fix: Support environments with only dotnet runtime for AssemblyAnalyzer

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
@@ -468,7 +468,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
     private boolean isDotnetPath() {
         final String[] args = new String[2];
         args[0] = "dotnet";
-        args[1] = "--version";
+        args[1] = "--info";
         final ProcessBuilder pb = new ProcessBuilder(args);
         try {
             final Process proc = pb.start();


### PR DESCRIPTION
## Fixes Issue #5074

## Description of Change

Change the invocation for 'system-path' dotnet-detection from `dotnet --version` to `dotnet --info` as `dotnet --version` is only supported when a dotnet SDK is installed in addition to the dotnet runtime.

## Have test cases been added to cover the new functionality?

no, existing tests cover the functionality, albeit with SDK installed. Proper test would require running the tests in an environment with only dotnet runtime installed. Locally tested that such an environment yields succesful tests of AssemblyAnalyzerTest.