### PR TITLE
fix: issue 5452 - ConcurrentModificationException in NodePackageAnalyzer.processDependencies - adding synchronized block 

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
@@ -458,18 +458,19 @@ public class NodePackageAnalyzer extends AbstractNpmAnalyzer {
                         LOGGER.debug("Unable to build package url for `" + packagePath + "`", ex);
                     }
                 }
-
-                final Dependency existing = findDependency(engine, name, version);
-                if (existing != null) {
-                    if (existing.isVirtual()) {
-                        DependencyMergingAnalyzer.mergeDependencies(child, existing, null);
-                        engine.removeDependency(existing);
-                        engine.addDependency(child);
+                synchronized (this) {
+                    final Dependency existing = findDependency(engine, name, version);
+                    if (existing != null) {
+                        if (existing.isVirtual()) {
+                            DependencyMergingAnalyzer.mergeDependencies(child, existing, null);
+                            engine.removeDependency(existing);
+                            engine.addDependency(child);
+                        } else {
+                            DependencyBundlingAnalyzer.mergeDependencies(existing, child, null);
+                        }
                     } else {
-                        DependencyBundlingAnalyzer.mergeDependencies(existing, child, null);
+                        engine.addDependency(child);
                     }
-                } else {
-                    engine.addDependency(child);
                 }
             }
         }


### PR DESCRIPTION
## Fixes Issue #
https://github.com/jeremylong/DependencyCheck/issues/5452 - ConcurrentModificationException in NodePackageAnalyzer.processDependencies

## Description of Change
Surrounding merging dependency code in synchronized block. I was facing the issue when I had multiple json files added - by `/tmp/*/package-lock.json`. Most of them contains the same set of dependencies. I've noticed that this issue doesn't exist when I change the number of threads in `org/owasp/dependencycheck/Engine.java:811` to 1. This would mean that this is ordinary concurrency issue. I've checked if it occurs if I add the synchronized to the `org.owasp.dependencycheck.analyzer.DependencyMergingAnalyzer#mergeDependencies` but the issue was still there. And I've noticed that the when one thread is throwing this exeption, the other one is trying to do `org.owasp.dependencycheck.Engine#removeDependency`.

This is why I've added the synchronized block to thos part of the method
```
 synchronized (this) {
                    final Dependency existing = findDependency(engine, name, version);
                    if (existing != null) {
                        if (existing.isVirtual()) {
                            DependencyMergingAnalyzer.mergeDependencies(child, existing, null);
                            engine.removeDependency(existing);
                            engine.addDependency(child);
                        } else {
                            DependencyBundlingAnalyzer.mergeDependencies(existing, child, null);
                        }
                    } else {
                        engine.addDependency(child);
                    }
                }
```
After this I don't see anymore the ConcurrentModificationException

## Have test cases been added to cover the new functionality?

no