### PR TITLE
fix: Updating column lenght to VARCHAR(100) in MSSQL init script

### DIFF
--- a/core/src/main/resources/data/initialize_mssql.sql
+++ b/core/src/main/resources/data/initialize_mssql.sql
@@ -45,8 +45,8 @@ CREATE TABLE cpeEntry (id INT identity(1,1) PRIMARY KEY, part CHAR(1), vendor VA
     version VARCHAR(255), update_version VARCHAR(255), edition VARCHAR(255), lang VARCHAR(20), sw_edition VARCHAR(255), 
     target_sw VARCHAR(255), target_hw VARCHAR(255), other VARCHAR(255), ecosystem VARCHAR(255));
 
-CREATE TABLE software (cveid INT, cpeEntryId INT, versionEndExcluding VARCHAR(60), versionEndIncluding VARCHAR(60), 
-                       versionStartExcluding VARCHAR(60), versionStartIncluding VARCHAR(60), vulnerable BIT
+CREATE TABLE software (cveid INT, cpeEntryId INT, versionEndExcluding VARCHAR(100), versionEndIncluding VARCHAR(100), 
+                       versionStartExcluding VARCHAR(100), versionStartIncluding VARCHAR(100), vulnerable BIT
     , CONSTRAINT FK_SoftwareCve FOREIGN KEY (cveid) REFERENCES vulnerability(id) ON DELETE CASCADE
     , CONSTRAINT FK_SoftwareCpeProduct FOREIGN KEY (cpeEntryId) REFERENCES cpeEntry(id));
 


### PR DESCRIPTION
## Fixes Issue #
Due to #5220 the column width of certain columns in the table 'software' was increased to 100 characters (instead of 60). The database setup scripts in `core\src\main\resources\data` were updated accordingly. The MSSQL script was missing a few bits though.

## Description of Change
Updated the MSSQL setup script to increase the column width as needed to resolve #5220 


## Have test cases been added to cover the new functionality?

no (unfortunately I'm not sure how to add tests for these setup scripts)