### PR TITLE
feat: Update HTML report Dependencies header based on display settings

### DIFF
--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -180,6 +180,13 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             return toggleDisplay(event.target, '.scaninfo', 'show all', 'show less');
           });
           $( "#vulnerabilityDisplayToggle" ).bind( "click", function( event ) {
+            const dependenciesHeader = $('#header-dependencies');
+            const dependenciesHeaderAllText = 'Dependencies (all)';
+            if (dependenciesHeader.text() == dependenciesHeaderAllText) {
+                dependenciesHeader.text('Dependencies (vulnerable)');
+            } else {
+                dependenciesHeader.text(dependenciesHeaderAllText);
+            }
             return toggleDisplay(event.target, '.notvulnerable', 'Showing Vulnerable Dependencies (click to show all)', 'Showing All Dependencies (click to show less)');
           });
           $( ".versionToggle" ).bind( "click", function( event ) {
@@ -812,7 +819,7 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                 #if($hasknown==1)
                 <p>* indicates the dependency has a known exploited vulnerability</p>
                 #end
-                <h2>Dependencies</h2>
+                <h2 id="header-dependencies">Dependencies (vulnerable)</h2>
                 #set($lnkcnt=0)
                 #set($vsctr=0) ##counter to create unique groups for vulnerable software
                 #foreach($dependency in $dependencies)


### PR DESCRIPTION
## Fixes Issue #

_none_

## Description of Change

Adjusts the text of the "Dependencies" header in the HTML report depending on whether all or only vulnerable dependencies are shown (since that section is affected by this toggle as well).

I am not sure if this is a clean enough solution and implementation, so feedback is appreciated!

## Have test cases been added to cover the new functionality?

*no*