### PR TITLE
chore: cleanup base suppression

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -6975,13 +6975,6 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per issue #6981
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/io\.etcd/jetcd-core@.*$</packageUrl>
-        <cpe>cpe:/a:etcd:etcd</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
         FP per issue #6981 - manual addition prometheus java_client libraries
         seen as the prometheus server, but they would receive product client_java
         (no CPE yet, but observed from the existing CPE for the go client client_go)


### PR DESCRIPTION
PR #7137 cleanse-up older suppressions in the generated suppression file that have already been copied into the base suppression file.