### PR TITLE
chore: Improve pull request template to encourage issue linking

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,16 @@
-## Fixes Issue #
-
 ## Description of Change
 
-*Please add a description of the proposed change*
+<!--
+Please add a description of the proposed change
+-->
+
+## Related issues
+
+<!--
+e.g 
+- fixes #xxxx
+- relates to #xxxx
+-->
 
 ## Have test cases been added to cover the new functionality?
 


### PR DESCRIPTION
## Description of Change

I've noticed that the format of the pull request template seems to often causes PRs to not be properly linked to the issues they fix, meaning the issues don't get closed/resolved automatically when the PR is merged.

This change encourages folks to set the PR description so it will link the issues and reduce issue maintenance overhead.

## Have test cases been added to cover the new functionality?

N/A