### PR TITLE
fix: #3762 itext licensing packages do not belong to 'cpe:/a:itextpdf:itext' CPE

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -483,6 +483,20 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
+        FP per #3762
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.itextpdf\.licensing/licensing\-base@.*$</packageUrl>
+        <cpe>cpe:/a:itextpdf:itext</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per #3762
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.itextpdf\.licensing/licensing\-remote@.*$</packageUrl>
+        <cpe>cpe:/a:itextpdf:itext</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
         FP per #2453
         TODO - there are likely several other testcontainer suppressions that should be added
         ]]></notes>


### PR DESCRIPTION
## Fixes Issue #

Fix #3762 

## Description of Change

This change declares `com.itextpdf.licensing/licensing-base` and `com.itextpdf.licensing/licensing-remote` as not linked to `cpe:2.3:a:itextpdf:itext:*:*:*:*:*:*:*:*`

## Have test cases been added to cover the new functionality?

*no*