### PR TITLE
build: Update Checkstyle configuration and Suppression DTD references

### DIFF
--- a/src/main/config/checkstyle-checks.xml
+++ b/src/main/config/checkstyle-checks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
     <!--

--- a/src/main/config/checkstyle-suppressions.xml
+++ b/src/main/config/checkstyle-suppressions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
 <!DOCTYPE suppressions PUBLIC
-     "-//Puppy Crawl//DTD Suppressions 1.0//EN"
-     "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
     <suppress checks=".*" files=".*[\\/]package-info\.java" />


### PR DESCRIPTION
## Description of Change

Discovered that the DTD locations were outdated http locations. Checkstyle project has them now published on checkstyle.org served with https. Also found that there have been some newer suppressions DTDs, so while updating the location and public ID to comply with current Checkstyle documentation also updated the suppressions file to point to the current version (which has been modified to allow more flexible filtering: `files` is no longer required and at least one of `checks` (previously required), `message` (new) or `id` (new) is required to be present as the item to filter)

## Have test cases been added to cover the new functionality?

N/A