### PR TITLE
chore: add chad as a FP approver

### DIFF
--- a/.github/workflows/false-positive-approvals.yml
+++ b/.github/workflows/false-positive-approvals.yml
@@ -17,7 +17,8 @@ jobs:
       contains(github.event.comment.body,'approved') &&
       (github.event.comment.user.login == 'jeremylong' ||
       github.event.comment.user.login == 'aikebah' || 
-      github.event.comment.user.login == 'nhumblot')  }}
+      github.event.comment.user.login == 'nhumblot' ||
+      github.event.comment.user.login == 'chadlwilson') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
@chadlwilson unless you object - we can add you as a false positive approver. You don't have to approve them if you do not want to. But you've been extremely helpful with your PRs and reviews.