### PR TITLE
feat: Use Maven settings decryption API for decrypting secrets from settings.xml

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -153,8 +153,8 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <artifactId>maven-reporting-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.sonatype.plexus</groupId>
-            <artifactId>plexus-sec-dispatcher</artifactId>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings-builder</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,6 @@ Copyright (c) 2012 - Jeremy Long
         <maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>
         <maven-reporting-api.version>4.0.0</maven-reporting-api.version>
         <org.apache.velocity.version>2.4.1</org.apache.velocity.version>
-        <plexus-sec-dispatcher.version>1.4</plexus-sec-dispatcher.version>
         <maven-dependency-tree.version>3.3.0</maven-dependency-tree.version>
         <org.glassfish.javax.json.version>1.1.4</org.glassfish.javax.json.version>
         <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
@@ -1192,6 +1191,12 @@ Copyright (c) 2012 - Jeremy Long
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-settings-builder</artifactId>
+                <version>${maven.api.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.maven.plugin-testing</groupId>
                 <artifactId>maven-plugin-testing-harness</artifactId>
                 <version>${maven-plugin-testing-harness.version}</version>
@@ -1216,11 +1221,6 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.apache.velocity</groupId>
                 <artifactId>velocity-engine-core</artifactId>
                 <version>${org.apache.velocity.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.sonatype.plexus</groupId>
-                <artifactId>plexus-sec-dispatcher</artifactId>
-                <version>${plexus-sec-dispatcher.version}</version>
             </dependency>
             <!-- upgrading beyond 2.2 requires reworking the dependency resolution -->
             <dependency>


### PR DESCRIPTION
## Description of Change

Replace the use of the plexus-security library, that is considered part of maven's internals for the official maven API for decrypting encrypted secrets from settings.xml.

## Related issues

fixes #7279 

## Have test cases been added to cover the new functionality?

no