### PR TITLE
fix: correct oracle and postgres schema versions when bootstrapped

### DIFF
--- a/core/src/main/resources/data/initialize_oracle.sql
+++ b/core/src/main/resources/data/initialize_oracle.sql
@@ -538,4 +538,4 @@ CREATE OR REPLACE VIEW v_update_ecosystems AS
     ON c.vendor=e.vendor
         AND c.product=e.product;
 
-INSERT INTO properties(id,value) VALUES ('version','5.4');
+INSERT INTO properties(id,value) VALUES ('version','5.5');

--- a/core/src/main/resources/data/initialize_postgres.sql
+++ b/core/src/main/resources/data/initialize_postgres.sql
@@ -324,4 +324,4 @@ GRANT EXECUTE ON FUNCTION public.insert_software (INT, CHAR(1), VARCHAR(255),
 
 
 
-INSERT INTO properties(id,value) VALUES ('version','5.4');
+INSERT INTO properties(id,value) VALUES ('version','5.5');


### PR DESCRIPTION
## Fixes Issue #

Noted by users at https://github.com/jeremylong/DependencyCheck/issues/6746#issuecomment-2200034691 and https://github.com/jeremylong/DependencyCheck/issues/6746#issuecomment-2200305208 for Postgres, but likely missed due to the many other unrelated comments. Similar oversight exists for Oracle, but not sure if there are other issues there as imagine oracle is less frequently used.

## Description of Change

No idea if the rest of the changes actually work, but these version numbers seem definitely wrong, and would need to an attempt to re-run delta scripts later?

## Have test cases been added to cover the new functionality?

no