### PR TITLE
docs: Fix incorrect instructions for building without running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Then load the resulting 'dependency-check-report.html' into your favorite browse
 
 #### Building without running tests
 To speed up your turnaround cycle times, you can also compile without running the tests each time:  
-`mvn -s settings.xml install -Dmaven.test.skip=true`
+`mvn -s settings.xml install -DskipTests=true`
 
 Please remember to at least run the tests once before opening the PR. :) 
 


### PR DESCRIPTION
## Fixes Issue

Fixes #5583

## Description of Change
Running with `-Dmaven.test.skip=true` causes a build failure, see #5583. Instead `-DskipTests=true` has to be used.

## Have test cases been added to cover the new functionality?

no