### PR TITLE
fix(fp): FP per issue #6798

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1625,9 +1625,9 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
 </suppress>
 <suppress base="true">
    <notes><![CDATA[
-   FP per issue #6666
+   FP per issue #6666 + #6798
    ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty-servlet-api@.*$</packageUrl>
+   <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/.*@.*$</packageUrl>
    <cpe>cpe:/a:jetty:jetty</cpe>
 </suppress>
 <suppress base="true">


### PR DESCRIPTION
## Fixes Issue #6798

## Description of Change

We'll be playing whack-a-mole on these forever otherwise :-)

There are 27 different artifacts within the `org.eclipse.jetty.toolchain` group, and none of them are versioned alongside Jetty.

## Have test cases been added to cover the new functionality?

no