### PR TITLE
fix: Configure nvd.api.delay default

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/NvdApiDataSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/NvdApiDataSource.java
@@ -298,7 +298,7 @@ public class NvdApiDataSource implements CachedWebDataSource {
         try {
             delay = settings.getLong(Settings.KEYS.NVD_API_DELAY);
         } catch (InvalidSettingException ex) {
-            LOGGER.debug("Invalid setting `NVD_API_DELAY`?");
+            LOGGER.warn("Invalid setting `NVD_API_DELAY`? ({}), using default delay", settings.getString(Settings.KEYS.NVD_API_DELAY));
         }
         if (delay > 0) {
             builder.withDelay(delay);

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -54,6 +54,7 @@ proxy.disableSchemas=true
 
 nvd.api.check.validforhours=4
 nvd.api.datafeed.validfordays=7
+nvd.api.delay=0
 #nvd.api.datafeed.url=https://example.com/nvd-cache/
 #nvd.api.datafeed.user=
 #nvd.api.datafeed.password=


### PR DESCRIPTION
Configure nvd.api.delay to take the coded defaults and raise log in case of actual misconfiguration to WARN level

## Fixes Issue #6111

## Description of Change

Add a default for nvd.api.key with value 0 to use the coded API-key present/not-present defaults and raise the log-level in case of Long parsing issues to WARN level as there was an invalid user-configured api delay

## Have test cases been added to cover the new functionality?

no