### PR TITLE
fix: Gitlab report format needs severity capitalized

### DIFF
--- a/core/src/main/resources/templates/gitlabReport.vsl
+++ b/core/src/main/resources/templates/gitlabReport.vsl
@@ -100,7 +100,8 @@
                         ## optional properties
                         "name": "$enc.json($vulnerability.name)",
                         "description": "$enc.json($vulnerability.description)",
-                        "severity": "$rpt.normalizeSeverity($vulnerability.cvssV3.cvssData.baseSeverity).toLowerCase()",
+                        #set($severity = $rpt.normalizeSeverity($vulnerability.cvssV3.cvssData.baseSeverity))
+                        "severity": "$severity.substring(0,1).toUpperCase()$severity.substring(1)",
                         ## "solution": "" --> not implemented
                         "links": [
                             #foreach( $ref in $vulnerability.getReferences(true) )


### PR DESCRIPTION
## Fixes Issue #6181

## Description of Change

Updates gitlabReport.vsl to format the severity correctly.

## Have test cases been added to cover the new functionality?

*no*