### PR TITLE
fix: document scanning dependency-check with dependency-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,11 +241,24 @@ docker run --rm ^
 ```
 
 Building From Source
--------------
+--------------------
+
 To build dependency-check (using Java 8) run the command:
 
 ```
 mvn -s settings.xml install
+```
+
+Running dependency-check on dependency-check
+--------------------------------------------
+
+Dependency-check references several vulnerables dependencies that are never used
+except as test resources. All of these optional test dependencies are included in
+the `test-dependencies` profile. To run dependency-check against itself simple
+exclude the `test-dependencies` profile;
+
+```shell
+mvn org.owasp:dependency-check-maven:aggregate -P-test-dependencies
 ```
 
 Building the documentation
@@ -258,7 +271,7 @@ The documentation on the [github pages](http://jeremylong.github.io/DependencyCh
 Once done, point your browser to `./target/staging/index.html`.
 
 Building The Docker Image
--------------
+-------------------------
 To build dependency-check docker image run the command:
 
 ```

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -307,159 +307,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- The following dependencies are only used during testing
-        and must not be converted to a properties based version number -->
-        <dependency>
-            <groupId>io.github.faob-dev</groupId>
-            <artifactId>aar</artifactId>
-            <version>1.0.0</version>
-            <type>aar</type>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jslipc</groupId>
-            <artifactId>jslipc</artifactId>
-            <version>0.2.0</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-cvsexe</artifactId>
-            <version>1.8.1</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-webmvc</artifactId>
-            <version>2.5.5</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-web</artifactId>
-            <version>3.0.0.RELEASE</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast</artifactId>
-            <version>2.5</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>net.sf.ehcache</groupId>
-            <artifactId>ehcache-core</artifactId>
-            <version>2.2.0</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.struts</groupId>
-            <artifactId>struts2-core</artifactId>
-            <version>2.1.2</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.mortbay.jetty</groupId>
-            <artifactId>jetty</artifactId>
-            <version>6.1.0</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.axis2</groupId>
-            <artifactId>axis2-spring</artifactId>
-            <version>1.4.1</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.axis2</groupId>
-            <artifactId>axis2-adb</artifactId>
-            <version>1.4.1</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.daytrader</groupId>
-            <artifactId>daytrader-ear</artifactId>
-            <version>2.1.7</version>
-            <type>ear</type>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.main.admingui</groupId>
-            <artifactId>war</artifactId>
-            <version>4.0</version>
-            <type>war</type>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.dojotoolkit</groupId>
-            <artifactId>dojo-war</artifactId>
-            <version>1.3.0</version>
-            <type>war</type>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.openjpa</groupId>
-            <artifactId>openjpa</artifactId>
-            <version>2.0.1</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-            <version>3.0</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.retry</groupId>
-            <artifactId>spring-retry</artifactId>
-            <version>1.1.0.RELEASE</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>uk.ltd.getahead</groupId>
-            <artifactId>dwr</artifactId>
-            <version>1.1.1</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-            <version>2.7.0</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.thoughtworks.xstream</groupId>
-            <artifactId>xstream</artifactId>
-            <version>1.4.8</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-            <version>1.2.1</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
@@ -593,82 +440,121 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                 </plugins>
             </build>
         </profile>
-        <!--
-            The following profile adds additional dependencies that are only
-            used during testing.
-
-            TODO move the following FP tests to a seperate invoker test in the
-            maven plugin project. Add checks against the XML to validate that
-            these do not report FP.
-        -->
-        <!--profile>
-            <id>False Positive Tests</id>
+        <profile>
+            <id>test-dependencies</id>
+            <!-- dependencies required for unit and integration tests -->
             <activation>
-                <property>
-                    <name>releaseTesting</name>
-                </property>
+                <activeByDefault>true</activeByDefault>
             </activation>
             <dependencies>
+                <!-- The following dependencies are only used during testing
+                and must not be converted to a properties based version number -->
                 <dependency>
-                    <groupId>org.apache.xmlgraphics</groupId>
-                    <artifactId>batik-util</artifactId>
-                    <version>1.7</version>
+                    <groupId>io.github.faob-dev</groupId>
+                    <artifactId>aar</artifactId>
+                    <version>1.0.0</version>
+                    <type>aar</type>
                     <scope>test</scope>
                     <optional>true</optional>
                 </dependency>
                 <dependency>
-                    <groupId>org.apache.ws.security</groupId>
-                    <artifactId>wss4j</artifactId>
-                    <version>1.5.7</version>
+                    <groupId>org.jslipc</groupId>
+                    <artifactId>jslipc</artifactId>
+                    <version>0.2.0</version>
                     <scope>test</scope>
                     <optional>true</optional>
                 </dependency>
                 <dependency>
-                    <groupId>com.ganyo</groupId>
-                    <artifactId>gcm-server</artifactId>
-                    <version>1.0.2</version>
+                    <groupId>org.apache.maven.scm</groupId>
+                    <artifactId>maven-scm-provider-cvsexe</artifactId>
+                    <version>1.8.1</version>
                     <scope>test</scope>
                     <optional>true</optional>
                 </dependency>
                 <dependency>
-                    <groupId>org.python</groupId>
-                    <artifactId>jython-standalone</artifactId>
-                    <version>2.7-b1</version>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-webmvc</artifactId>
+                    <version>2.5.5</version>
                     <scope>test</scope>
                     <optional>true</optional>
                 </dependency>
                 <dependency>
-                    <groupId>org.jruby</groupId>
-                    <artifactId>jruby-complete</artifactId>
-                    <version>1.7.4</version>
+                    <groupId>org.springframework.security</groupId>
+                    <artifactId>spring-security-web</artifactId>
+                    <version>3.0.0.RELEASE</version>
                     <scope>test</scope>
                     <optional>true</optional>
                 </dependency>
                 <dependency>
-                    <groupId>org.jruby</groupId>
-                    <artifactId>jruby</artifactId>
-                    <version>1.6.3</version>
+                    <groupId>com.hazelcast</groupId>
+                    <artifactId>hazelcast</artifactId>
+                    <version>2.5</version>
                     <scope>test</scope>
                     <optional>true</optional>
                 </dependency>
                 <dependency>
-                    <groupId>org.glassfish.jersey.core</groupId>
-                    <artifactId>jersey-client</artifactId>
-                    <version>2.12</version>
+                    <groupId>net.sf.ehcache</groupId>
+                    <artifactId>ehcache-core</artifactId>
+                    <version>2.2.0</version>
                     <scope>test</scope>
                     <optional>true</optional>
                 </dependency>
                 <dependency>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-client</artifactId>
-                    <version>1.11.1</version>
+                    <groupId>org.apache.struts</groupId>
+                    <artifactId>struts2-core</artifactId>
+                    <version>2.1.2</version>
                     <scope>test</scope>
                     <optional>true</optional>
                 </dependency>
                 <dependency>
-                    <groupId>com.sun.faces</groupId>
-                    <artifactId>jsf-impl</artifactId>
-                    <version>2.2.8-02</version>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty</artifactId>
+                    <version>6.1.0</version>
+                    <scope>test</scope>
+                    <optional>true</optional>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.axis2</groupId>
+                    <artifactId>axis2-spring</artifactId>
+                    <version>1.4.1</version>
+                    <scope>test</scope>
+                    <optional>true</optional>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.axis2</groupId>
+                    <artifactId>axis2-adb</artifactId>
+                    <version>1.4.1</version>
+                    <scope>test</scope>
+                    <optional>true</optional>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.geronimo.daytrader</groupId>
+                    <artifactId>daytrader-ear</artifactId>
+                    <version>2.1.7</version>
+                    <type>ear</type>
+                    <scope>test</scope>
+                    <optional>true</optional>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.main.admingui</groupId>
+                    <artifactId>war</artifactId>
+                    <version>4.0</version>
+                    <type>war</type>
+                    <scope>test</scope>
+                    <optional>true</optional>
+                </dependency>
+                <dependency>
+                    <groupId>org.dojotoolkit</groupId>
+                    <artifactId>dojo-war</artifactId>
+                    <version>1.3.0</version>
+                    <type>war</type>
+                    <scope>test</scope>
+                    <optional>true</optional>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openjpa</groupId>
+                    <artifactId>openjpa</artifactId>
+                    <version>2.0.1</version>
                     <scope>test</scope>
                     <optional>true</optional>
                 </dependency>
@@ -680,62 +566,41 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                     <optional>true</optional>
                 </dependency>
                 <dependency>
-                    <groupId>org.opensaml</groupId>
-                    <artifactId>xmltooling</artifactId>
-                    <version>1.4.1</version>
+                    <groupId>org.springframework.retry</groupId>
+                    <artifactId>spring-retry</artifactId>
+                    <version>1.1.0.RELEASE</version>
                     <scope>test</scope>
                     <optional>true</optional>
                 </dependency>
                 <dependency>
-                    <groupId>com.google.gerrit</groupId>
-                    <artifactId>gerrit-extension-api</artifactId>
-                    <version>2.11</version>
+                    <groupId>uk.ltd.getahead</groupId>
+                    <artifactId>dwr</artifactId>
+                    <version>1.1.1</version>
                     <scope>test</scope>
                     <optional>true</optional>
                 </dependency>
                 <dependency>
-                    <groupId>com.google.apis</groupId>
-                    <artifactId>google-api-services-sqladmin</artifactId>
-                    <version>v1beta4-rev5-1.20.0</version>
+                    <groupId>xalan</groupId>
+                    <artifactId>xalan</artifactId>
+                    <version>2.7.0</version>
                     <scope>test</scope>
                     <optional>true</optional>
                 </dependency>
                 <dependency>
-                    <groupId>com.google.gwt.google-apis</groupId>
-                    <artifactId>gwt-gears</artifactId>
+                    <groupId>com.thoughtworks.xstream</groupId>
+                    <artifactId>xstream</artifactId>
+                    <version>1.4.8</version>
+                    <scope>test</scope>
+                    <optional>true</optional>
+                </dependency>
+                <dependency>
+                    <groupId>commons-fileupload</groupId>
+                    <artifactId>commons-fileupload</artifactId>
                     <version>1.2.1</version>
                     <scope>test</scope>
                     <optional>true</optional>
                 </dependency>
-                <dependency>
-                    <groupId>org.mozilla</groupId>
-                    <artifactId>rhino</artifactId>
-                    <version>1.7.6</version>
-                    <scope>test</scope>
-                    <optional>true</optional>
-                </dependency>
-                <dependency>
-                    <groupId>com.microsoft.windowsazure</groupId>
-                    <artifactId>microsoft-azure-api-media</artifactId>
-                    <version>0.5.0</version>
-                    <scope>test</scope>
-                    <optional>true</optional>
-                </dependency>
-                <dependency>
-                    <groupId>com.microsoft.windowsazure</groupId>
-                    <artifactId>microsoft-azure-api-management-sql</artifactId>
-                    <version>0.5.0</version>
-                    <scope>test</scope>
-                    <optional>true</optional>
-                </dependency>
-                <dependency>
-                    <groupId>com.microsoft.bingads</groupId>
-                    <artifactId>microsoft.bingads</artifactId>
-                    <version>9.3.4</version>
-                    <scope>test</scope>
-                    <optional>true</optional>
-                </dependency>
             </dependencies>
-        </profile-->
+        </profile>
     </profiles>
 </project>

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PerlCpanfileAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PerlCpanfileAnalyzerTest.java
@@ -17,7 +17,7 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import edu.emory.mathcs.backport.java.util.Arrays;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import static org.junit.Assert.*;

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzerIT.java
@@ -17,11 +17,7 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import edu.emory.mathcs.backport.java.util.Arrays;
-
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.After;
 import org.junit.Assume;

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -166,16 +166,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <artifactId>maven-artifact</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model-builder</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -185,6 +185,9 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                     <name>releaseTesting</name>
                 </property>
             </activation>
+            <properties>
+                <maven.api.version>3.1.0</maven.api.version>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -65,7 +65,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>${version.maven-plugin-plugin}</version>
                 <configuration>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     <goalPrefix>dependency-check</goalPrefix>
                 </configuration>
                 <executions>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -38,7 +38,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <tag>v6.4.1</tag>
     </scm>
     <prerequisites>
-        <maven>${maven.api.version}</maven>
+        <maven>3.1.0</maven>
     </prerequisites>
     <build>
         <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@ Copyright (c) 2012 - Jeremy Long
         <logback.version>1.2.11</logback.version>
         
         <!-- Note that Maven will use classes from the distro, ignoring declared dependencies for Maven core... -->
-        <maven.api.version>3.1.0</maven.api.version>
+        <maven.api.version>3.8.1</maven.api.version>
         <reporting.checkstyle-plugin.version>3.2.0</reporting.checkstyle-plugin.version>
         <reporting.checkstyle.tool.version>9.3</reporting.checkstyle.tool.version>
         <doxia-module-markdown.version>1.11.1</doxia-module-markdown.version>
@@ -158,8 +158,7 @@ Copyright (c) 2012 - Jeremy Long
         <org.apache.maven.shared.file-management.version>3.1.0</org.apache.maven.shared.file-management.version>
         <maven-plugin-testing-harness.version>3.3.0</maven-plugin-testing-harness.version>
         <maven-plugin-annotations.version>3.7.0</maven-plugin-annotations.version>
-        <maven-reporting-api.version>3.1.1</maven-reporting-api.version>
-        <commons-collections.version>3.2.2</commons-collections.version>
+        <maven-reporting-api.version>3.1.1</maven-reporting-api.version>    
         <org.apache.velocity.version>2.3</org.apache.velocity.version>
         <plexus-sec-dispatcher.version>1.4</plexus-sec-dispatcher.version>
         <maven-dependency-tree.version>3.2.1</maven-dependency-tree.version>
@@ -1145,11 +1144,23 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
                 <version>${apache.ant.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.sun</groupId>
+                        <artifactId>tools</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant-testutil</artifactId>
                 <version>${apache.ant.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.sun</groupId>
+                        <artifactId>tools</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.lucene</groupId>
@@ -1185,6 +1196,11 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-core</artifactId>
                 <version>${maven.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-shared-utils</artifactId>
+                <version>3.3.3</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
@@ -1234,6 +1250,7 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.apache.maven.plugin-tools</groupId>
                 <artifactId>maven-plugin-annotations</artifactId>
                 <version>${maven-plugin-annotations.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.reporting</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1133,6 +1133,13 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- deprecated coordinates, replaced by org.hamcrest:hamcrest -->
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1230,18 +1230,6 @@ Copyright (c) 2012 - Jeremy Long
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-model-builder</artifactId>
-                <version>${maven.api.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-compat</artifactId>
-                <version>3.8.6</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.maven.plugin-testing</groupId>
                 <artifactId>maven-plugin-testing-harness</artifactId>
                 <version>${maven-plugin-testing-harness.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,8 @@ Copyright (c) 2012 - Jeremy Long
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.11</logback.version>
         
-        <!-- Note that Maven will use classes from the distro, ignoring declared dependencies for Maven core... -->
-        <maven.api.version>3.8.1</maven.api.version>
+        <!-- moved maven.api.version to the profile section -->
+        <!--maven.api.version>3.8.1</maven.api.version-->
         <reporting.checkstyle-plugin.version>3.2.0</reporting.checkstyle-plugin.version>
         <reporting.checkstyle.tool.version>9.3</reporting.checkstyle.tool.version>
         <doxia-module-markdown.version>1.11.1</doxia-module-markdown.version>
@@ -1385,6 +1385,22 @@ Copyright (c) 2012 - Jeremy Long
         </dependency>
     </dependencies>
     <profiles>
+        <profile>
+            <id>standard</id>
+            <!--
+            `releaseTesting` is used in the maven/pom.xml and downgrades the
+            Maven API to 3.1.0 during full refression testing to ensure that
+            no new Maven APIs were used and we maintain compatability with 3.1.
+            -->
+            <activation>
+                <property>
+                    <name>!releaseTesting</name>
+                </property>
+            </activation>
+            <properties>
+                <maven.api.version>3.8.1</maven.api.version>
+            </properties>
+        </profile>
         <profile>
             <id>release</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@ Copyright (c) 2012 - Jeremy Long
         <commons-jcs-core.version>2.2.1</commons-jcs-core.version>
         <aho-corasick-double-array-trie.version>1.2.3</aho-corasick-double-array-trie.version>
         <junit.version>4.13.2</junit.version>
-        <hamcrest-core.version>2.2</hamcrest-core.version>
+        <hamcrest.version>2.2</hamcrest.version>
         <jmockit.version>1.49</jmockit.version>
         <mockito-core.version>4.9.0</mockito-core.version>
         <jsoup.version>1.15.3</jsoup.version>
@@ -1273,8 +1273,8 @@ Copyright (c) 2012 - Jeremy Long
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>${hamcrest-core.version}</version>
+                <artifactId>hamcrest</artifactId>
+                <version>${hamcrest.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -1351,7 +1351,7 @@ Copyright (c) 2012 - Jeremy Long
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- upgrade and exclude dependencies.
- move optional, test dependencies to a profile called `test-dependencies`.
- document how to run dependency-check on dependency-check by excluding the `test-dependencies` profile.