### PR TITLE
fix(FP): Multiple artifacts wrongly attributed to the Go-lang YAML package CPE

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -621,6 +621,7 @@
             61. cpe:/a:storage_project:storage is software build in go (the github.com/containers/storage project) #4436
             62. cpe:/a:pivotal_software:rabbitmq is software build in Erlang #4178
             63. cpe:/a:saml_project:saml is a SAML implementation in Go #5167
+            64. cpe:/a:yaml_project:yaml is a YAML implementation in Go #5233 and #5234
         ]]></notes>
         <filePath regex="true">.*(\.(dll|jar|ear|war|pom|nupkg|nuspec|aar)|pom\.xml|package.json|packages.config)$</filePath>
         <cpe>cpe:/a:sandbox:sandbox</cpe>
@@ -686,6 +687,7 @@
         <cpe>cpe:/a:storage_project:storage</cpe>
         <cpe>cpe:/a:pivotal_software:rabbitmq</cpe>
         <cpe>cpe:/a:saml_project:saml</cpe>
+        <cpe>cpe:/a:yaml_project:yaml</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[


### PR DESCRIPTION


Fixes #5233, fixes #5234


## Description of Change

Add a broad suppression to avoid projects with YAML in the name that are not go packages to be associated with the Go YAML package which received the generic `yaml_project:yaml` product/vendor in the CPE

## Have test cases been added to cover the new functionality?

no