### PR TITLE
build(deps): Update minimum version of Maven to 3.6.3

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -37,7 +37,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <tag>v6.4.1</tag>
     </scm>
     <prerequisites>
-        <maven>3.1.0</maven>
+        <maven>3.6.3</maven>
     </prerequisites>
     <build>
         <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ Copyright (c) 2012 - Jeremy Long
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.11</logback.version>
         
-        <maven.api.version>3.1.0</maven.api.version>
+        <maven.api.version>3.6.3</maven.api.version>
         <reporting.checkstyle-plugin.version>3.4.0</reporting.checkstyle-plugin.version>
         <reporting.checkstyle.tool.version>9.3</reporting.checkstyle.tool.version>
         <doxia-module-markdown.version>1.12.0</doxia-module-markdown.version>


### PR DESCRIPTION
## Fixes Issue #6928

## Description of Change

Bump the required minimum maven version to use for the dependency-check-maven-plugin to 3.6.3 (in line with the current Apache Maven policy for new plugin releases).
As there is no direct benefit, and a small chance that some users might still be on lower Maven versions where this would constitute a breaking change, I think it's best to await the 11.0.0 snapshots to merge this in.

## Have test cases been added to cover the new functionality?

not applicable