### PR TITLE
build: Remove the animal-sniffer, propagate java version to plugin-archetype

### DIFF
--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -38,13 +38,6 @@ Copyright (c) 2017 Jeremy Long. All Rights Reserved.
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <configuration>

--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,7 +14,10 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
-    
+
+    <properties>
+        <maven.compiler.release>${maven.compiler.release}</maven.compiler.release>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.owasp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -243,11 +243,6 @@ Copyright (c) 2012 - Jeremy Long
                     <version>3.5.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>animal-sniffer-maven-plugin</artifactId>
-                    <version>1.23</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.1.2</version>
@@ -572,26 +567,6 @@ Copyright (c) 2012 - Jeremy Long
                                 </requireMavenVersion>
                             </rules>
                             <fail>true</fail>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>signature-check</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <signature>
-                                <groupId>org.codehaus.mojo.signature</groupId>
-                                <artifactId>java18</artifactId>
-                                <version>1.0</version>
-                            </signature>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Description of Change

As a result of a first PR that was using the Java 11 API I found out that the Java 11 migration PR had missed the removal of the no longer needed animal-sniffer plugin.

Now that we've upgraded to target Java 11 as the minimal baseline and use the javac `--release` option (triggered by the `maven.compiler.release` property) the compiler already takes care of ensuring compliance with the Java public API of the target version.

Also added population of the `maven.compiler.release` property to the pom that gets generated from the dependency-check-plugin archetype.

## Have test cases been added to cover the new functionality?

N/A
