### PR TITLE
docs: update documentation for Gradle plugin

### DIFF
--- a/src/site/markdown/dependency-check-gradle/configuration-aggregate.md
+++ b/src/site/markdown/dependency-check-gradle/configuration-aggregate.md
@@ -69,10 +69,8 @@ proxy        | nonProxyHosts     | The list of hosts that do not use a proxy. | 
 #### Example
 ```groovy
 dependencyCheck {
-    proxy {
-        server=some.proxy.server
-        port=8989
-    }
+    proxy.server=some.proxy.server
+    proxy.port=8989
 }
 ```
 
@@ -103,9 +101,7 @@ data         | password          | The password used when connecting to the data
 #### Example
 ```groovy
 dependencyCheck {
-    data {
-        directory='d:/nvd'
-    }
+    data.directory='d:/nvd'
 }
 ```
 
@@ -192,15 +188,9 @@ hostedSuppressions | validForHours   | The number of hours to wait before checki
 #### Example
 ```groovy
 dependencyCheck {
-    analyzers {
-        assemblyEnabled=false
-        artifactory {
-            enabled=true
-            url='https://internal.artifactory.url'
-        }
-        retirejs {
-            filters = ['(i)copyright Jeremy Long']
-        }
-    }
+    analyzers.assemblyEnabled=false
+    analyzers.artifactory.enabled=true
+    analyzers.artifactory.url='https://internal.artifactory.url'
+    analyzers.retirejs.filters = ['(i)copyright Jeremy Long']
 }
 ```

--- a/src/site/markdown/dependency-check-gradle/configuration-purge.md
+++ b/src/site/markdown/dependency-check-gradle/configuration-purge.md
@@ -49,8 +49,6 @@ data         | directory         | Sets the data directory to hold SQL CVEs cont
 #### Example
 ```groovy
 dependencyCheck {
-    data {
-        directory='d:/nvd'
-    }
+    data.directory='d:/nvd'
 }
 ```

--- a/src/site/markdown/dependency-check-gradle/configuration-update.md
+++ b/src/site/markdown/dependency-check-gradle/configuration-update.md
@@ -49,10 +49,8 @@ proxy        | nonProxyHosts     | The list of hosts that do not use a proxy. | 
 #### Example
 ```groovy
 dependencyCheck {
-    proxy {
-        server=some.proxy.server
-        port=8989
-    }
+    proxy.server=some.proxy.server
+    proxy.port=8989
 }
 ```
 
@@ -85,8 +83,6 @@ hostedSuppressions | validForHours   | The number of hours to wait before checki
 #### Example
 ```groovy
 dependencyCheck {
-    data {
-        directory='d:/nvd'
-    }
+    data.directory='d:/nvd'
 }
 ```

--- a/src/site/markdown/dependency-check-gradle/configuration.md
+++ b/src/site/markdown/dependency-check-gradle/configuration.md
@@ -85,9 +85,7 @@ data         | password          | The password used when connecting to the data
 #### Example
 ```groovy
 dependencyCheck {
-    data {
-        directory='d:/nvd'
-    }
+    data.directory='d:/nvd'
 }
 ```
 


### PR DESCRIPTION
## Fixes Issue #

## Description of Change

Update the "Example" and "Advanced Configuration" sections of the Gradle plugin documentation to use non-deprecated code samples.

Using a closure to configure `proxy` or `data` is now deprecated:

https://github.com/dependency-check/dependency-check-gradle/blob/aaab86c7fa26a855a625999df24d6907f088ce85/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy#L229-L232

https://github.com/dependency-check/dependency-check-gradle/blob/aaab86c7fa26a855a625999df24d6907f088ce85/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy#L328-L337

When adding this plugin to a project today, I noticed that a code snippet in my `build.gradle`, similar to examples in the documentation, was highlighted in IntelliJ as being deprecated. I'm not super well versed in Gradle, but I was able to quickly find a fix which works for configuring the `DependencyCheckExtension` and does not rely on using a closure.

I don't know what the best way to update the `analyzers` code sample in the `configuration-aggregate` documentation would be, though:

https://github.com/jeremylong/DependencyCheck/blob/531743481768dd089f3f354284f8fd5495de77cf/src/site/markdown/dependency-check-gradle/configuration-aggregate.md?plain=1#L193-L206

https://github.com/dependency-check/dependency-check-gradle/blob/aaab86c7fa26a855a625999df24d6907f088ce85/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy#L307-L316

I feel like there's a better way to do it than the code below, so I did not include a change for this in my pull request. If anyone has suggestions on how to best write this configuration without using a closure, I'd love to hear your suggestions!
```groovy
dependencyCheck {
    analyzers.assemblyEnabled=false
    analyzers.artifactory.enabled=true
    analyzers.artifactory.url='https://internal.artifactory.url'
    analyzers.retirejs.filters = ['(i)copyright Jeremy Long']
}
```

## Have test cases been added to cover the new functionality?

*no* Because new functionality has not been added.