### PR TITLE
fix: avoid escaping unnecessary chars in HTML report suppression regexes

### DIFF
--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -152,7 +152,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                 }
             }
             function escapeRegExp(text) {
-              return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+              return text.replace(/[[\]{}()*+?.\\^$|\s]/g, '\\$&');
             }
             function setCopyText(name, matchType, matchValue, suppressType, suppressVal) {
                 xml =  '<suppress>\n';


### PR DESCRIPTION
## Description of Change

Bit of a nitpick: when the HTML report generates an example suppression, it unnecessarily escapes hyphens when constructing a regex inside HTML.

e.g. `pkg:maven/org.eclipse.jetty.websocket/websocket-jetty-server`

becomes

```xml
   <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.websocket/websocket\-jetty\-server@.*$</packageUrl>
```

This is a little more annoying to read and maintain than it needs to be :-) This would be better:

```xml
   <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.websocket/websocket-jetty-server@.*$</packageUrl>
```

Within regexes, `-` only needs to be escaped within a character class, and only if not the first character in the character class (ironically the old code relied on this). Since we are not putting elements into character classes and the the relevant `[` is escaped we don't need to escape this, and it reads better to not escape.

Similar
- `#` has no special meaning in regex, not sure why it was being escaped
- `,` has no special meaning outside a repetition qualifier (already `{}` are escaped), so similarly does not need to be escaped

Technically the escaping is a bit janky right now as it is also escaping some things for the purpose of using JavaScript to construct XML so _technically_ it needs to `escapeForXml` afterwards, or the `packageUrl` = `pkg:hello-world-</packageUrl>` will get you into broken XML trouble, but I guess that is not a major concern :-)

I guess escaping the whitespace escaping with `\s` is one of these XML-related workarounds based on #2046 so have left it around.

## Have test cases been added to cover the new functionality?

no