### PR TITLE
fix: ensure open handles will not leak on errors

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/CveApiJson20CveItemSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/CveApiJson20CveItemSource.java
@@ -22,30 +22,23 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
+import org.apache.commons.io.IOUtils;
 
-import java.io.BufferedInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.util.zip.GZIPInputStream;
 
 public class CveApiJson20CveItemSource implements CveItemSource<DefCveItem> {
 
-    private final File jsonFile;
     private final ObjectMapper mapper;
     private final InputStream inputStream;
     private final JsonParser jsonParser;
     private DefCveItem currentItem;
     private DefCveItem nextItem;
 
-    public CveApiJson20CveItemSource(File jsonFile) throws IOException {
-        this.jsonFile = jsonFile;
+    public CveApiJson20CveItemSource(InputStream inputStream) throws IOException {
         mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
-        inputStream = jsonFile.getName().endsWith(".gz") ?
-                new BufferedInputStream(new GZIPInputStream(Files.newInputStream(jsonFile.toPath()))) :
-                new BufferedInputStream(Files.newInputStream(jsonFile.toPath()));
+        this.inputStream = inputStream;
         jsonParser = mapper.getFactory().createParser(inputStream);
 
         JsonToken token = null;
@@ -62,9 +55,7 @@ public class CveApiJson20CveItemSource implements CveItemSource<DefCveItem> {
 
     @Override
     public void close() throws Exception {
-        jsonParser.close();
-        inputStream.close();
-        Files.delete(jsonFile.toPath());
+        IOUtils.closeQuietly(jsonParser, inputStream);
     }
 
     @Override

--- a/core/src/test/java/org/owasp/dependencycheck/data/update/nvd/api/NvdApiProcessorTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/update/nvd/api/NvdApiProcessorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2014 OWASP.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.owasp.dependencycheck.data.update.nvd.api;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import org.junit.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.data.nvdcve.CveDB;
+import org.owasp.dependencycheck.utils.Settings;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+
+import static org.junit.Assert.assertThrows;
+
+/**
+ *
+ * @author Jeremy Long
+ */
+public class NvdApiProcessorTest extends BaseTest {
+
+    @Test
+    public void doesNotExistFile() throws Exception {
+        try (CveDB cve = new CveDB(getSettings())) {
+            File file = new File("does_not_exist");
+            NvdApiProcessor processor = new NvdApiProcessor(null, file);
+            assertThrows(NoSuchFileException.class, processor::call);
+        }
+    }
+
+    @Test
+    public void unspecifiedFileName() throws Exception {
+        try (CveDB cve = new CveDB(getSettings())) {
+            File file = File.createTempFile("test", "test");
+            writeFileString(file, "");
+            NvdApiProcessor processor = new NvdApiProcessor(null, file);
+            processor.call();
+        }
+    }
+
+    @Test
+    public void invalidFileContent() throws Exception {
+        try (CveDB cve = new CveDB(getSettings())) {
+            File file = File.createTempFile("test", "test.json");
+            // invalid content (broken array)
+            writeFileString(file, "[}");
+            NvdApiProcessor processor = new NvdApiProcessor(null, file);
+            assertThrows(JsonParseException.class, processor::call);
+        }
+    }
+
+    @Test
+    public void processValidStructure() throws Exception {
+        try (CveDB cve = new CveDB(getSettings())) {
+            File file = File.createTempFile("test", "test.json");
+            writeFileString(file, "[]");
+            NvdApiProcessor processor = new NvdApiProcessor(null, file);
+            processor.call();
+        }
+    }
+
+    static void writeFileString(File file, String content) throws IOException {
+        try (FileWriter writer = new FileWriter(file, false)) {
+            writer.write(content);
+            writer.flush();
+        }
+    }
+}


### PR DESCRIPTION
## Fixes Issue #
As mentioned in https://github.com/jeremylong/DependencyCheck/pull/6275#issuecomment-1861350407, I found possible hidden memory leaks in case of broken inputs.

Background: Before #6275, the I/O handling (managing streams, file handling) itself was handled in `NvdApiProcessor` (IMHO the right place) which also handled the auto-closing on errors. After the change, the stream creation and parsing have moved both into the source implementation classes. If the `readItem()` methods fail (unexpected), the source constructor will not be succeeded, which means no instance at all, which means no auto-close with try-catch and therefore the created input streams will not be closed anymore. 

Also the close runs several closes in sequential order ignoring any exceptions happening there.

Also the read file will not be deleted, however that may be fine.

## Description of Change

* The creations of input streams is back in `NvdApiProcessor` which ensures via auto-closing the streams will be closed anytimes.
* Because I did not managed to find a reference of deleting the original file `jsonFile` in the previous version, I skipped this for now. Maybe reconsider adding again if this is required.
* The closing implemented in the reader classes (e.e. `JsonArrayCveItemSource`) may suffer from leaking when a sequential list of closables breaks in the line. Even if this is not the case today, it can change anytimes depending on the external tooling (here Jackson). I have decided to use from `commons-io:commons-io` the `org.apache.commons.io.IOUtils#closeQuietly(java.io.Closeable...)`. If the errors should propagate, then use `#close(java.io.Closeable...)`


## Have test cases been added to cover the new functionality?

no