### PR TITLE
chore: Revert "build(deps): bump com.h2database:h2 from 2.1.214 to 2.2.224"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@ Copyright (c) 2012 - Jeremy Long
         <taglist-maven-plugin.version>3.0.0</taglist-maven-plugin.version>
         <versions-maven-plugin.version>2.16.1</versions-maven-plugin.version>
         <jetbrains.annotations.version>24.0.1</jetbrains.annotations.version>
-        <com.h2database.version>2.2.224</com.h2database.version>
+        <com.h2database.version>2.1.214</com.h2database.version>
         <commons-cli.version>1.6.0</commons-cli.version>
         <commons-io.version>2.15.0</commons-io.version>
         <commons-lang3.version>3.13.0</commons-lang3.version>


### PR DESCRIPTION
Reverts jeremylong/DependencyCheck#5940

Unfortunately, due to issue with Gradle the H2 dependency cannot be upgraded. we can reintroduce this PR once https://github.com/gradle/gradle/issues/27156 is resolved.