### PR TITLE
chore: Release 8.4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,19 +185,14 @@ jobs:
           prerelease: false
           draft: false
           body: |
-            ### Added
 
-            - feat: Add support for Nexus v3 to NexusAnalyzer (#5849)
-
-            ### Fixed
-
-            - fix: Hint Analyzer should run before VersionFilter Analyzer (#5818)
-            - chore: switch to sha1-pinning as suggested by Semgrep
-            - fix: OSS Index Analyzer SocketTimeoutException exception handling based on warn only parameter (#5845)
-            - fix: use curl with -L to follow github redirect (#5808)
-            - fix: use curl with -L to follow github redirect
-            - fix: #5671 out of memory error (#5789)
-            - fix: #5671 Exit method as soon as we detect a loop to prevent an infinite loop leading to an OutOfMemoryError
+            - fix: upgrade to JCS3 (#5114)
+            - fix: Support ~= version specifier in requirements.txt and pipfile (#5902)
+            - fix: Version of dependency no longer ignored when CPE product has a 'java' suffix in a product name (#5901)
+            - fix: Do not filter out evidences added by hints (#5900)
+            - fix: fixes FP #5925 (#5927)
+            
+            See the full listing of [changes](https://github.com/jeremylong/DependencyCheck/milestone/67?closed=1).
 
       - name: Upload CLI
         id: upload-release-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [Version 8.4.1](https://github.com/jeremylong/DependencyCheck/releases/tag/v8.4.1) (2023-10-21)
+
+### Fixed
+
+- fix: upgrade to JCS3 (#5114)
+- fix: Support ~= version specifier in requirements.txt and pipfile (#5902)
+- fix: Version of dependency no longer ignored when CPE product has a 'java' suffix in a product name (#5901)
+- fix: Do not filter out evidences added by hints (#5900)
+- fix: fixes FP #5925 (#5927)
+
+See the full listing of [changes](https://github.com/jeremylong/DependencyCheck/milestone/67?closed=1).
+
 ## [Version 8.4.0](https://github.com/jeremylong/DependencyCheck/releases/tag/v8.4.0) (2023-08-19)
 
 ### Added

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>8.4.1</version>
+        <version>8.4.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>dependency-check-ant</artifactId>
@@ -32,7 +32,7 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck/tree/main/ant</url>
         <developerConnection>scm:git:git@github.com:jeremylong/DependencyCheck.git</developerConnection>
-        <tag>v8.4.1</tag>
+        <tag>v6.4.1</tag>
     </scm>
     <build>
         <resources>

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>8.4.1-SNAPSHOT</version>
+        <version>8.4.1</version>
     </parent>
 
     <artifactId>dependency-check-ant</artifactId>
@@ -32,7 +32,7 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck/tree/main/ant</url>
         <developerConnection>scm:git:git@github.com:jeremylong/DependencyCheck.git</developerConnection>
-        <tag>v6.4.1</tag>
+        <tag>v8.4.1</tag>
     </scm>
     <build>
         <resources>

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -20,20 +20,20 @@ Copyright (c) 2017 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>8.4.1-SNAPSHOT</version>
+        <version>8.4.1</version>
     </parent>
     <artifactId>dependency-check-plugin</artifactId>
     <name>Dependency-Check Plugin Archetype</name>
     <packaging>jar</packaging>
     <properties>
         <!--reproducible build-->
-        <project.build.outputTimestamp>2023-08-19T12:57:43Z</project.build.outputTimestamp>
+        <project.build.outputTimestamp>2023-10-21T13:37:02Z</project.build.outputTimestamp>
     </properties>
     <scm>
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck/tree/main/archetype</url>
         <developerConnection>scm:git:git@github.com:jeremylong/DependencyCheck.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>v8.4.1</tag>
   </scm>
     <build>
         <plugins>

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -20,20 +20,20 @@ Copyright (c) 2017 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>8.4.1</version>
+        <version>8.4.2-SNAPSHOT</version>
     </parent>
     <artifactId>dependency-check-plugin</artifactId>
     <name>Dependency-Check Plugin Archetype</name>
     <packaging>jar</packaging>
     <properties>
         <!--reproducible build-->
-        <project.build.outputTimestamp>2023-10-21T13:37:02Z</project.build.outputTimestamp>
+        <project.build.outputTimestamp>2023-10-21T13:37:51Z</project.build.outputTimestamp>
     </properties>
     <scm>
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck/tree/main/archetype</url>
         <developerConnection>scm:git:git@github.com:jeremylong/DependencyCheck.git</developerConnection>
-      <tag>v8.4.1</tag>
+      <tag>HEAD</tag>
   </scm>
     <build>
         <plugins>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>8.4.1</version>
+        <version>8.4.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>dependency-check-cli</artifactId>
@@ -32,7 +32,7 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck/tree/main/cli</url>
         <developerConnection>scm:git:git@github.com:jeremylong/DependencyCheck.git</developerConnection>
-        <tag>v8.4.1</tag>
+        <tag>v6.4.1</tag>
     </scm>
     <build>
         <finalName>dependency-check-${project.version}</finalName>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>8.4.1-SNAPSHOT</version>
+        <version>8.4.1</version>
     </parent>
 
     <artifactId>dependency-check-cli</artifactId>
@@ -32,7 +32,7 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck/tree/main/cli</url>
         <developerConnection>scm:git:git@github.com:jeremylong/DependencyCheck.git</developerConnection>
-        <tag>v6.4.1</tag>
+        <tag>v8.4.1</tag>
     </scm>
     <build>
         <finalName>dependency-check-${project.version}</finalName>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>8.4.1-SNAPSHOT</version>
+        <version>8.4.1</version>
     </parent>
 
     <artifactId>dependency-check-core</artifactId>
@@ -32,7 +32,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck/tree/main/core</url>
         <developerConnection>scm:git:git@github.com:jeremylong/DependencyCheck.git</developerConnection>
-        <tag>v6.4.1</tag>
+        <tag>v8.4.1</tag>
     </scm>
     <build>
         <resources>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>8.4.1</version>
+        <version>8.4.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>dependency-check-core</artifactId>
@@ -32,7 +32,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck/tree/main/core</url>
         <developerConnection>scm:git:git@github.com:jeremylong/DependencyCheck.git</developerConnection>
-        <tag>v8.4.1</tag>
+        <tag>v6.4.1</tag>
     </scm>
     <build>
         <resources>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>8.4.1-SNAPSHOT</version>
+        <version>8.4.1</version>
     </parent>
     <artifactId>dependency-check-maven</artifactId>
     <packaging>maven-plugin</packaging>
@@ -35,7 +35,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck/tree/master/maven</url>
         <developerConnection>scm:git:git@github.com:jeremylong/DependencyCheck.git</developerConnection>
-        <tag>v6.4.1</tag>
+        <tag>v8.4.1</tag>
     </scm>
     <prerequisites>
         <maven>3.1.0</maven>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>8.4.1</version>
+        <version>8.4.2-SNAPSHOT</version>
     </parent>
     <artifactId>dependency-check-maven</artifactId>
     <packaging>maven-plugin</packaging>
@@ -35,7 +35,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck/tree/master/maven</url>
         <developerConnection>scm:git:git@github.com:jeremylong/DependencyCheck.git</developerConnection>
-        <tag>v8.4.1</tag>
+        <tag>v6.4.1</tag>
     </scm>
     <prerequisites>
         <maven>3.1.0</maven>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 - Jeremy Long
 
     <groupId>org.owasp</groupId>
     <artifactId>dependency-check-parent</artifactId>
-    <version>8.4.1-SNAPSHOT</version>
+    <version>8.4.1</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -94,7 +94,7 @@ Copyright (c) 2012 - Jeremy Long
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck</url>
         <developerConnection>scm:git:https://github.com/jeremylong/DependencyCheck.git</developerConnection>
-        <tag>v6.4.1</tag>
+        <tag>v8.4.1</tag>
     </scm>
     <issueManagement>
         <system>github</system>
@@ -112,7 +112,7 @@ Copyright (c) 2012 - Jeremy Long
     </licenses>
     <properties>
         <!--reproducible build-->
-        <project.build.outputTimestamp>2023-08-19T12:57:43Z</project.build.outputTimestamp>
+        <project.build.outputTimestamp>2023-10-21T13:37:02Z</project.build.outputTimestamp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 - Jeremy Long
 
     <groupId>org.owasp</groupId>
     <artifactId>dependency-check-parent</artifactId>
-    <version>8.4.1</version>
+    <version>8.4.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -94,7 +94,7 @@ Copyright (c) 2012 - Jeremy Long
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck</url>
         <developerConnection>scm:git:https://github.com/jeremylong/DependencyCheck.git</developerConnection>
-        <tag>v8.4.1</tag>
+        <tag>v6.4.1</tag>
     </scm>
     <issueManagement>
         <system>github</system>
@@ -112,7 +112,7 @@ Copyright (c) 2012 - Jeremy Long
     </licenses>
     <properties>
         <!--reproducible build-->
-        <project.build.outputTimestamp>2023-10-21T13:37:02Z</project.build.outputTimestamp>
+        <project.build.outputTimestamp>2023-10-21T13:37:51Z</project.build.outputTimestamp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>8.4.1-SNAPSHOT</version>
+        <version>8.4.1</version>
     </parent>
 
     <artifactId>dependency-check-utils</artifactId>
@@ -30,7 +30,7 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck/tree/main/utils</url>
         <developerConnection>scm:git:git@github.com:jeremylong/DependencyCheck.git</developerConnection>
-        <tag>v6.4.1</tag>
+        <tag>v8.4.1</tag>
     </scm>
     <properties>
         <findbugs.onlyAnalyze>org.owasp.dependencycheck.utils.*</findbugs.onlyAnalyze>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
     <parent>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-parent</artifactId>
-        <version>8.4.1</version>
+        <version>8.4.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>dependency-check-utils</artifactId>
@@ -30,7 +30,7 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/jeremylong/DependencyCheck.git</connection>
         <url>https://github.com/jeremylong/DependencyCheck/tree/main/utils</url>
         <developerConnection>scm:git:git@github.com:jeremylong/DependencyCheck.git</developerConnection>
-        <tag>v8.4.1</tag>
+        <tag>v6.4.1</tag>
     </scm>
     <properties>
         <findbugs.onlyAnalyze>org.owasp.dependencycheck.utils.*</findbugs.onlyAnalyze>


### PR DESCRIPTION
- fix: upgrade to JCS3 (#5114)
- fix: Support ~= version specifier in requirements.txt and pipfile (#5902)
- fix: Version of dependency no longer ignored when CPE product has a 'java' suffix in a product name (#5901)
- fix: Do not filter out evidences added by hints (#5900)
- fix: fixes FP #5925 (#5927)

See the full listing of [changes](https://github.com/jeremylong/DependencyCheck/milestone/67?closed=1).