### PR TITLE
fix: #6441 Improve suppression rule to not restrict to a single version

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -6565,10 +6565,10 @@
     </suppress>
     <suppress base="true">
        <notes><![CDATA[
-       FP per issue #5754
+       FP per issue #5754 #6441
        ]]></notes>
        <packageUrl regex="true">^pkg:maven/io\.swagger\.parser\.v3/swagger-parser-safe-url-resolver@.*$</packageUrl>
-       <cpe>cpe:/a:parse-url_project:2.1.14</cpe>
+       <cpe>cpe:/a:parse-url_project:</cpe>
     </suppress>
     <suppress base="true">
        <notes><![CDATA[


### PR DESCRIPTION
## Fixes Issue #

Fix #6441 

## Description of Change

Remove the exclusion restriction to a single version number. All versions of `^pkg:maven/io\.swagger\.parser\.v3/swagger-parser-safe-url-resolver@.*$` are now excluded from CPE `cpe:/a:parse-url_project:`.

## Have test cases been added to cover the new functionality?

*no*