### PR TITLE
fix: skip pyproject.toml unless it contains `tool.poetry`

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzer.java
@@ -155,6 +155,10 @@ public class PoetryAnalyzer extends AbstractFileTypeAnalyzer {
         }
 
         final Toml result = new Toml().read(dependency.getActualFile());
+        if (PYPROJECT_TOML.equals(dependency.getActualFile().getName()) && result.getTables("tool.poetry")==null) {
+            LOGGER.debug("skipping {} as it does not contain `tool.poetry`", dependency.getDisplayFileName());
+            return;
+        }
         final List<Toml> projectsLocks = result.getTables("package");
         if (projectsLocks == null) {
             return;

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzer.java
@@ -155,7 +155,7 @@ public class PoetryAnalyzer extends AbstractFileTypeAnalyzer {
         }
 
         final Toml result = new Toml().read(dependency.getActualFile());
-        if (PYPROJECT_TOML.equals(dependency.getActualFile().getName()) && result.getTables("tool.poetry")==null) {
+        if (PYPROJECT_TOML.equals(dependency.getActualFile().getName()) && result.getTables("tool.poetry") == null) {
             LOGGER.debug("skipping {} as it does not contain `tool.poetry`", dependency.getDisplayFileName());
             return;
         }


### PR DESCRIPTION
resolves #6303
