### PR TITLE
fix: Add double quote for "properties.security-severity" to fix processing of SARIF file in GitHub

### DIFF
--- a/core/src/main/resources/templates/sarifReport.vsl
+++ b/core/src/main/resources/templates/sarifReport.vsl
@@ -41,7 +41,7 @@ For more information see [How dependency-check works](https://jeremylong.github.
                 #end
                 #if($rule.cvssv3BaseSeverity)
                     "cvssv3_baseScore": $rule.cvssv3BaseScore,
-                    "security-severity": $rule.cvssv3BaseScore,
+                    "security-severity": "$rule.cvssv3BaseScore",
                     "cvssv3_attackVector": "$enc.json($rule.cvssv3AttackVector)",
                     "cvssv3_attackComplexity": "$enc.json($rule.cvssv3AttackComplexity)",
                     "cvssv3_privilegesRequired": "$enc.json($rule.cvssv3PrivilegesRequired)",


### PR DESCRIPTION
## Fixes Issue #

I'm so sorry. I somehow forgot the quotation marks in my PR here https://github.com/jeremylong/DependencyCheck/pull/5227 

I don't know how that could have happened. This causes the following exception in github processing:

```
Error: Code Scanning could not process the submitted SARIF file:
parsing restricted subset of SARIF data has failed: parse error: expected string near offset 2910 of '7.2'
```

This PR adds the quotation marks.