### PR TITLE
feat: Support Package.swift version 3 Specification

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageResolvedAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/SwiftPackageResolvedAnalyzer.java
@@ -165,7 +165,8 @@ public class SwiftPackageResolvedAnalyzer extends AbstractFileTypeAnalyzer {
                     analyzeSpmResolvedDependenciesV1(spmResolved, engine, file);
                     break;
                 case 2:
-                    analyzeSpmResolvedDependenciesV2(spmResolved, engine, file);
+                case 3:
+                    analyzeSpmResolvedDependenciesV2And3(spmResolved, engine, file);
                     break;
                 default:
                     return;
@@ -209,14 +210,14 @@ public class SwiftPackageResolvedAnalyzer extends AbstractFileTypeAnalyzer {
     }
 
     /**
-     * Analyzes the version 2 of the Package.resolved file to extract evidence
+     * Analyzes the versions 2 and 3 of the Package.resolved file to extract evidence
      * for the dependency.
      *
      * @param spmResolved the dependency to analyze
      * @param engine the analysis engine
      * @param resolved the json object of the file to analyze
      */
-    private void analyzeSpmResolvedDependenciesV2(Dependency spmResolved, Engine engine, JsonObject resolved) {
+    private void analyzeSpmResolvedDependenciesV2And3(Dependency spmResolved, Engine engine, JsonObject resolved) {
         final JsonArray pins = resolved.getJsonArray("pins");
         if (pins == null) {
             return;

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
@@ -210,6 +210,22 @@ public class SwiftAnalyzersTest extends BaseTest {
     }
 
     @Test
+    public void testSPMResolvedAnalyzerV3() throws AnalysisException {
+        final Engine engine = new Engine(getSettings());
+        final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
+                "swift/spmV3/Package.resolved"));
+        sprAnalyzer.analyze(result, engine);
+
+        assertThat(engine.getDependencies().length, equalTo(3));
+        assertThat(engine.getDependencies()[0].getName(), equalTo("alamofire"));
+        assertThat(engine.getDependencies()[0].getVersion(), equalTo("5.4.3"));
+        assertThat(engine.getDependencies()[1].getName(), equalTo("alamofireimage"));
+        assertThat(engine.getDependencies()[1].getVersion(), equalTo("4.2.0"));
+        assertThat(engine.getDependencies()[2].getName(), equalTo("facebook"));
+        assertThat(engine.getDependencies()[2].getVersion(), equalTo("9.3.0"));
+    }
+
+    @Test
     public void testIsEnabledIsTrueByDefault() {
         assertTrue(spmAnalyzer.isEnabled());
         assertTrue(sprAnalyzer.isEnabled());

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
@@ -221,7 +221,7 @@ public class SwiftAnalyzersTest extends BaseTest {
         assertThat(engine.getDependencies()[0].getVersion(), equalTo("5.4.3"));
         assertThat(engine.getDependencies()[1].getName(), equalTo("alamofireimage"));
         assertThat(engine.getDependencies()[1].getVersion(), equalTo("4.2.0"));
-        assertThat(engine.getDependencies()[2].getName(), equalTo("facebook"));
+        assertThat(engine.getDependencies()[2].getName(), equalTo("facebook-ios-sdk"));
         assertThat(engine.getDependencies()[2].getVersion(), equalTo("9.3.0"));
     }
 

--- a/core/src/test/resources/swift/spmV3/Package.resolved
+++ b/core/src/test/resources/swift/spmV3/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "61eefff3bfa0b743e81a1adc984d45c84d89137e9f3c6d1c0c2e8898ae90ea9a",
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "f96b619bcb2383b43d898402283924b80e2c4bae",
+        "version" : "5.4.3"
+      }
+    },
+    {
+      "identity" : "alamofireimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/AlamofireImage",
+      "state" : {
+        "revision" : "98cbb00ce0ec5fc8e52a5b50a6bfc08d3e5aee10",
+        "version" : "4.2.0"
+      }
+    },
+    {
+      "identity" : "facebook-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/facebook-ios-sdk",
+      "state" : {
+        "revision" : "c3d367656ae8ced1149c2c6a5e6b5dd91ecad63c",
+        "version" : "9.3.0"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

With the recent release of Swift 5.10 there is a new specification for the Package.resolved dependencies file. This PR aims to support the new spec on the analyzer since the structure of the file has changed.

## Have test cases been added to cover the new functionality?

*yes*