### PR TITLE
fix: check java 8 update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ issues arise you may need to purge the database:
 
 ## Requirements
 
+### Java Version
+
+Minimum Java Version: Java 8 update 251
+
+While dependency-check 9.0.0 and higher will still run on Java 8 - the update version
+must be higher then 251.
+
 ### Internet Access
 
 OWASP dependency-check requires access to several externally hosted resources.

--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -85,6 +85,7 @@ import static org.owasp.dependencycheck.analyzer.AnalysisPhase.PRE_IDENTIFIER_AN
 import static org.owasp.dependencycheck.analyzer.AnalysisPhase.PRE_INFORMATION_COLLECTION;
 import org.owasp.dependencycheck.analyzer.DependencyBundlingAnalyzer;
 import org.owasp.dependencycheck.dependency.naming.Identifier;
+import org.owasp.dependencycheck.utils.Utils;
 
 /**
  * Scans files, directories, etc. for Dependencies. Analyzers are loaded and
@@ -188,6 +189,9 @@ public class Engine implements FileFilter, AutoCloseable {
         this.serviceClassLoader = serviceClassLoader;
         this.mode = mode;
         this.accessExternalSchema = System.getProperty("javax.xml.accessExternalSchema");
+
+        checkRuntimeVersion();
+
         initializeEngine();
     }
 
@@ -252,8 +256,8 @@ public class Engine implements FileFilter, AutoCloseable {
 
     /**
      * Adds a dependency. In some cases, when adding a virtual dependency, the
-     * method will identify if the virtual dependency was previously added and update
-     * the existing dependency rather then adding a duplicate.
+     * method will identify if the virtual dependency was previously added and
+     * update the existing dependency rather then adding a duplicate.
      *
      * @param dependency the dependency to add
      */
@@ -1278,6 +1282,19 @@ public class Engine implements FileFilter, AutoCloseable {
             return count == left.size();
         }
         return false;
+    }
+
+    /**
+     * Checks that if Java 8 is being used, it is at least update 251. This is
+     * required as a new method was introduced that is used by Apache HTTP
+     * Client. See
+     * https://stackoverflow.com/questions/76226322/exception-in-thread-httpclient-dispatch-1-java-lang-nosuchmethoderror-javax-n#comment134427003_76226322
+     */
+    private void checkRuntimeVersion() {
+        if (Utils.getJavaVersion() == 8 && Utils.getJavaUpdateVersion() < 251) {
+            LOGGER.error("Non-supported Java Runtime: dependency-check requires at least Java 8 update 251 or higher.");
+            throw new RuntimeException("dependency-check requires Java 8 update 251 or higher");
+        }
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/utils/Utils.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/Utils.java
@@ -46,4 +46,44 @@ public final class Utils {
         }
         return Integer.parseInt(version);
     }
+
+    /**
+     * Returns the update version from the Java runtime.
+     *
+     * @return the update version
+     */
+    public static int getJavaUpdateVersion() {
+        //"1.8.0_144" "11.0.2+9" "17.0.8.1"
+        String runtimeVersion = System.getProperty("java.runtime.version");
+        try {
+            String[] parts = runtimeVersion.split("\\.");
+            if (parts.length == 4) {
+                return Integer.parseInt(parts[2]);
+            }
+            int pos = runtimeVersion.indexOf('_');
+            if (pos <= 0) {
+                pos = runtimeVersion.lastIndexOf('.');
+                if (pos <= 0) {
+                    //unexpected java version - return 0
+                    return 0;
+                }
+            }
+            int end = runtimeVersion.lastIndexOf('+');
+            if (end < 0) {
+                end = runtimeVersion.lastIndexOf('-');
+            }
+            if (end > pos) {
+                return Integer.parseInt(runtimeVersion.substring(pos + 1, end));
+            }
+            return Integer.parseInt(runtimeVersion.substring(pos + 1));
+        } catch (NumberFormatException nfe) {
+            // If the update version is not available, return 0
+            return 0;
+        }
+    }
+
+    public static void main(String[] args) {
+        System.out.println("Java version : " + getJavaVersion());
+        System.out.println("Java update  : " + getJavaUpdateVersion());
+    }
 }


### PR DESCRIPTION
Apache HTTP Client used by the open-vulnerability-clients library requires Java 8 update 251 or higher. See https://stackoverflow.com/questions/76226322/exception-in-thread-httpclient-dispatch-1-java-lang-nosuchmethoderror-javax-n#comment134427003_76226322

resolves #6114
