### PR TITLE
fix: stream NVD data via Jackson to reduce memory footprint

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/CveApiJson20CveItemSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/CveApiJson20CveItemSource.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.update.nvd.api;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.zip.GZIPInputStream;
+
+public class CveApiJson20CveItemSource implements CveItemSource<DefCveItem> {
+
+    private final File jsonFile;
+    private final ObjectMapper mapper;
+    private final InputStream inputStream;
+    private final JsonParser jsonParser;
+    private DefCveItem currentItem;
+    private DefCveItem nextItem;
+
+    public CveApiJson20CveItemSource(File jsonFile) throws IOException {
+        this.jsonFile = jsonFile;
+        mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        inputStream = jsonFile.getName().endsWith(".gz") ?
+                new GZIPInputStream(new BufferedInputStream(Files.newInputStream(jsonFile.toPath()))) :
+                new BufferedInputStream(Files.newInputStream(jsonFile.toPath()));
+        jsonParser = mapper.getFactory().createParser(inputStream);
+
+        JsonToken token = null;
+        do {
+            token = jsonParser.nextToken();
+            if (token  == JsonToken.FIELD_NAME) {
+                String fieldName = jsonParser.getCurrentName();
+                if (fieldName.equals("vulnerabilities") && (jsonParser.nextToken() == JsonToken.START_ARRAY)) {
+                    nextItem = readItem(jsonParser);
+                }
+            }
+        } while (token != null && nextItem == null);
+    }
+
+    @Override
+    public void close() throws Exception {
+        jsonParser.close();
+        inputStream.close();
+        Files.delete(jsonFile.toPath());
+    }
+
+    @Override
+    public boolean hasNext() {
+        return nextItem != null;
+    }
+
+    @Override
+    public DefCveItem next() throws IOException {
+        currentItem = nextItem;
+        nextItem = readItem(jsonParser);
+        return currentItem;
+    }
+
+    private DefCveItem readItem(JsonParser jsonParser) throws IOException {
+        if (jsonParser.nextToken() == JsonToken.START_OBJECT) {
+            return mapper.readValue(jsonParser, DefCveItem.class);
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/CveItemSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/CveItemSource.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.update.nvd.api;
+
+import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
+
+import java.io.IOException;
+
+public interface CveItemSource<T extends DefCveItem> extends AutoCloseable {
+
+    boolean hasNext();
+
+    T next() throws IOException;
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/JsonArrayCveItemSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/JsonArrayCveItemSource.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.update.nvd.api;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.zip.GZIPInputStream;
+
+public class JsonArrayCveItemSource implements CveItemSource<DefCveItem> {
+
+    private final File jsonFile;
+    private final ObjectMapper mapper;
+    private final InputStream inputStream;
+    private final JsonParser jsonParser;
+    private DefCveItem currentItem;
+    private DefCveItem nextItem;
+
+    public JsonArrayCveItemSource(File jsonFile) throws IOException {
+        this.jsonFile = jsonFile;
+        mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        inputStream = jsonFile.getName().endsWith(".gz") ?
+                new GZIPInputStream(new BufferedInputStream(Files.newInputStream(jsonFile.toPath()))) :
+                new BufferedInputStream(Files.newInputStream(jsonFile.toPath()));
+        jsonParser = mapper.getFactory().createParser(inputStream);
+
+        if (jsonParser.nextToken() == JsonToken.START_ARRAY) {
+            nextItem = readItem(jsonParser);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        jsonParser.close();
+        inputStream.close();
+        Files.delete(jsonFile.toPath());
+    }
+
+    @Override
+    public boolean hasNext() {
+        return nextItem != null;
+    }
+
+    @Override
+    public DefCveItem next() throws IOException {
+        currentItem = nextItem;
+        nextItem = readItem(jsonParser);
+        return currentItem;
+    }
+
+    private DefCveItem readItem(JsonParser jsonParser) throws IOException {
+        if (jsonParser.nextToken() == JsonToken.START_OBJECT) {
+            return mapper.readValue(jsonParser, DefCveItem.class);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Fixes Issue #

This is a follow-up of #6196. One of the suggestions made in that thread was to switch to using JSON streaming using Jackson. I have implemented this in this Pull Request.

The results are quite impressive, the initial download and initialization now succeeds with Xmx512m, which was previously not possible.

## Description of Change

Introduced new `CveItemSource` abstraction and using it in `NvdApiProcessor` instead of reading from the JSON directly. The implementations of `CveItemSource` take care of the JSON streaming internally using Jackson Streaming API.

## Have test cases been added to cover the new functionality?

no, as there is not really any new functionalitity. But can provide one if necessary.