### PR TITLE
fix: mask nvd.api.key in logs

### DIFF
--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -27,7 +27,7 @@ data.version=5.4
 odc.analysis.timeout=180
 
 # define which settings are masked when logged
-odc.settings.mask=.*password.*,.*token.*
+odc.settings.mask=.*password.*,.*token.*,.*api.key.*
 
 data.connection_string=jdbc:h2:file:%s;AUTOCOMMIT=ON;CACHE_SIZE=65536;RETENTION_TIME=1000;MAX_COMPACT_TIME=10000;
 #data.connection_string=jdbc:mysql://localhost:3306/dependencycheck

--- a/core/src/test/resources/dependencycheck.properties
+++ b/core/src/test/resources/dependencycheck.properties
@@ -23,7 +23,7 @@ data.version=5.4
 odc.analysis.timeout=20
 
 # define which settings are masked when logged
-odc.settings.mask=.*password.*,.*token.*
+odc.settings.mask=.*password.*,.*token.*,.*api.key.*
 
 data.connection_string=jdbc:h2:file:%s;AUTOCOMMIT=ON;CACHE_SIZE=65536;
 #data.connection_string=jdbc:mysql://localhost:3306/dependencycheck

--- a/utils/src/test/resources/dependencycheck.properties
+++ b/utils/src/test/resources/dependencycheck.properties
@@ -23,7 +23,7 @@ data.version=5.3
 odc.analysis.timeout=20
 
 # define which settings are masked when logged
-odc.settings.mask=.*password.*,.*token.*
+odc.settings.mask=.*password.*,.*token.*,.*api.key.*
 
 data.connection_string=jdbc:h2:file:%s;AUTOCOMMIT=ON;CACHE_SIZE=65536;
 #data.connection_string=jdbc:mysql://localhost:3306/dependencycheck


### PR DESCRIPTION
resolves GHSA-qqhq-8r2c-c3f5
