### PR TITLE
fix: skip pyproject.toml unless it contains `tool.poetry` before ensuring lockfiles

### DIFF
--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzerTest.java
@@ -73,9 +73,16 @@ public class PoetryAnalyzerTest extends BaseTest {
         assertTrue("Expeced to find PyYAML", found);
     }
 
-    @Test(expected = AnalysisException.class)
+    @Test
     public void testPyprojectToml() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "python-myproject-toml/pyproject.toml"));
+        //returns with no error.
+        analyzer.analyze(result, engine);
+    }
+
+    @Test(expected = AnalysisException.class)
+    public void testPoetryToml() throws AnalysisException {
+        final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "python-poetry-toml/pyproject.toml"));
         //causes an exception.
         analyzer.analyze(result, engine);
     }

--- a/core/src/test/resources/python-poetry-toml/pyproject.toml
+++ b/core/src/test/resources/python-poetry-toml/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "test"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.7"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Fixes Issue #5971 

## Description of Change

Even after [this PR](https://github.com/jeremylong/DependencyCheck/pull/6316) was merged I am encountering the issue found in #5971. When scanning a dependency with a `pyproject.toml` file that does not use Poetry, an exception is still thrown.

The changes in this PR check if "tool.poetry" exists in `pyproject.toml` _before_ checking that a lockfile (poetry.lock, requirements.txt) exist so that we can return gracefully if Poetry is not present instead of throwing an exception.

## Have test cases been added to cover the new functionality?

yes, but am open to adding more if needed