### PR TITLE
fix(FP): Fix #5213 on generic utils project

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -6106,4 +6106,11 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.james/apache-jsieve-core@.*$</packageUrl>
         <cpe>cpe:/a:apache:james</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #5213, CVEs for scripting pet projects
+        ]]></notes>
+        <packageUrl regex="true">^.*$</packageUrl>
+        <cve>CVE-2021-4277</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Fixes Issue #5213

## Description of Change

Suppresses all Maven artifacts for this CPE, which is not actually a real CPE, see https://github.com/jeremylong/DependencyCheck/issues/5213#issuecomment-1372442259

Willing to take input on whether this is the right approach.

## Have test cases been added to cover the new functionality?

no