### PR TITLE
fix: conventional commits

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -4,8 +4,9 @@
 
 - Ensure you're running the latest version of dependency-check.
 - Ensure the bug has not [already been reported](https://github.com/jeremylong/DependencyCheck/issues).
-- If you're unable to find an open issue addressing the problem, please [submit a new issue](https://github.com/jeremylong/DependencyCheck/issues/new).
-  - Please fill out the appropriate section of the bug report template provided. Please delete any sections not needed in the template.
+- If you're unable to find an open issue addressing the problem, please [submit a new issue](https://github.com/jeremylong/DependencyCheck/issues/new/choose).
+  - Please fill out the appropriate section of the bug report template provided.
+  - Delete any sections not needed in the template.
   
 ## Reporting Vulnerabilities
 
@@ -13,20 +14,20 @@
 
 ## Asking Questions
 
-- Your question may be answered by taking a look at the [documentataion](https://jeremylong.github.io/DependencyCheck/).
-- If you still have a question consider:
-  - posting to the [Google Group](https://groups.google.com/forum/#!forum/dependency-check)
-  - opening a [new issue](https://github.com/jeremylong/DependencyCheck/issues/new)
+- Your question may be answered by taking a look at the [documentation](https://jeremylong.github.io/DependencyCheck/).
+- Search both the [open and closed issues issues in GitHub](https://github.com/jeremylong/DependencyCheck/issues/)
+- If you still have a question ask a [new question](https://github.com/jeremylong/DependencyCheck/issues/new?assignees=&labels=question&template=ask-a-question.md&title=)
 
 ## Enhancement Requests
 
-- Suggest changes by [submitting a new issue](https://github.com/jeremylong/DependencyCheck/issues/new) and begin coding.
+- Suggest changes by [submitting a new issue](https://github.com/jeremylong/DependencyCheck/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=) and begin coding.
 
 ## Contributing Code
 
 - If you have written a new feature or have fixed a bug please open a new pull request with the patch.
+- Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/); even for the PR title.
 - Ensure the PR description clearly describes the problem and solution. Include any related issue number(s) if applicable.
-- Please ensure the PR passes the automated checks performed (travis-ci, codacy, etc.)
+- Please ensure the PR passes the automated checks performed
 - Please consider adding test cases for any new functionality
 
 ## Thank you for your contributions

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,2 @@
+## YAML Template.
+---

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -8,14 +8,16 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
-  statuses: write
+  contents: read
 
 jobs:
   main:
     name: Validate PR title
+    permissions:
+      pull-requests: read
+      statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v5.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+  statuses: write
+
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,2 +1,17 @@
-## YAML Template.
----
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to the contributing guide
- Add workflow to validate PR titles follow conventional commits for squash and merge
