### PR TITLE
fix: bump jcs3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1040,7 +1040,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>io.github.jeremylong</groupId>
                 <artifactId>jcs3-slf4j</artifactId>
-                <version>1.0.0</version>
+                <version>1.0.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-validator</groupId>


### PR DESCRIPTION
- resolves #6008
- updated log adapter correctly processes tokens in the logging template used by JCS