### PR TITLE
fix(fp): Improve suppression for Glassfish Server false positives

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1556,9 +1556,9 @@
 </suppress>
 <suppress base="true">
    <notes><![CDATA[
-   FP per issue #6626
+   hand-curated better suppression for FP per issues #6626 and #7015
    ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.glassfish\.expressly/expressly@.*$</packageUrl>
+   <packageUrl regex="true">^pkg:maven/org\.glassfish\.(?!main).*$</packageUrl>
    <cpe>cpe:/a:eclipse:glassfish</cpe>
 </suppress>
 <suppress base="true">


### PR DESCRIPTION
## Fixes Issue #

- fixes #7015

## Description of Change

Changes existing suppression to more generic, to exclude all org.glassfish maven artifacts other than `org.glassfish.main` where the main Glassfish Server is published.

## Have test cases been added to cover the new functionality?

N/A