### PR TITLE
feat: Add support for Nexus v3 to NexusAnalyzer

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
@@ -23,6 +23,7 @@ import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.data.nexus.NexusSearch;
 import org.owasp.dependencycheck.data.nexus.NexusV2Search;
+import org.owasp.dependencycheck.data.nexus.NexusV3Search;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
@@ -36,6 +37,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Locale;
 import javax.annotation.concurrent.ThreadSafe;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.exception.InitializationException;
@@ -170,17 +172,38 @@ public class NexusAnalyzer extends AbstractFileTypeAnalyzer {
         if (isEnabled()) {
             final boolean useProxy = useProxy();
             LOGGER.debug("Using proxy: {}", useProxy);
-            try {
-                searcher = new NexusV2Search(getSettings(), useProxy);
-                if (!searcher.preflightRequest()) {
-                    setEnabled(false);
-                    throw new InitializationException("There was an issue getting Nexus status. Disabling analyzer.");
-                }
-            } catch (MalformedURLException mue) {
-                setEnabled(false);
-                throw new InitializationException("Malformed URL to Nexus", mue);
-            }
+            searcher = createNexusSearchOrDisable(useProxy);
         }
+    }
+
+    /**
+     * Creates a NexusSearch for the appropriate Nexus version (Nexus V2 and V3 supported).
+     * <p>
+     * If errors are encountered creating or validating the NexusSearch it disables this analyzer.
+     *
+     * @param useProxy Whether a proxy is to be used
+     * @return A NexusSearch appropriate for the configured ANALYZER_NEXUS_URL
+     * @throws InitializationException Upon errors creating of validating the ANALYZER_NEXUS_URL
+     */
+    private NexusSearch createNexusSearchOrDisable(boolean useProxy) throws InitializationException {
+        final Settings settings = getSettings();
+        final String nexusRootURL=settings.getString(Settings.KEYS.ANALYZER_NEXUS_URL);
+        final NexusSearch result;
+        try {
+            if (nexusRootURL.toLowerCase(Locale.ROOT).contains("service/local/")) {
+                result = new NexusV2Search(settings, useProxy);
+            } else {
+                result = new NexusV3Search(settings, useProxy);
+            }
+            if (!result.preflightRequest()) {
+                setEnabled(false);
+                throw new InitializationException("There was an error getting Nexus status. Disabling NexusAnalyzer.");
+            }
+        } catch (MalformedURLException mue) {
+            setEnabled(false);
+            throw new InitializationException("Malformed URL to Nexus. Disabling NexusAnalyzer", mue);
+        }
+        return result;
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
@@ -21,6 +21,7 @@ import org.apache.commons.io.FileUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
+import org.owasp.dependencycheck.data.nexus.NexusSearch;
 import org.owasp.dependencycheck.data.nexus.NexusV2Search;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
@@ -100,7 +101,7 @@ public class NexusAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * The Nexus Search to be set up for this analyzer.
      */
-    private NexusV2Search searcher;
+    private NexusSearch searcher;
 
     /**
      * Field indicating if the analyzer is enabled.

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
@@ -187,7 +187,7 @@ public class NexusAnalyzer extends AbstractFileTypeAnalyzer {
      */
     private NexusSearch createNexusSearchOrDisable(boolean useProxy) throws InitializationException {
         final Settings settings = getSettings();
-        final String nexusRootURL=settings.getString(Settings.KEYS.ANALYZER_NEXUS_URL);
+        final String nexusRootURL = settings.getString(Settings.KEYS.ANALYZER_NEXUS_URL);
         final NexusSearch result;
         try {
             if (nexusRootURL.toLowerCase(Locale.ROOT).contains("service/local/")) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NexusAnalyzer.java
@@ -21,7 +21,7 @@ import org.apache.commons.io.FileUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
-import org.owasp.dependencycheck.data.nexus.NexusSearch;
+import org.owasp.dependencycheck.data.nexus.NexusV2Search;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
@@ -100,7 +100,7 @@ public class NexusAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * The Nexus Search to be set up for this analyzer.
      */
-    private NexusSearch searcher;
+    private NexusV2Search searcher;
 
     /**
      * Field indicating if the analyzer is enabled.
@@ -170,7 +170,7 @@ public class NexusAnalyzer extends AbstractFileTypeAnalyzer {
             final boolean useProxy = useProxy();
             LOGGER.debug("Using proxy: {}", useProxy);
             try {
-                searcher = new NexusSearch(getSettings(), useProxy);
+                searcher = new NexusV2Search(getSettings(), useProxy);
                 if (!searcher.preflightRequest()) {
                     setEnabled(false);
                     throw new InitializationException("There was an issue getting Nexus status. Disabling analyzer.");

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusSearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusSearch.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.nexus;
+
+import java.io.IOException;
+
+public interface NexusSearch {
+    /**
+     * Searches the configured Nexus repository for the given sha1 hash. If the
+     * artifact is found, a <code>MavenArtifact</code> is populated with the
+     * coordinate information.
+     *
+     * @param sha1 The SHA-1 hash string for which to search
+     * @return the populated Maven coordinates
+     * @throws IOException if it's unable to connect to the specified repository
+     *                     or if the specified artifact is not found.
+     */
+    MavenArtifact searchSha1(String sha1) throws IOException;
+
+    /**
+     * Do a preflight request to see if the repository is actually working.
+     *
+     * @return whether the repository is listening and returns the expected status response
+     */
+    boolean preflightRequest();
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV2Search.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV2Search.java
@@ -45,7 +45,7 @@ import org.xml.sax.SAXException;
  * @author colezlaw
  */
 @ThreadSafe
-public class NexusV2Search {
+public class NexusV2Search implements NexusSearch {
 
     /**
      * The root URL for the Nexus repository service.
@@ -83,16 +83,7 @@ public class NexusV2Search {
 
     }
 
-    /**
-     * Searches the configured Nexus repository for the given sha1 hash. If the
-     * artifact is found, a <code>MavenArtifact</code> is populated with the
-     * coordinate information.
-     *
-     * @param sha1 The SHA-1 hash string for which to search
-     * @return the populated Maven coordinates
-     * @throws IOException if it's unable to connect to the specified repository
-     * or if the specified artifact is not found.
-     */
+    @Override
     public MavenArtifact searchSha1(String sha1) throws IOException {
         if (null == sha1 || !sha1.matches("^[0-9A-Fa-f]{40}$")) {
             throw new IllegalArgumentException("Invalid SHA1 format");
@@ -168,12 +159,7 @@ public class NexusV2Search {
         }
     }
 
-    /**
-     * Do a preflight request to see if the repository is actually working.
-     *
-     * @return whether the repository is listening and returns the /status URL
-     * correctly
-     */
+    @Override
     public boolean preflightRequest() {
         final HttpURLConnection conn;
         try {

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV2Search.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV2Search.java
@@ -45,7 +45,7 @@ import org.xml.sax.SAXException;
  * @author colezlaw
  */
 @ThreadSafe
-public class NexusSearch {
+public class NexusV2Search {
 
     /**
      * The root URL for the Nexus repository service.
@@ -63,7 +63,7 @@ public class NexusSearch {
     /**
      * Used for logging.
      */
-    private static final Logger LOGGER = LoggerFactory.getLogger(NexusSearch.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(NexusV2Search.class);
 
     /**
      * Creates a NexusSearch for the given repository URL.
@@ -73,7 +73,7 @@ public class NexusSearch {
      * @throws java.net.MalformedURLException thrown if the configured URL is
      * invalid
      */
-    public NexusSearch(Settings settings, boolean useProxy) throws MalformedURLException {
+    public NexusV2Search(Settings settings, boolean useProxy) throws MalformedURLException {
         this.settings = settings;
         this.useProxy = useProxy;
 

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV3Search.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV3Search.java
@@ -1,0 +1,254 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2023 Hans Aikema. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.nexus;
+
+import org.owasp.dependencycheck.utils.Settings;
+import org.owasp.dependencycheck.utils.URLConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import java.io.BufferedInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+/**
+ * Class of methods to search Nexus v3 repositories.
+ *
+ * @author Hans Aikema
+ */
+@ThreadSafe
+public class NexusV3Search implements NexusSearch {
+
+    /**
+     * By default, NexusV3Search accepts only classifier-less artifacts.
+     * <p>
+     * This prevents, among others, sha1-collisions for empty jars on empty javadoc/sources jars.
+     * See e.g. issues #5559 and #5118
+     */
+    private final Set<String> acceptedClassifiers = new HashSet<>();
+
+    /**
+     * The root URL for the Nexus repository service.
+     */
+    private final URL rootURL;
+
+    /**
+     * Whether to use the Proxy when making requests.
+     */
+    private final boolean useProxy;
+    /**
+     * The configured settings.
+     */
+    private final Settings settings;
+    /**
+     * Used for logging.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(NexusV3Search.class);
+
+    /**
+     * Creates a NexusV3Search for the given repository URL.
+     *
+     * @param settings the configured settings
+     * @param useProxy flag indicating if the proxy settings should be used
+     * @throws MalformedURLException thrown if the configured URL is
+     *                               invalid
+     */
+    public NexusV3Search(Settings settings, boolean useProxy) throws MalformedURLException {
+        this.settings = settings;
+        this.useProxy = useProxy;
+        this.acceptedClassifiers.add(null);
+        final String searchUrl = settings.getString(Settings.KEYS.ANALYZER_NEXUS_URL);
+        LOGGER.debug("Nexus Search URL: {}", searchUrl);
+        this.rootURL = new URL(searchUrl);
+
+    }
+
+    @Override
+    public MavenArtifact searchSha1(String sha1) throws IOException {
+        if (null == sha1 || !sha1.matches("^[0-9A-Fa-f]{40}$")) {
+            throw new IllegalArgumentException("Invalid SHA1 format");
+        }
+
+        final List<MavenArtifact> collectedMatchingArtifacts = new ArrayList<>(1);
+
+        String continuationToken = retrievePageAndAddMatchingArtifact(collectedMatchingArtifacts, sha1, null);
+        while (continuationToken != null && collectedMatchingArtifacts.isEmpty()) {
+            continuationToken = retrievePageAndAddMatchingArtifact(collectedMatchingArtifacts, sha1, continuationToken);
+        }
+        if (collectedMatchingArtifacts.isEmpty()) {
+            throw new FileNotFoundException("Artifact not found in Nexus");
+        } else {
+            return collectedMatchingArtifacts.get(0);
+        }
+    }
+
+    private String retrievePageAndAddMatchingArtifact(List<MavenArtifact> collectedMatchingArtifacts, String sha1, String continuationToken) throws IOException {
+        final URL url;
+        LOGGER.debug("Search with continuation token {}", continuationToken);
+        if (continuationToken == null) {
+            url = new URL(rootURL, String.format("v1/search/?sha1=%s",
+                    sha1.toLowerCase()));
+        } else {
+            url = new URL(rootURL, String.format("v1/search/?sha1=%s&continuationToken=%s",
+                    sha1.toLowerCase(), continuationToken));
+        }
+
+        LOGGER.debug("Searching Nexus url {}", url);
+        // Determine if we need to use a proxy. The rules:
+        // 1) If the proxy is set, AND the setting is set to true, use the proxy
+        // 2) Otherwise, don't use the proxy (either the proxy isn't configured,
+        // or proxy is specifically set to false
+        final HttpURLConnection conn;
+        final URLConnectionFactory factory = new URLConnectionFactory(settings);
+        conn = factory.createHttpURLConnection(url, useProxy);
+        conn.setDoOutput(true);
+        final String authHeader = buildHttpAuthHeaderValue();
+        if (!authHeader.isEmpty()) {
+            conn.addRequestProperty("Authorization", authHeader);
+        }
+
+        conn.addRequestProperty("Accept", "application/json");
+        conn.connect();
+        final String nextContinuationToken;
+        if (conn.getResponseCode() == 200) {
+            nextContinuationToken = parseResponse(conn, sha1, collectedMatchingArtifacts);
+        } else {
+            LOGGER.debug("Could not connect to Nexus received response code: {} {}",
+                    conn.getResponseCode(), conn.getResponseMessage());
+            throw new IOException(String.format("Could not connect to Nexus, HTTP response code %d", conn.getResponseCode()));
+        }
+        return nextContinuationToken;
+    }
+
+    private String parseResponse(HttpURLConnection conn, String sha1, List<MavenArtifact> matchingArtifacts) throws IOException {
+        try (InputStream in = new BufferedInputStream(conn.getInputStream());
+             JsonReader jsonReader = Json.createReader(in)) {
+            final JsonObject jsonResponse = jsonReader.readObject();
+            String continuationToken = jsonResponse.getString("continuationToken", null);
+            final JsonArray components = jsonResponse.getJsonArray("items");
+            boolean found = false;
+            for (int i = 0; i < components.size() && !found; i++) {
+                boolean jarFound = false;
+                boolean pomFound = false;
+                String downloadUrl = null;
+                String groupId = null;
+                String artifactId = null;
+                String version = null;
+                String pomUrl = null;
+
+                final JsonObject component = components.getJsonObject(i);
+
+                final String format = components.getJsonObject(0).getString("format", "unknown");
+                if ("maven2".equals(format)) {
+                    final JsonArray assets = component.getJsonArray("assets");
+                    for (int j = 0; !found && j < assets.size(); j++) {
+                        final JsonObject asset = assets.getJsonObject(j);
+                        final JsonObject checksums = asset.getJsonObject("checksum");
+                        final JsonObject maven2 = asset.getJsonObject("maven2");
+                        if (maven2 != null
+                                && "jar".equals(maven2.getString("extension", null))
+                                && acceptedClassifiers.contains(maven2.getString("classifier", null))
+                                && checksums != null && sha1.equals(checksums.getString("sha1", null))
+                        ) {
+                            downloadUrl = asset.getString("downloadUrl");
+                            groupId = maven2.getString("groupId");
+                            artifactId = maven2.getString("artifactId");
+                            version = maven2.getString("version");
+
+                            jarFound = true;
+                        } else if (maven2 != null && "pom".equals(maven2.getString("extension"))) {
+                            pomFound = true;
+                            pomUrl = asset.getString("downloadUrl");
+                        }
+                        if (pomFound && jarFound) {
+                            found = true;
+                        }
+                    }
+                    if (found) {
+                        matchingArtifacts.add(new MavenArtifact(groupId, artifactId, version, downloadUrl, pomUrl));
+                    } else if (jarFound) {
+                        final MavenArtifact ma = new MavenArtifact(groupId, artifactId, version, downloadUrl);
+                        ma.setPomUrl(MavenArtifact.derivePomUrl(artifactId, version, downloadUrl));
+                        matchingArtifacts.add(ma);
+                        found = true;
+                    }
+                }
+            }
+            return continuationToken;
+        }
+    }
+
+    @Override
+    public boolean preflightRequest() {
+        final HttpURLConnection conn;
+        try {
+            final URL url = new URL(rootURL, "v1/status");
+            final URLConnectionFactory factory = new URLConnectionFactory(settings);
+            conn = factory.createHttpURLConnection(url, useProxy);
+            conn.addRequestProperty("Accept", "application/json");
+            final String authHeader = buildHttpAuthHeaderValue();
+            if (!authHeader.isEmpty()) {
+                conn.addRequestProperty("Authorization", authHeader);
+            }
+            conn.connect();
+            if (conn.getResponseCode() != 200) {
+                LOGGER.warn("Expected 200 result from Nexus, got {}", conn.getResponseCode());
+                return false;
+            }
+            if (conn.getContentLength() != 0) {
+                LOGGER.warn("Expected empty OK response (content-length 0), got content-length {}", conn.getContentLength());
+                return false;
+            }
+        } catch (IOException e) {
+            LOGGER.warn("Pre-flight request to Nexus failed: ", e);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Constructs the base64 encoded basic authentication header value.
+     *
+     * @return the base64 encoded basic authentication header value
+     */
+    private String buildHttpAuthHeaderValue() {
+        final String user = settings.getString(Settings.KEYS.ANALYZER_NEXUS_USER, "");
+        final String pass = settings.getString(Settings.KEYS.ANALYZER_NEXUS_PASSWORD, "");
+        String result = "";
+        if (user.isEmpty() || pass.isEmpty()) {
+            LOGGER.debug("Skip authentication as user and/or password for nexus is empty");
+        } else {
+            final String auth = user + ':' + pass;
+            final String base64Auth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+            result = "Basic " + base64Auth;
+        }
+        return result;
+    }
+
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV3Search.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV3Search.java
@@ -35,7 +35,11 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Class of methods to search Nexus v3 repositories.
@@ -108,7 +112,8 @@ public class NexusV3Search implements NexusSearch {
         }
     }
 
-    private String retrievePageAndAddMatchingArtifact(List<MavenArtifact> collectedMatchingArtifacts, String sha1, String continuationToken) throws IOException {
+    private String retrievePageAndAddMatchingArtifact(List<MavenArtifact> collectedMatchingArtifacts, String sha1, String continuationToken)
+            throws IOException {
         final URL url;
         LOGGER.debug("Search with continuation token {}", continuationToken);
         if (continuationToken == null) {
@@ -150,7 +155,7 @@ public class NexusV3Search implements NexusSearch {
         try (InputStream in = new BufferedInputStream(conn.getInputStream());
              JsonReader jsonReader = Json.createReader(in)) {
             final JsonObject jsonResponse = jsonReader.readObject();
-            String continuationToken = jsonResponse.getString("continuationToken", null);
+            final String continuationToken = jsonResponse.getString("continuationToken", null);
             final JsonArray components = jsonResponse.getJsonArray("items");
             boolean found = false;
             for (int i = 0; i < components.size() && !found; i++) {

--- a/core/src/test/java/org/owasp/dependencycheck/data/nexus/NexusV2SearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nexus/NexusV2SearchTest.java
@@ -29,10 +29,10 @@ import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class NexusSearchTest extends BaseTest {
+public class NexusV2SearchTest extends BaseTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NexusSearchTest.class);
-    private NexusSearch searcher;
+    private static final Logger LOGGER = LoggerFactory.getLogger(NexusV2SearchTest.class);
+    private NexusV2Search searcher;
 
     @Before
     @Override
@@ -40,7 +40,7 @@ public class NexusSearchTest extends BaseTest {
         super.setUp();
         String nexusUrl = getSettings().getString(Settings.KEYS.ANALYZER_NEXUS_URL);
         LOGGER.debug(nexusUrl);
-        searcher = new NexusSearch(getSettings(), false);
+        searcher = new NexusV2Search(getSettings(), false);
         Assume.assumeTrue(searcher.preflightRequest());
     }
 

--- a/core/src/test/java/org/owasp/dependencycheck/data/nexus/NexusV3SearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nexus/NexusV3SearchTest.java
@@ -17,9 +17,6 @@
  */
 package org.owasp.dependencycheck.data.nexus;
 
-import java.io.FileNotFoundException;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -29,10 +26,15 @@ import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class NexusV2SearchTest extends BaseTest {
+import java.io.FileNotFoundException;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NexusV2SearchTest.class);
-    private NexusV2Search searcher;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class NexusV3SearchTest extends BaseTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NexusV3SearchTest.class);
+    private NexusV3Search searcher;
 
     @Before
     @Override
@@ -41,10 +43,11 @@ public class NexusV2SearchTest extends BaseTest {
         Settings sett = getSettings();
 //        sett.setString(Settings.KEYS.ANALYZER_NEXUS_USER, "demo");
 //        sett.setString(Settings.KEYS.ANALYZER_NEXUS_PASSWORD, "demo");
-//        sett.setString(Settings.KEYS.ANALYZER_NEXUS_URL, "https://localhost/nexus/service/local/");
+//        sett.setString(Settings.KEYS.ANALYZER_NEXUS_URL, "http://localhost/service/rest/");
         String nexusUrl = sett.getString(Settings.KEYS.ANALYZER_NEXUS_URL);
+
         LOGGER.debug(nexusUrl);
-        searcher = new NexusV2Search(sett, false);
+        searcher = new NexusV3Search(sett, false);
         Assume.assumeTrue(searcher.preflightRequest());
     }
 

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -24,7 +24,7 @@
     <logger name="org.owasp.dependencycheck.data.central.ArtifactorySearchTest" additivity="false" level="WARN">
         <appender-ref ref="console"/>
     </logger>
-    <logger name="org.owasp.dependencycheck.data.nexus.NexusSearchTest" additivity="false" level="WARN">
+    <logger name="org.owasp.dependencycheck.data.nexus.NexusV2SearchTest" additivity="false" level="WARN">
         <appender-ref ref="console"/>
     </logger>
     <!-- disable error log statements during test cases on FileUtils -->


### PR DESCRIPTION
## Fixes Issue #5319

## Description of Change

Implement support for Nexus V3 REST API to search for artifact by SHA-1 hash in addition to the current Nexus V2 API support.

The NexusAnalyzer now attempts to use Nexus v2 API if the standard Nexus v2 API prefix (`service/local`) is found in the Nexus Analyzer URL. Otherwise it will attempt to use the Nexus v3 API.

## Have test cases been added to cover the new functionality?

Existing test-case for NexusV2 has been cloned into a copy for V3, including the `@Ignore` of all testcases by default. Locally they have been used to test against private Nexus Repository OSS V2 and Nexus Repository OSS V3 instances to validate that both the Nexus V2 and Nexus V3 implementations are passing the tests.