### PR TITLE
fix: Hint Analyzer should run before VersionFilter Analyzer

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -78,7 +78,9 @@ import static org.owasp.dependencycheck.analyzer.AnalysisPhase.INFORMATION_COLLE
 import static org.owasp.dependencycheck.analyzer.AnalysisPhase.INITIAL;
 import static org.owasp.dependencycheck.analyzer.AnalysisPhase.POST_FINDING_ANALYSIS;
 import static org.owasp.dependencycheck.analyzer.AnalysisPhase.POST_IDENTIFIER_ANALYSIS;
-import static org.owasp.dependencycheck.analyzer.AnalysisPhase.POST_INFORMATION_COLLECTION;
+import static org.owasp.dependencycheck.analyzer.AnalysisPhase.POST_INFORMATION_COLLECTION1;
+import static org.owasp.dependencycheck.analyzer.AnalysisPhase.POST_INFORMATION_COLLECTION2;
+import static org.owasp.dependencycheck.analyzer.AnalysisPhase.POST_INFORMATION_COLLECTION3;
 import static org.owasp.dependencycheck.analyzer.AnalysisPhase.PRE_FINDING_ANALYSIS;
 import static org.owasp.dependencycheck.analyzer.AnalysisPhase.PRE_IDENTIFIER_ANALYSIS;
 import static org.owasp.dependencycheck.analyzer.AnalysisPhase.PRE_INFORMATION_COLLECTION;
@@ -1294,7 +1296,9 @@ public class Engine implements FileFilter, AutoCloseable {
                 PRE_INFORMATION_COLLECTION,
                 INFORMATION_COLLECTION,
                 INFORMATION_COLLECTION2,
-                POST_INFORMATION_COLLECTION
+                POST_INFORMATION_COLLECTION1,
+                POST_INFORMATION_COLLECTION2,
+                POST_INFORMATION_COLLECTION3
         ),
         /**
          * In evidence processing mode the {@link Engine} processes the evidence

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AnalysisPhase.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AnalysisPhase.java
@@ -26,54 +26,126 @@ public enum AnalysisPhase {
 
     /**
      * Initialization phase.
+     * @implNote Bound analyzers are {@link ArchiveAnalyzer}
      */
     INITIAL,
     /**
      * Pre information collection phase.
+     * @implNote Bound analyzers are {@link ElixirMixAuditAnalyzer},{@link RubyBundleAuditAnalyzer}
      */
     PRE_INFORMATION_COLLECTION,
     /**
      * Information collection phase.
+     * @implNote Bound analyzers are
+     * {@link ArtifactoryAnalyzer}
+     * {@link AssemblyAnalyzer}
+     * {@link AutoconfAnalyzer}
+     * {@link CMakeAnalyzer}
+     * {@link CentralAnalyzer}
+     * {@link CocoaPodsAnalyzer}
+     * {@link ComposerLockAnalyzer}
+     * {@link DartAnalyzer}
+     * {@link FileNameAnalyzer}
+     * {@link GolangDepAnalyzer}
+     * {@link GolangModAnalyzer}
+     * {@link JarAnalyzer}
+     * {@link LibmanAnalyzer}
+     * {@link MSBuildProjectAnalyzer}
+     * {@link NexusAnalyzer}
+     * {@link NodeAuditAnalyzer}
+     * {@link NugetconfAnalyzer}
+     * {@link NuspecAnalyzer}
+     * {@link OpenSSLAnalyzer}
+     * {@link PinnedMavenInstallAnalyzer}
+     * {@link PipAnalyzer}
+     * {@link PipfileAnalyzer}
+     * {@link PipfilelockAnalyzer}
+     * {@link PoetryAnalyzer}
+     * {@link PythonDistributionAnalyzer}
+     * {@link PythonPackageAnalyzer}
+     * {@link RubyGemspecAnalyzer}
+     * {@link RubyBundlerAnalyzer}
+     * {@link SwiftPackageManagerAnalyzer}
+     * {@link SwiftPackageResolvedAnalyzer}
      */
     INFORMATION_COLLECTION,
     /**
      * Information collection phase 2.
+     * @implNote Bound analyzers are
+     * {@link PEAnalyzer}
      */
     INFORMATION_COLLECTION2,
     /**
-     * Post information collection phase.
+     * Post information collection phase 1.
+     * @implNote Bound analyzers are
+     * {@link DependencyMergingAnalyzer}
      */
-    POST_INFORMATION_COLLECTION,
+    POST_INFORMATION_COLLECTION1,
+    /**
+     * Post information collection phase 2.
+     * @implNote Bound analyzers are
+     * {@link HintAnalyzer} (must run before {@link VersionFilterAnalyzer}, should run after {@link DependencyMergingAnalyzer})
+     */
+    POST_INFORMATION_COLLECTION2,
+    /**
+     * Post information collection phase 3.
+     * @implNote Bound analyzers are
+     * {@link VersionFilterAnalyzer}
+     */
+    POST_INFORMATION_COLLECTION3,
     /**
      * Pre identifier analysis phase.
+     * @implNote Bound analyzers are
+     * {@link NpmCPEAnalyzer} (must run in a separate phase from {@link CPEAnalyzer} due to singleton re-use)
      */
     PRE_IDENTIFIER_ANALYSIS,
     /**
      * Identifier analysis phase.
+     * @implNote Bound analyzers are
+     * {@link CPEAnalyzer}
      */
     IDENTIFIER_ANALYSIS,
     /**
      * Post identifier analysis phase.
+     * @implNote Bound analyzers are
+     * {@link CpeSuppressionAnalyzer}
+     * {@link FalsePositiveAnalyzer}
      */
     POST_IDENTIFIER_ANALYSIS,
     /**
      * Pre finding analysis phase.
+     * @implNote No analyzers bound to this phase
      */
     PRE_FINDING_ANALYSIS,
     /**
      * Finding analysis phase.
+     * @implNote Bound analyzers are
+     * {@link NodeAuditAnalyzer}
+     * {@link NvdCveAnalyzer}
+     * {@link PnpmAuditAnalyzer}
+     * {@link RetireJsAnalyzer}
+     * {@link YarnAuditAnalyzer}
+     *
      */
     FINDING_ANALYSIS,
     /**
      * Finding analysis phase 2.
+     * @implNote Bound analyzers are
+     * {@link OssIndexAnalyzer}
      */
     FINDING_ANALYSIS_PHASE2,
     /**
      * Post analysis phase.
+     * @implNote Bound analyzers are
+     * {@link KnownExploitedVulnerabilityAnalyzer}
+     * {@link VulnerabilitySuppressionAnalyzer}
      */
     POST_FINDING_ANALYSIS,
     /**
      * The final analysis phase.
+     * @implNote Bound analyzers are
+     * {@link DependencyBundlingAnalyzer}
+     * {@link UnusedSuppressionRuleAnalyzer}
      */
     FINAL
 }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/DependencyMergingAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/DependencyMergingAnalyzer.java
@@ -47,7 +47,7 @@ public class DependencyMergingAnalyzer extends AbstractDependencyComparingAnalyz
     /**
      * The phase that this analyzer is intended to run in.
      */
-    private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.POST_INFORMATION_COLLECTION;
+    private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.POST_INFORMATION_COLLECTION1;
     /**
      * Used for synchronization when merging related dependencies.
      */

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/HintAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/HintAnalyzer.java
@@ -80,7 +80,7 @@ public class HintAnalyzer extends AbstractAnalyzer {
     /**
      * The phase that this analyzer is intended to run in.
      */
-    private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.PRE_IDENTIFIER_ANALYSIS;
+    private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.POST_INFORMATION_COLLECTION2;
 
     /**
      * Returns the name of the analyzer.

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NpmCPEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NpmCPEAnalyzer.java
@@ -49,7 +49,7 @@ public class NpmCPEAnalyzer extends CPEAnalyzer {
     /**
      * The Logger.
      */
-    private static final Logger LOGGER = LoggerFactory.getLogger(CPEAnalyzer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(NpmCPEAnalyzer.class);
 
     /**
      * Returns the analysis phase that this analyzer should run in.

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/VersionFilterAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/VersionFilterAnalyzer.java
@@ -86,7 +86,7 @@ public class VersionFilterAnalyzer extends AbstractAnalyzer {
     /**
      * The phase that this analyzer is intended to run in.
      */
-    private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.POST_INFORMATION_COLLECTION;
+    private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.POST_INFORMATION_COLLECTION3;
 
     //</editor-fold>
     //<editor-fold defaultstate="collapsed" desc="Standard implementation of Analyzer">

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyMergingAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyMergingAnalyzerTest.java
@@ -53,7 +53,7 @@ public class DependencyMergingAnalyzerTest extends BaseTest {
     @Test
     public void testGetAnalysisPhase() {
         DependencyMergingAnalyzer instance = new DependencyMergingAnalyzer();
-        AnalysisPhase expResult = AnalysisPhase.POST_INFORMATION_COLLECTION;
+        AnalysisPhase expResult = AnalysisPhase.POST_INFORMATION_COLLECTION1;
         AnalysisPhase result = instance.getAnalysisPhase();
         assertEquals(expResult, result);
     }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/HintAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/HintAnalyzerTest.java
@@ -54,7 +54,7 @@ public class HintAnalyzerTest extends BaseDBTestCase {
     @Test
     public void testGetAnalysisPhase() {
         HintAnalyzer instance = new HintAnalyzer();
-        AnalysisPhase expResult = AnalysisPhase.PRE_IDENTIFIER_ANALYSIS;
+        AnalysisPhase expResult = AnalysisPhase.POST_INFORMATION_COLLECTION2;
         AnalysisPhase result = instance.getAnalysisPhase();
         assertEquals(expResult, result);
     }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/VersionFilterAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/VersionFilterAnalyzerTest.java
@@ -49,7 +49,7 @@ public class VersionFilterAnalyzerTest extends BaseTest {
     public void testGetAnalysisPhase() {
         VersionFilterAnalyzer instance = new VersionFilterAnalyzer();
         instance.initialize(getSettings());
-        AnalysisPhase expResult = AnalysisPhase.POST_INFORMATION_COLLECTION;
+        AnalysisPhase expResult = AnalysisPhase.POST_INFORMATION_COLLECTION3;
         AnalysisPhase result = instance.getAnalysisPhase();
         assertEquals(expResult, result);
     }


### PR DESCRIPTION
## Fixes Issue #5812

## Description of Change

Ensure that HintAnalyzer runs before VersionFilterAnalyzer as HintAnalyzer may add versions that are not yet present in the evidences. VersionFilterAnalyzer may otherwise wrongly set an explicit version for the dependency if the collected evidences converge to a single version but the hints add a new and different version.

Also added an implementation note on the AnalysisPhase to document which analyzers are bound to which phase.

Introduces 2 additional POST_INFORMATION_COLLECTION phases so that DependencyMergingAnalyzer is guaranteed to run before HintAnalyzer which in its turn is guaranteed to run before VersionFilterAnalyzer


## Have test cases been added to cover the new functionality?

no