### PR TITLE
feat: gitlab dependency scanner report format #5919

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
+++ b/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
@@ -124,7 +124,13 @@ public class ReportGenerator {
         /**
          * Generate JUNIT report.
          */
-        JUNIT
+        JUNIT,
+        /**
+         * Generate Report in GitLab dependency check format:
+         * @see <a href="https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/blob/master/dist/dependency-scanning-report-format.json">format definition</a>
+         * @see <a href="https://docs.gitlab.com/ee/development/integrations/secure.html">additional explantions on the format</a>
+         */
+        GITLAB
     }
 
     /**
@@ -251,6 +257,7 @@ public class ReportGenerator {
         final String scanDate = DateTimeFormatter.RFC_1123_DATE_TIME.format(dt);
         final String scanDateXML = DateTimeFormatter.ISO_INSTANT.format(dt);
         final String scanDateJunit = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(dt);
+        final String scanDateGitLab = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(dt.withNano(0));
 
         final VelocityContext ctxt = new VelocityContext();
         ctxt.put("applicationName", applicationName);
@@ -261,6 +268,7 @@ public class ReportGenerator {
         ctxt.put("scanDate", scanDate);
         ctxt.put("scanDateXML", scanDateXML);
         ctxt.put("scanDateJunit", scanDateJunit);
+        ctxt.put("scanDateGitLab", scanDateGitLab);
         ctxt.put("enc", new EscapeTool());
         ctxt.put("rpt", new ReportTool());
         ctxt.put("checksum", Checksum.class);
@@ -393,6 +401,9 @@ public class ReportGenerator {
         }
         if (format == Format.SARIF && !pathToCheck.endsWith(".sarif")) {
             return new File(outFile, "dependency-check-report.sarif");
+        }
+        if (format == Format.GITLAB && !pathToCheck.endsWith(".json")) {
+            return new File(outFile, "dependency-check-gitlab.json");
         }
         return outFile;
     }

--- a/core/src/main/java/org/owasp/dependencycheck/reporting/ReportTool.java
+++ b/core/src/main/java/org/owasp/dependencycheck/reporting/ReportTool.java
@@ -122,7 +122,7 @@ public class ReportTool {
         return "Unknown";
     }
 
-    private String normalizeSeverity(String sev) {
+    public String normalizeSeverity(String sev) {
         switch (sev) {
             case "critical":
                 return "Critical";

--- a/core/src/main/resources/templates/gitlabReport.vsl
+++ b/core/src/main/resources/templates/gitlabReport.vsl
@@ -54,19 +54,26 @@
                     #end
                     ##    ((List<Dependency>)context.get("dependencies")).get(5).getVulnerabilities().stream().collect(Collectors.toList()).get(0)
                     {
-                        "id": "$enc.json($vulnerability.name)", ##todo
+                        "id": "$enc.json($vulnerability.name)",
                         "identifiers": [
-                            #foreach( $ref in $vulnerability.getReferences(true) )
-                                {
-                                    "type": "$enc.json($ref.source)",
-                                    "name": "$enc.json($ref.name)",
-                                    "value": "$enc.json($ref.name)",
+                            {
+                                "type": "$enc.json($vulnerability.getSource().name())"
+                                #if( $vulnerability.getSource().name().equals("NVD") )
+                                    , "name": "$enc.json($vulnerability.name)"
+                                #elseif( $vulnerability.getSource().name().equals("NPM") )
+                                    , "name": "$enc.json($vulnerability.name) (NPM)"
+                                #else
+                                    , "name": "$enc.json($vulnerability.name)"
+                                #end
+                                , "value": "$enc.json($dependency.Sha1sum)"
 
-                                    ## optional properties
-                                    "url": "$enc.json($ref.url)"
-                                }
-                                #if( $foreach.hasNext ),#end
-                            #end
+                                ## optional properties
+                                #if( $vulnerability.getSource().name().equals("NVD") )
+                                    , "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=$enc.url($vulnerability.name)"
+                                #elseif( $vulnerability.getSource().name().equals("NPM") )
+                                    , "url": "https://github.com/advisories/$enc.url($vulnerability.name)"
+                                #end
+                            }
                         ],
                         "location": {
                             "file": "$enc.json($dependency.filePath)",
@@ -97,7 +104,17 @@
                         ## we have to include this field to be compliant with the format spec
                         "solution": "" ## todo: not in our dataset?
 
-                        ## "links": [], --> not implemented
+                        "links": [
+                            #foreach( $ref in $vulnerability.getReferences(true) )
+                                {
+                                    "name": "$enc.json($ref.name)",
+
+                                    ## optional properties
+                                    "url": "$enc.json($ref.url)"
+                                }
+                                #if( $foreach.hasNext ),#end
+                            #end
+                        ],
                         ## "details": [], --> not implemented
                         ## "tracking": {}, --> not implemented
                         ## "flags": [], --> not implemented.

--- a/core/src/main/resources/templates/gitlabReport.vsl
+++ b/core/src/main/resources/templates/gitlabReport.vsl
@@ -1,0 +1,137 @@
+{
+    "version": "15.0.6",
+    "schema": "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v15.0.6/dist/dependency-scanning-report-format.json?ref_type=tags", ##todo
+    "scan": {
+        ## this describes the tool responsible for scanning
+        "scanner": {
+            "id": "org.owasp.dependency-check",
+            "name": "Dependency-Check Core",
+            "version": "$enc.json($version)",
+            "vendor": {
+                "name": "OWASP"
+            },
+
+            ## optional properties
+            "url": "https://github.com/jeremylong/DependencyCheck/"
+        },
+        ## this describes the tool responsible for interpreting the scan result
+        ## in our case it's the same as the scanner
+        "analyzer": {
+            "id": "org.owasp.dependency-check",
+            "name": "Dependency-Check Core",
+            "version": "$enc.json($version)",
+            "vendor": {
+                "name": "OWASP"
+            },
+
+            ## optional properties
+            "url": "https://github.com/jeremylong/DependencyCheck/"
+        },
+
+        "end_time": "$enc.json($scanDateGitLab)",
+        ## we don't acutally have the real start time, so this is the best we can do
+        "start_time": "$enc.json($scanDateGitLab)",
+        ## we only generate a scan report, if the scan has successfully finished
+        "status": #if($exceptions) "failure" #else "success" #end ,
+        ## this is the only type of scan there is according to the format definition
+        "type": "dependency_scanning"
+
+        ## optional properties
+        ## "messages": [], --> not implemented
+        ##"options": [], --> not implemented
+        ##"primary_identifiers": [], --> not implemented
+    },
+    "vulnerabilities": [
+        #set( $vulnerability_first = true )
+        #foreach( $dependency in $dependencies )
+            #if( $dependency.vulnerabilities.size() != 0 )
+                #foreach( $vulnerability in $dependency.getVulnerabilities(true) )
+                    ## make sure to insert comma between array elements
+                    #if( $vulnerability_first == true )
+                        #set( $vulnerability_first = false )
+                    #else
+                    ,
+                    #end
+                    ##    ((List<Dependency>)context.get("dependencies")).get(5).getVulnerabilities().stream().collect(Collectors.toList()).get(0)
+                    {
+                        "id": "$enc.json($vulnerability.name)", ##todo
+                        "identifiers": [
+                            #foreach( $ref in $vulnerability.getReferences(true) )
+                                {
+                                    "type": "$enc.json($ref.source)",
+                                    "name": "$enc.json($ref.name)",
+                                    "value": "$enc.json($ref.name)",
+
+                                    ## optional properties
+                                    "url": "$enc.json($ref.url)"
+                                }
+                                #if( $foreach.hasNext ),#end
+                            #end
+                        ],
+                        "location": {
+                            "file": "$enc.json($dependency.filePath)",
+                            "dependency": {
+                                "package": {
+                                    "name": "$enc.json($dependency.name)"
+                                },
+                                "version": "$enc.json($dependency.version)"
+                                ## optional properties
+                                ## "iid": "", --> not implemented
+                                ## "direct": false, --> not implemented
+                                ## we don't have a good way of assigning iids, so this won't work
+                                ##"dependency_path": [
+                                ##    #foreach( $inc in $dependency.includedBy )
+                                ##        {
+                                ##            "iid":
+                                ##        }
+                                ##        #if( $foreach.hasNext ),#end
+                                ##    #end
+                                ##]
+                            }
+                        },
+
+                        ## optional properties
+                        "name": "$enc.json($vulnerability.name)",
+                        "description": "$enc.json($vulnerability.description)",
+                        "severity": "$enc.json($vulnerability.cvssV3.getBaseSeverity())",
+                        ## we have to include this field to be compliant with the format spec
+                        "solution": "" ## todo: not in our dataset?
+
+                        ## "links": [], --> not implemented
+                        ## "details": [], --> not implemented
+                        ## "tracking": {}, --> not implemented
+                        ## "flags": [], --> not implemented.
+                    }
+                #end
+            #end
+        #end
+    ],
+    "dependency_files": [
+        ## for lack of better knowledge, we just assume we have only scanned a single pom.xml file…
+        {
+            "path": "pom.xml",
+            "package_manager": "maven",
+            "dependencies": [
+                #foreach( $dependency in $dependencies )
+                    {
+                        "package": {
+                            "name": "$enc.json($dependency.name)"
+                        },
+                        "version": "$enc.json($dependency.version)"
+
+                        ## optional properties
+                        ## "iid": number, --> not implemtend
+                        ##"direct": false, --> not implemeten
+                        ##"dependency_path": [] --> not implemented
+                    }
+                    #if( $foreach.hasNext ),#end
+                #end
+            ]
+            ## no optional properties
+        }
+    ],
+
+    ## optional properties
+    "remediations": [], ## not implemented
+
+}

--- a/core/src/main/resources/templates/gitlabReport.vsl
+++ b/core/src/main/resources/templates/gitlabReport.vsl
@@ -147,6 +147,6 @@
     ],
 
     ## optional properties
-    "remediations": [], ## not implemented
+    "remediations": [] ## not implemented
 
 }

--- a/core/src/main/resources/templates/gitlabReport.vsl
+++ b/core/src/main/resources/templates/gitlabReport.vsl
@@ -112,7 +112,7 @@
                                 }
                                 #if( $foreach.hasNext ),#end
                             #end
-                        ],
+                        ]
                         ## "details": [], --> not implemented
                         ## "tracking": {}, --> not implemented
                         ## "flags": [], --> not implemented.

--- a/core/src/main/resources/templates/gitlabReport.vsl
+++ b/core/src/main/resources/templates/gitlabReport.vsl
@@ -101,9 +101,7 @@
                         "name": "$enc.json($vulnerability.name)",
                         "description": "$enc.json($vulnerability.description)",
                         "severity": "$enc.json($vulnerability.cvssV3.getBaseSeverity())",
-                        ## we have to include this field to be compliant with the format spec
-                        "solution": "" ## todo: not in our dataset?
-
+                        ## "solution": "" --> not implemented
                         "links": [
                             #foreach( $ref in $vulnerability.getReferences(true) )
                                 {

--- a/core/src/main/resources/templates/gitlabReport.vsl
+++ b/core/src/main/resources/templates/gitlabReport.vsl
@@ -100,7 +100,7 @@
                         ## optional properties
                         "name": "$enc.json($vulnerability.name)",
                         "description": "$enc.json($vulnerability.description)",
-                        "severity": "$enc.json($vulnerability.cvssV3.getBaseSeverity())",
+                        "severity": "$rpt.normalizeSeverity($vulnerability.cvssV3.getBaseSeverity().toLowerCase())",
                         ## "solution": "" --> not implemented
                         "links": [
                             #foreach( $ref in $vulnerability.getReferences(true) )


### PR DESCRIPTION
## Fixes Issue #5919

## Description of Change

As described in #5919, I am working on adding a new report format to DependencyCheck that can be directly fed to GitLab to be used as a dependency scanner in ci/cd-pipelines.

## Have test cases been added to cover the new functionality?

no