### PR TITLE
fix: Use the correct key for NVD API-Key from Maven Settings serverId

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2324,7 +2324,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         settings.setIntIfNotNull(Settings.KEYS.NVD_API_VALID_FOR_HOURS, nvdValidForHours);
 
         if (nvdApiKey == null && nvdApiServerId != null) {
-            configureServerCredentialsApiKey(nvdApiServerId, Settings.KEYS.NVD_API_DATAFEED_PASSWORD);
+            configureServerCredentialsApiKey(nvdApiServerId, Settings.KEYS.NVD_API_KEY);
         } else {
             settings.setStringIfNotEmpty(Settings.KEYS.NVD_API_KEY, nvdApiKey);
         }


### PR DESCRIPTION
## Fixes Issue #6106

## Description of Change

Fixup of the Settings-key that gets set for the nvdApiServerId configuration in the maven plugin

## Have test cases been added to cover the new functionality?

no, locally tested using snapshot build