### PR TITLE
fix: Tranform into UTC the last modified date from database

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/NvdApiDataSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/NvdApiDataSource.java
@@ -306,7 +306,9 @@ public class NvdApiDataSource implements CachedWebDataSource {
             builder.withEndpoint(endpoint);
         }
         if (lastModifiedRequest != null) {
-            final ZonedDateTime end = lastModifiedRequest.minusDays(-120);
+			// make it UTC as required by NvdCveClientBuilder#withLastModifiedFilter
+        	lastModifiedRequest=lastModifiedRequest.withZoneSameInstant( ZoneId.of("UTC") );
+            final ZonedDateTime end = lastModifiedRequest.plusDays(120);
             builder.withLastModifiedFilter(lastModifiedRequest, end);
         }
         final String key = settings.getString(Settings.KEYS.NVD_API_KEY);

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/NvdApiDataSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/NvdApiDataSource.java
@@ -307,7 +307,7 @@ public class NvdApiDataSource implements CachedWebDataSource {
         }
         if (lastModifiedRequest != null) {
             // make it UTC as required by NvdCveClientBuilder#withLastModifiedFilter
-            lastModifiedRequest=lastModifiedRequest.withZoneSameInstant(ZoneId.of("UTC"));
+            lastModifiedRequest = lastModifiedRequest.withZoneSameInstant(ZoneId.of("UTC"));
             final ZonedDateTime end = lastModifiedRequest.plusDays(120);
             builder.withLastModifiedFilter(lastModifiedRequest, end);
         }

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/NvdApiDataSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/NvdApiDataSource.java
@@ -306,8 +306,8 @@ public class NvdApiDataSource implements CachedWebDataSource {
             builder.withEndpoint(endpoint);
         }
         if (lastModifiedRequest != null) {
-			// make it UTC as required by NvdCveClientBuilder#withLastModifiedFilter
-        	lastModifiedRequest=lastModifiedRequest.withZoneSameInstant( ZoneId.of("UTC") );
+            // make it UTC as required by NvdCveClientBuilder#withLastModifiedFilter
+            lastModifiedRequest=lastModifiedRequest.withZoneSameInstant(ZoneId.of("UTC"));
             final ZonedDateTime end = lastModifiedRequest.plusDays(120);
             builder.withLastModifiedFilter(lastModifiedRequest, end);
         }


### PR DESCRIPTION
## Fixes Issue #
 - #7164 
 - #7219 
 - #7228

## Description of Change
 * [x] turn into UTC the last modified date retrieved from database
 * [x] change ``minusDays(-120)`` into ``plusDays(120)`` to enhance code legibility

## Have test cases been added to cover the new functionality?
n/a not a new functionality