### PR TITLE
fix: exemple 5 with new nvdDatafeedUrl parameter

### DIFF
--- a/maven/src/site/markdown/index.md.vm
+++ b/maven/src/site/markdown/index.md.vm
@@ -159,8 +159,7 @@ and META files must also be mirrored; see https://nvd.nist.gov/vuln/data-feeds#J
                 <artifactId>dependency-check-maven</artifactId>
                 <version>${project.version}</version>
                 <configuration>
-                    <cveUrlModified>http://internal-mirror.mycorp.com/nvdcve-1.1-modified.json.gz</cveUrlModified>
-                    <cveUrlBase>http://internal-mirror.mycorp.com/nvdcve-1.1-%d.json.gz</cveUrlBase>
+                    <nvdDatafeedUrl>http://internal-mirror.mycorp.com/nvdcve-{0}.json.gz</nvdDatafeedUrl>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Old configuration with cveUrlBase and cveUrlModified does not work anymore in 9.x