### PR TITLE
fix: Use `https://` URLs in report templates

### DIFF
--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -632,7 +632,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
     <body>
         <div id="modal-background"></div>
         <div id="modal-content">
-            <div>Press CTR-C to copy XML&nbsp;<a href="http://jeremylong.github.io/DependencyCheck/general/suppression.html" class="infolink" target="_blank" title="Help with suppressing false positives">[help]</a></div>
+            <div>Press CTR-C to copy XML&nbsp;<a href="https://jeremylong.github.io/DependencyCheck/general/suppression.html" class="infolink" target="_blank" title="Help with suppressing false positives">[help]</a></div>
                 <button id="modal-suppress-change-to-packageUrl" class="modal-button suppresstype" title="Supress by Maven Group Artifact Version">Suppress By GAV</button>
                 <button id="modal-suppress-change-to-sha1" class="modal-button suppresstype" title="Supress by SHA1 hash">Suppress By SHA1</button><br/>
                 <input type="hidden" id="suppress-name"/>
@@ -649,8 +649,8 @@ the reporting provided constitutes acceptance for use in an AS IS condition, and
 implied or otherwise, with regard to the analysis or its use. Any use of the tool and the reporting provided
 is at the user’s risk. In no event shall the copyright holder or OWASP be held liable for any damages whatsoever
 arising out of or in connection with the use of this tool, the analysis performed, or the resulting report.</p>
-<h3><a href="http://jeremylong.github.io/DependencyCheck/general/thereport.html" target="_blank">How&nbsp;to&nbsp;read&nbsp;the&nbsp;report</a> | 
-<a href="http://jeremylong.github.io/DependencyCheck/general/suppression.html" target="_blank">Suppressing false positives</a> |
+<h3><a href="https://jeremylong.github.io/DependencyCheck/general/thereport.html" target="_blank">How&nbsp;to&nbsp;read&nbsp;the&nbsp;report</a> | 
+<a href="https://jeremylong.github.io/DependencyCheck/general/suppression.html" target="_blank">Suppressing false positives</a> |
 Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" target="_blank">github issues</a><br/><br/>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="10pt" height="10pt" viewBox="0 0 10 10" version="1.1"><g id="surface1"><path style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:1;" d="M 8.125 4.167969 C 7.089844 4.167969 6.25 5.007812 6.25 6.042969 C 6.25 7.078125 7.089844 7.917969 8.125 7.917969 C 9.160156 7.917969 10 7.078125 10 6.042969 C 10 5.007812 9.160156 4.167969 8.125 4.167969 Z M 9.167969 6.25 L 8.332031 6.25 L 8.332031 7.082031 L 7.917969 7.082031 L 7.917969 6.25 L 7.082031 6.25 L 7.082031 5.832031 L 7.917969 5.832031 L 7.917969 5 L 8.332031 5 L 8.332031 5.832031 L 9.167969 5.832031 Z M 6.445312 8.164062 C 5.984375 8.617188 5.5 9.089844 5 9.582031 C 2.320312 6.925781 0 4.9375 0 2.996094 C 0 1.328125 1.289062 0.417969 2.617188 0.417969 C 3.53125 0.417969 4.464844 0.851562 5 1.769531 C 5.53125 0.855469 6.46875 0.421875 7.386719 0.421875 C 8.710938 0.421875 10 1.324219 10 2.996094 C 10 3.308594 9.933594 3.621094 9.824219 3.933594 C 9.605469 3.757812 9.355469 3.617188 9.085938 3.511719 C 9.136719 3.335938 9.167969 3.164062 9.167969 2.996094 C 9.167969 1.800781 8.242188 1.253906 7.386719 1.253906 C 6.027344 1.253906 5.3125 2.703125 5 3.347656 C 4.6875 2.703125 3.964844 1.25 2.617188 1.25 C 1.652344 1.25 0.832031 1.882812 0.832031 2.996094 C 0.832031 4.429688 2.808594 6.265625 5 8.414062 L 5.878906 7.554688 C 6.035156 7.785156 6.226562 7.988281 6.445312 8.164062 Z M 6.445312 8.164062 "/></g></svg>&nbsp;<a aria-label="Sponsor @jeremylong" target="_blank" href="https://github.com/sponsors/jeremylong">Sponsor</a></h3>
 ]]#
@@ -824,7 +824,7 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                         #end
                         <p>
                         #if ($dependency.license)
-                            #if ($dependency.license.startsWith("http://"))
+                            #if ($dependency.license.matches("https?://.+"))
                             <b>License:</b><pre class="indent"><a href="$enc.html($dependency.license)">$enc.html($dependency.license)</a></pre>
                             #else
                             <b>License:</b><pre class="indent">$enc.html($dependency.license)</pre>
@@ -956,7 +956,7 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                         #foreach($vuln in $dependency.getVulnerabilities(true))
                             #set($vsctr=$vsctr+1)
                             #if($vuln.getSource().name().equals("NVD"))
-                                <p><b><a target="_blank" href="http://web.nvd.nist.gov/view/vuln/detail?vulnId=$enc.url($vuln.name)">$enc.html($vuln.name)</a></b>&nbsp;&nbsp;<button class="copybutton" title="Generate Suppression XML for this CVE for this file" data-display-name="$enc.html($dependency.DisplayFileName)" data-sha1="$enc.html($dependency.Sha1sum)" data-pkgurl="#if($supressPkgUrl)$enc.html($supressPkgUrl)#end" data-type-to-suppress="cve" data-id-to-suppress="$enc.html($vuln.name)">suppress</button></p>
+                                <p><b><a target="_blank" href="https://web.nvd.nist.gov/view/vuln/detail?vulnId=$enc.url($vuln.name)">$enc.html($vuln.name)</a></b>&nbsp;&nbsp;<button class="copybutton" title="Generate Suppression XML for this CVE for this file" data-display-name="$enc.html($dependency.DisplayFileName)" data-sha1="$enc.html($dependency.Sha1sum)" data-pkgurl="#if($supressPkgUrl)$enc.html($supressPkgUrl)#end" data-type-to-suppress="cve" data-id-to-suppress="$enc.html($vuln.name)">suppress</button></p>
                             #elseif($vuln.getSource().name().equals("NPM"))
                                 <p><b><a target="_blank" href="https://github.com/advisories/$enc.url($vuln.name)">$enc.html($vuln.name) (NPM)</a></b>&nbsp;&nbsp;<button class="copybutton" title="Generate Suppression XML for this vulnerability for this file" data-display-name="$enc.html($dependency.DisplayFileName)" data-sha1="$enc.html($dependency.Sha1sum)" data-pkgurl="#if($supressPkgUrl)$enc.html($supressPkgUrl)#end" data-type-to-suppress="vulnerabilityName" data-id-to-suppress="$enc.html($vuln.name)">suppress</button></p>
                             #else
@@ -1056,7 +1056,7 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                                 #end
                                 <p>
                                 #if ($dependency.license)
-                                    #if ($dependency.license.startsWith("http://"))
+                                    #if ($dependency.license.matches("https?://.+"))
                                     <b>License:</b><pre class="indent"><a href="$enc.html($dependency.license)">$enc.html($dependency.license)</a></pre>
                                     #else
                                     <b>License:</b><pre class="indent">$enc.html($dependency.license)</pre>
@@ -1157,7 +1157,7 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                                 #foreach($vuln in $dependency.getSuppressedVulnerabilities(true))
                                     #set($vsctr=$vsctr+1)
                                     #if($vuln.getSource().name().equals("NVD"))
-                                        <p><b><a target="_blank" href="http://web.nvd.nist.gov/view/vuln/detail?vulnId=$enc.url($vuln.name)">$enc.html($vuln.name)</a></b>&nbsp;&nbsp;<span class="suppressedLabel" >suppressed</span></p>
+                                        <p><b><a target="_blank" href="https://web.nvd.nist.gov/view/vuln/detail?vulnId=$enc.url($vuln.name)">$enc.html($vuln.name)</a></b>&nbsp;&nbsp;<span class="suppressedLabel" >suppressed</span></p>
                                     #elseif($vuln.getSource().name().equals("NPM"))
                                         <p><b><a target="_blank" href="https://github.com/advisories/$enc.url($vuln.name)">$enc.html($vuln.name) (NPM)</a></b>&nbsp;&nbsp;<span class="suppressedLabel" >suppressed</span></p>
                                     #else

--- a/core/src/main/resources/templates/jenkinsReport.vsl
+++ b/core/src/main/resources/templates/jenkinsReport.vsl
@@ -439,8 +439,8 @@ the reporting provided constitutes acceptance for use in an AS IS condition, and
 implied or otherwise, with regard to the analysis or its use. Any use of the tool and the reporting provided
 is at the user’s risk. In no event shall the copyright holder or OWASP be held liable for any damages whatsoever
 arising out of or in connection with the use of this tool, the analysis performed, or the resulting report.</p>
-<h3><a href="http://jeremylong.github.io/DependencyCheck/general/thereport.html" target="_blank">How&nbsp;to&nbsp;read&nbsp;the&nbsp;report</a> | 
-<a href="http://jeremylong.github.io/DependencyCheck/general/suppression.html" target="_blank">Suppressing false positives</a> |
+<h3><a href="https://jeremylong.github.io/DependencyCheck/general/thereport.html" target="_blank">How&nbsp;to&nbsp;read&nbsp;the&nbsp;report</a> | 
+<a href="https://jeremylong.github.io/DependencyCheck/general/suppression.html" target="_blank">Suppressing false positives</a> |
 Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" target="_blank">github issues</a><br/><br/>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="10pt" height="10pt" viewBox="0 0 10 10" version="1.1"><g id="surface1"><path style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:1;" d="M 8.125 4.167969 C 7.089844 4.167969 6.25 5.007812 6.25 6.042969 C 6.25 7.078125 7.089844 7.917969 8.125 7.917969 C 9.160156 7.917969 10 7.078125 10 6.042969 C 10 5.007812 9.160156 4.167969 8.125 4.167969 Z M 9.167969 6.25 L 8.332031 6.25 L 8.332031 7.082031 L 7.917969 7.082031 L 7.917969 6.25 L 7.082031 6.25 L 7.082031 5.832031 L 7.917969 5.832031 L 7.917969 5 L 8.332031 5 L 8.332031 5.832031 L 9.167969 5.832031 Z M 6.445312 8.164062 C 5.984375 8.617188 5.5 9.089844 5 9.582031 C 2.320312 6.925781 0 4.9375 0 2.996094 C 0 1.328125 1.289062 0.417969 2.617188 0.417969 C 3.53125 0.417969 4.464844 0.851562 5 1.769531 C 5.53125 0.855469 6.46875 0.421875 7.386719 0.421875 C 8.710938 0.421875 10 1.324219 10 2.996094 C 10 3.308594 9.933594 3.621094 9.824219 3.933594 C 9.605469 3.757812 9.355469 3.617188 9.085938 3.511719 C 9.136719 3.335938 9.167969 3.164062 9.167969 2.996094 C 9.167969 1.800781 8.242188 1.253906 7.386719 1.253906 C 6.027344 1.253906 5.3125 2.703125 5 3.347656 C 4.6875 2.703125 3.964844 1.25 2.617188 1.25 C 1.652344 1.25 0.832031 1.882812 0.832031 2.996094 C 0.832031 4.429688 2.808594 6.265625 5 8.414062 L 5.878906 7.554688 C 6.035156 7.785156 6.226562 7.988281 6.445312 8.164062 Z M 6.445312 8.164062 "/></g></svg>&nbsp;<a aria-label="Sponsor @jeremylong" target="_blank" href="https://github.com/sponsors/jeremylong">Sponsor</a></h3>
 ]]#
@@ -604,7 +604,7 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                         #end
                         <p>
                         #if ($dependency.license)
-                            #if ($dependency.license.startsWith("http://"))
+                            #if ($dependency.license.matches("https?://.+"))
                             <b>License:</b><pre class="indent"><a href="$enc.html($dependency.license)">$enc.html($dependency.license)</a></pre>
                             #else
                             <b>License:</b><pre class="indent">$enc.html($dependency.license)</pre>
@@ -711,7 +711,7 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                         #foreach($vuln in $dependency.getVulnerabilities(true))
                             #set($vsctr=$vsctr+1)
                             #if($vuln.getSource().name().equals("NVD"))
-                                <p><b><a target="_blank" href="http://web.nvd.nist.gov/view/vuln/detail?vulnId=$enc.url($vuln.name)">$enc.html($vuln.name)</a></b></p>
+                                <p><b><a target="_blank" href="https://web.nvd.nist.gov/view/vuln/detail?vulnId=$enc.url($vuln.name)">$enc.html($vuln.name)</a></b></p>
                             #elseif($vuln.getSource().name().equals("NPM"))
                                 <p><b><a target="_blank" href="https://github.com/advisories/$enc.url($vuln.name)">$enc.html($vuln.name) (NPM)</a></b></p>
                             #else

--- a/core/src/main/resources/templates/jsonReport.vsl
+++ b/core/src/main/resources/templates/jsonReport.vsl
@@ -45,7 +45,7 @@
         #if($applicationVersion)"version":"$enc.json($applicationVersion)",#end
         "reportDate": "$enc.json($scanDateXML)",
         "credits": {
-            "NVD": "This report contains data retrieved from the National Vulnerability Database: http://nvd.nist.gov",
+            "NVD": "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
             "CISA": "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
             "NPM": "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
             "RETIREJS": "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",

--- a/core/src/main/resources/templates/sarifReport.vsl
+++ b/core/src/main/resources/templates/sarifReport.vsl
@@ -19,7 +19,7 @@
               },
               "help": {
                 "text": "",
-                "markdown": "#if($rule.getSource().equals("NVD"))For more information see [$enc.json($rule.name)](http://web.nvd.nist.gov/view/vuln/detail?vulnId=$enc.url($rule.name)).\n
+                "markdown": "#if($rule.getSource().equals("NVD"))For more information see [$enc.json($rule.name)](https://web.nvd.nist.gov/view/vuln/detail?vulnId=$enc.url($rule.name)).\n
 #elseif($rule.getSource().equals("NPM"))For more information see [$enc.json($rule.name)](https://github.com/advisories/$enc.url($rule.name))\n#end
 \n\n
 If this is a false positive - consider using the HTML report to generate a suppression file. 
@@ -61,7 +61,7 @@ For more information see [How dependency-check works](https://jeremylong.github.
           ],
         "properties": {
           "disclaimer": "Dependency-Check is an open source tool performing a best effort analysis of 3rd party dependencies; false positives and false negatives may exist in the analysis performed by the tool. Use of the tool and the reporting provided constitutes acceptance for use in an AS IS condition, and there are NO warranties, implied or otherwise, with regard to the analysis or its use. Any use of the tool and the reporting provided is at the user's risk. In no event shall the copyright holder or OWASP be held liable for any damages whatsoever arising out of or in connection with the use of this tool, the analysis performed, or the resulting report.",
-          "nvd": "This report contains data retrieved from the National Vulnerability Database: http://nvd.nist.gov",
+          "nvd": "This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
           "cisa": "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
           "npm": "This report may contain data retrieved from the the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
           "retirejs": "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",


### PR DESCRIPTION
## Fixes Issue
_none_

## Description of Change

- Update URLs in report templates to use `https://` instead of `http://`
- Update HTML and Jenkins report template to also convert `https://` license URLs to links

## Have test cases been added to cover the new functionality?

no