### PR TITLE
fix: Gracefully handle CVEs with bad configuration nodes missing CPE match expressions

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveItemOperator.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveItemOperator.java
@@ -18,6 +18,8 @@
 package org.owasp.dependencycheck.data.nvdcve;
 
 import io.github.jeremylong.openvulnerability.client.nvd.Config;
+
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.owasp.dependencycheck.data.nvd.ecosystem.Ecosystem;
 
@@ -219,15 +221,15 @@ public class CveItemOperator {
     boolean testCveCpeStartWithFilter(final DefCveItem cve) {
         if (cve.getCve().getConfigurations() != null) {
             //cycle through to see if this is a CPE we care about (use the CPE filters
-            final boolean result = cve.getCve().getConfigurations().stream()
+            return cve.getCve().getConfigurations().stream()
                     .map(Config::getNodes)
                     .flatMap(List::stream)
-                    .filter(node -> node != null)
+                    .filter(Objects::nonNull)
                     .map(Node::getCpeMatch)
+                    .filter(Objects::nonNull)
                     .flatMap(List::stream)
                     .filter(cpe -> cpe != null && cpe.getCriteria() != null)
                     .anyMatch(cpe -> cpe.getCriteria().startsWith(cpeStartsWithFilter));
-            return result;
         }
         return false;
     }

--- a/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/CveItemOperatorTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/CveItemOperatorTest.java
@@ -33,6 +33,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 /**
@@ -87,6 +88,33 @@ public class CveItemOperatorTest {
         boolean result = instance.testCveCpeStartWithFilter(cve);
         assertEquals(expResult, result);
 
+    }
+
+    @Test
+    public void testTestCveCpeStartWithFilterForConfigurationWithoutCpeMatches() {
+        ZonedDateTime published = ZonedDateTime.now();
+        ZonedDateTime lastModified = ZonedDateTime.now();
+        LocalDate cisaExploitAdd = null;
+        LocalDate cisaActionDue = null;
+        List<CveTag> cveTags = null;
+        List<LangString> descriptions = null;
+        List<Reference> references = null;
+        Metrics metrics = null;
+        List<Weakness> weaknesses = null;
+
+        Node noCpeMatches = new Node(Node.Operator.OR, null, null);
+        Config c = new Config(Config.Operator.AND, null, List.of(noCpeMatches));
+        List<VendorComment> vendorComments = null;
+        CveItem cveItem = new CveItem("id", "sourceIdentifier", "vulnStatus", published, lastModified,
+                "evaluatorComment", "evaluatorSolution", "evaluatorImpact", cisaExploitAdd, cisaActionDue,
+                "cisaRequiredAction", "cisaVulnerabilityName", cveTags, descriptions, references, metrics,
+                weaknesses, List.of(c), vendorComments);
+
+        DefCveItem cve = new DefCveItem(cveItem);
+        CveItemOperator instance = new CveItemOperator("cpe:2.3:o:");
+        boolean expResult = false;
+        boolean result = instance.testCveCpeStartWithFilter(cve);
+        assertEquals(expResult, result);
     }
 
 }


### PR DESCRIPTION
- fixes #7121

## Description of Change

The NVD API sometimes returns nodes (`OR`, `AND` etc) for `configuration`s that are missing the required `cpeMatch` array implied by the schema at https://csrc.nist.gov/schema/nvd/api/2.0/cve_api_json_2.0.schema

While the data is bad, it'd probably be better for ODC to be robust to handle these when checking for matches. The change ignores attempting to match configurations which have no `cpeMatch` array (treats the same as an empty array).

## Have test cases been added to cover the new functionality?

yes