### PR TITLE
fix(FP): Suppress improper CPE assignment for liferay subcomponents

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -1095,6 +1095,105 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
+        FP per issue #5085
+        suppressing the liferay libraries that have a versioning scheme separate from the main framework version
+        but get linked to the framework CPE
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.liferay\.portal/com\.liferay\.portal\.impl@.*$</packageUrl>
+        <cpe>cpe:/a:liferay:liferay</cpe>
+        <cpe>cpe:/a:liferay:liferay_portal</cpe>
+        <cpe>cpe:/a:liferay:portal</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #5085
+        suppressing the liferay libraries that have a versioning scheme separate from the main framework version
+        but get linked to the framework CPE
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.liferay\.portal/com\.liferay\.support\.tomcat@.*$</packageUrl>
+        <cpe>cpe:/a:liferay:liferay</cpe>
+        <cpe>cpe:/a:liferay:liferay_portal</cpe>
+        <cpe>cpe:/a:liferay:portal</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #5085
+        suppressing the liferay libraries that have a versioning scheme separate from the main framework version
+        but get linked to the framework CPE
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.liferay\.portal/com\.liferay\.util\.bridges@.*$</packageUrl>
+        <cpe>cpe:/a:liferay:liferay</cpe>
+        <cpe>cpe:/a:liferay:liferay_portal</cpe>
+        <cpe>cpe:/a:liferay:portal</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #5085
+        suppressing the liferay libraries that have a versioning scheme separate from the main framework version
+        but get linked to the framework CPE
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.liferay\.portal/com\.liferay\.util\.java@.*$</packageUrl>
+        <cpe>cpe:/a:liferay:liferay</cpe>
+        <cpe>cpe:/a:liferay:liferay_portal</cpe>
+        <cpe>cpe:/a:liferay:portal</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #5085
+        suppressing the liferay libraries that have a versioning scheme separate from the main framework version
+        but get linked to the framework CPE
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.liferay\.portal/com\.liferay\.util\.taglib@.*$</packageUrl>
+        <cpe>cpe:/a:liferay:liferay</cpe>
+        <cpe>cpe:/a:liferay:liferay_portal</cpe>
+        <cpe>cpe:/a:liferay:portal</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #5085
+        suppressing the liferay libraries that have a versioning scheme separate from the main framework version
+        but get linked to the framework CPE
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.liferay\.portal/com\.liferay\.portal\.test@.*$</packageUrl>
+        <cpe>cpe:/a:liferay:liferay</cpe>
+        <cpe>cpe:/a:liferay:liferay_portal</cpe>
+        <cpe>cpe:/a:liferay:portal</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #5085
+        suppressing the liferay libraries that have a versioning scheme separate from the main framework version
+        but get linked to the framework CPE
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.liferay\.portal/com\.liferay\.portal\.kernel@.*$</packageUrl>
+        <cpe>cpe:/a:liferay:liferay</cpe>
+        <cpe>cpe:/a:liferay:liferay_portal</cpe>
+        <cpe>cpe:/a:liferay:portal</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #5085
+        suppressing the liferay libraries that have a versioning scheme separate from the main framework version
+        but get linked to the framework CPE
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.liferay\.portletmvc4spring/com\.liferay\.portletmvc4spring\.test@.*$</packageUrl>
+        <cpe>cpe:/a:liferay:liferay</cpe>
+        <cpe>cpe:/a:liferay:liferay_portal</cpe>
+        <cpe>cpe:/a:liferay:portal</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #5085
+        suppressing the liferay libraries that have a versioning scheme separate from the main framework version
+        but get linked to the framework CPE
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.liferay/biz\.aQute\.bnd\.annotation@.*$</packageUrl>
+        <cpe>cpe:/a:liferay:liferay</cpe>
+        <cpe>cpe:/a:liferay:liferay_portal</cpe>
+        <cpe>cpe:/a:liferay:portal</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
         Suppresses false positives per issue #1585
         ]]></notes>
         <gav regex="true">^org\.apache\.geronimo\.javamail:geronimo-javamail_1\.4_mail:.*$</gav>


### PR DESCRIPTION
## Fixes Issue #5085

## Description of Change

Suppress the liferay CPE for components contained in Liferay `release.portal.api` that are individually versioned. Suppression is deemed safe as per the discussion in the issue, because projects using/building on liferay portal infrastructure will depend on the main `release.portal.api` which is properly versioned in line with NVD CPE coordinates, leading to the vulnerability being reported

## Have test cases been added to cover the new functionality?

no