### PR TITLE
fix: Support RELEASE and LATEST metaversions in the transitive dependencies

### DIFF
--- a/maven/src/it/4397-metaversion-for-transitive-dependency/dep/pom.xml
+++ b/maven/src/it/4397-metaversion-for-transitive-dependency/dep/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2023 Hans Aikema. All Rights Reserved.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.owasp.test</groupId>
+  <artifactId>4397-dependency-with-meta-transitive</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>4397-dependency-with-meta-transitive</name>
+  <description>Helper-project to play the role of dependency with transitive dependendencies
+    that use Maven's LATEST or RELEASE meta-versions.
+
+    An integration test similar to IT 3721-metaversion-dependencies, but with the RELEASE/LATEST meta-version
+    inside the pom of a transitive dependency
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-pool2</artifactId>
+      <version>LATEST</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/maven/src/it/4397-metaversion-for-transitive-dependency/invoker.properties
+++ b/maven/src/it/4397-metaversion-for-transitive-dependency/invoker.properties
@@ -1,0 +1,20 @@
+#
+# This file is part of dependency-check-maven.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright (c) 2023 Hans Aikema. All Rights Reserved.
+#
+# Note: the first goals needs the -U in order to properly resolve the RELEASE / LATEST meta-versions
+invoker.goals.1 = install --no-transfer-progress --batch-mode -f dep/pom.xml -U
+invoker.goals.2 = verify --no-transfer-progress --batch-mode -Dcve.startyear=2018  -Danalyzer.ossindex.enabled=false -f main/pom.xml

--- a/maven/src/it/4397-metaversion-for-transitive-dependency/main/pom.xml
+++ b/maven/src/it/4397-metaversion-for-transitive-dependency/main/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2023 Hans Aikema. All Rights Reserved.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.owasp.test</groupId>
+    <artifactId>4397-metaversion-transitive-dependencies</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>4397-metaversion-transitive-dependencies</name>
+    <description>An integration test similar to IT 3721-metaversion-dependencies, but with the RELEASE/LATEST meta-version
+        inside the pom of a transitive dependency
+    </description>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.owasp.test</groupId>
+            <artifactId>4397-dependency-with-meta-transitive</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>${odc.version}</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <format>XML</format>
+                    <centralAnalyzerEnabled>false</centralAnalyzerEnabled>
+                    <enableExperimental>true</enableExperimental>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven/src/it/4397-metaversion-for-transitive-dependency/pom.xml
+++ b/maven/src/it/4397-metaversion-for-transitive-dependency/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of dependency-check-maven.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright (c) 2023 Hans Aikema. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.owasp.test.aggregate</groupId>
+    <artifactId>4397-dummy</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <description>Just an empty pom to make maven-invoker-plugin discover this integration test.</description>
+</project>

--- a/maven/src/it/4397-metaversion-for-transitive-dependency/postbuild.groovy
+++ b/maven/src/it/4397-metaversion-for-transitive-dependency/postbuild.groovy
@@ -1,0 +1,46 @@
+/*
+ * This file is part of dependency-check-maven.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2023 Hans Aikema. All Rights Reserved.
+ */
+
+import org.apache.commons.io.FileUtils;
+import org.w3c.dom.NodeList;
+
+import java.nio.charset.Charset;
+import javax.xml.xpath.*
+import javax.xml.parsers.DocumentBuilderFactory
+
+def countMatches(String xml, String xpathQuery) {
+    def xpath = XPathFactory.newInstance().newXPath()
+    def builder     = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+    def inputStream = new ByteArrayInputStream( xml.bytes )
+    def records     = builder.parse(inputStream).documentElement
+    NodeList nodes       = xpath.evaluate( xpathQuery, records, XPathConstants.NODESET ) as NodeList
+    nodes.getLength();
+}
+
+String log = FileUtils.readFileToString(new File(basedir, "main/target/dependency-check-report.xml"), Charset.defaultCharset().name());
+int count = countMatches(log,"/analysis/dependencies/dependency/evidenceCollected/evidence[@type='product' and ./value = 'commons-compress' and ./name = 'artifactid']");
+if (count != 1){
+    System.out.println(String.format("commons-compress was identified %s times, expected 1", count));
+    return false;
+}
+count = countMatches(log,"/analysis/dependencies/dependency/evidenceCollected/evidence[@type='product' and ./value = 'commons-pool2' and ./name = 'artifactid']");
+if (count != 1){
+    System.out.println(String.format("commons-pool2  was identified %s times, expected 1", count));
+    return false;
+}
+return true;

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1547,7 +1547,12 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         }
         boolean result = Objects.equals(res.getArtifact().getGroupId(), unresolvedArtifact.getGroupId());
         result &= Objects.equals(res.getArtifact().getArtifactId(), unresolvedArtifact.getArtifactId());
-        result &= Objects.equals(res.getArtifact().getBaseVersion(), unresolvedArtifact.getBaseVersion());
+        // accept any version as matching "LATEST" and any non-snapshot version as matching "RELEASE" meta-version
+        if ("RELEASE".equals(unresolvedArtifact.getBaseVersion())) {
+            result &= !res.getArtifact().isSnapshot();
+        } else if (!"LATEST".equals(unresolvedArtifact.getBaseVersion())) {
+            result &= Objects.equals(res.getArtifact().getBaseVersion(), unresolvedArtifact.getBaseVersion());
+        }
         result &= Objects.equals(res.getArtifact().getClassifier(), unresolvedArtifact.getClassifier());
         result &= Objects.equals(res.getArtifact().getType(), unresolvedArtifact.getType());
         return result;


### PR DESCRIPTION
## Fixes Issue #4397 

## Description of Change

Adapted version-matching logic in sameArtifact to make the RELEASE and LATEST dependencies match up with whatever version of the artifact has been resolved (in case of RELEASE only if the resolved artifact is not a SNAPSHOT)

## Have test cases been added to cover the new functionality?

yes, new integration-test added