### PR TITLE
fix: OSS Index Analyzer SocketTimeoutException exception handling based on warn only parameter

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -54,6 +54,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import java.net.SocketTimeoutException;
+
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.sonatype.goodies.packageurl.InvalidException;
@@ -153,6 +155,14 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
                     } else {
                         LOG.debug("Error requesting component reports, disabling the analyzer", ex);
                         throw new AnalysisException("Failed to request component-reports", ex);
+                    }
+                } catch (SocketTimeoutException e) {
+                    final boolean warnOnly = getSettings().getBoolean(Settings.KEYS.ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS, false);
+                    if (warnOnly) {
+                        LOG.warn("OSS Index socket timeout, disabling the analyzer", e);
+                    } else {
+                        LOG.debug("OSS Index socket timeout", e);
+                        throw new AnalysisException("Failed to establish socket to OSS Index", e);
                     }
                 } catch (Exception e) {
                     LOG.debug("Error requesting component reports", e);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -158,6 +158,7 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
                     }
                 } catch (SocketTimeoutException e) {
                     final boolean warnOnly = getSettings().getBoolean(Settings.KEYS.ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS, false);
+                    this.setEnabled(false);
                     if (warnOnly) {
                         LOG.warn("OSS Index socket timeout, disabling the analyzer", e);
                     } else {


### PR DESCRIPTION
## Fixes Issue #
When OSS Index is down and not responding on its TCP socket, a `SocketTimeoutException` is thrown by the analyzer regardless of the `ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS` setting. 
I encountered this issue this morning in `8.3.1`: 
```
exception: org.owasp.dependencycheck.analyzer.exception.AnalysisException: Failed to request component-reports
org.owasp.dependencycheck.analyzer.OssIndexAnalyzer.analyzeDependency(OssIndexAnalyzer.java:159)
org.owasp.dependencycheck.analyzer.AbstractAnalyzer.analyze(AbstractAnalyzer.java:131)
org.owasp.dependencycheck.AnalysisTask.call(AnalysisTask.java:88)
org.owasp.dependencycheck.AnalysisTask.call(AnalysisTask.java:37)
java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
java.base/java.lang.Thread.run(Thread.java:833)

Read timed out
cause: java.net.SocketTimeoutException: Read timed out java.base/sun.nio.ch.NioSocketImpl.timedRead(NioSocketImpl.java:283)
java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:309)
java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:350)
java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:803)
java.base/java.net.Socket$SocketInputStream.read(Socket.java:976)
java.base/sun.security.ssl.SSLSocketInputRecord.read(SSLSocketInputRecord.java:484)
java.base/sun.security.ssl.SSLSocketInputRecord.readHeader(SSLSocketInputRecord.java:478)
java.base/sun.security.ssl.SSLSocketInputRecord.bytesInCompletePacket(SSLSocketInputRecord.java:70)
java.base/sun.security.ssl.SSLSocketImpl.readApplicationRecord(SSLSocketImpl.java:1465)
java.base/sun.security.ssl.SSLSocketImpl$AppInputStream.read(SSLSocketImpl.java:1069)
java.base/java.io.BufferedInputStream.fill(BufferedInputStream.java:244)
java.base/java.io.BufferedInputStream.read1(BufferedInputStream.java:284)
java.base/java.io.BufferedInputStream.read(BufferedInputStream.java:343)
java.base/sun.net.www.http.HttpClient.parseHTTPHeader(HttpClient.java:824)
java.base/sun.net.www.http.HttpClient.parseHTTP(HttpClient.java:759)
java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1691)
java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1592)
java.base/java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:529)
java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:308)
[org.sonatype.ossindex.service.client.transport.HttpUrlConnectionTransport.post](http://org.sonatype.ossindex.service.client.transport.httpurlconnectiontransport.post/)(HttpUrlConnectionTransport.java:95)
org.sonatype.ossindex.service.client.internal.OssindexClientImpl.doRequestComponentReports(OssindexClientImpl.java:204)
org.sonatype.ossindex.service.client.internal.OssindexClientImpl.requestComponentReports(OssindexClientImpl.java:170)
org.owasp.dependencycheck.analyzer.OssIndexAnalyzer.requestReports(OssIndexAnalyzer.java:219)
org.owasp.dependencycheck.analyzer.OssIndexAnalyzer.analyzeDependency(OssIndexAnalyzer.java:134)
org.owasp.dependencycheck.analyzer.AbstractAnalyzer.analyze(AbstractAnalyzer.java:131)
org.owasp.dependencycheck.AnalysisTask.call(AnalysisTask.java:88)
org.owasp.dependencycheck.AnalysisTask.call(AnalysisTask.java:37)
java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
java.base/java.lang.Thread.run(Thread.java:833)
```

## Description of Change
This PR will use the `ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS` to determine whether an error or warning should be returned in the event of OSS Index causing a `SocketTimeoutException` to be raised.

## Have test cases been added to cover the new functionality?

*yes*


Thanks for all of your awesome work on Dependency check! 