### PR TITLE
fix: some more flaws with gitlab report format

### DIFF
--- a/core/src/main/resources/templates/gitlabReport.vsl
+++ b/core/src/main/resources/templates/gitlabReport.vsl
@@ -116,9 +116,10 @@
                         "links": [
                             #foreach( $ref in $vulnerability.getReferences(true) )
                                 {
+                                #if($ref.name)
+                                    ## optional property
                                     "name": "$enc.json($ref.name)",
-
-                                    ## optional properties
+                                #end
                                     "url": "$enc.json($ref.url)"
                                 }
                                 #if( $foreach.hasNext ),#end

--- a/core/src/main/resources/templates/gitlabReport.vsl
+++ b/core/src/main/resources/templates/gitlabReport.vsl
@@ -100,7 +100,17 @@
                         ## optional properties
                         "name": "$enc.json($vulnerability.name)",
                         "description": "$enc.json($vulnerability.description)",
-                        #set($severity = $rpt.normalizeSeverity($vulnerability.cvssV3.cvssData.baseSeverity))
+                        #if($vulnerability.unscoredSeverity)
+                            #if($vulnerability.unscoredSeverity.equals("0.0"))
+                                #set($severity = "Unknown")
+                            #else
+                                #set($severity = $rpt.normalizeSeverity($vulnerability.unscoredSeverity))
+                            #end
+                        #elseif($vulnerability.cvssV3 && $vulnerability.cvssV3.cvssData && $vulnerability.cvssV3.cvssData.baseSeverity)
+                            #set($severity = $rpt.normalizeSeverity($vulnerability.cvssV3.cvssData.baseSeverity))
+                        #elseif($vulnerability.cvssV2 && $vulnerability.cvssV2.cvssData && $vulnerability.cvssV2.cvssData.baseSeverity)
+                            #set($severity = $rpt.normalizeSeverity($vulnerability.cvssV2.cvssData.baseSeverity))
+                        #end
                         "severity": "$severity.substring(0,1).toUpperCase()$severity.substring(1)",
                         ## "solution": "" --> not implemented
                         "links": [

--- a/core/src/main/resources/templates/gitlabReport.vsl
+++ b/core/src/main/resources/templates/gitlabReport.vsl
@@ -140,6 +140,7 @@
             "package_manager": "maven",
             "dependencies": [
                 #foreach( $dependency in $dependencies )
+                    #if( $dependency.name )
                     {
                         "package": {
                             "name": "$enc.json($dependency.name)"
@@ -152,6 +153,7 @@
                         ##"dependency_path": [] --> not implemented
                     }
                     #if( $foreach.hasNext ),#end
+                    #end
                 #end
             ]
             ## no optional properties


### PR DESCRIPTION
## Fixes Issue #6187

## Description of Change

This changes the format of some fields in the gitlab report template:

* Adapt the logic to find the severity of a vulnerability so that it behaves like other reports.
* Handle references without a name
* Handle dependencies consisting of multiple files where only the main file has a name and a description.

## Have test cases been added to cover the new functionality?

*no*