### PR TITLE
chore: Update the packaged suppressions to include new hosted suppressions

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -6892,5 +6892,307 @@
         <cve>CVE-2023-25155</cve>
         <cve>CVE-2023-28856</cve>
     </suppress>
-    
+    <!-- generated suppression 8.4.0 up to 9.1.0 -->
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5904
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.adobe\.cq/core\.wcm\.components\.core@.*$</packageUrl>
+        <cpe>cpe:/a:adobe:download_manager</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5905
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.adobe\.cq/core\.wcm\.components\.core@.*$</packageUrl>
+        <cpe>cpe:/a:adobe:experience_manager</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5906
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.adobe\.cq/core\.wcm\.components\.core@.*$</packageUrl>
+        <cpe>cpe:/a:adobe:experience_manager_forms</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5908
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.adobe\.cq/core\.wcm\.components\.core@.*$</packageUrl>
+        <cpe>cpe:/a:adobe:form_client</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5909
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.adobe\.cq/core\.wcm\.components\.core@.*$</packageUrl>
+        <cpe>cpe:/a:list_site_pro:list_site_pro</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5910
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.adobe\.cq/core\.wcm\.components\.core@.*$</packageUrl>
+        <cpe>cpe:/a:oembed_project:oembed</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5911
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.adobe\.cq/core\.wcm\.components\.core@.*$</packageUrl>
+        <cpe>cpe:/a:xml_library_project:xml_library</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5916
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring-plugin-core@.*$</packageUrl>
+        <cpe>cpe:/a:vmware:spring</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5915 - suppress the CVE only to avoid clash when cpe:/a:vmware:spring were to get broader use
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework(?!\.kafka).*$</packageUrl>
+        <cve>CVE-2023-34040</cve>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5932
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.logback-extensions/logback-ext-spring@.*$</packageUrl>
+        <cpe>cpe:/a:qos:logback</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5948
+   ]]></notes>
+        <packageUrl regex="true">^pkg:npm/mysql@.*$</packageUrl>
+        <cpe>cpe:/a:mysql:mysql</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5913
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.projectreactor\.netty\.incubator/reactor-netty-incubator-quic@.*$</packageUrl>
+        <cpe>cpe:/a:quic_project:quic</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5958
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/net\.rossillo\.mvc\.cache/spring-mvc-cache-control@.*$</packageUrl>
+        <cpe>cpe:/a:spring:spring</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5961
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback\.contrib/logback-json-core@.*$</packageUrl>
+        <cpe>cpe:/a:json-c:json-c</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5956
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty\.incubator/netty-incubator-codec-native-quic@.*$</packageUrl>
+        <cpe>cpe:/a:quic_project:quic</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5966
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback\.contrib/logback-json-classic@.*$</packageUrl>
+        <cpe>cpe:/a:json-c:json-c</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5953
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.asyncer/r2dbc-mysql@.*$</packageUrl>
+        <cpe>cpe:/a:mysql:mysql</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5968
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty\.incubator/netty-incubator-codec-native-quic@.*$</packageUrl>
+        <cpe>cpe:/a:chromium_project:chromium</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5967
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty\.incubator/netty-incubator-codec-native-quic@.*$</packageUrl>
+        <cpe>cpe:/a:chromium:chromium</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #5939
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/xalan/xalan@.*$</packageUrl>
+        <cpe>cpe:/a:apache:commons_bcel</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6088
+   ]]></notes>
+        <packageUrl regex="true">^pkg:nuget/CommandLineParser@.*$</packageUrl>
+        <cpe>cpe:/a:line:line</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6056
+   ]]></notes>
+        <packageUrl regex="true">^pkg:nuget/Serilog\.Sinks\.Async@.*$</packageUrl>
+        <cpe>cpe:/a:async_project:async</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6041
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.flywaydb/flyway-database-postgresql@.*$</packageUrl>
+        <cpe>cpe:/a:postgresql:postgresql</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6038
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/net\.lbruun\.springboot/preliquibase-spring-boot-starter@.*$</packageUrl>
+        <cpe>cpe:/a:liquibase:liquibase</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6138 and #6139
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/rubygems/.*@.*$</packageUrl>
+        <cpe>cpe:/a:rubygems:rubygems</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6170
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.parquet/parquet-avro@.*$</packageUrl>
+        <cpe>cpe:/a:apache:avro</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6169
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/commons-net/commons-net@.*$</packageUrl>
+        <cpe>cpe:/a:ftp_project:ftp</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6313
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.camel/camel-reactive-executor-tomcat@.*$</packageUrl>
+        <cpe>cpe:/a:apache_tomcat:apache_tomcat</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6286
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/info\.picocli/picocli@.*$</packageUrl>
+        <cpe>cpe:/a:line:line</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6242
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jruby\.rack/jruby-rack@.*$</packageUrl>
+        <cpe>cpe:/a:rack_project:rack</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6199
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.r2dbc/r2dbc-mssql@.*$</packageUrl>
+        <cpe>cpe:/a:microsoft:sql_server</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6031
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.thymeleaf\.extras/thymeleaf-extras-java8time@.*$</packageUrl>
+        <cpe>cpe:/a:thymeleaf:thymeleaf</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6340
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.idealista/format-preserving-encryption@.*$</packageUrl>
+        <cpe>cpe:/a:vega_project:vega</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6367
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.keycloak/keycloak-model-infinispan@.*$</packageUrl>
+        <cpe>cpe:/a:infinispan:infinispan</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6369
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.wildfly\.security\.elytron-web/undertow-server@.*$</packageUrl>
+        <cpe>cpe:/a:web_project:web</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6368
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jgroups\.azure/jgroups-azure@.*$</packageUrl>
+        <cpe>cpe:/a:redhat:jgroups</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6459
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.bornium/oauth2-openid@.*$</packageUrl>
+        <cpe>cpe:/a:openid:openid</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6460
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.hsqldb/hsqldb@.*$</packageUrl>
+        <cpe>cpe:/a:hyper:hyper</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6421
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.swagger/swagger-parser-safe-url-resolver@.*$</packageUrl>
+        <cpe>cpe:/a:parse-url_project:parse-url</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6408
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jboss\.activemq\.artemis\.integration/artemis-wildfly-integration@.*$</packageUrl>
+        <cpe>cpe:/a:redhat:wildfly</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6482
+   ]]></notes>
+        <packageUrl regex="true">^pkg:npm/bare-os@.*$</packageUrl>
+        <cpe>cpe:/a:bareos:bareos</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6463
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.ktor/ktor-server-metrics-micrometer-jvm@.*$</packageUrl>
+        <cpe>cpe:/a:csm_server_project:csm_server</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+   FP per issue #6538
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.camel\.quarkus/camel-quarkus-core@.*$</packageUrl>
+        <cpe>cpe:/a:apache:camel</cpe>
+    </suppress>
+    <!-- end of genereated suppressions that will be included in 9.1.1 -->
 </suppressions>


### PR DESCRIPTION
Spotted that it had been a while since the latest hosted suppressions were included in the packaged set. Marked the new inclusion point in generatedSuppressions branch and took over all suppressions up to now