### PR TITLE
fix: Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ mvn -s settings.xml install
 License
 -------
 
-Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://github.com/jeremylong/DependencyCheck/blob/main/LICENSE.txt) file for the full license.
+Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://raw.githubusercontent.com/jeremylong/DependencyCheck/master/LICENSE.txt) file for the full license.
 
 Dependency-Check makes use of several other open source libraries. Please see the [NOTICE.txt][notices] file for more information.
 

--- a/README.md
+++ b/README.md
@@ -269,11 +269,11 @@ mvn -s settings.xml install
 License
 -------
 
-Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://raw.githubusercontent.com/jeremylong/DependencyCheck/master/LICENSE.txt) file for the full license.
+Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://github.com/jeremylong/DependencyCheck/blob/main/LICENSE.txt) file for the full license.
 
 Dependency-Check makes use of several other open source libraries. Please see the [NOTICE.txt][notices] file for more information.
 
 Copyright (c) 2012-2022 Jeremy Long. All Rights Reserved.
 
   [wiki]: https://github.com/jeremylong/DependencyCheck/wiki
-  [notices]: https://github.com/jeremylong/DependencyCheck/blob/master/NOTICE.txt
+  [notices]: https://github.com/jeremylong/DependencyCheck/blob/main/NOTICE.txt

--- a/ant/README.md
+++ b/ant/README.md
@@ -20,6 +20,6 @@ Copyright & License
 
 Dependency-Check is Copyright (c) 2012-2014 Jeremy Long. All Rights Reserved.
 
-Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://raw.githubusercontent.com/jeremylong/DependencyCheck/master/LICENSE.txt) file for the full license.
+Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://github.com/jeremylong/DependencyCheck/blob/main/LICENSE.txt) file for the full license.
 
-Dependency-Check-Ant makes use of other open source libraries. Please see the [NOTICE.txt](https://raw.githubusercontent.com/jeremylong/DependencyCheck/master/dependency-check-ant/NOTICE.txt) file for more information.
+Dependency-Check-Ant makes use of other open source libraries. Please see the [NOTICE.txt](https://github.com/jeremylong/DependencyCheck/blob/main/ant/NOTICE.txt) file for more information.

--- a/cli/README.md
+++ b/cli/README.md
@@ -19,6 +19,6 @@ Copyright & License
 
 Dependency-Check is Copyright (c) 2012-2014 Jeremy Long. All Rights Reserved.
 
-Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://raw.githubusercontent.com/jeremylong/DependencyCheck/master/LICENSE.txt) file for the full license.
+Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://github.com/jeremylong/DependencyCheck/blob/main/cli/LICENSE.txt) file for the full license.
 
-Dependency-Check Command Line makes use of other open source libraries. Please see the [NOTICE.txt](https://raw.githubusercontent.com/jeremylong/DependencyCheck/master/dependency-check-cli/NOTICE.txt) file for more information.
+Dependency-Check Command Line makes use of other open source libraries. Please see the [NOTICE.txt](https://github.com/jeremylong/DependencyCheck/blob/main/cli/NOTICE.txt) file for more information.

--- a/core/README.md
+++ b/core/README.md
@@ -17,7 +17,7 @@ Copyright & License
 
 Dependency-Check is Copyright (c) 2012-2014 Jeremy Long. All Rights Reserved.
 
-Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://github.com/jeremylong/DependencyCheck/blob/main/LICENSE.txt) file for the full license.
+Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://raw.githubusercontent.com/jeremylong/DependencyCheck/master/LICENSE.txt) file for the full license.
 
 Dependency-Check makes use of several other open source libraries. Please see the [NOTICE.txt][notices] file for more information.
 

--- a/core/README.md
+++ b/core/README.md
@@ -17,7 +17,7 @@ Copyright & License
 
 Dependency-Check is Copyright (c) 2012-2014 Jeremy Long. All Rights Reserved.
 
-Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://raw.githubusercontent.com/jeremylong/DependencyCheck/master/LICENSE.txt) file for the full license.
+Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://github.com/jeremylong/DependencyCheck/blob/main/LICENSE.txt) file for the full license.
 
 Dependency-Check makes use of several other open source libraries. Please see the [NOTICE.txt] [notices] file for more information.
 
@@ -25,4 +25,4 @@ Dependency-Check makes use of several other open source libraries. Please see th
   [wiki]: https://github.com/jeremylong/DependencyCheck/wiki
   [subscribe]: mailto:dependency-check+subscribe@googlegroups.com
   [post]: mailto:dependency-check@googlegroups.com
-  [notices]: https://raw.githubusercontent.com/jeremylong/DependencyCheck/master/NOTICE.txt
+  [notices]: https://github.com/jeremylong/DependencyCheck/blob/main/NOTICE.txt

--- a/core/README.md
+++ b/core/README.md
@@ -6,9 +6,9 @@ Dependency-Check-Core is the main engine used by all of the other modules to do 
 Mailing List
 ------------
 
-Subscribe: [dependency-check+subscribe@googlegroups.com] [subscribe]
+Subscribe: [dependency-check+subscribe@googlegroups.com][subscribe]
 
-Post: [dependency-check@googlegroups.com] [post]
+Post: [dependency-check@googlegroups.com][post]
 
 Archive: [google group](https://groups.google.com/forum/#!forum/dependency-check)
 
@@ -19,7 +19,7 @@ Dependency-Check is Copyright (c) 2012-2014 Jeremy Long. All Rights Reserved.
 
 Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://github.com/jeremylong/DependencyCheck/blob/main/LICENSE.txt) file for the full license.
 
-Dependency-Check makes use of several other open source libraries. Please see the [NOTICE.txt] [notices] file for more information.
+Dependency-Check makes use of several other open source libraries. Please see the [NOTICE.txt][notices] file for more information.
 
 
   [wiki]: https://github.com/jeremylong/DependencyCheck/wiki

--- a/maven/README.md
+++ b/maven/README.md
@@ -17,10 +17,10 @@ Copyright & License
 
 Dependency-Check is Copyright (c) 2012-2014 Jeremy Long. All Rights Reserved.
 
-Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://raw.githubusercontent.com/jeremylong/DependencyCheck/master/LICENSE.txt) file for the full license.
+Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://github.com/jeremylong/DependencyCheck/blob/main/LICENSE.txt) file for the full license.
 
 Dependency-Check makes use of several other open source libraries. Please see the [NOTICE.txt] [notices] file for more information.
 
   [subscribe]: mailto:dependency-check+subscribe@googlegroups.com
   [post]: mailto:dependency-check@googlegroups.com
-  [notices]: https://raw.githubusercontent.com/jeremylong/DependencyCheck/master/dependency-check-maven/NOTICE.txt
+  [notices]: https://github.com/jeremylong/DependencyCheck/blob/main/maven/NOTICE.txt

--- a/maven/README.md
+++ b/maven/README.md
@@ -8,9 +8,9 @@ Documentation and links to production binary releases can be found on the [githu
 Mailing List
 -
 
-Subscribe: [dependency-check+subscribe@googlegroups.com] [subscribe]
+Subscribe: [dependency-check+subscribe@googlegroups.com][subscribe]
 
-Post: [dependency-check@googlegroups.com] [post]
+Post: [dependency-check@googlegroups.com][post]
 
 Copyright & License
 -------------------
@@ -19,7 +19,7 @@ Dependency-Check is Copyright (c) 2012-2014 Jeremy Long. All Rights Reserved.
 
 Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt](https://github.com/jeremylong/DependencyCheck/blob/main/LICENSE.txt) file for the full license.
 
-Dependency-Check makes use of several other open source libraries. Please see the [NOTICE.txt] [notices] file for more information.
+Dependency-Check makes use of several other open source libraries. Please see the [NOTICE.txt][notices] file for more information.
 
   [subscribe]: mailto:dependency-check+subscribe@googlegroups.com
   [post]: mailto:dependency-check@googlegroups.com

--- a/src/site/markdown/dependency-check-gradle/index.md.vm
+++ b/src/site/markdown/dependency-check-gradle/index.md.vm
@@ -1,6 +1,6 @@
 Usage
 ==============================
-The OWASP dependency-check-gradle plugin provides monitoring of the projects dependent
+The [OWASP dependency-check-gradle plugin][plugin-site] provides monitoring of the projects dependent
 libraries; creating a report of known vulnerable components that are included in the build.
 
 It is important to understand that the first time this task is executed it may
@@ -45,6 +45,8 @@ The OWASP dependency-check-gradle plugin contains three tasks: [dependencyCheckA
 [dependencyCheckAggregate](configuration-aggregate.html), [dependencyCheckUpdate](configuration-update.html),
 and [dependencyCheckPurge](configuration-purge.html). Please see each tasks configuration page for more information.
 
+More information can be found in the [GitHub repository][github].
+
 Mailing List
 ------------
 
@@ -63,3 +65,5 @@ Dependency-Check makes use of several other open source libraries. Please see th
   [post]: mailto:dependency-check@googlegroups.com
   [license]: https://github.com/dependency-check/dependency-check-gradle/blob/main/LICENSE.txt
   [notices]: https://github.com/dependency-check/dependency-check-gradle/blob/main/NOTICE.txt
+  [plugin-site]: https://plugins.gradle.org/plugin/org.owasp.dependencycheck
+  [github]: https://github.com/dependency-check/dependency-check-gradle

--- a/src/site/markdown/dependency-check-gradle/index.md.vm
+++ b/src/site/markdown/dependency-check-gradle/index.md.vm
@@ -48,16 +48,16 @@ and [dependencyCheckPurge](configuration-purge.html). Please see each tasks conf
 Mailing List
 ------------
 
-Subscribe: [dependency-check+subscribe@googlegroups.com] [subscribe]
+Subscribe: [dependency-check+subscribe@googlegroups.com][subscribe]
 
-Post: [dependency-check@googlegroups.com] [post]
+Post: [dependency-check@googlegroups.com][post]
 
 License
 -------------------
 
-Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt] [license] file for the full license.
+Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt][license] file for the full license.
 
-Dependency-Check makes use of several other open source libraries. Please see the [NOTICE.txt] [notices] file for more information.
+Dependency-Check makes use of several other open source libraries. Please see the [NOTICE.txt][notices] file for more information.
 
   [subscribe]: mailto:dependency-check+subscribe@googlegroups.com
   [post]: mailto:dependency-check@googlegroups.com

--- a/src/site/markdown/dependency-check-gradle/index.md.vm
+++ b/src/site/markdown/dependency-check-gradle/index.md.vm
@@ -61,5 +61,5 @@ Dependency-Check makes use of several other open source libraries. Please see th
 
   [subscribe]: mailto:dependency-check+subscribe@googlegroups.com
   [post]: mailto:dependency-check@googlegroups.com
-  [license]: https://github.com/jeremylong/DependencyCheck/blob/master/dependency-check-gradle/LICENSE.txt
-  [notices]: https://github.com/jeremylong/DependencyCheck/blob/master/dependency-check-gradle/NOTICE.txt
+  [license]: https://github.com/dependency-check/dependency-check-gradle/blob/main/LICENSE.txt
+  [notices]: https://github.com/dependency-check/dependency-check-gradle/blob/main/NOTICE.txt

--- a/src/site/markdown/dependency-check-jenkins/index.md
+++ b/src/site/markdown/dependency-check-jenkins/index.md
@@ -12,9 +12,9 @@ Note, not all of the features in the HTML report produced by dependency-check, w
 Mailing List
 ------------
 
-Subscribe: [dependency-check+subscribe@googlegroups.com] [subscribe]
+Subscribe: [dependency-check+subscribe@googlegroups.com][subscribe]
 
-Post: [dependency-check@googlegroups.com] [post]
+Post: [dependency-check@googlegroups.com][post]
 
 Copyright & License
 -------------------
@@ -23,9 +23,9 @@ Dependency-Check is Copyright (c) 2012-2014 Jeremy Long. All Rights Reserved.
 
 Dependency-Check Jenkins Plugin is Copyright (c) 2013-2014 Steve Springett. All Rights Reserved.
 
-Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt] [license] file for the full license.
+Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE.txt][license] file for the full license.
 
-Dependency-Check makes use of several other open source libraries. Please see the [NOTICE.txt] [notices] file for more information.
+Dependency-Check makes use of several other open source libraries. Please see the [NOTICE.txt][notices] file for more information.
 
 
   [wiki]: https://wiki.jenkins-ci.org/display/JENKINS/OWASP+Dependency-Check+Plugin

--- a/src/site/markdown/dependency-check-jenkins/index.md
+++ b/src/site/markdown/dependency-check-jenkins/index.md
@@ -3,9 +3,10 @@ Dependency-Check Jenkins Plugin
 
 Dependency-Check is a utility that identifies project dependencies and checks if there are any known, publicly disclosed, vulnerabilities. This tool can be part of the solution to the OWASP Top 10 2013: A9 - Using Components with Known Vulnerabilities. This plug-in can independently execute a Dependency-Check analysis and visualize results.
 
-The Dependency-Check Jenkins Plugin features the ability to perform a dependency analysis build and later view results post build. The plugin is built using [analysis-core] and features many of the same features that Jenkins static analysis plugins offer, including thresholds, charts and the ability to view vulnerability information should a dependency have one identified.
+[The Dependency-Check Jenkins Plugin][plugin-site]
+ features the ability to perform a dependency analysis build and later view results post build. The plugin is built using [analysis-core] and features many of the same features that Jenkins static analysis plugins offer, including thresholds, charts and the ability to view vulnerability information should a dependency have one identified.
 
-More information can be found on the [wiki].
+More information can be found on the [wiki], source code is available at [github].
 
 Note, not all of the features in the HTML report produced by dependency-check, when viewed from within Jenkins, may not work correctly as [Jenkins set a restrictive CSP header](https://wiki.jenkins-ci.org/display/JENKINS/Configuring+Content+Security+Policy). This does not affect the functionality of the tool or other reporting capabilities within the Jenkins plugin. Two options to re-enable the missing features in the HTML report would be to either download the report and view it locally or modify the CSP header to allow in-line script.
 
@@ -34,3 +35,5 @@ Dependency-Check makes use of several other open source libraries. Please see th
   [post]: mailto:dependency-check@googlegroups.com
   [license]: https://github.com/jenkinsci/dependency-check-plugin/blob/master/LICENSE.txt
   [notices]: https://github.com/jenkinsci/dependency-check-plugin/blob/master/NOTICES.txt
+  [plugin-site]: https://plugins.jenkins.io/dependency-check-jenkins-plugin/
+  [github]: https://github.com/jenkinsci/dependency-check-plugin


### PR DESCRIPTION
## Fixes Issue: no issue
I clicked on one of these links and thought I would fix all.

## Description of Change
 * Updated the links (NOTICE.txt and LICENSE.txt) to all be the same pattern. Some of them were pointing to `master` instead of `main`, some of them were pointing to the wrong path in the repo, some were pointing to the wrong repo.
 * Fixed all the links that were displayed strangely (regex search: `(?<!yyyy)\] \[`):
   * [Website](https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/index.html)  
     ![image](https://user-images.githubusercontent.com/2906988/206153520-02204456-6afe-4aed-883e-f1a5b4ad63e3.png)
   * [GitHub](https://github.com/jeremylong/DependencyCheck/tree/main/maven)  
     ![image](https://user-images.githubusercontent.com/2906988/206153896-851b8d44-b4e9-45bf-b1a5-8ff5446754b8.png)
   * Fixed (black is my preview's color only, but both website and GH should look like this)  
     ![image](https://user-images.githubusercontent.com/2906988/206154060-5893f272-73dc-4e7d-92dc-55f5de0fd793.png)
 * Added links to external repos, because it's really hard to find them from the main repo even though their documentation is linked.

## Have test cases been added to cover the new functionality?

*no*