### PR TITLE
fix: set correct property for nonProxyHosts

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2194,7 +2194,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                     System.setProperty("https.proxyPassword", mavenProxy.getPassword());
                 }
                 if (mavenProxy.getNonProxyHosts() != null && !mavenProxy.getNonProxyHosts().isEmpty()) {
-                    System.setProperty("https.nonProxyHosts", mavenProxy.getNonProxyHosts());
+                    System.setProperty("http.nonProxyHosts", mavenProxy.getNonProxyHosts());
                 }
             }
 


### PR DESCRIPTION
## Fixes Issue #6283

## Description of Change

While there are different system properties for http and https proxies, there is only one shared property for proxy exclusions: `http.nonProxyHosts`

Setting `https.nonProxyHosts` has no effect on any recent JDK

## Have test cases been added to cover the new functionality?

*no*