### PR TITLE
fix: improve memory usage on NVD update

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/CveApiJson20CveItemSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/CveApiJson20CveItemSource.java
@@ -44,14 +44,14 @@ public class CveApiJson20CveItemSource implements CveItemSource<DefCveItem> {
         mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
         inputStream = jsonFile.getName().endsWith(".gz") ?
-                new GZIPInputStream(new BufferedInputStream(Files.newInputStream(jsonFile.toPath()))) :
+                new BufferedInputStream(new GZIPInputStream(Files.newInputStream(jsonFile.toPath()))) :
                 new BufferedInputStream(Files.newInputStream(jsonFile.toPath()));
         jsonParser = mapper.getFactory().createParser(inputStream);
 
         JsonToken token = null;
         do {
             token = jsonParser.nextToken();
-            if (token  == JsonToken.FIELD_NAME) {
+            if (token == JsonToken.FIELD_NAME) {
                 String fieldName = jsonParser.getCurrentName();
                 if (fieldName.equals("vulnerabilities") && (jsonParser.nextToken() == JsonToken.START_ARRAY)) {
                     nextItem = readItem(jsonParser);

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/JsonArrayCveItemSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/JsonArrayCveItemSource.java
@@ -44,7 +44,7 @@ public class JsonArrayCveItemSource implements CveItemSource<DefCveItem> {
         mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
         inputStream = jsonFile.getName().endsWith(".gz") ?
-                new GZIPInputStream(new BufferedInputStream(Files.newInputStream(jsonFile.toPath()))) :
+                new BufferedInputStream(new GZIPInputStream(Files.newInputStream(jsonFile.toPath()))) :
                 new BufferedInputStream(Files.newInputStream(jsonFile.toPath()));
         jsonParser = mapper.getFactory().createParser(inputStream);
 


### PR DESCRIPTION
## Fixes Issue #

Fix high memory usage when updating NVD database.

Before:
![image](https://github.com/jeremylong/DependencyCheck/assets/2931989/d618dd08-566c-4df0-ab67-b941779a886d)

After:
![image](https://github.com/jeremylong/DependencyCheck/assets/2931989/ea737e6d-3f5c-44ec-b304-b7e9ace47fdc)

## Description of Change
Just moved BufferedInputStream to wrap GzipInputStream and not the other way around.

## Test description
I did not test this extensively. I lost some hours finding a way to run this, so sorry if I did not do this as it should.

1. Download NVD cache generated from vulnz and create a local HTTP server to serve it (remove Download latency from equation)
2. Load project via Eclipse
3. Add two run configurations on CLI module pointing to local HTTP server for data feed: one with `--purge` and other with `--updateonly`
4. Monitor memory usage when running `--updateonly` after database is purged

## How I got to that point of error?
On `NvdApiDatasource`, I saw that there were two ExecutorServices when using Datafeed, so first I limited Download to 1 thread and saw no difference in memory usage and then I limited `processingExecutorService` to 1 and saw a huge difference.

## Further improvements
I believe first gunzipping to a temporary file and reading from it would save a lot of memory. Because GzipInputStream has an internal buffer, as Gzip decompression works in blocks, and JSON usually has a high compression rate (around 80 to 95% in some cases, but in this case I saw around 90%), there is a lot of gunzipped content in memory probably. Not sure if BufferedInputStream is enough though, so I did not bother to test that.

## Have test cases been added to cover the new functionality?
No