### PR TITLE
fix: generic identifier in ComposerLockAnalyzer

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
@@ -122,7 +122,7 @@ public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
                     d.addSoftwareIdentifier(new PurlIdentifier(purl, Confidence.HIGHEST));
                 } catch (MalformedPackageURLException ex) {
                     LOGGER.debug("Unable to build package url for composer", ex);
-                    d.addSoftwareIdentifier(new GenericIdentifier("cocoapods:" + dep.getGroup() + "/" + dep.getProject()
+                    d.addSoftwareIdentifier(new GenericIdentifier("composer:" + dep.getGroup() + "/" + dep.getProject()
                             + "@" + dep.getVersion(), Confidence.HIGHEST));
                 }
                 d.setPackagePath(String.format("%s:%s", dep.getProject(), dep.getVersion()));


### PR DESCRIPTION
## Fixes Issue #

## Description of Change
Change the generic identifier prefix from "cocoapod" to "composer".

## Have test cases been added to cover the new functionality?

*no*