### PR TITLE
feat: Add "properties.security-severity" to SARIF report be able to filter and sort by Severity in GitHub Security Code scanning

### DIFF
--- a/core/src/main/resources/templates/sarifReport.vsl
+++ b/core/src/main/resources/templates/sarifReport.vsl
@@ -42,6 +42,7 @@ For more information see [How dependency-check works](https://jeremylong.github.
                 #end
                 #if($rule.cvssv3BaseSeverity)
                     "cvssv3_baseScore": $rule.cvssv3BaseScore,
+                    "security-severity": $rule.cvssv3BaseScore,
                     "cvssv3_attackVector": "$enc.json($rule.cvssv3AttackVector)",
                     "cvssv3_attackComplexity": "$enc.json($rule.cvssv3AttackComplexity)",
                     "cvssv3_privilegesRequired": "$enc.json($rule.cvssv3PrivilegesRequired)",


### PR DESCRIPTION
## Description of Change

Actually, all issues have the same Severity in the Security Code scanning overview.

As described [here](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#reportingdescriptor-object) it's possible/recommended to add a severity with the `properties.security-severity`.

So we added the "properties.security-severity" to the SARIF template to be able to filter and sort by Severity in GitHub Security Code scanning.

We think, that the base score described [here](https://nvd.nist.gov/vuln-metrics/cvss), should have the correct value.

## Have test cases been added to cover the new functionality?
no - but I uploaded the generated SARIF file and verified, that the file could be processed by GitHub and I could filter and sort in the Security Code scanning overview.