### PR TITLE
fix: Use ASCII apostrophe for console message

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -641,7 +641,7 @@ public class Engine implements FileFilter, AutoCloseable {
         LOGGER.info("\n\nDependency-Check is an open source tool performing a best effort analysis of 3rd party dependencies; false positives and "
                 + "false negatives may exist in the analysis performed by the tool. Use of the tool and the reporting provided constitutes "
                 + "acceptance for use in an AS IS condition, and there are NO warranties, implied or otherwise, with regard to the analysis "
-                + "or its use. Any use of the tool and the reporting provided is at the user’s risk. In no event shall the copyright holder "
+                + "or its use. Any use of the tool and the reporting provided is at the user's risk. In no event shall the copyright holder "
                 + "or OWASP be held liable for any damages whatsoever arising out of or in connection with the use of this tool, the analysis "
                 + "performed, or the resulting report.\n\n\n"
                 + "   About ODC: https://jeremylong.github.io/DependencyCheck/general/internals.html\n"


### PR DESCRIPTION
## Fixes Issue #
_none_

## Description of Change

Relates to #3902

The Unicode apostrophe `’` might not be displayed correctly, depending on the encoding of the console. For example on Windows either a '?' or apparently also a 'Æ' is displayed.

Notes:
- The same sentence using the `’` also appears in the HTML and Jenkins report, but since those specify `charset=UTF-8`, I assume it is not a problem there
- The '💖' a few lines below might also not be displayed correctly (under Windows it is just shown as '?'), but that is not as distracting or confusing since it is at the beginning of the line instead of in the middle of the sentence, so that might be fine

## Have test cases been added to cover the new functionality?

*no*