### PR TITLE
fix(fp): Suppress the whole CPE for the mysql server against mysql connectors

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1922,3 +1922,13 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
 <packageUrl regex="true">^pkg:maven/io\.prometheus/prometheus-.*$</packageUrl>
 <cpe>cpe:/a:prometheus:prometheus</cpe>
 </suppress>
+<suppress base="true">
+   <notes><![CDATA[
+   Original suppression as per #952 suppressed individual CVEs.
+   As per false negative #7057 MySQL java connector has CPEs of its own, so it's proper to suppress the server CPE
+   NOTE: the additional colon in the CPE is required to not match on prefix with cpe:/a:mysql:mysql_connector_j etc
+   ]]></notes>
+   <gav regex="true">^(mysql:mysql-connector-java|com\.mysql:mysql-connector-j|org\.drizzle\.jdbc:drizzle-jdbc):.*$</gav>
+   <cpe>cpe:/a:mysql:mysql:</cpe>
+   <cpe>cpe:/a:oracle:mysql:</cpe>
+</suppress>


### PR DESCRIPTION
## Fixes Issue #

- fixes #7057

## Description of Change

Current suppressions are in the base suppressions packaged with ODC here

https://github.com/jeremylong/DependencyCheck/blob/main/core/src/main/resources/dependencycheck-base-suppression.xml#L3210-L3818

The connectors have their own CPEs as a group and individually, so there is no reason to be doing this and it's impossible to maintain. If CVEs are mapped incorrectly, they should be fixed upstream to map to the connector CPEs.

```
cpe:2.3:a:oracle:mysql_connector\/j:9.0.0:*:*:*:*:*:*:* 
cpe:2.3:a:oracle:mysql_connectorsj:9.0.0:*:*:*:*:*:*:* 
```

As has been done with postgres, switching this to suppressing the server CPEs directly.

One mystery is that to get this to work I needed to suppress `cpe:/a:oracle:mysql:` whereas most existing suppressions are against the old deprecated CPE `cpe:/a:mysql:mysql:` before its rename and seem to work OK (I guess ODC has magic to understand the renames that doesn't always work?). 

I will follow-up this PR to tidy the base suppression file when/if this is merged and published to `generatedSuppressions`.

WDYT @aikebah ?

## Have test cases been added to cover the new functionality?

N/A