### PR TITLE
fix: disable OSS Index Analyzer when transport errors occur

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -141,10 +141,11 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
                     } else if (StringUtils.endsWith(message, "403")) {
                         throw new AnalysisException("OSS Index access forbidden", ex);
                     } else if (StringUtils.endsWith(message, "429")) {
+                        this.setEnabled(false);
                         if (warnOnly) {
-                            LOG.warn("OSS Index rate limit exceeded", ex);
+                            LOG.warn("OSS Index rate limit exceeded, disabling the analyzer", ex);
                         } else {
-                            throw new AnalysisException("OSS Index rate limit exceeded", ex);
+                            throw new AnalysisException("OSS Index rate limit exceeded, disabling the analyzer", ex);
                         }
                     } else if (warnOnly) {
                         LOG.warn("Error requesting component reports", ex);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -135,22 +135,23 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
                 } catch (TransportException ex) {
                     final String message = ex.getMessage();
                     final boolean warnOnly = getSettings().getBoolean(Settings.KEYS.ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS, false);
-
+                    this.setEnabled(false);
                     if (StringUtils.endsWith(message, "401")) {
+                        LOG.error("Invalid credentials for the OSS Index, disabling the analyzer");
                         throw new AnalysisException("Invalid credentials provided for OSS Index", ex);
                     } else if (StringUtils.endsWith(message, "403")) {
+                        LOG.error("OSS Index access forbidden, disabling the analyzer");
                         throw new AnalysisException("OSS Index access forbidden", ex);
                     } else if (StringUtils.endsWith(message, "429")) {
-                        this.setEnabled(false);
                         if (warnOnly) {
                             LOG.warn("OSS Index rate limit exceeded, disabling the analyzer", ex);
                         } else {
                             throw new AnalysisException("OSS Index rate limit exceeded, disabling the analyzer", ex);
                         }
                     } else if (warnOnly) {
-                        LOG.warn("Error requesting component reports", ex);
+                        LOG.warn("Error requesting component reports, disabling the analyzer", ex);
                     } else {
-                        LOG.debug("Error requesting component reports", ex);
+                        LOG.debug("Error requesting component reports, disabling the analyzer", ex);
                         throw new AnalysisException("Failed to request component-reports", ex);
                     }
                 } catch (Exception e) {

--- a/src/site/markdown/dependency-check-gradle/configuration-aggregate.md
+++ b/src/site/markdown/dependency-check-gradle/configuration-aggregate.md
@@ -177,6 +177,7 @@ retirejs     | filters               | Configures the list of regular expessions
 ossIndex     | enabled               | Sets whether [OSS Index Analyzer](../analyzers/oss-index-analyzer.html) will be used. This analyzer requires an internet connection. | true
 ossIndex     | username              | The optional user name to connect to Sonatype's OSS Index.                                                        | &nbsp;
 ossIndex     | password              | The password or API token to connect to Sonatype's OSS Index.                                                     | &nbsp;
+ossIndex     | warnOnlyOnRemoteErrors| Sets whether remote errors from the OSS Index (e.g. BAD GATEWAY, RATE LIMIT EXCEEDED) will result in warnings only instead of failing execution. | false
 slack        | enabled               | Whether or not slack notifications are enabled.                                                                   | false
 slack        | webhookUrl            | The custom incoming webhook URL to receive notifications.                                                         | &nbsp;
 

--- a/src/site/markdown/dependency-check-gradle/configuration.md
+++ b/src/site/markdown/dependency-check-gradle/configuration.md
@@ -162,6 +162,7 @@ retirejs     | filters               | Configures the list of regular expessions
 ossIndex     | enabled               | Sets whether Sonatype's [OSS Index Analyzer](../analyzers/oss-index-analyzer.html) will be used. This analyzer requires an internet connection.                                                                  | true
 ossIndex     | username              | The optional user name to connect to Sonatype's OSS Index.                                                        | &nbsp;
 ossIndex     | password              | The optional passwod or API token to connect to Sonatype's OSS Index,                                             | &nbsp;
+ossIndex     | warnOnlyOnRemoteErrors| Sets whether remote errors from the OSS Index (e.g. BAD GATEWAY, RATE LIMIT EXCEEDED) will result in warnings only instead of failing execution. | false
 slack        | enabled               | Whether or not slack notifications are enabled.                                                                   | false
 slack        | webhookUrl            | The custom incoming webhook URL to receive notifications.                                                         | &nbsp;
 hostedSuppressions | enabled         | The number of hours to wait before checking for new updates of the hosted suppressions file .                     | 2


### PR DESCRIPTION
- disable OSS Index Analyzer to prevent hundreds of exceptions in report
- update documentation for the OSS Index Analyzer
