### PR TITLE
build(deps): Update codeql-action to v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -61,4 +61,4 @@ jobs:
        mvn -s settings.xml clean package -DskipTests=true --no-transfer-progress --batch-mode
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Update the codeql version used in the codeql-analysis workflow file to v3, given that v2 will be deprecated on 5 December 2024.

Spotted it's notification in the build-logs of main

```
Run github/codeql-action/init@v2
Warning: CodeQL Action v2 will be deprecated on December 5th, 2024. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/
```

## Have test cases been added to cover the new functionality?

N/A