### PR TITLE
fix: ensure suppression file is not removed during publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,3 +276,4 @@ jobs:
         with:
           branch: gh-pages
           folder: target/staging
+          clean: false


### PR DESCRIPTION
The generated suppression file in `gh-pages` was `cleaned` by the `JamesIves/github-pages-deploy-action@v4.4.1`. This PR resolves the issue.