### PR TITLE
build(deps): bump open-vulnerability-clients from 6.1.6 to 6.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -972,7 +972,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>io.github.jeremylong</groupId>
                 <artifactId>open-vulnerability-clients</artifactId>
-                <version>6.1.6</version>
+                <version>6.1.7</version>
             </dependency>
             <dependency>
                 <groupId>org.anarres.jdiagnostics</groupId>


### PR DESCRIPTION
This  will close #6834 as it will:

1. Resolve the current error message indicating the NVD would like to have a lower resultsPerPage value.
2. Improve the error handling/reporting so other similar errors are easier to identify and fix.