### PR TITLE
fix(fp): Improve suppression for Glassfish Server false positives (round 2)

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1556,9 +1556,9 @@
 </suppress>
 <suppress base="true">
    <notes><![CDATA[
-   hand-curated better suppression for FP per issues #6626 and #7015
+   hand-curated better suppression for FP per issues #6626, #7015, #7019, #7020, #7021, #7022
    ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.glassfish\.(?!main).*$</packageUrl>
+   <packageUrl regex="true">^pkg:maven/org\.glassfish(?!\.main).*$</packageUrl>
    <cpe>cpe:/a:eclipse:glassfish</cpe>
 </suppress>
 <suppress base="true">


### PR DESCRIPTION
## Fixes Issue #
- fixes #7019
- fixes #7020
- fixes #7021
- fixes #7022
- fixes comment at https://github.com/jeremylong/DependencyCheck/pull/7016#issuecomment-2401802196 re `org.glassfish/jakarta.json`

## Description of Change

Extends suppression from #7016  to also suppress for projects under the `org.glassfish` group; such as `javax.json`, `jakarta.json` etc. it seems the full Glassfish server has always been published under `org.glassfish.main`, although there are probably artifacts in subgroup for `.main` which are also false positives, so might require someone with more familiarity with Glassfish server to tweak further.

## Have test cases been added to cover the new functionality?

N/A