### PR TITLE
fix: Support maven extensions like Tycho adding system-scoped dependencies without a systemPath

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2681,12 +2681,17 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 }
             }
             if (!isResolved) {
-                getLog().error("Unable to resolve system scoped dependency: " + dependencyNode.toNodeString());
+                final StringBuilder message = new StringBuilder("Unable to resolve system scoped dependency: ");
+                if (artifactFile != null) {
+                    message.append(dependencyNode.toNodeString()).append(" at path ").append(artifactFile);
+                } else {
+                    message.append(dependencyNode.toNodeString()).append(" at path ").append(a.getFile());
+                }
+                getLog().error(message);
                 if (exCol == null) {
                     exCol = new ExceptionCollection();
                 }
-                exCol.addException(new DependencyNotFoundException("Unable to resolve system scoped dependency: "
-                        + dependencyNode.toNodeString()));
+                exCol.addException(new DependencyNotFoundException(message.toString()));
             }
         } else {
             final Artifact dependencyArtifact = dependencyNode.getArtifact();

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2686,7 +2686,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 // so attempt to do a resolution for system-scoped too if still nothing found
                 try {
                     tryResolutionOnce(project, allResolvedDeps, buildingRequest);
-                    Artifact result = findInAllDeps(allResolvedDeps, dependencyNode.getArtifact(), project);
+                    final Artifact result = findInAllDeps(allResolvedDeps, dependencyNode.getArtifact(), project);
                     isResolved = result.isResolved();
                     artifactFile = result.getFile();
                     groupId = result.getGroupId();
@@ -2694,7 +2694,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                     version = result.getVersion();
                     availableVersions = result.getAvailableVersions();
                 } catch (DependencyNotFoundException | DependencyResolverException e) {
-                    getLog().warn("Error performing last-resort System-scoped dependency resolution: "+e.getMessage());
+                    getLog().warn("Error performing last-resort System-scoped dependency resolution: " + e.getMessage());
                     ignored = e;
                 }
             }
@@ -2709,7 +2709,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 if (exCol == null) {
                     exCol = new ExceptionCollection();
                 }
-                Exception thrown = new DependencyNotFoundException(message.toString());
+                final Exception thrown = new DependencyNotFoundException(message.toString());
                 if (ignored != null) {
                     thrown.addSuppressed(ignored);
                 }


### PR DESCRIPTION
## Fixes Issue #4969

## Description of Change

When regular system-scoped dependencies don't yield a resolved system-scoped artifact attempt resolving the dependencies to make maven extension hook into the artifact resolution and provide us with the appropriate dependencies.

## Have test cases been added to cover the new functionality?

No, adding an integrationtest with Tycho pomless 2.7.5. would require the build to run on JDK 11 or later, the updated Tycho 3 version would require JDK17 or later.
Manually verified that the scan runs to completion with the reproduction sample referred to in issue #4969 (both original Tycho 2.7.5 and the updated Tycho 3.0.0 versions)