### PR TITLE
fix: Node package dependencies ending up as related dependency of the wrong version of the package

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
@@ -369,7 +369,7 @@ public class NodePackageAnalyzer extends AbstractNpmAnalyzer {
                     base = Paths.get(baseDir.getPath(), pathName).toFile();
                 } else {
                     base = Paths.get(baseDir.getPath(), "node_modules", name).toFile();
-                    if (!base.isFile()) {
+                    if (!base.isDirectory()) {
                         final File test = new File(modulesRoot, name);
                         if (test.isDirectory()) {
                             base = test;


### PR DESCRIPTION
## Fixes Issue #5477

## Description of Change

Fix-up location determination of the base folder for package.json so that when multiple versions of a package are in the node_modules tree the versions that differ from the version in the root get associated with the appropriate version (which is in the private node_modules folder of their parent)

## Have test cases been added to cover the new functionality?

no, locally tested with npm v6, v8 and v9 (package-lock versions 1, 2 and 3) using the reference package.json of the issue in a gradle project.