### PR TITLE
fix: #5451 - Correction to console.log definition for reprocessing

### DIFF
--- a/.github/workflows/false-positive-ops.yml
+++ b/.github/workflows/false-positive-ops.yml
@@ -18,13 +18,20 @@ jobs:
         uses: actions/github-script@v6.4.0
         with:
           script: |
-              console.log(github.event.issue.labels);
               github.rest.issues.removeLabel({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 name: 'pending more information'
               })
+              console.log(
+              await github.rest.issues.listLabelsOnIssue
+              ({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              })
+              )
       - uses: actions/checkout@v3
         with:
           path: odc


### PR DESCRIPTION
## Fixes Issue #5451

## Description of Change

When processing a 'False Positive' issue report, the system fails when an invalid Package URI is provided (this is correct behaviour).  This failure occurs in the _Parse Package URL_ step.
However attempts to correct the problem (e.g. by providing a value Package URI) would fail in the _Remove Labels_ step.

This was traced to the console.log call.  The console.log call has been extended to call 'listLabelsOnIssue'.  An alternative would be to remove the console.log call in this step entirely.

## Have test cases been added to cover the new functionality?

no 

(My local fork does not appear to allow the creation of Issues.  Tests can be conducted with the existing Issue #5450 