### PR TITLE
fix: Prefer pom.properties G/A/V over pom.xml G/A/V to resolve GAV interpolation issues

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -446,6 +446,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
                     final Properties pomProperties = retrievePomProperties(path, jar);
                     final File pomFile = extractPom(path, jar);
                     final Model pom = PomUtils.readPom(pomFile);
+                    pom.setGAVFromPomDotProperties(pomProperties);
                     pom.processProperties(pomProperties);
 
                     final String artifactId = new File(path).getParentFile().getName();

--- a/core/src/main/java/org/owasp/dependencycheck/xml/pom/Model.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/pom/Model.java
@@ -335,18 +335,6 @@ public class Model implements Serializable {
         if (properties == null) {
             return;
         }
-        this.groupId = interpolateString(this.groupId, properties);
-        if (groupId == null && properties.containsKey("groupId")) {
-            this.groupId = properties.getProperty("groupId");
-        }
-        this.artifactId = interpolateString(this.artifactId, properties);
-        if (artifactId == null && properties.containsKey("artifactId")) {
-            this.artifactId = properties.getProperty("artifactId");
-        }
-        this.version = interpolateString(this.version, properties);
-        if (version == null && properties.containsKey("version")) {
-            this.version = properties.getProperty("version");
-        }
         this.description = interpolateString(this.description, properties);
         for (License l : this.getLicenses()) {
             l.setName(interpolateString(l.getName(), properties));
@@ -396,6 +384,24 @@ public class Model implements Serializable {
         }
         final StringSubstitutor substitutor = new StringSubstitutor(new PropertyLookup(properties));
         return substitutor.replace(text);
+    }
+
+    /**
+     * Replaces the group/artifact/version obtained from the pom.xml which may contain variable references
+     * with the interpolated values of the
+     * <a href="https://maven.apache.org/shared/maven-archiver/#pom-properties-content>pom.properties</a>
+     * content (when present). Validates that at least the documented properties for the G/A/V coordinates
+     * are all present. If not it will leave the model unmodified as the property-source was apparently not
+     * a valid pom.properties file for the pom.xml.
+     * @param pomProperties A properties object that holds the properties from a pom.properties file.
+     */
+    public void setGAVFromPomDotProperties(Properties pomProperties) {
+        if (!pomProperties.containsKey("groupId") || !pomProperties.containsKey("artifactId")|| !pomProperties.containsKey("version")) {
+            return;
+        }
+        this.groupId = pomProperties.getProperty("groupId");
+        this.artifactId = pomProperties.getProperty("artifactId");
+        this.version = pomProperties.getProperty("version");
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/xml/pom/Model.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/pom/Model.java
@@ -396,7 +396,7 @@ public class Model implements Serializable {
      * @param pomProperties A properties object that holds the properties from a pom.properties file.
      */
     public void setGAVFromPomDotProperties(Properties pomProperties) {
-        if (!pomProperties.containsKey("groupId") || !pomProperties.containsKey("artifactId")|| !pomProperties.containsKey("version")) {
+        if (!pomProperties.containsKey("groupId") || !pomProperties.containsKey("artifactId") || !pomProperties.containsKey("version")) {
             return;
         }
         this.groupId = pomProperties.getProperty("groupId");


### PR DESCRIPTION
Improves the fix of #5418 to retain the proper pURL when a pom.properties is found.

## Fixes Issue #5450
## Fixes Issue #5448

## Description of Change

When pom.properties is found with at least the properties for G/A/V as documented by maven use the G/A/V coordinates from the pom.properties as those are expected to always contain the fully interpolated values for G/A/V whereas the pom.xml may contain property references that are resolved by Maven in the model-building.

## Have test cases been added to cover the new functionality?

no