### PR TITLE
fix: Fixup parameter sequence for Dowloader credentials

### DIFF
--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
@@ -202,8 +202,8 @@ public final class Downloader {
     private void tryAddNexusAnalyzerCredentials(Settings settings, CredentialsStore credentialsStore) throws InvalidSettingException {
         if (settings.getString(Settings.KEYS.ANALYZER_NEXUS_PASSWORD) != null) {
             addUserPasswordCreds(settings, credentialsStore,
-                    Settings.KEYS.ANALYZER_NEXUS_URL,
                     Settings.KEYS.ANALYZER_NEXUS_USER,
+                    Settings.KEYS.ANALYZER_NEXUS_URL,
                     Settings.KEYS.ANALYZER_NEXUS_PASSWORD,
                     "Nexus Analyzer");
         }
@@ -212,8 +212,8 @@ public final class Downloader {
     private void tryAddNVDApiDatafeed(Settings settings, CredentialsStore credentialsStore) throws InvalidSettingException {
         if (settings.getString(Settings.KEYS.NVD_API_DATAFEED_PASSWORD) != null) {
             addUserPasswordCreds(settings, credentialsStore,
-                    Settings.KEYS.NVD_API_DATAFEED_URL,
                     Settings.KEYS.NVD_API_DATAFEED_USER,
+                    Settings.KEYS.NVD_API_DATAFEED_URL,
                     Settings.KEYS.NVD_API_DATAFEED_PASSWORD,
                     "NVD API Datafeed");
         }


### PR DESCRIPTION
## Description of Change

While working on (still work in progress) also using HTTPClient for access to Nexus I encountered an authentication issue due to an improper sequence of arguments for some of the tryAdd...Credentials methods that was overlooked in the changes of PR #6949. Two occurrences had the arguments accidentally coded as the sequence urlkey, userkey, passwordkey instead of the userkey, urlkey, passwordkey required by the `addUserPasswordCreds` method

## Have test cases been added to cover the new functionality?

no