### PR TITLE
fix: use Java properties for proxy configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -972,7 +972,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>io.github.jeremylong</groupId>
                 <artifactId>open-vulnerability-clients</artifactId>
-                <version>5.0.3</version>
+                <version>5.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.anarres.jdiagnostics</groupId>


### PR DESCRIPTION
- bump open-vulnerability-client; latest version correctly uses system properties for proxy configuration. See https://github.com/jeremylong/Open-Vulnerability-Project/pull/104
- resolves #6127
