### PR TITLE
build: Fixup PR workflow for semgrep 1.15.0 release

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Semgrep
         id: semgrep
         run: |
-            docker run --rm -v "${PWD}:/src" returntocorp/semgrep --config "p/ci" --sarif > semgrep.sarif
+            docker run --rm -v "${PWD}:/src" returntocorp/semgrep semgrep --config "p/ci" --sarif > semgrep.sarif
       - name: Maven Site
         if: always()
         run: |


### PR DESCRIPTION
See https://github.com/returntocorp/semgrep/releases/tag/v1.15.0 Semgrep requires explicit  invocation as of version 1.15.0

## Description of Change

Explicitly call `semgrep` as per the instructions on the semgrep release notes of v1.15.0 which was released yesterday

## Have test cases been added to cover the new functionality?

no