### PR TITLE
chore(docs): Fixup javadoc warnings

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/lucene/AlphaNumericFilter.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/lucene/AlphaNumericFilter.java
@@ -28,9 +28,10 @@ import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 /**
  * A simple alphanumeric filter that removes non-alphanumeric characters from
  * the terms. If a term contains a non-alphanumeric character it may be split
- * into multiple terms:
+ * into multiple terms.
  *
- * <table summary="Example filtering">
+ * <table>
+ * <caption>Filtering examples</caption>
  * <tr><th>term</th><th>results in</th></tr>
  * <tr><td>bob</td><td>bob</td></tr>
  * <tr><td>bob-cat</td><td>bob cat</td></tr>

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DatabaseProperties.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DatabaseProperties.java
@@ -110,9 +110,8 @@ public class DatabaseProperties {
      *
      * @param key the property key
      * @param value the property value
-     * @throws UpdateException is thrown if there is an update exception
      */
-    public synchronized void save(String key, String value) throws UpdateException {
+    public synchronized void save(String key, String value) {
         properties.put(key, value);
         cveDB.saveProperty(key, value);
     }
@@ -194,7 +193,7 @@ public class DatabaseProperties {
      * @param key the property key
      * @param timestamp the zoned date time
      */
-    public void save(String key, ZonedDateTime timestamp) throws UpdateException {
+    public void save(String key, ZonedDateTime timestamp) {
         final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ssX");
         save(key, dtf.format(timestamp));
     }
@@ -206,7 +205,7 @@ public class DatabaseProperties {
      * @param key the property key
      * @param timestamp the zoned date time
      */
-    public static void setTimestamp(Properties properties, String key, ZonedDateTime timestamp) throws UpdateException {
+    public static void setTimestamp(Properties properties, String key, ZonedDateTime timestamp) {
         final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ssX");
         properties.put(key, dtf.format(timestamp));
     }

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/H2Functions.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/H2Functions.java
@@ -458,7 +458,7 @@ public final class H2Functions {
      * @param requiredAction the action required
      * @param dueDate the due date
      * @param notes notes
-     * @throws SQLException
+     * @throws SQLException thrown if there is a database error merging the Known Exploited information to the database
      */
     public static void mergeKnownExploited(final Connection conn, String cveId,
             String vendorProject, String product, String vulnerabilityName,

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/NvdApiDataSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/NvdApiDataSource.java
@@ -591,7 +591,8 @@ public class NvdApiDataSource implements CachedWebDataSource {
     /**
      * Downloads the metadata properties of the NVD API cache.
      *
-     * @param url the URL to the NVD API cache
+     * @param url the base URL to the NVD API cache
+     * @param pattern the pattern of the datafile name for the NVD API cache
      * @return the cache properties
      * @throws UpdateException thrown if the properties file could not be
      * downloaded

--- a/core/src/main/java/org/owasp/dependencycheck/utils/PyPACoreMetadataParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/PyPACoreMetadataParser.java
@@ -64,6 +64,7 @@ public final class PyPACoreMetadataParser {
      *         The Wheel metadata of a Python package as a File
      *
      * @return The metadata properties read from the file
+     * @throws AnalysisException thrown if there is an analysis exception
      */
     public static Properties getProperties(File file) throws AnalysisException {
         try (BufferedReader utf8Reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {

--- a/core/src/main/java/org/owasp/dependencycheck/utils/SeverityUtil.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/SeverityUtil.java
@@ -128,7 +128,7 @@ public final class SeverityUtil {
      * @param severity The textual severity, may be null
      * @return A float that can be used to numerically sort vulnerabilities in
      * approximated severity (highest float represents highest severity).
-     * @see #sortAdjustedCVSSv3BaseScore(float)
+     * @see #sortAdjustedCVSSv3BaseScore(Double)
      */
     public static Double estimatedSortAdjustedCVSSv3(final String severity) {
         switch (Severity.forUnscored(severity)) {

--- a/core/src/main/java/org/owasp/dependencycheck/xml/pom/Model.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/pom/Model.java
@@ -350,7 +350,7 @@ public class Model implements Serializable {
     /**
      * Replaces the group/artifact/version obtained from the `pom.xml` which may
      * contain variable references with the interpolated values of the
-     * <a href="https://maven.apache.org/shared/maven-archiver/#pom-properties-content>pom.properties</a>
+     * <a href="https://maven.apache.org/shared/maven-archiver/#pom-properties-content">pom.properties</a>
      * content (when present). Validates that at least the documented properties
      * for the G/A/V coordinates are all present. If not it will leave the model
      * unmodified as the property-source was apparently not a valid

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2159,6 +2159,8 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      *
      * @return a newly instantiated <code>Engine</code>
      * @throws DatabaseException thrown if there is a database exception
+     * @throws MojoExecutionException on configuration errors when failOnError is true
+     * @throws MojoFailureException on configuration errors when failOnError is false
      */
     protected Engine initializeEngine() throws DatabaseException, MojoExecutionException, MojoFailureException {
         populateSettings();

--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,19 @@ Copyright (c) 2012 - Jeremy Long
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${maven-javadoc-plugin.version}</version>
+                    <configuration>
+                        <tags>
+                            <!-- see https://openjdk.org/jeps/8068562#Implementation
+                                 the  apiNote / implNote / implSpec
+                                 need to be supplied to javadoc tool when used
+                             -->
+                            <tag>
+                                <name>implNote</name>
+                                <placement>a</placement>
+                                <head>Implementation Note:</head>
+                            </tag>
+                        </tags>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
@@ -67,6 +67,10 @@ import java.util.Locale;
 
 import static java.lang.String.format;
 
+/**
+ * A Utility class to centralize download logic like HTTP(S) proxy configuration and proxy- and server credential handling.
+ * @author Jeremy Long, Hans Aikema
+ */
 public final class Downloader {
 
     /**
@@ -267,10 +271,10 @@ public final class Downloader {
      *
      * @param url        the URL of the file to download
      * @param outputPath the path to the save the file to
-     * @throws org.owasp.dependencycheck.utils.DownloadFailedException is thrown
-     *                                                                 if there is an error downloading the file
-     * @throws TooManyRequestsException                                thrown when a 429 is received
-     * @throws ResourceNotFoundException                               thrown when a 404 is received
+     * @throws DownloadFailedException       is thrown if there is an error downloading the file
+     * @throws URLConnectionFailureException is thrown when certificate-chain trust errors occur downloading the file
+     * @throws TooManyRequestsException      thrown when a 429 is received
+     * @throws ResourceNotFoundException     thrown when a 404 is received
      */
     public void fetchFile(URL url, File outputPath)
             throws DownloadFailedException, TooManyRequestsException, ResourceNotFoundException, URLConnectionFailureException {
@@ -284,10 +288,10 @@ public final class Downloader {
      * @param outputPath the path to the save the file to
      * @param useProxy   whether to use the configured proxy when downloading
      *                   files
-     * @throws org.owasp.dependencycheck.utils.DownloadFailedException is thrown
-     *                                                                 if there is an error downloading the file
-     * @throws TooManyRequestsException                                thrown when a 429 is received
-     * @throws ResourceNotFoundException                               thrown when a 404 is received
+     * @throws DownloadFailedException       is thrown if there is an error downloading the file
+     * @throws URLConnectionFailureException is thrown when certificate-chain trust errors occur downloading the file
+     * @throws TooManyRequestsException      thrown when a 429 is received
+     * @throws ResourceNotFoundException     thrown when a 404 is received
      */
     public void fetchFile(URL url, File outputPath, boolean useProxy) throws DownloadFailedException,
             TooManyRequestsException, ResourceNotFoundException, URLConnectionFailureException {
@@ -342,10 +346,10 @@ public final class Downloader {
      *                    files
      * @param userKey     the settings key for the username to be used
      * @param passwordKey the settings key for the password to be used
-     * @throws org.owasp.dependencycheck.utils.DownloadFailedException is thrown
-     *                                                                 if there is an error downloading the file
-     * @throws TooManyRequestsException                                thrown when a 429 is received
-     * @throws ResourceNotFoundException                               thrown when a 404 is received
+     * @throws DownloadFailedException       is thrown if there is an error downloading the file
+     * @throws URLConnectionFailureException is thrown when certificate-chain trust errors occur downloading the file
+     * @throws TooManyRequestsException      thrown when a 429 is received
+     * @throws ResourceNotFoundException     thrown when a 404 is received
      * @implNote This method should only be used in cases where the target host cannot be determined beforehand from settings, so that ad-hoc
      * Credentials needs to be constructed for the target URL when the user/password keys point to configured credentials. The method delegates to
      * {@link #fetchFile(URL, File, boolean)} when credentials are not configured for the given keys or the resource points to a file.
@@ -393,15 +397,15 @@ public final class Downloader {
     /**
      * Posts a payload to the URL and returns the response as a string.
      *
-     * @param url     the URL to POST to
-     * @param payload the Payload to post
+     * @param url         the URL to POST to
+     * @param payload     the Payload to post
      * @param payloadType the string describing the payload's mime-type
-     * @param hdr Additional headers to add to the HTTP request
+     * @param hdr         Additional headers to add to the HTTP request
      * @return the content of the response
-     * @throws DownloadFailedException   is thrown if there is an error
-     *                                   downloading the file
-     * @throws TooManyRequestsException  thrown when a 429 is received
-     * @throws ResourceNotFoundException thrown when a 404 is received
+     * @throws DownloadFailedException       is thrown if there is an error downloading the file
+     * @throws URLConnectionFailureException is thrown when certificate-chain trust errors occur downloading the file
+     * @throws TooManyRequestsException      thrown when a 429 is received
+     * @throws ResourceNotFoundException     thrown when a 404 is received
      */
     public String postBasedFetchContent(URI url, String payload, ContentType payloadType, List<Header> hdr)
             throws DownloadFailedException, TooManyRequestsException, ResourceNotFoundException, URLConnectionFailureException {

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/ExplicitEncodingToStringResponseHandler.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/ExplicitEncodingToStringResponseHandler.java
@@ -24,6 +24,11 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
+/**
+ * A responseHandler that uses an explicit client-defined characterset to interpret the response payload as a string.
+ *
+ * @author Hans Aikema
+ */
 public class ExplicitEncodingToStringResponseHandler extends AbstractHttpClientResponseHandler<String> {
 
     /**


### PR DESCRIPTION
## Description of Change

While looking at build output I spotted a series of Javadoc warnings and errors.

The changes fixup javadoc warnings on missing documentation parts and invalid HTML5 constructs. Partly by fixing the documentation and partly by removing unneeded (and undocumented) throws-clauses for exceptions that are never thrown by the method body.
Also includes a configuration fix for the javadoc plugin to make Javadoc aware of the `@implNote` javadoc tag that is standardized in Java 8, but not yet by default supported by the Javadoc tool, so that it requires explicit activation as a custom tag.

## Have test cases been added to cover the new functionality?

N/A