### PR TITLE
fix: Upgrade semver4j to 4.1.1 to prevent NullPointerException

### DIFF
--- a/core/src/test/java/org/owasp/dependencycheck/utils/SemverTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/SemverTest.java
@@ -13,6 +13,7 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -31,5 +32,16 @@ public class SemverTest {
     public void testSemver() {
         Semver semver = new Semver("3.1.4");
         assertTrue(semver.satisfies("^3.0.0-0"));
+    }
+    /**
+     * Test of semver4j. See https://github.com/jeremylong/DependencyCheck/issues/5158
+     */
+    @Test
+    public void testSemverComplex() {
+        Semver semver = new Semver("18.11.5");
+        assertFalse(semver.satisfies("^14.14.20 || ^16.0.0"));
+        
+        semver = new Semver("14.15.0");
+        assertTrue(semver.satisfies("^14.14.20 || ^16.0.0"));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1069,7 +1069,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>org.semver4j</groupId>
                 <artifactId>semver4j</artifactId>
-                <version>4.1.0</version>
+                <version>4.1.1</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains</groupId>


### PR DESCRIPTION
## Fixes Issue #

Fix #5158 

## Description of Change

This PR fix an issue in semver4j causing a NullPointerException by upgrading it to the latest version

## Have test cases been added to cover the new functionality?

*no*