### PR TITLE
false positives for jetcd libraries

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1978,3 +1978,18 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
    <packageUrl regex="true">^pkg:maven/com\.azure/azure-core-amqp@.*$</packageUrl>
    <cpe>cpe:/a:microsoft:azure_cli</cpe>
 </suppress>
+<suppress>
+   <notes><![CDATA[
+   FP per issue #7123
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.etcd/jetcd-[a-z]*@.*$</packageUrl>
+   <cpe>cpe:/a:redhat:etcd</cpe>
+   <cpe>cpe:/a:etcd:etcd</cpe>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   FP per issue #7123
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.etcd/jetcd-grpc@.*$</packageUrl>
+   <cpe>cpe:/a:grpc:grpc</cpe>
+</suppress>


### PR DESCRIPTION
## Fixes Issue #7123


## Description of Change

* jetcd libraries (core, api, grpc) were treated as etcd server (similar to issue #6981)
* jetcd-grpc was treated as io.grpc library (which it includes)


## Have test cases been added to cover the new functionality?

no