### PR TITLE
fix(db): make upgrade work on postgresql

### DIFF
--- a/core/src/main/resources/data/upgrade_5.4.sql
+++ b/core/src/main/resources/data/upgrade_5.4.sql
@@ -40,4 +40,4 @@ ALTER TABLE vulnerability ADD   COLUMN v4environmentalSeverity VARCHAR(15);
 ALTER TABLE vulnerability ADD   COLUMN v4source VARCHAR(50);
 ALTER TABLE vulnerability ADD   COLUMN v4type VARCHAR(15);
 
-UPDATE Properties SET `value`='5.5' WHERE ID='version';
+UPDATE Properties SET value='5.5' WHERE ID='version';


### PR DESCRIPTION
## Fixes Issue #

When running the upgrade script on Postgres (I use version 16) it will print the following error at the end:
```
psql:/tmp/upgrade_5.4.sql:43: ERROR:  syntax error at or near "`"
LINE 1: UPDATE Properties SET `value`='5.5' WHERE ID='version';
```
Getting rid of these ` symbols resolves the issue. Rerunning it looked like this:

```
psql:/tmp/upgrade_5.4.sql:1: ERROR:  column "v4version" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:2: ERROR:  column "v4attackvector" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:3: ERROR:  column "v4attackcomplexity" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:4: ERROR:  column "v4attackrequirements" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:5: ERROR:  column "v4privilegesrequired" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:6: ERROR:  column "v4userinteraction" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:7: ERROR:  column "v4vulnconfidentialityimpact" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:8: ERROR:  column "v4vulnintegrityimpact" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:9: ERROR:  column "v4vulnavailabilityimpact" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:10: ERROR:  column "v4subconfidentialityimpact" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:11: ERROR:  column "v4subintegrityimpact" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:12: ERROR:  column "v4subavailabilityimpact" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:13: ERROR:  column "v4exploitmaturity" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:14: ERROR:  column "v4confidentialityrequirement" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:15: ERROR:  column "v4integrityrequirement" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:16: ERROR:  column "v4availabilityrequirement" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:17: ERROR:  column "v4modifiedattackvector" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:18: ERROR:  column "v4modifiedattackcomplexity" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:19: ERROR:  column "v4modifiedattackrequirements" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:20: ERROR:  column "v4modifiedprivilegesrequired" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:21: ERROR:  column "v4modifieduserinteraction" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:22: ERROR:  column "v4modifiedvulnconfidentialityimpact" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:23: ERROR:  column "v4modifiedvulnintegrityimpact" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:24: ERROR:  column "v4modifiedvulnavailabilityimpact" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:25: ERROR:  column "v4modifiedsubconfidentialityimpact" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:26: ERROR:  column "v4modifiedsubintegrityimpact" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:27: ERROR:  column "v4modifiedsubavailabilityimpact" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:28: ERROR:  column "v4safety" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:29: ERROR:  column "v4automatable" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:30: ERROR:  column "v4recovery" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:31: ERROR:  column "v4valuedensity" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:32: ERROR:  column "v4vulnerabilityresponseeffort" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:33: ERROR:  column "v4providerurgency" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:34: ERROR:  column "v4basescore" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:35: ERROR:  column "v4baseseverity" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:36: ERROR:  column "v4threatscore" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:37: ERROR:  column "v4threatseverity" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:38: ERROR:  column "v4environmentalscore" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:39: ERROR:  column "v4environmentalseverity" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:40: ERROR:  column "v4source" of relation "vulnerability" already exists
psql:/tmp/upgrade_5.4.sql:41: ERROR:  column "v4type" of relation "vulnerability" already exists
UPDATE 1
```