### PR TITLE
fix: ensure pyproject.toml has lock

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzer.java
@@ -200,7 +200,8 @@ public class PoetryAnalyzer extends AbstractFileTypeAnalyzer {
         File requirements = new File(parent, "requirements.txt");
         boolean found = lock.isFile() || requirements.isFile();
         if (!found) {
-            throw new AnalysisException("Python `pyproject.toml` found and there is not a `poetry.lock` or `requirements.txt` - analysis will be incomplete");
+            throw new AnalysisException("Python `pyproject.toml` found and there "
+                    + "is not a `poetry.lock` or `requirements.txt` - analysis will be incomplete");
         }
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzer.java
@@ -35,10 +35,9 @@ import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.owasp.dependencycheck.utils.Settings;
 
 import com.moandjiezana.toml.Toml;
-import org.apache.commons.lang3.StringUtils;
+import java.io.File;
 import org.owasp.dependencycheck.data.nvd.ecosystem.Ecosystem;
 import org.owasp.dependencycheck.dependency.naming.GenericIdentifier;
-import org.owasp.dependencycheck.dependency.naming.Identifier;
 import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
 import org.owasp.dependencycheck.utils.Checksum;
 import org.slf4j.Logger;
@@ -69,12 +68,15 @@ public class PoetryAnalyzer extends AbstractFileTypeAnalyzer {
      * Lock file name.
      */
     private static final String POETRY_LOCK = "poetry.lock";
-
+    /**
+     * Poetry project file.
+     */
+    private static final String PYPROJECT_TOML = "pyproject.toml";
     /**
      * The file filter for poetry.lock
      */
     private static final FileFilter POETRY_LOCK_FILTER = FileFilterBuilder.newInstance()
-            .addFilenames(POETRY_LOCK)
+            .addFilenames(POETRY_LOCK, PYPROJECT_TOML)
             .build();
 
     /**
@@ -145,6 +147,13 @@ public class PoetryAnalyzer extends AbstractFileTypeAnalyzer {
         //do not report on the build file itself
         engine.removeDependency(dependency);
 
+        if (PYPROJECT_TOML.equals(dependency.getActualFile().getName())) {
+            File parentPath = dependency.getActualFile().getParentFile();
+            ensureLock(parentPath);
+            //exit as we can't analyze pyproject.toml - insufficient version information
+            return;
+        }
+
         final Toml result = new Toml().read(dependency.getActualFile());
         final List<Toml> projectsLocks = result.getTables("package");
         if (projectsLocks == null) {
@@ -161,12 +170,12 @@ public class PoetryAnalyzer extends AbstractFileTypeAnalyzer {
             d.setVersion(version);
 
             try {
-              final PackageURL purl = PackageURLBuilder.aPackageURL()
-                      .withType("pypi")
-                      .withName(name)
-                      .withVersion(version)
-                      .build();
-              d.addSoftwareIdentifier(new PurlIdentifier(purl, Confidence.HIGHEST));
+                final PackageURL purl = PackageURLBuilder.aPackageURL()
+                        .withType("pypi")
+                        .withName(name)
+                        .withVersion(version)
+                        .build();
+                d.addSoftwareIdentifier(new PurlIdentifier(purl, Confidence.HIGHEST));
             } catch (MalformedPackageURLException ex) {
                 LOGGER.debug("Unable to build package url for pypi", ex);
                 d.addSoftwareIdentifier(new GenericIdentifier("pypi:" + name + "@" + version, Confidence.HIGH));
@@ -184,5 +193,14 @@ public class PoetryAnalyzer extends AbstractFileTypeAnalyzer {
             d.addEvidence(EvidenceType.VENDOR, POETRY_LOCK, "vendor", name, Confidence.HIGHEST);
             engine.addDependency(d);
         });
+    }
+
+    private void ensureLock(File parent) throws AnalysisException {
+        File lock = new File(parent, POETRY_LOCK);
+        File requirements = new File(parent, "requirements.txt");
+        boolean found = lock.isFile() || requirements.isFile();
+        if (!found) {
+            throw new AnalysisException("Python `pyproject.toml` found and there is not a `poetry.lock` or `requirements.txt` - analysis will be incomplete");
+        }
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzer.java
@@ -148,7 +148,7 @@ public class PoetryAnalyzer extends AbstractFileTypeAnalyzer {
         engine.removeDependency(dependency);
 
         if (PYPROJECT_TOML.equals(dependency.getActualFile().getName())) {
-            File parentPath = dependency.getActualFile().getParentFile();
+            final File parentPath = dependency.getActualFile().getParentFile();
             ensureLock(parentPath);
             //exit as we can't analyze pyproject.toml - insufficient version information
             return;
@@ -196,9 +196,9 @@ public class PoetryAnalyzer extends AbstractFileTypeAnalyzer {
     }
 
     private void ensureLock(File parent) throws AnalysisException {
-        File lock = new File(parent, POETRY_LOCK);
-        File requirements = new File(parent, "requirements.txt");
-        boolean found = lock.isFile() || requirements.isFile();
+        final File lock = new File(parent, POETRY_LOCK);
+        final File requirements = new File(parent, "requirements.txt");
+        final boolean found = lock.isFile() || requirements.isFile();
         if (!found) {
             throw new AnalysisException("Python `pyproject.toml` found and there "
                     + "is not a `poetry.lock` or `requirements.txt` - analysis will be incomplete");

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzerTest.java
@@ -72,4 +72,11 @@ public class PoetryAnalyzerTest extends BaseTest {
         }
         assertTrue("Expeced to find PyYAML", found);
     }
+
+    @Test(expected = AnalysisException.class)
+    public void testPyprojectToml() throws AnalysisException {
+        final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "python-myproject-toml/pyproject.toml"));
+        //causes an exception.
+        analyzer.analyze(result, engine);
+    }
 }

--- a/core/src/test/resources/python-myproject-toml/pyproject.toml
+++ b/core/src/test/resources/python-myproject-toml/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "s3-metadata-tagger"
+version = "1.0.1"
+description = "A package to add metadata tags to objects saved in s3"
+readme = "README.md"
+requires-python = ">=3.7"
+keywords = ["aws", "s3", "metadata"]
+license = { file="LICENSE" }
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: POSIX :: Linux",
+    "Topic :: Multimedia",
+]
+dependencies = [
+    "autopep8",
+    "boto3",
+    "boto3-stubs",
+    "botocore",
+    "botocore-stubs",
+    "mypy-boto3-s3",
+    "pycodestyle",
+    "typing_extensions",
+]
+
+[project.optional-dependencies]
+pdf = ["PyPDF2"]
+picture = ["Pillow", "types-Pillow"]
+
+[project.urls]
+"Homepage" = "https://github.com/DDS-GmbH/s3-metadata-tagger-lib/"
+"Bug Tracker" = "https://github.com/DDS-GmbH/s3-metadata-tagger-lib/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+metadata_tagger = ["py.typed"]


### PR DESCRIPTION
Resolves #4995

If `pyproject.toml` is found and there is not a `poetry.lock` or `requirements.txt` an `AnalysisException` will be thrown.