### PR TITLE
fix: use curl with -L to follow github redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The latest CLI can be downloaded from github in the [releases section](https://g
 Downloading the latest release:
 ```
 $ VERSION=$(curl -s https://jeremylong.github.io/DependencyCheck/current.txt)
-$ curl -s "https://github.com/jeremylong/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip" --output dependency-check.zip
+$ curl -Ls "https://github.com/jeremylong/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip" --output dependency-check.zip
 ```
 
 On *nix


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

This only adds the `-L` option to curl to follow the download redirect.

## Have test cases been added to cover the new functionality?

*no*