### PR TITLE
fix: bad version string interpolation

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -1295,7 +1295,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
      * @return the correct value which may be null
      */
     private static String intepolationFailCheck(String value) {
-        if (value != null && value.startsWith("${") && value.endsWith("}")) {
+        if (value != null && value.contains("${")) {
             return null;
         }
         return value;

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -593,12 +593,12 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
         }
         boolean foundSomething = false;
         boolean addAsIdentifier = true;
-        String groupid = pom.getGroupId();
-        String parentGroupId = pom.getParentGroupId();
-        String artifactid = pom.getArtifactId();
-        String parentArtifactId = pom.getParentArtifactId();
-        String version = pom.getVersion();
-        String parentVersion = pom.getParentVersion();
+        String groupid = intepolationFailCheck(pom.getGroupId());
+        String parentGroupId = intepolationFailCheck(pom.getParentGroupId());
+        String artifactid = intepolationFailCheck(pom.getArtifactId());
+        String parentArtifactId = intepolationFailCheck(pom.getParentArtifactId());
+        String version = intepolationFailCheck(pom.getVersion());
+        String parentVersion = intepolationFailCheck(pom.getParentVersion());
 
         if (("org.sonatype.oss".equals(parentGroupId) && "oss-parent".equals(parentArtifactId))
                 || ("org.springframework.boot".equals(parentGroupId) && "spring-boot-starter-parent".equals(parentArtifactId))) {
@@ -1286,6 +1286,19 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
         return !key.matches(".*(version|title|vendor|name|license|description).*")
                 && value.matches("^[a-zA-Z_][a-zA-Z0-9_\\$]*\\.([a-zA-Z_][a-zA-Z0-9_\\$]*\\.)*([a-zA-Z_][a-zA-Z0-9_\\$]*)$");
 
+    }
+
+    /**
+     * Returns null if the value starts with `${` and ends with `}`.
+     *
+     * @param value the value to check
+     * @return the correct value which may be null
+     */
+    private static String intepolationFailCheck(String value) {
+        if (value != null && value.startsWith("${") && value.endsWith("}")) {
+            return null;
+        }
+        return value;
     }
 
     /**

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1283,8 +1283,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 pluginCoordinate.setArtifactId(resolved.getArtifactId());
                 pluginCoordinate.setVersion(resolved.getVersion());
 
-                //TOOD - convert this to a packageURl instead of GAV
-                final String parent = resolved.getGroupId() + ":" + resolved.getArtifactId() + ":" + resolved.getVersion();
+                final String parent = buildReference(resolved.getGroupId(), resolved.getArtifactId(), resolved.getVersion());
                 for (Artifact artifact : resolveArtifactDependencies(pluginCoordinate, project)) {
                     exCol = addPluginToDependencies(project, engine, artifact, parent, exCol);
                 }
@@ -2789,18 +2788,23 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     }
 
     /**
-     * Try resolution of artifacts once, allowing for DependencyResolutionException due to reactor-dependencies not
-     * being resolvable.
+     * Try resolution of artifacts once, allowing for
+     * DependencyResolutionException due to reactor-dependencies not being
+     * resolvable.
      * <br>
-     * The resolution is attempted only if allResolvedDeps is still empty. The assumption is that for any given project
-     * at least one of the dependencies will successfully resolve. If not, resolution will be attempted once for every
-     * dependency (as allResolvedDeps remains empty).
+     * The resolution is attempted only if allResolvedDeps is still empty. The
+     * assumption is that for any given project at least one of the dependencies
+     * will successfully resolve. If not, resolution will be attempted once for
+     * every dependency (as allResolvedDeps remains empty).
      *
      * @param project The project to dependencies for
-     * @param allResolvedDeps The collection of successfully resolved dependencies, will be filled with the successfully
-     *                        resolved dependencies, even in case of resolution failures.
-     * @param buildingRequest The buildingRequest to hand to Maven's DependencyResolver.
-     * @throws DependencyResolverException For any DependencyResolverException other than an Eclipse Aether DependencyResolutionException
+     * @param allResolvedDeps The collection of successfully resolved
+     * dependencies, will be filled with the successfully resolved dependencies,
+     * even in case of resolution failures.
+     * @param buildingRequest The buildingRequest to hand to Maven's
+     * DependencyResolver.
+     * @throws DependencyResolverException For any DependencyResolverException
+     * other than an Eclipse Aether DependencyResolutionException
      */
     private void tryResolutionOnce(MavenProject project, List<ArtifactResult> allResolvedDeps, ProjectBuildingRequest buildingRequest) throws DependencyResolverException {
         if (allResolvedDeps.isEmpty()) { // no (partially successful) resolution attempt done


### PR DESCRIPTION
- Resolves https://github.com/jeremylong/DependencyCheck/issues/5418 by returning a null value when variable interpolation fails when evaluating a pom.xml
- also includes a fix for a missed TODO when constructing the includedBy data