### PR TITLE
feat: enable local proxy configuration in maven plugin configuration

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2204,8 +2204,8 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         else if ( this.proxy != null && this.proxy.host != null) {
             settings.setString(Settings.KEYS.PROXY_SERVER, this.proxy.host);
             settings.setString(Settings.KEYS.PROXY_PORT, Integer.toString(this.proxy.port));
-            settings.setStringIfNotNull(Settings.KEYS.PROXY_USERNAME, this.proxy.username);
-            settings.setStringIfNotNull(Settings.KEYS.PROXY_PASSWORD, this.proxy.password);
+            // user name and password from <server> entry settings.xml
+            configureServerCredentials(this.proxy.serverId, Settings.KEYS.PROXY_USERNAME, Settings.KEYS.PROXY_PASSWORD);
         }
         
         final String[] suppressions = determineSuppressions();

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1062,8 +1062,8 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     @Parameter(property = "odc.dependencies.scan", defaultValue = "true", required = false)
     private boolean scanDependencies = true;
 
-    @Parameter(name = "proxy")
-    private ProxyConfig proxyConfig;
+    @Parameter
+    private ProxyConfig proxy;
     
     // </editor-fold>
     //<editor-fold defaultstate="collapsed" desc="Base Maven implementation">
@@ -2164,12 +2164,12 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         settings.setStringIfNotNull(Settings.KEYS.ANALYZER_PNPM_PATH, pathToPnpm);
 
         // use global maven proxy if provided
-        final Proxy proxy = getMavenProxy();
-        if (proxy != null) {
-            settings.setString(Settings.KEYS.PROXY_SERVER, proxy.getHost());
-            settings.setString(Settings.KEYS.PROXY_PORT, Integer.toString(proxy.getPort()));
-            final String userName = proxy.getUsername();
-            String password = proxy.getPassword();
+        final Proxy mavenProxy = getMavenProxy();
+        if (mavenProxy != null) {
+            settings.setString(Settings.KEYS.PROXY_SERVER, mavenProxy.getHost());
+            settings.setString(Settings.KEYS.PROXY_PORT, Integer.toString(mavenProxy.getPort()));
+            final String userName = mavenProxy.getUsername();
+            String password = mavenProxy.getPassword();
             if (password != null && !password.isEmpty()) {
                 if (settings.getBoolean(Settings.KEYS.PROXY_DISABLE_SCHEMAS, true)) {
                     System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "");
@@ -2177,12 +2177,12 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 try {
                     password = decryptPasswordFromSettings(password);
                 } catch (SecDispatcherException ex) {
-                    password = handleSecDispatcherException("proxy", proxy.getId(), password, ex);
+                    password = handleSecDispatcherException("proxy", mavenProxy.getId(), password, ex);
                 }
             }
             settings.setStringIfNotNull(Settings.KEYS.PROXY_USERNAME, userName);
             settings.setStringIfNotNull(Settings.KEYS.PROXY_PASSWORD, password);
-            settings.setStringIfNotNull(Settings.KEYS.PROXY_NON_PROXY_HOSTS, proxy.getNonProxyHosts());
+            settings.setStringIfNotNull(Settings.KEYS.PROXY_NON_PROXY_HOSTS, mavenProxy.getNonProxyHosts());
         }
         // or use standard Java system properties
         else if (System.getProperty("http.proxyHost") != null) {
@@ -2201,11 +2201,11 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
             }
         }
         // or use configured <proxy>
-        else if ( this.proxyConfig != null && this.proxyConfig.host != null) {
-            settings.setString(Settings.KEYS.PROXY_SERVER, this.proxyConfig.host);
-            settings.setString(Settings.KEYS.PROXY_PORT, Integer.toString(this.proxyConfig.port));
-            settings.setStringIfNotNull(Settings.KEYS.PROXY_USERNAME, this.proxyConfig.username);
-            settings.setStringIfNotNull(Settings.KEYS.PROXY_PASSWORD, this.proxyConfig.password);
+        else if ( this.proxy != null && this.proxy.host != null) {
+            settings.setString(Settings.KEYS.PROXY_SERVER, this.proxy.host);
+            settings.setString(Settings.KEYS.PROXY_PORT, Integer.toString(this.proxy.port));
+            settings.setStringIfNotNull(Settings.KEYS.PROXY_USERNAME, this.proxy.username);
+            settings.setStringIfNotNull(Settings.KEYS.PROXY_PASSWORD, this.proxy.password);
         }
         
         final String[] suppressions = determineSuppressions();

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/ProxyConfig.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/ProxyConfig.java
@@ -9,7 +9,9 @@ public class ProxyConfig {
 	
 	int port = 8080;
 	
-	String username;
+	/**
+	 * ID od server in Maven settings.xml, <username> and <password> will be used.
+	 */
+	String serverId;
 
-	String password;
 }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/ProxyConfig.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/ProxyConfig.java
@@ -1,0 +1,15 @@
+package org.owasp.dependencycheck.maven;
+
+/**
+ * Proxy configuration options.
+ */
+public class ProxyConfig {
+
+	String host;
+	
+	int port = 8080;
+	
+	String username;
+
+	String password;
+}


### PR DESCRIPTION
## Relates to Issue #5040

## Description of Change

CICD-SEC-03 recommends:
1. ... packages are pulled through an internal proxy rather than directly from the internet ...
2. ... pull packages from internal repositories ...

We have solved (2), trust our developers, they trust the developers of the third party libraries in use, and those trust the developers of dependent fourth party libraries ...
Nevertheless, we would like to go one step further and completely disable access to the Internet in our CI/CD pipeline.
Therefore, we need to configure a proxy for the dependency-check-maven plugin.

Currently, you can define a proxy to use in the dependency-check-maven plugin via the Maven settings or the system property `http.proxyHost`.
However, in both cases, the configured proxy is used not only for loading data for analysis, but potentially for dependency resolution as well:
* https://maven.apache.org/guides/mini/guide-proxies.html "... configure a proxy to use for some or all of your HTTP requests with Maven ..."
* https://www.baeldung.com/maven-behind-proxy

With the proposed change, a local proxy can be configured for the dependency-check-maven plugin, which is then used exclusively for loading the analysis data:

```
<configuration>
	...
	<proxy>
		<host>myproxy</host>
		<port>1234</port>
	</proxy>
	...
</configuration>
```


## Have test cases been added to cover the new functionality?

*no*