### PR TITLE
fix: Ensure retrievePomProperties always returns non-null

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -512,7 +512,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
      * @return a Properties object or null if no pom.properties was found
      */
     private Properties retrievePomProperties(String path, final JarFile jar) {
-        Properties pomProperties = new Properties();
+        final Properties pomProperties = new Properties();
         final String propPath = path.substring(0, path.length() - 7) + "pom.properties";
         final ZipEntry propEntry = jar.getEntry(propPath);
         if (propEntry != null) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -512,12 +512,11 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
      * @return a Properties object or null if no pom.properties was found
      */
     private Properties retrievePomProperties(String path, final JarFile jar) {
-        Properties pomProperties = null;
+        Properties pomProperties = new Properties();
         final String propPath = path.substring(0, path.length() - 7) + "pom.properties";
         final ZipEntry propEntry = jar.getEntry(propPath);
         if (propEntry != null) {
             try (Reader reader = new InputStreamReader(jar.getInputStream(propEntry), StandardCharsets.UTF_8)) {
-                pomProperties = new Properties();
                 pomProperties.load(reader);
                 LOGGER.debug("Read pom.properties: {}", propPath);
             } catch (UnsupportedEncodingException ex) {


### PR DESCRIPTION
Fixes #5511

## Fixes Issue #5511

## Description of Change

Update code to prevent null-valued object to be returned

## Have test cases been added to cover the new functionality?

no, validated with a local build using `pkg:maven/io.micronaut/micronaut-inject@3.8.5` that the NPE is resolved, intend to look for either detection in an existing regression-test or addition of one in order to not have regressions in the future, but consider the bug's disruptive disruptive potential enough to first fix it and work on getting a proper test in later.