### PR TITLE
fix: bump commons-compress from 1.25.0 to 1.26.0 to fix CVE-2024-25710 and CVE-2024-26308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@ Copyright (c) 2012 - Jeremy Long
         <jmockit.version>1.49</jmockit.version>
         <mockito-core.version>4.11.0</mockito-core.version>
         <jsoup.version>1.16.2</jsoup.version>
-        <commons-compress.version>1.25.0</commons-compress.version>
+        <commons-compress.version>1.26.0</commons-compress.version>
         <org.apache.maven.shared.file-management.version>3.1.0</org.apache.maven.shared.file-management.version>
         <maven-plugin-testing-harness.version>3.3.0</maven-plugin-testing-harness.version>
         <maven-plugin-annotations.version>3.10.2</maven-plugin-annotations.version>


### PR DESCRIPTION
## Fixes Issue #
CVE-2024-25710
CVE-2024-26308

## Description of Change
Bumped package version from 1.25.0 to 1.26.0 that fixes the CVE's

## Have test cases been added to cover the new functionality?
No