### PR TITLE
chore: Replace use of several deprecated methods/classes by their successors

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzer.java
@@ -28,7 +28,7 @@ import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2Utils;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipUtils;
-import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.IOUtils;
 import org.eclipse.packager.rpm.RpmTag;
 import org.eclipse.packager.rpm.parse.RpmInputStream;
 import org.owasp.dependencycheck.Engine;
@@ -460,7 +460,7 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
                     tin = new TarArchiveInputStream(in);
                     extractArchive(tin, destination, engine);
                 } else if ("gz".equals(archiveExt) || "tgz".equals(archiveExt)) {
-                    final String uncompressedName = GzipUtils.getUncompressedFilename(archive.getName());
+                    final String uncompressedName = GzipUtils.getUncompressedFileName(archive.getName());
                     final File f = new File(destination, uncompressedName);
                     if (engine.accept(f)) {
                         final String destPath = destination.getCanonicalPath();
@@ -475,7 +475,7 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
                         decompressFile(gin, f);
                     }
                 } else if ("bz2".equals(archiveExt) || "tbz2".equals(archiveExt)) {
-                    final String uncompressedName = BZip2Utils.getUncompressedFilename(archive.getName());
+                    final String uncompressedName = BZip2Utils.getUncompressedFileName(archive.getName());
                     final File f = new File(destination, uncompressedName);
                     if (engine.accept(f)) {
                         final String destPath = destination.getCanonicalPath();
@@ -728,7 +728,7 @@ public class ArchiveAnalyzer extends AbstractFileTypeAnalyzer {
         boolean isJar = false;
         ZipFile zip = null;
         try {
-            zip = new ZipFile(dependency.getActualFilePath());
+            zip = ZipFile.builder().setFile(dependency.getActualFilePath()).get();
             if (zip.getEntry("META-INF/MANIFEST.MF") != null
                     || zip.getEntry("META-INF/maven") != null) {
                 final Enumeration<ZipArchiveEntry> entries = zip.getEntries();

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzer.java
@@ -150,7 +150,7 @@ public class MSBuildProjectAnalyzer extends AbstractFileTypeAnalyzer {
             final List<NugetPackageReference> packages;
 
             try (FileInputStream fis = new FileInputStream(dependency.getActualFilePath());
-                    BOMInputStream bis = new BOMInputStream(fis)) {
+                    BOMInputStream bis = BOMInputStream.builder().setInputStream(fis).get()) {
                 //skip BOM if it exists
                 bis.getBOM();
                 packages = parser.parse(bis, props, centrallyManaged);
@@ -315,7 +315,7 @@ public class MSBuildProjectAnalyzer extends AbstractFileTypeAnalyzer {
         if (directoryProps != null && directoryProps.isFile()) {
             final DirectoryBuildPropsParser parser = new DirectoryBuildPropsParser();
             try (FileInputStream fis = new FileInputStream(directoryProps);
-                    BOMInputStream bis = new BOMInputStream(fis)) {
+                    BOMInputStream bis = BOMInputStream.builder().setInputStream(fis).get()) {
                 //skip BOM if it exists
                 bis.getBOM();
                 entries = parser.parse(bis);
@@ -344,7 +344,7 @@ public class MSBuildProjectAnalyzer extends AbstractFileTypeAnalyzer {
         if (packages != null && packages.isFile()) {
             final DirectoryPackagesPropsParser parser = new DirectoryPackagesPropsParser();
             try (FileInputStream fis = new FileInputStream(packages);
-                    BOMInputStream bis = new BOMInputStream(fis)) {
+                    BOMInputStream bis = BOMInputStream.builder().setInputStream(fis).get()) {
                 //skip BOM if it exists
                 bis.getBOM();
                 return parser.parse(bis, props);

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/CveApiJson20CveItemSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/CveApiJson20CveItemSource.java
@@ -45,7 +45,7 @@ public class CveApiJson20CveItemSource implements CveItemSource<DefCveItem> {
         do {
             token = jsonParser.nextToken();
             if (token == JsonToken.FIELD_NAME) {
-                String fieldName = jsonParser.getCurrentName();
+                String fieldName = jsonParser.currentName();
                 if (fieldName.equals("vulnerabilities") && (jsonParser.nextToken() == JsonToken.START_ARRAY)) {
                     nextItem = readItem(jsonParser);
                 }

--- a/core/src/main/java/org/owasp/dependencycheck/xml/hints/HintParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/hints/HintParser.java
@@ -148,7 +148,7 @@ public class HintParser {
                 InputStream schemaStream12 = FileUtils.getResourceAsStream(HINT_SCHEMA_1_2);
                 InputStream schemaStream11 = FileUtils.getResourceAsStream(HINT_SCHEMA_1_1)) {
 
-            final BOMInputStream bomStream = new BOMInputStream(inputStream);
+            final BOMInputStream bomStream = BOMInputStream.builder().setInputStream(inputStream).get();
             final ByteOrderMark bom = bomStream.getBOM();
             final String defaultEncoding = StandardCharsets.UTF_8.name();
             final String charsetName = bom == null ? defaultEncoding : bom.getCharsetName();

--- a/core/src/main/java/org/owasp/dependencycheck/xml/pom/PomParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/pom/PomParser.java
@@ -111,7 +111,8 @@ public class PomParser {
             final XMLReader xmlReader = saxParser.getXMLReader();
             xmlReader.setContentHandler(handler);
 
-            final BOMInputStream bomStream = new BOMInputStream(new XmlInputStream(new PomProjectInputStream(inputStream)));
+            final BOMInputStream bomStream = BOMInputStream.builder()
+                    .setInputStream(new XmlInputStream(new PomProjectInputStream(inputStream))).get();
             final ByteOrderMark bom = bomStream.getBOM();
             final String defaultEncoding = StandardCharsets.UTF_8.name();
             final String charsetName = bom == null ? defaultEncoding : bom.getCharsetName();
@@ -141,7 +142,7 @@ public class PomParser {
             final XMLReader xmlReader = saxParser.getXMLReader();
             xmlReader.setContentHandler(handler);
 
-            final BOMInputStream bomStream = new BOMInputStream(new XmlInputStream(inputStream));
+            final BOMInputStream bomStream = BOMInputStream.builder().setInputStream(new XmlInputStream(inputStream)).get();
             final ByteOrderMark bom = bomStream.getBOM();
             final String defaultEncoding = StandardCharsets.UTF_8.name();
             final String charsetName = bom == null ? defaultEncoding : bom.getCharsetName();

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionParser.java
@@ -106,7 +106,7 @@ public class SuppressionParser {
                 InputStream schemaStream11 = FileUtils.getResourceAsStream(SUPPRESSION_SCHEMA_1_1);
                 InputStream schemaStream10 = FileUtils.getResourceAsStream(SUPPRESSION_SCHEMA_1_0)) {
 
-            final BOMInputStream bomStream = new BOMInputStream(inputStream);
+            final BOMInputStream bomStream = BOMInputStream.builder().setInputStream(inputStream).get();
             final ByteOrderMark bom = bomStream.getBOM();
             final String defaultEncoding = StandardCharsets.UTF_8.name();
             final String charsetName = bom == null ? defaultEncoding : bom.getCharsetName();

--- a/core/src/test/java/org/owasp/dependencycheck/BaseDBTestCase.java
+++ b/core/src/test/java/org/owasp/dependencycheck/BaseDBTestCase.java
@@ -24,7 +24,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseManager;
 import org.owasp.dependencycheck.utils.WriteLock;

--- a/pom.xml
+++ b/pom.xml
@@ -440,7 +440,6 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     <showDeprecation>true</showDeprecation>
                     <release>8</release>
                     <compilerArgs>


### PR DESCRIPTION
## Description of Change

While checking the buildlog of the 'update maven requirement to 3.6.3' efforts I spotted several deprecation warnings.
The deprecations within the MavenProject unfortunately do not appear to have a replacement (yet), but as a side-activity I've worked through the other deprecations in order to clean them out of the codebase.

## Have test cases been added to cover the new functionality?

not applicable