### PR TITLE
fix: Ensure valid JSON output for gitlab report

### DIFF
--- a/core/src/main/resources/templates/gitlabReport.vsl
+++ b/core/src/main/resources/templates/gitlabReport.vsl
@@ -139,8 +139,10 @@
             "path": "pom.xml",
             "package_manager": "maven",
             "dependencies": [
+                #set($addComma=0)
                 #foreach( $dependency in $dependencies )
                     #if( $dependency.name )
+                    #if( $addComma>0 ),#end
                     {
                         "package": {
                             "name": "$enc.json($dependency.name)"
@@ -152,7 +154,7 @@
                         ##"direct": false, --> not implemeten
                         ##"dependency_path": [] --> not implemented
                     }
-                    #if( $foreach.hasNext ),#end
+                    #set($addComma=1)
                     #end
                 #end
             ]


### PR DESCRIPTION
## Fixes Issue #6593

## Description of Change

Add a different guard for adding a comma, so that in case of nameless dependencies no trailing comma is added.

## Have test cases been added to cover the new functionality?

no