### PR TITLE
fix(fp): FP per issue #6138 and #6139

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1385,3 +1385,10 @@
    <packageUrl regex="true">^pkg:maven/net\.lbruun\.springboot/preliquibase-spring-boot-starter@.*$</packageUrl>
    <cpe>cpe:/a:liquibase:liquibase</cpe>
 </suppress>
+<suppress base="true">
+   <notes><![CDATA[
+   FP per issue #6138 and #6139
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/rubygems/.*@.*$</packageUrl>
+   <cpe>cpe:/a:rubygems:rubygems</cpe>
+</suppress>


### PR DESCRIPTION
- fixes #6138 
- fixes #6139

## Description of Change

The FP automation doesn't work for these Maven Central-stored RubyGems, but seems more sensible to fix these properly since they seem to have started with `9.0.x` where all specific Ruby Gems are being incorrectly detected as rubygems itself.

Merging to the `generatedSuppressions` branch itself to avoid this needing a "release" - similar to other FP suppressions.

## Have test cases been added to cover the new functionality?

no