### PR TITLE
fix: DownloadTaskTest missing correct setting

### DIFF
--- a/core/src/test/java/org/owasp/dependencycheck/data/update/nvd/DownloadTaskTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/update/nvd/DownloadTaskTest.java
@@ -36,6 +36,7 @@ public class DownloadTaskTest extends BaseTest {
      */
     @Test
     public void testCall() throws Exception {
+        if ("".equals(System.getProperty(Settings.KEYS.CVE_MODIFIED_JSON))) System.clearProperty(Settings.KEYS.CVE_MODIFIED_JSON); // Somehow this is geting set to an empty string before this test on Mac OS
         NvdCveInfo cve = new NvdCveInfo("modified",getSettings().getString(Settings.KEYS.CVE_MODIFIED_JSON),1337L);
         ExecutorService processExecutor = null;
         CveDB cveDB = null;


### PR DESCRIPTION
fix broken unit test on Mac OS

## Fixes Issue #
DownloadTaskTest failing on Mac OS with openjdk11

## Description of Change

SystemProperty gets inadvertently set to empty string, need to reset it for this test to get the correct value

## Have test cases been added to cover the new functionality?
yes