### PR TITLE
fix(partial): Issue #5144 Avoid NPE on non-Include packageReference

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/XPathMSBuildProjectParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/XPathMSBuildProjectParser.java
@@ -69,6 +69,10 @@ public class XPathMSBuildProjectParser implements MSBuildProjectParser {
                 final NamedNodeMap attrs = node.getAttributes();
 
                 final String include = attrs.getNamedItem("Include").getNodeValue();
+                if (include == null) {
+                    // Issue 5144 work-around for NPE on packageReferences other than includes
+                    continue;
+                }
                 String version = null;
 
                 if (attrs.getNamedItem("Version") != null) {


### PR DESCRIPTION
## Description of Change

Prevents the NPE on non-Include package references by just ignoring them. A proper fix should actually do something with the package references, but due to a lack of documentation of the non-include options it's hard to tell what would have to be done with them. By ignoring the entry we at least allow DependencyCheck to complete successfully.

## Have test cases been added to cover the new functionality?

no