### PR TITLE
feat: show from which dependency the CVE comes in failure report

### DIFF
--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -20,6 +20,8 @@ package org.owasp.dependencycheck.taskdefs;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.apache.tools.ant.BuildException;
@@ -35,6 +37,7 @@ import org.owasp.dependencycheck.agent.DependencyCheckScanAgent;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Vulnerability;
+import org.owasp.dependencycheck.dependency.naming.Identifier;
 import org.owasp.dependencycheck.exception.ExceptionCollection;
 import org.owasp.dependencycheck.exception.ReportException;
 import org.owasp.dependencycheck.reporting.ReportGenerator.Format;
@@ -2301,7 +2304,11 @@ public class Check extends Update {
                         || (failBuildOnCVSS <= 0.0f)) {
                     if (addName) {
                         addName = false;
-                        ids.append(NEW_LINE).append(d.getFileName()).append(": ");
+                        ids.append(NEW_LINE).append(d.getFileName()).append(" (")
+                           .append(Stream.concat(d.getSoftwareIdentifiers().stream(), d.getVulnerableSoftwareIdentifiers().stream())
+                                         .map(Identifier::getValue)
+                                         .collect(Collectors.joining(", ")))
+                           .append(") : ");
                         ids.append(v.getName());
                     } else {
                         ids.append(", ").append(v.getName());

--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -2308,8 +2308,8 @@ public class Check extends Update {
                            .append(Stream.concat(d.getSoftwareIdentifiers().stream(), d.getVulnerableSoftwareIdentifiers().stream())
                                          .map(Identifier::getValue)
                                          .collect(Collectors.joining(", ")))
-                           .append(") : ");
-                        ids.append(v.getName());
+                           .append("): ")
+                           .append(v.getName());
                     } else {
                         ids.append(", ").append(v.getName());
                     }

--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -338,7 +338,7 @@ public class App {
                            .append(Stream.concat(d.getSoftwareIdentifiers().stream(), d.getVulnerableSoftwareIdentifiers().stream())
                                          .map(Identifier::getValue)
                                          .collect(Collectors.joining(", ")))
-                           .append(") : ");
+                           .append("): ");
                         ids.append(v.getName()).append('(').append(score).append(')');
                     } else {
                         ids.append(", ").append(v.getName()).append('(').append(score).append(')');

--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.cli.ParseException;
 import org.apache.tools.ant.DirectoryScanner;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
@@ -31,6 +33,7 @@ import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Vulnerability;
 import org.apache.tools.ant.types.LogLevel;
 import org.owasp.dependencycheck.data.update.exception.UpdateException;
+import org.owasp.dependencycheck.dependency.naming.Identifier;
 import org.owasp.dependencycheck.exception.ExceptionCollection;
 import org.owasp.dependencycheck.exception.ReportException;
 import org.owasp.dependencycheck.utils.Downloader;
@@ -331,7 +334,11 @@ public class App {
                     }
                     if (addName) {
                         addName = false;
-                        ids.append(NEW_LINE).append(d.getFileName()).append(": ");
+                        ids.append(NEW_LINE).append(d.getFileName()).append(" (")
+                           .append(Stream.concat(d.getSoftwareIdentifiers().stream(), d.getVulnerableSoftwareIdentifiers().stream())
+                                         .map(Identifier::getValue)
+                                         .collect(Collectors.joining(", ")))
+                           .append(") : ");
                         ids.append(v.getName()).append('(').append(score).append(')');
                     } else {
                         ids.append(", ").append(v.getName()).append('(').append(score).append(')');

--- a/core/src/main/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgent.java
+++ b/core/src/main/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgent.java
@@ -1015,8 +1015,8 @@ public class DependencyCheckScanAgent {
                            .append(Stream.concat(d.getSoftwareIdentifiers().stream(), d.getVulnerableSoftwareIdentifiers().stream())
                                          .map(Identifier::getValue)
                                          .collect(Collectors.joining(", ")))
-                           .append("): ");
-                        ids.append(v.getName());
+                           .append("): ")
+                           .append(v.getName());
                     } else {
                         ids.append(", ").append(v.getName());
                     }

--- a/core/src/main/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgent.java
+++ b/core/src/main/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgent.java
@@ -1015,7 +1015,7 @@ public class DependencyCheckScanAgent {
                            .append(Stream.concat(d.getSoftwareIdentifiers().stream(), d.getVulnerableSoftwareIdentifiers().stream())
                                          .map(Identifier::getValue)
                                          .collect(Collectors.joining(", ")))
-                           .append(") : ");
+                           .append("): ");
                         ids.append(v.getName());
                     } else {
                         ids.append(", ").append(v.getName());

--- a/core/src/main/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgent.java
+++ b/core/src/main/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgent.java
@@ -1011,7 +1011,11 @@ public class DependencyCheckScanAgent {
                         || (failBuildOnCVSS <= 0.0f)) {
                     if (addName) {
                         addName = false;
-                        ids.append(NEW_LINE).append(d.getFileName()).append(": ");
+                        ids.append(NEW_LINE).append(d.getFileName()).append(" (")
+                           .append(Stream.concat(d.getSoftwareIdentifiers().stream(), d.getVulnerableSoftwareIdentifiers().stream())
+                                         .map(Identifier::getValue)
+                                         .collect(Collectors.joining(", ")))
+                           .append(") : ");
                         ids.append(v.getName());
                     } else {
                         ids.append(", ").append(v.getName());

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -21,6 +21,8 @@ import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL.StandardTypes;
 import com.github.packageurl.PackageURL;
 import io.github.jeremylong.jcs3.slf4j.Slf4jAdapter;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
@@ -2662,8 +2664,12 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                     }
                     if (addName) {
                         addName = false;
-                        ids.append(NEW_LINE).append(d.getFileName()).append(": ");
-                        ids.append(name);
+                        ids.append(NEW_LINE).append(d.getFileName()).append(" (")
+                           .append(Stream.concat(d.getSoftwareIdentifiers().stream(), d.getVulnerableSoftwareIdentifiers().stream())
+                                         .map(Identifier::getValue)
+                                         .collect(Collectors.joining(", ")))
+                           .append(") : ");
+                        ids.append(v.getName());
                     } else {
                         ids.append(", ").append(name);
                     }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2668,8 +2668,8 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                            .append(Stream.concat(d.getSoftwareIdentifiers().stream(), d.getVulnerableSoftwareIdentifiers().stream())
                                          .map(Identifier::getValue)
                                          .collect(Collectors.joining(", ")))
-                           .append("): ");
-                        ids.append(name);
+                           .append("): ")
+                           .append(name);
                     } else {
                         ids.append(", ").append(name);
                     }

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2668,8 +2668,8 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                            .append(Stream.concat(d.getSoftwareIdentifiers().stream(), d.getVulnerableSoftwareIdentifiers().stream())
                                          .map(Identifier::getValue)
                                          .collect(Collectors.joining(", ")))
-                           .append(") : ");
-                        ids.append(v.getName());
+                           .append("): ");
+                        ids.append(name);
                     } else {
                         ids.append(", ").append(name);
                     }


### PR DESCRIPTION
## Fixes Issue #7223

## Description of Change

Show the software identifiers in the failure report. So that it's clear from which dependency the CVE comes.

## Have test cases been added to cover the new functionality?

*no* (N/A)