### PR TITLE
feat: suppress by 'includedBy'

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionHandler.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionHandler.java
@@ -89,6 +89,10 @@ public class SuppressionHandler extends DefaultHandler {
      */
     public static final String CVSS_BELOW = "cvssBelow";
     /**
+     * The includedBy element name.
+     */
+    public static final String INCLUDED_BY = "includedBy";
+    /**
      * A list of suppression rules.
      */
     private final List<SuppressionRule> suppressionRules = new ArrayList<>();
@@ -196,6 +200,9 @@ public class SuppressionHandler extends DefaultHandler {
                 case CVSS_BELOW:
                     final float cvss = Float.parseFloat(currentText.toString().trim());
                     rule.addCvssBelow(cvss);
+                    break;
+                case INCLUDED_BY:
+                    rule.addIncludedBy(currentText.toString().trim());
                     break;
                 default:
                     break;

--- a/core/src/main/resources/schema/suppression.xsd
+++ b/core/src/main/resources/schema/suppression.xsd
@@ -48,6 +48,7 @@
                                 <xs:element name="cve" type="dc:cveType"/>
                                 <xs:element name="cwe" type="xs:positiveInteger"/>
                                 <xs:element name="cvssBelow" type="dc:cvssScoreType"/>
+                                <xs:element name="includedBy" type="xs:string"/>
                             </xs:choice>
                         </xs:sequence>
                         <xs:attribute name="base" use="optional" type="xs:boolean" default="false"/>

--- a/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionRuleTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionRuleTest.java
@@ -86,6 +86,22 @@ public class SuppressionRuleTest extends BaseTest {
     }
 
     /**
+     * Test of IncludedBy property, of class SuppressionRule.
+     */
+    @Test
+    public void testGetIncludedBy() {
+        SuppressionRule instance = new SuppressionRule();
+        List<String> includedBy = new ArrayList<>();
+        instance.setIncludedBy(includedBy);
+        assertFalse(instance.hasIncludedBy());
+        instance.addIncludedBy("pkg:maven/com.github.spotbugs/spotbugs@4.7.3");
+        assertTrue(instance.hasIncludedBy());
+        List<String> result = instance.getIncludedBy();
+        assertEquals(includedBy, result);
+    }
+
+
+    /**
      * Test of CvssBelow property, of class SuppressionRule.
      */
     @Test
@@ -128,6 +144,17 @@ public class SuppressionRuleTest extends BaseTest {
         assertTrue(instance.hasCve());
         List<String> result = instance.getCve();
         assertEquals(cve, result);
+    }
+
+    public void testIncludedBy() {
+        SuppressionRule instance = new SuppressionRule();
+        List<String> includedBy = new ArrayList<>();
+        instance.setIncludedBy(includedBy);
+        assertFalse(instance.hasIncludedBy());
+        instance.addIncludedBy("pkg:maven/com.github.spotbugs/spotbugs@4.7.3");
+        assertTrue(instance.hasIncludedBy());
+        List<String> result = instance.getIncludedBy();
+        assertEquals(includedBy, result);
     }
 
     /**
@@ -418,6 +445,8 @@ public class SuppressionRuleTest extends BaseTest {
         dependency.addVulnerableSoftwareIdentifier(cpeId);
         String sha1 = dependency.getSha1sum();
         dependency.setSha1sum("384FAA82E193D4E4B0546059CA09572654BC3970");
+        dependency.addIncludedBy("pkg:maven/com.github.spotbugs/spotbugs@4.7.3");
+        dependency.addIncludedBy("pkg:maven/org.apache.kafka/mirror@3.7.0-SNAPSHOT");
         Vulnerability v = createVulnerability();
         dependency.addVulnerability(v);
 
@@ -450,6 +479,17 @@ public class SuppressionRuleTest extends BaseTest {
         instance.process(dependency);
         assertEquals(1, dependency.getVulnerabilities().size());
         instance.addCve("CVE-2013-1337");
+        instance.process(dependency);
+        assertTrue(dependency.getVulnerabilities().isEmpty());
+        assertEquals(1, dependency.getSuppressedVulnerabilities().size());
+
+        //includedBy
+        dependency.addVulnerability(v);
+        instance = new SuppressionRule();
+        instance.addIncludedBy("pkg:maven/com.github.spotbugs/spotbugs@4.7.3");
+        instance.process(dependency);
+        assertEquals(1, dependency.getVulnerabilities().size());
+        instance.addIncludedBy("pkg:maven/org.apache.kafka/mirror@3.7.0-SNAPSHOT");
         instance.process(dependency);
         assertTrue(dependency.getVulnerabilities().isEmpty());
         assertEquals(1, dependency.getSuppressedVulnerabilities().size());


### PR DESCRIPTION
## Fixes Issue #

Related to #5686, though I'm not sure it fixes exactly that scenario

## Description of Change

Add an option to suppress a vulnerability when it is only found as a transitive dependency via the listed dependencies.

## Have test cases been added to cover the new functionality?

Yes, but keeping this in 'Draft' for now as it needs further testing.