### PR TITLE
fix: Support ~= version specifier in requirements.txt and pipfile

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PipAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PipAnalyzer.java
@@ -74,7 +74,7 @@ public class PipAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * o * Matches AC_INIT variables in the output configure script.
      */
-    private static final Pattern PACKAGE_VERSION = Pattern.compile("^([^#].*?)(?:[=>]=([\\.\\*0-9]+?))?$", Pattern.MULTILINE);
+    private static final Pattern PACKAGE_VERSION = Pattern.compile("^([^#].*?)(?:[=~>]=([\\.\\*0-9]+?))?$", Pattern.MULTILINE);
 
     /**
      * The file filter used to determine which files this analyzer supports.

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PipfileAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PipfileAnalyzer.java
@@ -81,7 +81,7 @@ public class PipfileAnalyzer extends AbstractFileTypeAnalyzer {
     /**
      * o * Matches AC_INIT variables in the output configure script.
      */
-    private static final Pattern PACKAGE_VERSION = Pattern.compile("^([^#].*?) = \"(?:[=>]=([\\.\\*0-9]+?))?\"$", Pattern.MULTILINE);
+    private static final Pattern PACKAGE_VERSION = Pattern.compile("^([^#].*?) = \"(?:[=~>]=([\\.\\*0-9]+?))?\"$", Pattern.MULTILINE);
 
     /**
      * The file filter used to determine which files this analyzer supports.

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PipAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PipAnalyzerTest.java
@@ -103,17 +103,25 @@ public class PipAnalyzerTest extends BaseDBTestCase {
             engine.addDependency(result);
             analyzer.analyze(result, engine);
             assertFalse(ArrayUtils.contains(engine.getDependencies(), result));
-            assertEquals(23, engine.getDependencies().length);
-            boolean found = false;
+            assertEquals(24, engine.getDependencies().length);
+            boolean foundPyYAML = false;
+            boolean foundCryptography = false;
             for (Dependency d : engine.getDependencies()) {
                 if ("PyYAML".equals(d.getName())) {
-                    found = true;
+                    foundPyYAML = true;
                     assertEquals("3.12", d.getVersion());
                     assertThat(d.getDisplayFileName(), equalTo("PyYAML:3.12"));
                     assertEquals(PythonDistributionAnalyzer.DEPENDENCY_ECOSYSTEM, d.getEcosystem());
                 }
+                if ("cryptography".equals(d.getName())) {
+                    foundCryptography = true;
+                    assertEquals("1.8.2", d.getVersion());
+                    assertThat(d.getDisplayFileName(), equalTo("cryptography:1.8.2"));
+                    assertEquals(PythonDistributionAnalyzer.DEPENDENCY_ECOSYSTEM, d.getEcosystem());
+                }
             }
-            assertTrue("Expeced to find PyYAML", found);
+            assertTrue("Expected to find PyYAML", foundPyYAML);
+            assertTrue("Expected to find cryptography", foundCryptography);
         }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PipfileAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PipfileAnalyzerTest.java
@@ -101,17 +101,25 @@ public class PipfileAnalyzerTest extends BaseDBTestCase {
             engine.addDependency(result);
             analyzer.analyze(result, engine);
             assertFalse(ArrayUtils.contains(engine.getDependencies(), result));
-            assertEquals(39, engine.getDependencies().length);
-            boolean found = false;
+            assertEquals(40, engine.getDependencies().length);
+            boolean foundUrllib3 = false;
+            boolean foundCryptography = false;
             for (Dependency d : engine.getDependencies()) {
                 if ("urllib3".equals(d.getName())) {
-                    found = true;
+                    foundUrllib3 = true;
                     assertEquals("1.25.9", d.getVersion());
                     assertThat(d.getDisplayFileName(), equalTo("urllib3:1.25.9"));
                     assertEquals(PythonDistributionAnalyzer.DEPENDENCY_ECOSYSTEM, d.getEcosystem());
                 }
+                if ("cryptography".equals(d.getName())) {
+                    foundCryptography = true;
+                    assertEquals("1.8.2", d.getVersion());
+                    assertThat(d.getDisplayFileName(), equalTo("cryptography:1.8.2"));
+                    assertEquals(PythonDistributionAnalyzer.DEPENDENCY_ECOSYSTEM, d.getEcosystem());
+                }
             }
-            assertTrue("Expeced to find urllib3", found);
+            assertTrue("Expeced to find urllib3", foundUrllib3);
+            assertTrue("Expeced to find cryptography", foundCryptography);
         }
     }
 }

--- a/src/test/resources/Pipfile
+++ b/src/test/resources/Pipfile
@@ -46,6 +46,7 @@ py-flags = "==1.1.2"
 CacheControl = "==0.12.5"
 prometheus_client = "==0.7.1"
 PyYAML = "==5.3.1"
+cryptography = "~=1.8.2"
 
 [requires]
 python_version = "3.6"

--- a/src/test/resources/requirements.txt
+++ b/src/test/resources/requirements.txt
@@ -21,3 +21,4 @@ spyne==2.12.14
 suds-jurko==0.6
 urllib3
 Werkzeug>=0.14.1
+cryptography~=1.8.2


### PR DESCRIPTION
## Fixes Issue #5898

## Description of Change

Extend the pattern for package/version extraction from pip requirements.txt and pipenv pipfile to support the backward-compatible `~=` pattern on top of the existing `==` and `>=` 

## Have test cases been added to cover the new functionality?

yes, existing testcases extended with a ~= specified dependency