### PR TITLE
fix: crash when analyzing node package with a local dependency

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
@@ -390,6 +390,7 @@ public class NodePackageAnalyzer extends AbstractNpmAnalyzer {
                     // Ignore/skip linked entries (as they don't have "version" and
                     // later logic will crash)
                     if (jo.getBoolean("link", false)) {
+                        LOGGER.warn("Skipping `" + name + "` because it is a link dependency");
                         continue;
                     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
@@ -386,6 +386,13 @@ public class NodePackageAnalyzer extends AbstractNpmAnalyzer {
 
                 if (entry.getValue() instanceof JsonObject) {
                     jo = (JsonObject) entry.getValue();
+
+                    // Ignore/skip linked entries (as they don't have "version" and
+                    // later logic will crash)
+                    if (jo.getBoolean("link", false)) {
+                        continue;
+                    }
+
                     version = jo.getString("version");
                     optional = jo.getBoolean("optional", false);
                     isDev = jo.getBoolean("dev", false);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzerTest.java
@@ -309,4 +309,26 @@ public class NodePackageAnalyzerTest extends BaseTest {
         analyzer.analyze(packageLockJson, engine);
         assertEquals("Expected 1 dependencies", 6, engine.getDependencies().length);
     }
+
+    /**
+     * Test of analysis of package with a local package as a dependency.
+     *
+     * This test crashes with an NPE if issue #1947 isn't resolved.
+     *
+     * @throws AnalysisException if there was a problem with the analysis
+     */
+    @Test
+    public void testLocalPackageDependency() throws AnalysisException, InvalidSettingException {
+        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED), is(true));
+        final Dependency packageJson = new Dependency(BaseTest.getResourceAsFile(this,
+                "nodejs/local_package/package.json"));
+        final Dependency packageLockJson = new Dependency(BaseTest.getResourceAsFile(this,
+                "nodejs/local_package/package-lock.json"));
+        engine.addDependency(packageJson);
+        engine.addDependency(packageLockJson);
+        analyzer.analyze(packageJson, engine);
+        assertEquals("Expected 1 dependencies", 1, engine.getDependencies().length);
+        analyzer.analyze(packageLockJson, engine);
+        assertEquals("Expected 2 dependencies", 2, engine.getDependencies().length);
+    }
 }

--- a/core/src/test/resources/nodejs/local_package/mypackage/package.json
+++ b/core/src/test/resources/nodejs/local_package/mypackage/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mypackage",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+  }
+}

--- a/core/src/test/resources/nodejs/local_package/node_modules/.package-lock.json
+++ b/core/src/test/resources/nodejs/local_package/node_modules/.package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "local_package",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "mypackage": {
+      "version": "1.0.0",
+      "license": "ISC"
+    },
+    "node_modules/mypackage": {
+      "resolved": "mypackage",
+      "link": true
+    }
+  }
+}

--- a/core/src/test/resources/nodejs/local_package/node_modules/mypackage
+++ b/core/src/test/resources/nodejs/local_package/node_modules/mypackage
@@ -1,0 +1,1 @@
+../mypackage

--- a/core/src/test/resources/nodejs/local_package/package-lock.json
+++ b/core/src/test/resources/nodejs/local_package/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "local_package",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "local_package",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "mypackage": "file:./mypackage"
+      }
+    },
+    "mypackage": {
+      "version": "1.0.0",
+      "license": "ISC"
+    },
+    "node_modules/mypackage": {
+      "resolved": "mypackage",
+      "link": true
+    }
+  },
+  "dependencies": {
+    "mypackage": {
+      "version": "file:mypackage"
+    }
+  }
+}

--- a/core/src/test/resources/nodejs/local_package/package.json
+++ b/core/src/test/resources/nodejs/local_package/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "local_package",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "mypackage": "file:./mypackage"
+  }
+}


### PR DESCRIPTION
## Fixes Issue #1947 

## Description of Change

When a package has a local dependency, the package-lock.json file contains an entry without a version number, with "link": "true". This lack of version attribute causes the NodePackageAnalyzer class to crash.

These entries should be skipped instead as they cannot be processed.

## Have test cases been added to cover the new functionality?

yes