### PR TITLE
fix: broken unit test on Mac OS

### DIFF
--- a/core/src/test/java/org/owasp/dependencycheck/data/update/nvd/DownloadTaskTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/update/nvd/DownloadTaskTest.java
@@ -36,6 +36,7 @@ public class DownloadTaskTest extends BaseTest {
      */
     @Test
     public void testCall() throws Exception {
+    	if ("".equals(System.getProperty(Settings.KEYS.CVE_MODIFIED_JSON))) System.clearProperty(Settings.KEYS.CVE_MODIFIED_JSON); // Somehow this is geting set to an empty string before this test on Mac OS
         NvdCveInfo cve = new NvdCveInfo("modified",getSettings().getString(Settings.KEYS.CVE_MODIFIED_JSON),1337L);
         ExecutorService processExecutor = null;
         CveDB cveDB = null;


### PR DESCRIPTION
## Fixes Issue #
DownloadTaskTest failing in 7.4.4 branch on Mac OS

## Description of Change
reset missing setting value in SystemProperties before using it

## Have test cases been added to cover the new functionality?
yes