### PR TITLE
fix: showing all reference tags in reports

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -1227,12 +1227,12 @@ public final class CveDB implements AutoCloseable {
             if (cve.getCve().getReferences() != null) {
                 for (Reference r : cve.getCve().getReferences()) {
                     insertReference.setInt(1, vulnerabilityId);
-                    Optional<String> name = Optional.empty();
+                    String name = null;
                     if (r.getTags() != null) {
-                        name = r.getTags().stream().sorted().findFirst();
+                        name = r.getTags().stream().sorted().collect(Collectors.joining(",")).toUpperCase().replaceAll("\\s", "_");
                     }
-                    if (name.isPresent()) {
-                        insertReference.setString(2, name.get());
+                    if (name != null) {
+                        insertReference.setString(2, name);
                     } else {
                         insertReference.setNull(2, java.sql.Types.VARCHAR);
                     }


### PR DESCRIPTION
## Fixes Issue #
#6234 

## Description of Change
When adding tags to the DB it will no longer retrieve the first ordered item from the list but will join them all (comma separated)

## Have test cases been added to cover the new functionality?
no