### PR TITLE
 fix: correct name on reference links

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,16 +186,14 @@ jobs:
           prerelease: false
           draft: false
           body: |
-            - fix: check java 8 update version; minimum JRE is 8 update 251 (#6118)
-            - fix: add retry for failed NVD API requests (#6136)
-            - docs: add default values to documentation for the NVD API Delay (#6135)
-            - chore: Revert "build(deps): bump com.h2database:h2 from 2.1.214 to 2.2.224" (#6131)
-              - this is a **breaking change** for anyone that successfully created the H2 database with 9.0.0.
-            - fix: mute jcs logging (#6130)
-            - docs: update NVD notice (#6110)
-            - fix: Use the correct key for NVD API-Key from Maven Settings serverId (#6109)
+            - fix: remove virtual match string on NVD API Request (#6177)
+            - fix: correct meta data in report after switching the NVD API (#6154)
+            - fix: retry HTTP connections to NVD on 502 and 504 errors (#6151)
+            - fix: Gitlab report format needs severity capitalized (#6182)
+            - fix: improve JDK update version parsing (#6163)
+            - fix: mute JCS logging (again) (#6153)
 
-            See the full listing of [changes](https://github.com/jeremylong/DependencyCheck/milestone/71?closed=1).
+            See the full listing of [changes](https://github.com/jeremylong/DependencyCheck/milestone/72?closed=1).
 
       - name: Upload CLI
         id: upload-release-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+
+## [Version 9.0.2](https://github.com/jereong/DependencyCheck/releases/tag/v9.0.2) (2023-12-01)
+
+- fix: remove virtual match string on NVD API Request (#6177)
+- fix: correct meta data in report after switching the NVD API (#6154)
+- fix: retry HTTP connections to NVD on 502 and 504 errors (#6151)
+- fix: Gitlab report format needs severity capitalized (#6182)
+- fix: improve JDK update version parsing (#6163)
+- fix: mute JCS logging (again) (#6153)
+
+See the full listing of [changes](https://github.com/jeremylong/DependencyCheck/milestone/72?closed=1).
+
 ## [Version 9.0.1](https://github.com/jereong/DependencyCheck/releases/tag/v9.0.1) (2023-11-26)
 
 **breaking changes**: See the [upgrade notice](https://github.com/jeremylong/DependencyCheck#900-upgrade-notice)

--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -1035,9 +1035,11 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                             #if ($vuln.getReferences().size()>0)
                                 <br/>References:<ul>
                                 #foreach($ref in $vuln.getReferences(true))
-                                    #if ($ref.url)
+                                    #if ($ref.url && $ref.name)
                                     <li>$enc.html($ref.source) - <a target="_blank" href="$enc.html($ref.url)">$enc.html($ref.name)</a></li>
-                                    #else
+                                    #elseif ($ref.uri)
+                                    <li>$enc.html($ref.source) - <a target="_blank" href="$enc.html($ref.url)">$enc.html($ref.url)</a></li>
+                                    #elseif ($ref.name)
                                     <li>$enc.html($ref.source) - $enc.html($ref.name)</li>
                                     #end
                                 #end
@@ -1235,9 +1237,11 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                                     #if ($vuln.getReferences().size()>0)
                                         <br/>References: <ul>
                                         #foreach($ref in $vuln.getReferences(true))
-                                            #if ($ref.url)
+                                            #if ($ref.url && $ref.name)
                                             <li>$enc.html($ref.source) - <a target="_blank" href="$enc.html($ref.url)">$enc.html($ref.name)</a></li>
-                                            #else
+                                            #elseif ($ref.uri)
+                                            <li>$enc.html($ref.source) - <a target="_blank" href="$enc.html($ref.url)">$enc.html($ref.url)</a></li>
+                                            #elseif ($ref.name)
                                             <li>$enc.html($ref.source) - $enc.html($ref.name)</li>
                                             #end
                                         #end

--- a/core/src/main/resources/templates/jenkinsReport.vsl
+++ b/core/src/main/resources/templates/jenkinsReport.vsl
@@ -743,9 +743,11 @@ Getting Help: <a href="https://github.com/jeremylong/DependencyCheck/issues" tar
                             #if ($vuln.getReferences().size()>0)
                                 <br/>References:<ul>
                                 #foreach($ref in $vuln.getReferences(true))
-                                    #if ($ref.url)
+                                    #if ($ref.url && $ref.name)
                                     <li>$enc.html($ref.source) - <a target="_blank" href="$enc.html($ref.url)">$enc.html($ref.name)</a></li>
-                                    #else
+                                    #elseif ($ref.uri)
+                                    <li>$enc.html($ref.source) - <a target="_blank" href="$enc.html($ref.url)">$enc.html($ref.url)</a></li>
+                                    #elseif ($ref.name)
                                     <li>$enc.html($ref.source) - $enc.html($ref.name)</li>
                                     #end
                                 #end

--- a/core/src/main/resources/templates/jsonReport.vsl
+++ b/core/src/main/resources/templates/jsonReport.vsl
@@ -254,7 +254,7 @@
                         #if($foreach.count > 1),#end {
                         "source": "$enc.json($ref.source)",
                         #if ($ref.url)"url": "$enc.json($ref.url)",#end
-                        "name": "$enc.json($ref.name)"
+                        #if ($ref.name)"name": "$enc.json($ref.name)"#end
                     }#end
                 ],
                 "vulnerableSoftware": [
@@ -331,7 +331,7 @@
                         #if($foreach.count > 1),#end {
                     "source": "$enc.json($ref.source)",
                     #if ($ref.url)"url": "$enc.json($ref.url)",#end
-                    "name": "$enc.json($ref.name)"
+                    #if ($ref.name)"name": "$enc.json($ref.name)"#end
                     }#end
                 ],
                 "vulnerableSoftware": [

--- a/core/src/main/resources/templates/junitReport.vsl
+++ b/core/src/main/resources/templates/junitReport.vsl
@@ -85,7 +85,7 @@
             #end
             <system-out>#if($vuln.description)$enc.xml($vuln.description)#else<![CDATA[ 
                 #foreach($ref in $vuln.getReferences())
-                    #if($ref.url)$enc.xml($ref.name): $enc.xml($ref.url)#end
+                    #if($ref.url && $ref.name)$enc.xml($ref.name): $enc.xml($ref.url)#elseif($ref.url)uri: $enc.xml($ref.url)#end
                 #end]]>#end</system-out>
             #set($referencedProjects="")
             #set($projectReferenced=false)

--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -287,7 +287,7 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
                         <reference>
                             <source>$enc.xml($ref.source)</source>
                             #if($ref.url)<url>$enc.xml($ref.url)</url>#end
-                            <name>$enc.xml($ref.name)</name>
+                            #if($ref.name)<name>$enc.xml($ref.name)</name>#end
                         </reference>
 #end
                     </references>
@@ -359,8 +359,8 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
 #foreach($ref in $vuln.getReferences())
                         <reference>
                             <source>$enc.xml($ref.source)</source>
-                            <url>$enc.xml($ref.url)</url>
-                            <name>$enc.xml($ref.name)</name>
+                            #if($ref.url)<url>$enc.xml($ref.url)</url>#end
+                            #if($ref.name)<name>$enc.xml($ref.name)</name>#end
                         </reference>
 #end
                     </references>


### PR DESCRIPTION
## Fixes Issue #6200

Updates the report's CVE references as the "name" field may not exist.