### PR TITLE
fix: Do not filter out evidences added by hints

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/HintAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/HintAnalyzer.java
@@ -198,7 +198,7 @@ public class HintAnalyzer extends AbstractAnalyzer {
             for (VendorDuplicatingHintRule dhr : vendorHints) {
                 if (dhr.getValue().equalsIgnoreCase(e.getValue())) {
                     dependency.addEvidence(EvidenceType.VENDOR, new Evidence(e.getSource() + " (hint)",
-                            e.getName(), dhr.getDuplicate(), e.getConfidence()));
+                            e.getName(), dhr.getDuplicate(), e.getConfidence(), true));
                 }
             }
         }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/VersionFilterAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/VersionFilterAnalyzer.java
@@ -136,7 +136,7 @@ public class VersionFilterAnalyzer extends AbstractAnalyzer {
         final Set<Evidence> remove;
         if (dependency.getVersion() != null) {
             remove = dependency.getEvidence(EvidenceType.VERSION).stream()
-                    .filter(e -> !dependency.getVersion().equals(e.getValue()))
+                    .filter(e -> !e.isFromHint() && !dependency.getVersion().equals(e.getValue()))
                     .collect(Collectors.toSet());
         } else {
             remove = new HashSet<>();
@@ -165,7 +165,8 @@ public class VersionFilterAnalyzer extends AbstractAnalyzer {
                     LOGGER.debug("filtering evidence from {}", dependency.getFileName());
 
                     for (Evidence e : dependency.getEvidence(EvidenceType.VERSION)) {
-                        if (!(pomMatch && VERSION.equals(e.getName())
+                        if (!e.isFromHint() &&
+                                !(pomMatch && VERSION.equals(e.getName())
                                 && (NEXUS.equals(e.getSource()) || CENTRAL.equals(e.getSource()) || POM.equals(e.getSource())))
                                 && !(fileMatch && VERSION.equals(e.getName()) && FILE.equals(e.getSource()))
                                 && !(manifestMatch && MANIFEST.equals(e.getSource()) && IMPLEMENTATION_VERSION.equals(e.getName()))) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/VersionFilterAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/VersionFilterAnalyzer.java
@@ -165,8 +165,8 @@ public class VersionFilterAnalyzer extends AbstractAnalyzer {
                     LOGGER.debug("filtering evidence from {}", dependency.getFileName());
 
                     for (Evidence e : dependency.getEvidence(EvidenceType.VERSION)) {
-                        if (!e.isFromHint() &&
-                                !(pomMatch && VERSION.equals(e.getName())
+                        if (!e.isFromHint()
+                                && !(pomMatch && VERSION.equals(e.getName())
                                 && (NEXUS.equals(e.getSource()) || CENTRAL.equals(e.getSource()) || POM.equals(e.getSource())))
                                 && !(fileMatch && VERSION.equals(e.getName()) && FILE.equals(e.getSource()))
                                 && !(manifestMatch && MANIFEST.equals(e.getSource()) && IMPLEMENTATION_VERSION.equals(e.getName()))) {

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Evidence.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Evidence.java
@@ -60,6 +60,11 @@ public class Evidence implements Serializable, Comparable<Evidence> {
     private Confidence confidence;
 
     /**
+     * Whether the evidence originates from a hint.
+     */
+    private boolean fromHint;
+
+    /**
      * Creates a new Evidence object.
      */
     public Evidence() {
@@ -74,10 +79,24 @@ public class Evidence implements Serializable, Comparable<Evidence> {
      * @param confidence the confidence of the evidence.
      */
     public Evidence(String source, String name, String value, Confidence confidence) {
+        this(source, name, value, confidence, false);
+    }
+
+    /**
+     * Creates a new Evidence objects.
+     *
+     * @param source     the source of the evidence.
+     * @param name       the name of the evidence.
+     * @param value      the value of the evidence.
+     * @param confidence the confidence of the evidence.
+     * @param fromHint whether the evidence was introduced by a hint.
+     */
+    public Evidence(String source, String name, String value, Confidence confidence, boolean fromHint) {
         this.source = source;
         this.name = name;
         this.value = value;
         this.confidence = confidence;
+        this.fromHint = fromHint;
     }
 
     /**
@@ -153,6 +172,24 @@ public class Evidence implements Serializable, Comparable<Evidence> {
     }
 
     /**
+     * Get the value of fromHint.
+     *
+     * @return the value of fromHint
+     */
+    public boolean isFromHint() {
+        return fromHint;
+    }
+
+    /**
+     * Set the value of fromHint.
+     *
+     * @param fromHint new value of fromHint
+     */
+    public void setFromHint(boolean fromHint) {
+        this.fromHint = fromHint;
+    }
+
+    /**
      * Implements the hashCode for Evidence.
      *
      * @return hash code.
@@ -187,6 +224,7 @@ public class Evidence implements Serializable, Comparable<Evidence> {
                 .append(this.name == null ? null : this.name.toLowerCase(), o.name == null ? null : o.name.toLowerCase())
                 .append(this.value == null ? null : this.value.toLowerCase(), o.value == null ? null : o.value.toLowerCase())
                 .append(this.confidence, o.getConfidence())
+                .append(this.fromHint, o.isFromHint())
                 .build();
     }
 
@@ -196,7 +234,6 @@ public class Evidence implements Serializable, Comparable<Evidence> {
      * @param o the evidence being compared
      * @return an integer indicating the ordering of the two objects
      */
-    @SuppressWarnings("deprecation")
     @Override
     public int compareTo(@NotNull Evidence o) {
         return new CompareToBuilder()
@@ -204,6 +241,7 @@ public class Evidence implements Serializable, Comparable<Evidence> {
                 .append(this.name == null ? null : this.name.toLowerCase(), o.name == null ? null : o.name.toLowerCase())
                 .append(this.value == null ? null : this.value.toLowerCase(), o.value == null ? null : o.value.toLowerCase())
                 .append(this.confidence, o.getConfidence())
+                .append(this.fromHint, o.isFromHint())
                 .toComparison();
     }
 
@@ -214,6 +252,6 @@ public class Evidence implements Serializable, Comparable<Evidence> {
      */
     @Override
     public String toString() {
-        return "Evidence{" + "name=" + name + ", source=" + source + ", value=" + value + ", confidence=" + confidence + '}';
+        return "Evidence{" + "name=" + name + ", source=" + source + ", value=" + value + ", confidence=" + confidence + ", fromHint=" + fromHint + '}';
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Evidence.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Evidence.java
@@ -252,6 +252,7 @@ public class Evidence implements Serializable, Comparable<Evidence> {
      */
     @Override
     public String toString() {
-        return "Evidence{" + "name=" + name + ", source=" + source + ", value=" + value + ", confidence=" + confidence + ", fromHint=" + fromHint + '}';
+        return "Evidence{" + "name=" + name + ", source=" + source + ", value=" + value + ", confidence=" + confidence
+                + ", fromHint=" + fromHint + '}';
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/xml/hints/HintRule.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/hints/HintRule.java
@@ -147,7 +147,7 @@ public class HintRule {
      * @param confidence the confidence of the evidence
      */
     public void addAddProduct(String source, String name, String value, Confidence confidence) {
-        addProduct.add(new Evidence(source, name, value, confidence));
+        addProduct.add(new Evidence(source, name, value, confidence, true));
     }
 
     /**
@@ -168,7 +168,7 @@ public class HintRule {
      * @param confidence the confidence of the evidence
      */
     public void addAddVersion(String source, String name, String value, Confidence confidence) {
-        addVersion.add(new Evidence(source, name, value, confidence));
+        addVersion.add(new Evidence(source, name, value, confidence, true));
     }
 
     /**
@@ -189,7 +189,7 @@ public class HintRule {
      * @param confidence the confidence of the evidence
      */
     public void addAddVendor(String source, String name, String value, Confidence confidence) {
-        addVendor.add(new Evidence(source, name, value, confidence));
+        addVendor.add(new Evidence(source, name, value, confidence, true));
     }
 
     /**

--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -148,48 +148,6 @@
         </add>
     </hint>
     
-    <!-- begin hack for temporary patch of issue #534-->
-    <hint>
-        <given>
-            <fileName regex="true" contains=".*hibernate-validator-5\.0\..*"/>
-        </given>
-        <add>
-            <evidence type="version" source="hint" name="version" value="5.0" confidence="HIGHEST"/>
-        </add>
-    </hint>
-    <hint>
-        <given>
-            <fileName regex="true" contains=".*hibernate-validator-5\.1\.[01].*"/>
-        </given>
-        <add>
-            <evidence type="version" source="hint" name="version" value="5.1" confidence="HIGHEST"/>
-        </add>
-    </hint>
-    <hint>
-        <given>
-            <fileName regex="true" contains=".*hibernate-validator-4\.1\..*"/>
-        </given>
-        <add>
-            <evidence type="version" source="hint" name="version" value="4.1.0" confidence="HIGHEST"/>
-        </add>
-    </hint>
-    <hint>
-        <given>
-            <fileName regex="true" contains=".*hibernate-validator-4\.2\.0.*"/>
-        </given>
-        <add>
-            <evidence type="version" source="hint" name="version" value="4.2.0" confidence="HIGHEST"/>
-        </add>
-    </hint>
-    <hint>
-        <given>
-            <fileName regex="true" contains=".*hibernate-validator-4\.3\.[01]\..*"/>
-        </given>
-        <add>
-            <evidence type="version" source="hint" name="version" value="4.3.0" confidence="HIGHEST"/>
-        </add>
-    </hint>
-    <!-- end hack for temporary patch of issue #534-->
     <!-- creating a spring boot starter project can cause your app to incorrectly be flagged as spring-->
     <hint>
         <given>

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/HintAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/HintAnalyzerTest.java
@@ -86,11 +86,11 @@ public class HintAnalyzerTest extends BaseDBTestCase {
                     sdep = d;
                 }
             }
-            final Evidence springTest1 = new Evidence("hint analyzer", "product", "springsource_spring_framework", Confidence.HIGHEST);
-            final Evidence springTest2 = new Evidence("hint analyzer", "vendor", "SpringSource", Confidence.HIGHEST);
-            final Evidence springTest3 = new Evidence("hint analyzer", "vendor", "vmware", Confidence.HIGHEST);
-            final Evidence springTest4 = new Evidence("hint analyzer", "product", "springsource_spring_framework", Confidence.HIGHEST);
-            final Evidence springTest5 = new Evidence("hint analyzer", "vendor", "vmware", Confidence.HIGHEST);
+            final Evidence springTest1 = new Evidence("hint analyzer", "product", "springsource_spring_framework", Confidence.HIGHEST, true);
+            final Evidence springTest2 = new Evidence("hint analyzer", "vendor", "SpringSource", Confidence.HIGHEST, true);
+            final Evidence springTest3 = new Evidence("hint analyzer", "vendor", "vmware", Confidence.HIGHEST, true);
+            final Evidence springTest4 = new Evidence("hint analyzer", "product", "springsource_spring_framework", Confidence.HIGHEST, true);
+            final Evidence springTest5 = new Evidence("hint analyzer", "vendor", "vmware", Confidence.HIGHEST, true);
 
             assertFalse(gdep.contains(EvidenceType.PRODUCT, springTest1));
             assertFalse(gdep.contains(EvidenceType.VENDOR, springTest2));


### PR DESCRIPTION
## Fixes Issue #5894

## Description of Change

Add a marker to the evidences to indicate an evidence came from a hints file (as the evidence source is fully user-controllable the source is not usable to detect hint-origin) and avoid removal of those hints when filtering 'inaccurate' evidences in the VersionFilterAnalyzer.

Also removes the now obsolete hint for a historical Hibernate-validator false-negative that is already properly resolved since the switch to JSON datafeeds.

## Have test cases been added to cover the new functionality?

no