### PR TITLE
Remove unused dependencies on maven libraries

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -166,16 +166,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <artifactId>maven-artifact</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model-builder</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1133,6 +1133,13 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- deprecated coordinates, replaced by org.hamcrest:hamcrest -->
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1230,18 +1230,6 @@ Copyright (c) 2012 - Jeremy Long
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-model-builder</artifactId>
-                <version>${maven.api.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-compat</artifactId>
-                <version>3.8.6</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.maven.plugin-testing</groupId>
                 <artifactId>maven-plugin-testing-harness</artifactId>
                 <version>${maven-plugin-testing-harness.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@ Copyright (c) 2012 - Jeremy Long
         <commons-jcs-core.version>2.2.1</commons-jcs-core.version>
         <aho-corasick-double-array-trie.version>1.2.3</aho-corasick-double-array-trie.version>
         <junit.version>4.13.2</junit.version>
-        <hamcrest-core.version>2.2</hamcrest-core.version>
+        <hamcrest.version>2.2</hamcrest.version>
         <jmockit.version>1.49</jmockit.version>
         <mockito-core.version>4.9.0</mockito-core.version>
         <jsoup.version>1.15.3</jsoup.version>
@@ -1273,8 +1273,8 @@ Copyright (c) 2012 - Jeremy Long
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>${hamcrest-core.version}</version>
+                <artifactId>hamcrest</artifactId>
+                <version>${hamcrest.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -1351,7 +1351,7 @@ Copyright (c) 2012 - Jeremy Long
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Description of Change

Processed the 'unused declared dependencies' mentioned for the maven plugin in response to my remarks of an obsolete maven-compat dependency.

org.hamcrest:hamcrest-core was listed as unused as it contains only deprecated classes and a note on the artifact itself being deprecated, with a transitive dependency on org.hamcrest:hamcrest, which is the up-to-date coordinate of hamcrest, so I've updated that coordinate to its future-proof coordinate and excluded the old artifactId from the transitive dependencies of JUnit.

## Have test cases been added to cover the new functionality?

No, existing testcases have been used to validate the changes.