### PR TITLE
Optimize file checksums calculation

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -55,10 +55,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>compile</scope>


### PR DESCRIPTION
## Fixes Issue #
I noticed checksums can be very slow to calculate for some larger files. One of the reasons is that the file is read 3 times - once per each checksum. (See `Dependency.calculateChecksums(File)`.) This is easy to optimize by reading the file only once and calculating all 3 checksums together.

## Description of Change
There are two commits:
1) calculates (and caches) all supported checksums together for files
2) (optional) removes dependency on commons-codec since I realized it's barely used and the methods that actually are used are already implemented in this `Checksum` class

## Have test cases been added to cover the new functionality?
No new functionality added, and existing tests already cover the changed functionality.