### PR TITLE
fix(partial): Issue #5144 Avoid NPE on non-Include packageReference

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nuget/XPathMSBuildProjectParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nuget/XPathMSBuildProjectParser.java
@@ -68,11 +68,12 @@ public class XPathMSBuildProjectParser implements MSBuildProjectParser {
                 final Node node = nodeList.item(i);
                 final NamedNodeMap attrs = node.getAttributes();
 
-                final String include = attrs.getNamedItem("Include").getNodeValue();
-                if (include == null) {
+                final Node includeAttr = attrs.getNamedItem("Include");
+                if (includeAttr == null) {
                     // Issue 5144 work-around for NPE on packageReferences other than includes
                     continue;
                 }
+                final String include = includeAttr.getNodeValue();
                 String version = null;
 
                 if (attrs.getNamedItem("Version") != null) {


### PR DESCRIPTION
Original PR #5293 was incorrect for fixing the NPE. We should not attempt dereference of the null-valued getNamedItem return value for an absent Include attribute.

See also #5352 