### PR TITLE
fix(site): Update Fluido skin to resolve broken fork-me-on-github image

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -22,7 +22,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <skin>
         <groupId>org.apache.maven.skins</groupId>
         <artifactId>maven-fluido-skin</artifactId>
-        <version>1.6</version>
+        <version>1.12.0</version>
     </skin>
     <custom>
         <fluidoSkin>


### PR DESCRIPTION
## Fixes Issue #6910

## Description of Change

Fluido skin switched to CSS-only fork-link rendering at version 1.11.1 in 2022. Apparently the S3-bucket where the image for the previous fork rendering resided is now defunct.

## Have test cases been added to cover the new functionality?

*no*