### PR TITLE
fix: for #6374 to delete non-empty directories

### DIFF
--- a/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
@@ -25,15 +25,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.UUID;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
-
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,7 +91,10 @@ public final class FileUtils {
         }
 
         try {
-            Files.delete(file.toPath());
+            Files.walk(file.toPath())
+            .sorted(Comparator.reverseOrder())
+            .map(Path::toFile)
+            .forEach(File::delete);
         } catch (IOException ex) {
             LOGGER.trace(ex.getMessage(), ex);
             LOGGER.debug("Failed to delete file: {} (error message: {}); attempting to delete on exit.", file.getPath(), ex.getMessage());

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/FileUtilsTest.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/FileUtilsTest.java
@@ -58,4 +58,21 @@ public class FileUtilsTest extends BaseTest {
         assertTrue("delete returned a failed status", status);
         assertFalse("Temporary file exists after attempting deletion", file.exists());
     }
+
+    /**
+     * Test of delete method with a non-empty directory, of class FileUtils.
+     */
+    @Test
+    public void testDeleteWithSubDirectories() throws Exception {
+
+        File dir = new File(getSettings().getTempDirectory(), "delete-me");
+        dir.mkdirs();
+        File file = File.createTempFile("tmp", "deleteme", dir);
+        assertTrue("Unable to create a temporary file " + file.getAbsolutePath(), file.exists());
+
+        // delete the file
+        boolean status = FileUtils.delete(dir);
+        assertTrue("delete returned a failed status", status);
+        assertFalse("Temporary file exists after attempting deletion", file.exists());
+    }
 }


### PR DESCRIPTION
## Fixes Issue #6374

## Description of Change
Walk the files to delete using just java.

## Have test cases been added to cover the new functionality?
yes