### PR TITLE
fix: references to cvssv2 and cvssv3 fields in json and xml reports

### DIFF
--- a/core/src/main/resources/templates/jsonReport.vsl
+++ b/core/src/main/resources/templates/jsonReport.vsl
@@ -214,11 +214,11 @@
 #if($vuln.cvssV2.cvssData.version),"version": "$enc.json($vuln.cvssV2.cvssData.version)"#end
 #if($vuln.cvssV2.exploitabilityScore),"exploitabilityScore": "$enc.json($vuln.cvssV2.exploitabilityScore)"#end
 #if($vuln.cvssV2.impactScore),"impactScore": "$enc.json($vuln.cvssV2.impactScore)"#end
-#if($vuln.cvssV2.cvssData.acInsufInfo),"acInsufInfo": "$enc.json($vuln.cvssV2.cvssData.acInsufInfo)"#end
-#if($vuln.cvssV2.cvssData.obtainAllPrivilege),"obtainAllPrivilege": "$enc.json($vuln.cvssV2.cvssData.obtainAllPrivilege)"#end
-#if($vuln.cvssV2.cvssData.obtainUserPrivilege),"obtainUserPrivilege": "$enc.json($vuln.cvssV2.cvssData.obtainUserPrivilege)"#end
-#if($vuln.cvssV2.cvssData.obtainOtherPrivilege),"obtainOtherPrivilege": "$enc.json($vuln.cvssV2.cvssData.obtainOtherPrivilege)"#end
-#if($vuln.cvssV2.cvssData.userInteractionRequired),"userInteractionRequired": "$enc.json($vuln.cvssV2.cvssData.userInteractionRequired)"#end
+#if($vuln.cvssV2.acInsufInfo),"acInsufInfo": "$enc.json($vuln.cvssV2.acInsufInfo)"#end
+#if($vuln.cvssV2.obtainAllPrivilege),"obtainAllPrivilege": "$enc.json($vuln.cvssV2.obtainAllPrivilege)"#end
+#if($vuln.cvssV2.obtainUserPrivilege),"obtainUserPrivilege": "$enc.json($vuln.cvssV2.obtainUserPrivilege)"#end
+#if($vuln.cvssV2.obtainOtherPrivilege),"obtainOtherPrivilege": "$enc.json($vuln.cvssV2.obtainOtherPrivilege)"#end
+#if($vuln.cvssV2.userInteractionRequired),"userInteractionRequired": "$enc.json($vuln.cvssV2.userInteractionRequired)"#end
                     },
 #end
 #if($vuln.cvssV3)

--- a/core/src/main/resources/templates/jsonReport.vsl
+++ b/core/src/main/resources/templates/jsonReport.vsl
@@ -212,8 +212,8 @@
                         ,"availabilityImpact": "$enc.json($vuln.cvssV2.cvssData.availabilityImpact)"
                         ,"severity": "$enc.json($vuln.cvssV2.cvssData.baseSeverity)"
 #if($vuln.cvssV2.cvssData.version),"version": "$enc.json($vuln.cvssV2.cvssData.version)"#end
-#if($vuln.cvssV2.cvssData.exploitabilityScore),"exploitabilityScore": "$enc.json($vuln.cvssV2.cvssData.exploitabilityScore)"#end
-#if($vuln.cvssV2.cvssData.impactScore),"impactScore": "$enc.json($vuln.cvssV2.cvssData.impactScore)"#end
+#if($vuln.cvssV2.exploitabilityScore),"exploitabilityScore": "$enc.json($vuln.cvssV2.exploitabilityScore)"#end
+#if($vuln.cvssV2.impactScore),"impactScore": "$enc.json($vuln.cvssV2.impactScore)"#end
 #if($vuln.cvssV2.cvssData.acInsufInfo),"acInsufInfo": "$enc.json($vuln.cvssV2.cvssData.acInsufInfo)"#end
 #if($vuln.cvssV2.cvssData.obtainAllPrivilege),"obtainAllPrivilege": "$enc.json($vuln.cvssV2.cvssData.obtainAllPrivilege)"#end
 #if($vuln.cvssV2.cvssData.obtainUserPrivilege),"obtainUserPrivilege": "$enc.json($vuln.cvssV2.cvssData.obtainUserPrivilege)"#end
@@ -233,8 +233,8 @@
                         ,"integrityImpact": "$enc.json($vuln.cvssV3.cvssData.integrityImpact)"
                         ,"availabilityImpact": "$enc.json($vuln.cvssV3.cvssData.availabilityImpact)"
                         ,"baseSeverity": "$enc.json($vuln.cvssV3.cvssData.baseSeverity)"
-#if($vuln.cvssV3.cvssData.exploitabilityScore),"exploitabilityScore": "$enc.json($vuln.cvssV3.cvssData.exploitabilityScore)"#end
-#if($vuln.cvssV3.cvssData.impactScore),"impactScore": "$enc.json($vuln.cvssV3.cvssData.impactScore)"#end
+#if($vuln.cvssV3.exploitabilityScore),"exploitabilityScore": "$enc.json($vuln.cvssV3.exploitabilityScore)"#end
+#if($vuln.cvssV3.impactScore),"impactScore": "$enc.json($vuln.cvssV3.impactScore)"#end
 #if($vuln.cvssV3.cvssData.version),"version": "$enc.json($vuln.cvssV3.cvssData.version)"#end
                     },
 #end

--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -245,8 +245,8 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
                         <availabilityImpact>#if($vuln.cvssV2.cvssData.availabilityImpact)$enc.xml($vuln.cvssV2.cvssData.availabilityImpact)#end</availabilityImpact>
                         <severity>#if($vuln.cvssV2.cvssData.baseSeverity)$enc.xml($vuln.cvssV2.cvssData.baseSeverity)#end</severity>
 #if($vuln.cvssV2.cvssData.version)<version>$enc.xml($vuln.cvssV2.cvssData.version)</version>#end
-#if($vuln.cvssV2.cvssData.exploitabilityScore)<exploitabilityScore>$enc.xml($vuln.cvssV2.cvssData.exploitabilityScore)</exploitabilityScore>#end
-#if($vuln.cvssV2.cvssData.impactScore)<impactScore>$enc.xml($vuln.cvssV2.cvssData.impactScore)</impactScore>#end
+#if($vuln.cvssV2.exploitabilityScore)<exploitabilityScore>$enc.xml($vuln.cvssV2.exploitabilityScore)</exploitabilityScore>#end
+#if($vuln.cvssV2.impactScore)<impactScore>$enc.xml($vuln.cvssV2.impactScore)</impactScore>#end
 #if($vuln.cvssV2.cvssData.acInsufInfo)<acInsufInfo>$enc.xml($vuln.cvssV2.cvssData.acInsufInfo)</acInsufInfo>#end
 #if($vuln.cvssV2.cvssData.obtainAllPrivilege)<obtainAllPrivilege>$enc.xml($vuln.cvssV2.cvssData.obtainAllPrivilege)</obtainAllPrivilege>#end
 #if($vuln.cvssV2.cvssData.obtainUserPrivilege)<obtainUserPrivilege>$enc.xml($vuln.cvssV2.cvssData.obtainUserPrivilege)</obtainUserPrivilege>#end
@@ -266,8 +266,8 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
                         <integrityImpact>#if($vuln.cvssV3.cvssData.integrityImpact)$enc.xml($vuln.cvssV3.cvssData.integrityImpact)#end</integrityImpact>
                         <availabilityImpact>#if($vuln.cvssV3.cvssData.availabilityImpact)$enc.xml($vuln.cvssV3.cvssData.availabilityImpact)#end</availabilityImpact>
                         <baseSeverity>#if($vuln.cvssV3.cvssData.baseSeverity)$enc.xml($vuln.cvssV3.cvssData.baseSeverity)#end</baseSeverity>
-#if($vuln.cvssV3.cvssData.exploitabilityScore)<exploitabilityScore>$enc.xml($vuln.cvssV3.cvssData.exploitabilityScore)</exploitabilityScore>#end
-#if($vuln.cvssV3.cvssData.impactScore)<impactScore>$enc.xml($vuln.cvssV3.cvssData.impactScore)</impactScore>#end
+#if($vuln.cvssV3.exploitabilityScore)<exploitabilityScore>$enc.xml($vuln.cvssV3.exploitabilityScore)</exploitabilityScore>#end
+#if($vuln.cvssV3.impactScore)<impactScore>$enc.xml($vuln.cvssV3.impactScore)</impactScore>#end
 #if($vuln.cvssV3.cvssData.version)<version>$enc.xml($vuln.cvssV3.cvssData.version)</version>#end
                     </cvssV3>
 #end

--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -247,11 +247,11 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
 #if($vuln.cvssV2.cvssData.version)<version>$enc.xml($vuln.cvssV2.cvssData.version)</version>#end
 #if($vuln.cvssV2.exploitabilityScore)<exploitabilityScore>$enc.xml($vuln.cvssV2.exploitabilityScore)</exploitabilityScore>#end
 #if($vuln.cvssV2.impactScore)<impactScore>$enc.xml($vuln.cvssV2.impactScore)</impactScore>#end
-#if($vuln.cvssV2.cvssData.acInsufInfo)<acInsufInfo>$enc.xml($vuln.cvssV2.cvssData.acInsufInfo)</acInsufInfo>#end
-#if($vuln.cvssV2.cvssData.obtainAllPrivilege)<obtainAllPrivilege>$enc.xml($vuln.cvssV2.cvssData.obtainAllPrivilege)</obtainAllPrivilege>#end
-#if($vuln.cvssV2.cvssData.obtainUserPrivilege)<obtainUserPrivilege>$enc.xml($vuln.cvssV2.cvssData.obtainUserPrivilege)</obtainUserPrivilege>#end
-#if($vuln.cvssData.obtainOtherPrivilege)<obtainOtherPrivilege>$enc.xml($vuln.cvssV2.cvssData.obtainOtherPrivilege)</obtainOtherPrivilege>#end
-#if($vuln.cvssV2.cvssData.userInteractionRequired)<userInteractionRequired>$enc.xml($vuln.cvssV2.cvssData.userInteractionRequired)</userInteractionRequired>#end
+#if($vuln.cvssV2.acInsufInfo)<acInsufInfo>$enc.xml($vuln.cvssV2.acInsufInfo)</acInsufInfo>#end
+#if($vuln.cvssV2.obtainAllPrivilege)<obtainAllPrivilege>$enc.xml($vuln.cvssV2.obtainAllPrivilege)</obtainAllPrivilege>#end
+#if($vuln.cvssV2.obtainUserPrivilege)<obtainUserPrivilege>$enc.xml($vuln.cvssV2.obtainUserPrivilege)</obtainUserPrivilege>#end
+#if($vuln.cvssV2.obtainOtherPrivilege)<obtainOtherPrivilege>$enc.xml($vuln.cvssV2.obtainOtherPrivilege)</obtainOtherPrivilege>#end
+#if($vuln.cvssV2.userInteractionRequired)<userInteractionRequired>$enc.xml($vuln.cvssV2.userInteractionRequired)</userInteractionRequired>#end
                     </cvssV2>
 #end
 #if($vuln.cvssV3)

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 - Jeremy Long
 
     <groupId>org.owasp</groupId>
     <artifactId>dependency-check-parent</artifactId>
-    <version>9.0.3-SNAPSHOT</version>
+    <version>9.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2012 - Jeremy Long
 
     <groupId>org.owasp</groupId>
     <artifactId>dependency-check-parent</artifactId>
-    <version>9.0.2-SNAPSHOT</version>
+    <version>9.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
## Fixes Issue #
#6210 

## Description of Change

updated references to exploitabilityScore and impactScore fields for CvssV2 and CvssV3 in json and xml reports.

## Have test cases been added to cover the new functionality?
no