### PR TITLE
build(deps): bump logback from 1.2.11 to 1.2.13 (#7156)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@ Copyright (c) 2012 - Jeremy Long
         
         <!-- upgrading slf4j and logback can cause issues ;) https://github.com/jeremylong/DependencyCheck/issues/4846 -->
         <slf4j.version>1.7.36</slf4j.version>
-        <logback.version>1.2.11</logback.version>
+        <logback.version>1.2.13</logback.version>
         
         <maven.api.version>3.6.3</maven.api.version>
         <reporting.checkstyle-plugin.version>3.6.0</reporting.checkstyle-plugin.version>


### PR DESCRIPTION
## Description of Change

Upgrades logback version from `1.2.11` to `1.2.13` so Dependency Check stops flagging logback as being vulnerable to [ CVE-2023-6378](https://github.com/advisories/GHSA-vmq6-5m68-f53m). As it is just a patch update, [this prevent requiring to upgrade slf4j at the same time and having to deal with breaking changes](https://github.com/jeremylong/DependencyCheck/pull/6178#issuecomment-1855568652).

## Related issues

- relates to #7156 

## Have test cases been added to cover the new functionality?

*no*