### PR TITLE
fix: long version of go dependency unable to inserted into software table (CVE-2020-36569)

### DIFF
--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -25,11 +25,14 @@ Copyright (c) 2017 Jeremy Long. All Rights Reserved.
     <artifactId>dependency-check-plugin</artifactId>
     <name>Dependency-Check Plugin Archetype</name>
     <packaging>jar</packaging>
+    <properties>
+        <!--reproducible build-->
+        <project.build.outputTimestamp>${git.commit.time}</project.build.outputTimestamp>
+    </properties>
     <scm>
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck/tree/main/archetype</url>
         <developerConnection>scm:git:git@github.com:jeremylong/DependencyCheck.git</developerConnection>
-        <tag>v6.4.1</tag>
     </scm>
     <build>
         <plugins>

--- a/core/src/main/resources/data/initialize.sql
+++ b/core/src/main/resources/data/initialize.sql
@@ -28,8 +28,8 @@ CREATE TABLE cpeEntry (id INT auto_increment PRIMARY KEY, part CHAR(1), vendor V
 version VARCHAR(255), update_version VARCHAR(255), edition VARCHAR(255), lang VARCHAR(20), sw_edition VARCHAR(255), 
 target_sw VARCHAR(255), target_hw VARCHAR(255), other VARCHAR(255), ecosystem VARCHAR(255));
 
-CREATE TABLE software (cveid INT, cpeEntryId INT, versionEndExcluding VARCHAR(60), versionEndIncluding VARCHAR(60),
-                       versionStartExcluding VARCHAR(60), versionStartIncluding VARCHAR(60), vulnerable BOOLEAN
+CREATE TABLE software (cveid INT, cpeEntryId INT, versionEndExcluding VARCHAR(100), versionEndIncluding VARCHAR(100),
+                       versionStartExcluding VARCHAR(100), versionStartIncluding VARCHAR(100), vulnerable BOOLEAN
     , CONSTRAINT fkSoftwareCve FOREIGN KEY (cveid) REFERENCES vulnerability(id) ON DELETE CASCADE
     , CONSTRAINT fkSoftwareCpeProduct FOREIGN KEY (cpeEntryId) REFERENCES cpeEntry(id));
 
@@ -56,4 +56,4 @@ CREATE ALIAS update_vulnerability FOR "org.owasp.dependencycheck.data.nvdcve.H2F
 CREATE ALIAS insert_software FOR "org.owasp.dependencycheck.data.nvdcve.H2Functions.insertSoftware";
 
 CREATE TABLE properties (id varchar(50) PRIMARY KEY, `value` varchar(500));
-INSERT INTO properties(id, `value`) VALUES ('version', '5.2.2');
+INSERT INTO properties(id, `value`) VALUES ('version', '5.3');

--- a/core/src/main/resources/data/initialize.sql
+++ b/core/src/main/resources/data/initialize.sql
@@ -56,4 +56,4 @@ CREATE ALIAS update_vulnerability FOR "org.owasp.dependencycheck.data.nvdcve.H2F
 CREATE ALIAS insert_software FOR "org.owasp.dependencycheck.data.nvdcve.H2Functions.insertSoftware";
 
 CREATE TABLE properties (id varchar(50) PRIMARY KEY, `value` varchar(500));
-INSERT INTO properties(id, `value`) VALUES ('version', '5.2.1');
+INSERT INTO properties(id, `value`) VALUES ('version', '5.2.2');

--- a/core/src/main/resources/data/initialize_mssql.sql
+++ b/core/src/main/resources/data/initialize_mssql.sql
@@ -207,7 +207,7 @@ END;
 
 GO
 
-INSERT INTO properties(id,value) VALUES ('version','5.2.1');
+INSERT INTO properties(id,value) VALUES ('version','5.2.2');
 
 GO
 /**

--- a/core/src/main/resources/data/initialize_mssql.sql
+++ b/core/src/main/resources/data/initialize_mssql.sql
@@ -169,8 +169,8 @@ CREATE PROCEDURE insert_software (
     @vulnerabilityId INT, @part CHAR(1), @vendor VARCHAR(255), @product VARCHAR(255),
     @version VARCHAR(255), @update_version VARCHAR(255), @edition VARCHAR(255), @lang VARCHAR(20),
     @sw_edition VARCHAR(255), @target_sw VARCHAR(255), @target_hw VARCHAR(255), @other VARCHAR(255), 
-    @ecosystem VARCHAR(255), @versionEndExcluding VARCHAR(50), @versionEndIncluding VARCHAR(50), 
-    @versionStartExcluding VARCHAR(50), @versionStartIncluding VARCHAR(50), @vulnerable BIT) AS
+    @ecosystem VARCHAR(255), @versionEndExcluding VARCHAR(100), @versionEndIncluding VARCHAR(100), 
+    @versionStartExcluding VARCHAR(100), @versionStartIncluding VARCHAR(100), @vulnerable BIT) AS
 BEGIN
     DECLARE @cpeId INT;
     DECLARE @currentEcosystem VARCHAR(255);
@@ -207,7 +207,7 @@ END;
 
 GO
 
-INSERT INTO properties(id,value) VALUES ('version','5.2.2');
+INSERT INTO properties(id,value) VALUES ('version','5.3');
 
 GO
 /**

--- a/core/src/main/resources/data/initialize_mysql.sql
+++ b/core/src/main/resources/data/initialize_mysql.sql
@@ -274,4 +274,4 @@ GRANT EXECUTE ON PROCEDURE dependencycheck.update_ecosystems2 TO 'dcuser';
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON dependencycheck.* TO 'dcuser';
 
-INSERT INTO properties(id, value) VALUES ('version', '5.2.1');
+INSERT INTO properties(id, value) VALUES ('version', '5.2.2');

--- a/core/src/main/resources/data/initialize_mysql.sql
+++ b/core/src/main/resources/data/initialize_mysql.sql
@@ -46,8 +46,8 @@ CREATE TABLE cpeEntry (id INT auto_increment PRIMARY KEY, part CHAR(1), vendor V
 version VARCHAR(255), update_version VARCHAR(255), edition VARCHAR(255), lang VARCHAR(20), sw_edition VARCHAR(255), 
 target_sw VARCHAR(255), target_hw VARCHAR(255), other VARCHAR(255), ecosystem VARCHAR(255));
 
-CREATE TABLE software (cveid INT, cpeEntryId INT, versionEndExcluding VARCHAR(60), versionEndIncluding VARCHAR(60), 
-                       versionStartExcluding VARCHAR(60), versionStartIncluding VARCHAR(60), vulnerable BOOLEAN
+CREATE TABLE software (cveid INT, cpeEntryId INT, versionEndExcluding VARCHAR(100), versionEndIncluding VARCHAR(100), 
+                       versionStartExcluding VARCHAR(100), versionStartIncluding VARCHAR(100), vulnerable BOOLEAN
     , CONSTRAINT fkSoftwareCve FOREIGN KEY (cveid) REFERENCES vulnerability(id) ON DELETE CASCADE
     , CONSTRAINT fkSoftwareCpeProduct FOREIGN KEY (cpeEntryId) REFERENCES cpeEntry(id));
     
@@ -193,8 +193,8 @@ CREATE PROCEDURE insert_software (
     IN p_vulnerabilityId INT, IN p_part CHAR(1), IN p_vendor VARCHAR(255), IN p_product VARCHAR(255),
     IN p_version VARCHAR(255), IN p_update_version VARCHAR(255), IN p_edition VARCHAR(255), IN p_lang VARCHAR(20),
     IN p_sw_edition VARCHAR(255), IN p_target_sw VARCHAR(255), IN p_target_hw VARCHAR(255), IN p_other VARCHAR(255), 
-    IN p_ecosystem VARCHAR(255), IN p_versionEndExcluding VARCHAR(50), IN p_versionEndIncluding VARCHAR(50), 
-    IN p_versionStartExcluding VARCHAR(50), IN p_versionStartIncluding VARCHAR(50), IN p_vulnerable BOOLEAN)
+    IN p_ecosystem VARCHAR(255), IN p_versionEndExcluding VARCHAR(100), IN p_versionEndIncluding VARCHAR(100), 
+    IN p_versionStartExcluding VARCHAR(100), IN p_versionStartIncluding VARCHAR(100), IN p_vulnerable BOOLEAN)
 BEGIN
 
     DECLARE cpeId INT DEFAULT 0;
@@ -274,4 +274,4 @@ GRANT EXECUTE ON PROCEDURE dependencycheck.update_ecosystems2 TO 'dcuser';
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON dependencycheck.* TO 'dcuser';
 
-INSERT INTO properties(id, value) VALUES ('version', '5.2.2');
+INSERT INTO properties(id, value) VALUES ('version', '5.3');

--- a/core/src/main/resources/data/initialize_oracle.sql
+++ b/core/src/main/resources/data/initialize_oracle.sql
@@ -396,4 +396,4 @@ CREATE OR REPLACE VIEW v_update_ecosystems AS
     ON c.vendor=e.vendor
         AND c.product=e.product;
 
-INSERT INTO properties(id,value) VALUES ('version','5.2.1');
+INSERT INTO properties(id,value) VALUES ('version','5.2.2');

--- a/core/src/main/resources/data/initialize_oracle.sql
+++ b/core/src/main/resources/data/initialize_oracle.sql
@@ -118,8 +118,8 @@ CREATE TABLE cpeEntry (id INT NOT NULL PRIMARY KEY, part CHAR(1), vendor VARCHAR
 version VARCHAR(255), update_version VARCHAR(255), edition VARCHAR(255), lang VARCHAR(20), sw_edition VARCHAR(255), 
 target_sw VARCHAR(255), target_hw VARCHAR(255), other VARCHAR(255), ecosystem VARCHAR(255));
 
-CREATE TABLE software (cveid INT, cpeEntryId INT, versionEndExcluding VARCHAR(60), versionEndIncluding VARCHAR(60), 
-                       versionStartExcluding VARCHAR(60), versionStartIncluding VARCHAR(60), vulnerable number(1)
+CREATE TABLE software (cveid INT, cpeEntryId INT, versionEndExcluding VARCHAR(100), versionEndIncluding VARCHAR(100), 
+                       versionStartExcluding VARCHAR(100), versionStartIncluding VARCHAR(100), vulnerable number(1)
     , CONSTRAINT fkSoftwareCve FOREIGN KEY (cveid) REFERENCES vulnerability(id) ON DELETE CASCADE
     , CONSTRAINT fkSoftwareCpeProduct FOREIGN KEY (cpeEntryId) REFERENCES cpeEntry(id));
 
@@ -396,4 +396,4 @@ CREATE OR REPLACE VIEW v_update_ecosystems AS
     ON c.vendor=e.vendor
         AND c.product=e.product;
 
-INSERT INTO properties(id,value) VALUES ('version','5.2.2');
+INSERT INTO properties(id,value) VALUES ('version','5.3');

--- a/core/src/main/resources/data/initialize_postgres.sql
+++ b/core/src/main/resources/data/initialize_postgres.sql
@@ -211,4 +211,4 @@ GRANT EXECUTE ON FUNCTION public.insert_software (INT, CHAR(1), VARCHAR(255),
 
 
 
-INSERT INTO properties(id,value) VALUES ('version','5.2.1');
+INSERT INTO properties(id,value) VALUES ('version','5.2.2');

--- a/core/src/main/resources/data/initialize_postgres.sql
+++ b/core/src/main/resources/data/initialize_postgres.sql
@@ -33,8 +33,8 @@ CREATE TABLE cpeEntry (id SERIAL PRIMARY KEY, part CHAR(1), vendor VARCHAR(255),
     version VARCHAR(255), update_version VARCHAR(255), edition VARCHAR(255), lang VARCHAR(20), sw_edition VARCHAR(255), 
     target_sw VARCHAR(255), target_hw VARCHAR(255), other VARCHAR(255), ecosystem VARCHAR(255));
 
-CREATE TABLE software (cveid INT, cpeEntryId INT, versionEndExcluding VARCHAR(60), versionEndIncluding VARCHAR(60), 
-                       versionStartExcluding VARCHAR(60), versionStartIncluding VARCHAR(60), vulnerable BOOLEAN
+CREATE TABLE software (cveid INT, cpeEntryId INT, versionEndExcluding VARCHAR(100), versionEndIncluding VARCHAR(100), 
+                       versionStartExcluding VARCHAR(100), versionStartIncluding VARCHAR(100), vulnerable BOOLEAN
     , CONSTRAINT fkSoftwareCve FOREIGN KEY (cveid) REFERENCES vulnerability(id) ON DELETE CASCADE
     , CONSTRAINT fkSoftwareCpeProduct FOREIGN KEY (cpeEntryId) REFERENCES cpeEntry(id));
 
@@ -168,8 +168,8 @@ CREATE FUNCTION insert_software (
     IN p_vulnerabilityId INT, IN p_part CHAR(1), IN p_vendor VARCHAR(255), IN p_product VARCHAR(255),
     IN p_version VARCHAR(255), IN p_update_version VARCHAR(255), IN p_edition VARCHAR(255), IN p_lang VARCHAR(20),
     IN p_sw_edition VARCHAR(255), IN p_target_sw VARCHAR(255), IN p_target_hw VARCHAR(255), IN p_other VARCHAR(255), 
-    IN p_ecosystem VARCHAR(255), IN p_versionEndExcluding VARCHAR(50), IN p_versionEndIncluding VARCHAR(50), 
-    IN p_versionStartExcluding VARCHAR(50), IN p_versionStartIncluding VARCHAR(50), IN p_vulnerable BOOLEAN)
+    IN p_ecosystem VARCHAR(255), IN p_versionEndExcluding VARCHAR(100), IN p_versionEndIncluding VARCHAR(100), 
+    IN p_versionStartExcluding VARCHAR(100), IN p_versionStartIncluding VARCHAR(100), IN p_vulnerable BOOLEAN)
 RETURNS void
 AS $$
 DECLARE 
@@ -211,4 +211,4 @@ GRANT EXECUTE ON FUNCTION public.insert_software (INT, CHAR(1), VARCHAR(255),
 
 
 
-INSERT INTO properties(id,value) VALUES ('version','5.2.2');
+INSERT INTO properties(id,value) VALUES ('version','5.3');

--- a/core/src/main/resources/data/upgrade_5.2.1.sql
+++ b/core/src/main/resources/data/upgrade_5.2.1.sql
@@ -1,0 +1,6 @@
+ALTER TABLE software ALTER COLUMN versionEndExcluding SET DATA TYPE VARCHAR(100);
+ALTER TABLE software ALTER COLUMN versionEndIncluding SET DATA TYPE VARCHAR(100);
+ALTER TABLE software ALTER COLUMN versionStartExcluding SET DATA TYPE VARCHAR(100);
+ALTER TABLE software ALTER COLUMN versionStartIncluding SET DATA TYPE VARCHAR(100);
+
+UPDATE Properties SET `value`='5.3' WHERE ID='version'; 

--- a/core/src/main/resources/data/upgrade_5.3.sql
+++ b/core/src/main/resources/data/upgrade_5.3.sql
@@ -1,0 +1,6 @@
+ALTER TABLE software ALTER COLUMN versionEndExcluding SET DATA TYPE VARCHAR(75);
+ALTER TABLE software ALTER COLUMN versionEndIncluding SET DATA TYPE VARCHAR(75);
+ALTER TABLE software ALTER COLUMN versionStartExcluding SET DATA TYPE VARCHAR(75);
+ALTER TABLE software ALTER COLUMN versionStartIncluding SET DATA TYPE VARCHAR(75);
+
+UPDATE Properties SET `value`='5.3' WHERE ID='version'; 

--- a/core/src/main/resources/data/upgrade_5.3.sql
+++ b/core/src/main/resources/data/upgrade_5.3.sql
@@ -3,4 +3,4 @@ ALTER TABLE software ALTER COLUMN versionEndIncluding SET DATA TYPE VARCHAR(75);
 ALTER TABLE software ALTER COLUMN versionStartExcluding SET DATA TYPE VARCHAR(75);
 ALTER TABLE software ALTER COLUMN versionStartIncluding SET DATA TYPE VARCHAR(75);
 
-UPDATE Properties SET `value`='5.3' WHERE ID='version'; 
+UPDATE Properties SET `value`='5.2.2' WHERE ID='version'; 

--- a/core/src/main/resources/data/upgrade_5.3.sql
+++ b/core/src/main/resources/data/upgrade_5.3.sql
@@ -1,6 +1,0 @@
-ALTER TABLE software ALTER COLUMN versionEndExcluding SET DATA TYPE VARCHAR(75);
-ALTER TABLE software ALTER COLUMN versionEndIncluding SET DATA TYPE VARCHAR(75);
-ALTER TABLE software ALTER COLUMN versionStartExcluding SET DATA TYPE VARCHAR(75);
-ALTER TABLE software ALTER COLUMN versionStartIncluding SET DATA TYPE VARCHAR(75);
-
-UPDATE Properties SET `value`='5.2.2' WHERE ID='version'; 

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -21,7 +21,7 @@ data.file_name=odc.mv.db
 ### if you increment the DB version then you must increment the database file path
 ### in the mojo.properties, task.properties (maven and ant respectively), and
 ### the gradle PurgeDataExtension.
-data.version=5.2.2
+data.version=5.3
 
 #The analysis timeout in minutes
 odc.analysis.timeout=180

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -21,7 +21,7 @@ data.file_name=odc.mv.db
 ### if you increment the DB version then you must increment the database file path
 ### in the mojo.properties, task.properties (maven and ant respectively), and
 ### the gradle PurgeDataExtension.
-data.version=5.2.1
+data.version=5.2.2
 
 #The analysis timeout in minutes
 odc.analysis.timeout=180

--- a/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/DatabasePropertiesIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/DatabasePropertiesIT.java
@@ -17,7 +17,6 @@
  */
 package org.owasp.dependencycheck.data.nvdcve;
 
-import org.semver4j.Semver;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import java.util.Properties;
 import org.junit.After;
@@ -99,8 +98,9 @@ public class DatabasePropertiesIT extends BaseDBTestCase {
         DatabaseProperties instance = cveDb.getDatabaseProperties();
         String result = instance.getProperty(key);
         
-        Semver ver = new Semver(result);
-        assertTrue(ver.getMajor() >= 5);
+        int major = Integer.parseInt(result.substring(0, result.indexOf('.')));
+       
+        assertTrue(major >= 5);
     }
 
     /**

--- a/core/src/test/resources/dependencycheck.properties
+++ b/core/src/test/resources/dependencycheck.properties
@@ -17,7 +17,7 @@ engine.version.url=https://jeremylong.github.io/DependencyCheck/current.txt
 data.directory=[JAR]/data/7.0
 #if the filename has a %s it will be replaced with the current expected version
 data.file_name=odc.mv.db
-data.version=5.2.1
+data.version=5.2.2
 
 #The analysis timeout in minutes
 odc.analysis.timeout=20

--- a/core/src/test/resources/dependencycheck.properties
+++ b/core/src/test/resources/dependencycheck.properties
@@ -17,7 +17,7 @@ engine.version.url=https://jeremylong.github.io/DependencyCheck/current.txt
 data.directory=[JAR]/data/7.0
 #if the filename has a %s it will be replaced with the current expected version
 data.file_name=odc.mv.db
-data.version=5.2.2
+data.version=5.3
 
 #The analysis timeout in minutes
 odc.analysis.timeout=20

--- a/utils/src/test/resources/dependencycheck.properties
+++ b/utils/src/test/resources/dependencycheck.properties
@@ -17,7 +17,7 @@ engine.version.url=https://jeremylong.github.io/DependencyCheck/current.txt
 data.directory=[JAR]/data
 #if the filename has a %s it will be replaced with the current expected version
 data.file_name=0dc.mv.db
-data.version=5.2.1
+data.version=5.2.2
 
 #The analysis timeout in minutes
 odc.analysis.timeout=20

--- a/utils/src/test/resources/dependencycheck.properties
+++ b/utils/src/test/resources/dependencycheck.properties
@@ -17,7 +17,7 @@ engine.version.url=https://jeremylong.github.io/DependencyCheck/current.txt
 data.directory=[JAR]/data
 #if the filename has a %s it will be replaced with the current expected version
 data.file_name=0dc.mv.db
-data.version=5.2.2
+data.version=5.3
 
 #The analysis timeout in minutes
 odc.analysis.timeout=20


### PR DESCRIPTION
supersedes #5221

## Fixes Issue #
Fix: long version of go dependency unable to inserted into software table (CVE-2020-36569) 

## Description of Change
Alter's column size to varchar 75

*Please add a description of the proposed change*
Alters to a minimum possible value of version columns to 75 characters. Could be more or less as well.


## Have test cases been added to cover the new functionality?

no