### PR TITLE
fix: name calculation

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
@@ -363,7 +363,7 @@ public class NodePackageAnalyzer extends AbstractNpmAnalyzer {
                 String name = pathName;
                 File base;
 
-                final int indexOfNodeModule = name.lastIndexOf(NODE_MODULES_DIRNAME);
+                final int indexOfNodeModule = name.lastIndexOf(NODE_MODULES_DIRNAME + "/");
                 if (indexOfNodeModule >= 0) {
                     name = name.substring(indexOfNodeModule + NODE_MODULES_DIRNAME.length() + 1);
                     base = Paths.get(baseDir.getPath(), pathName).toFile();

--- a/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilder.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilder.java
@@ -109,7 +109,7 @@ public final class NpmPayloadBuilder {
 
         if (dependencies != null) {
             dependencies.forEach((key, value) -> {
-                final int indexOfNodeModule = key.lastIndexOf(NodePackageAnalyzer.NODE_MODULES_DIRNAME);
+                final int indexOfNodeModule = key.lastIndexOf(NodePackageAnalyzer.NODE_MODULES_DIRNAME + "/");
                 if (indexOfNodeModule >= 0) {
                     key = key.substring(indexOfNodeModule + NodePackageAnalyzer.NODE_MODULES_DIRNAME.length() + 1);
                 }


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

The current name calculation just looks for the last occurence of the string "node_modules" and calculates a substring after the occurence plus 1 arbitrary additional character. However, if this string is used as part of the package name the calculation ist wrong and the dependency check crashes with:
 "Could not perform Node Audit analysis. Invalid payload submitted to Node Audit API". 

We ran into this problem as we updated to the latest gradle plugin version due to #5220 and having "[node_modules-path](https://www.npmjs.com/package/node_modules-path)" as a transitive dependency. 

I added the slash to the indexOf check to ensure the right pattern is matched.

## Have test cases been added to cover the new functionality?

*no*