### PR TITLE
fix: fix npm alias present in requires of dependencies

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilder.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilder.java
@@ -244,7 +244,15 @@ public final class NpmPayloadBuilder {
             depBuilder.add("integrity", dep.getString("integrity"));
         }
         if (dep.containsKey("requires")) {
-            depBuilder.add("requires", dep.getJsonObject("requires"));
+            final JsonObjectBuilder requiresBuilder = Json.createObjectBuilder();
+            dep.getJsonObject("requires").forEach((key, value) -> {
+                if (NodePackageAnalyzer.shouldSkipDependency(key, ((JsonString) value).getString())) {
+                    return;
+                }
+    
+                requiresBuilder.add(key, value);
+            });
+            depBuilder.add("requires", requiresBuilder.build());
         }
         if (dep.containsKey("dependencies")) {
             final JsonObjectBuilder dependeciesBuilder = Json.createObjectBuilder();


### PR DESCRIPTION
Hi,

In my project, i have a dependencies of a dependencies of a dependencies ... that have an alias :

```
└─┬ rimraf@5.0.0
  └─┬ glob@10.2.2
    └─┬ jackspeak@2.2.0
      └─┬ @isaacs/cliui@8.0.2
        └── string-width-cjs@npm:string-width@4.2.3
```

So in the the package-lock.json i have this in the dependencies section : 
```json
    "node_modules/@isaacs/cliui": {
      "version": "8.0.2",
      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
      "dependencies": {
        "string-width": "^5.1.2",
        "string-width-cjs": "npm:string-width@^4.2.0",
        "strip-ansi": "^7.0.1",
        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
        "wrap-ansi": "^8.1.0",
        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
      },
      "engines": {
        "node": ">=12"
      }
    },
```

The call of the API with the payload return me that the dependencie tree is invalid
```bash
curl --location --request POST 'https://registry.npmjs.org/-/npm/v1/security/audits' --header 'Content-Type: application/json' --data '@/tmp/payload.json'
{"statusCode":400,"error":"Bad Request","message":"Invalid package tree, run  npm install  to rebuild your package-lock.json"}%         
```

As alias (npm:*) is removed from requires of a npm project with the method `NodePackageAnalyzer.shouldSkipDependency`, the dependencies tree reference missing package.

My modifcation add a test to remove this alias too.

## Fixes Issue #

Maybe #3717

## Description of Change

The change is to add in the requires section of the dependencies of dependencies the same filter that for other dependencies.

## Have test cases been added to cover the new functionality?

no