### PR TITLE
feat: ArtifactoryAnalyzer updated to use the HTTPClient5-based Downloader and skip unusable results

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchResponseHandler.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchResponseHandler.java
@@ -1,0 +1,200 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2018 - 2024 Nicolas Henneaux; Hans Aikema. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.artifactory;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.owasp.dependencycheck.data.nexus.MavenArtifact;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class ArtifactorySearchResponseHandler implements HttpClientResponseHandler<List<MavenArtifact>> {
+    /**
+     * Pattern to match the path returned by the Artifactory AQL API.
+     */
+    private static final Pattern PATH_PATTERN = Pattern.compile("^/(?<groupId>.+)/(?<artifactId>[^/]+)/(?<version>[^/]+)/[^/]+$");
+
+    /**
+     * Used for logging.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactorySearchResponseHandler.class);
+
+    /**
+     * Search result reader
+     */
+    private final ObjectReader fileImplReader;
+
+    /**
+     * The dependency that is expected to be in the response from Artifactory (if found)
+     */
+    private final Dependency expectedDependency;
+
+    /**
+     * Creates a responsehandler for the response on a single dependency-search attempt.
+     *
+     * @param dependency The dependency that is expected to be in the response when found (for validating the FileItem(s) in the response)
+     */
+    ArtifactorySearchResponseHandler(Dependency dependency) {
+        this.fileImplReader = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).readerFor(FileImpl.class);
+        this.expectedDependency = dependency;
+    }
+
+    protected boolean init(JsonParser parser) throws IOException {
+        com.fasterxml.jackson.core.JsonToken nextToken = parser.nextToken();
+        if (nextToken != com.fasterxml.jackson.core.JsonToken.START_OBJECT) {
+            throw new IOException("Expected " + com.fasterxml.jackson.core.JsonToken.START_OBJECT + ", got " + nextToken);
+        }
+
+        do {
+            nextToken = parser.nextToken();
+            if (nextToken == null) {
+                break;
+            }
+
+            if (nextToken.isStructStart()) {
+                if (nextToken == com.fasterxml.jackson.core.JsonToken.START_ARRAY && "results".equals(parser.currentName())) {
+                    return true;
+                } else {
+                    parser.skipChildren();
+                }
+            }
+        } while (true);
+
+        return false;
+    }
+
+    /**
+     * Validates the hashes of the dependency.
+     *
+     * @param checksums the collection of checksums (md5, sha1, [sha256])
+     * @return Whether all available hashes match
+     */
+    private boolean checkHashes(ChecksumsImpl checksums) {
+        final String md5sum = expectedDependency.getMd5sum();
+        final String hashMismatchFormat = "Artifact found by API is not matching the {} of the artifact (repository hash is {} while actual is {}) !";
+        boolean match = true;
+        if (!checksums.getMd5().equals(md5sum)) {
+            LOGGER.warn(hashMismatchFormat, "md5", md5sum, checksums.getMd5());
+            match = false;
+        }
+        final String sha1sum = expectedDependency.getSha1sum();
+        if (!checksums.getSha1().equals(sha1sum)) {
+            LOGGER.warn(hashMismatchFormat, "sha1", sha1sum, checksums.getSha1());
+            match = false;
+        }
+        final String sha256sum = expectedDependency.getSha256sum();
+        /* For sha256 we need to validate that the checksum is non-null in the artifactory response.
+         * Extract from Artifactory documentation:
+         * New artifacts that are uploaded to Artifactory 5.5 and later will automatically have their SHA-256 checksum calculated.
+         * However, artifacts that were already hosted in Artifactory before the upgrade will not have their SHA-256 checksum in the database yet.
+         * To make full use of Artifactory's SHA-256 capabilities, you need to Migrate the Database to Include SHA-256 making sure that the record
+         * for each artifact includes its SHA-256 checksum.
+         */
+        if (checksums.getSha256() != null && !checksums.getSha256().equals(sha256sum)) {
+            LOGGER.warn(hashMismatchFormat, "sha256", sha256sum, checksums.getSha256());
+            match = false;
+        }
+        return match;
+    }
+
+    /**
+     * Process the Artifactory response.
+     *
+     * @param response the HTTP response
+     * @return a list of the Maven Artifact informations that match the searched dependency hash
+     * @throws FileNotFoundException When a matching artifact is not found
+     * @throws IOException           thrown if there is an I/O error
+     */
+    @Override
+    public List<MavenArtifact> handleResponse(ClassicHttpResponse response) throws IOException {
+        final List<MavenArtifact> result = new ArrayList<>();
+
+        try (InputStreamReader streamReader = new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8);
+             JsonParser parser = fileImplReader.getFactory().createParser(streamReader)) {
+
+            if (init(parser) && parser.nextToken() == JsonToken.START_OBJECT) {
+                // at least one result
+                do {
+                    final FileImpl file = fileImplReader.readValue(parser);
+
+                    final Optional<Matcher> validationResult = validateUsability(file);
+                    if (validationResult.isEmpty()) {
+                        continue;
+                    }
+                    final Matcher pathMatcher = validationResult.get();
+
+                    final String groupId = pathMatcher.group("groupId").replace('/', '.');
+                    final String artifactId = pathMatcher.group("artifactId");
+                    final String version = pathMatcher.group("version");
+
+                    result.add(new MavenArtifact(groupId, artifactId, version, file.getDownloadUri(),
+                            MavenArtifact.derivePomUrl(artifactId, version, file.getDownloadUri())));
+
+                } while (parser.nextToken() == JsonToken.START_OBJECT);
+            } else {
+                throw new FileNotFoundException("Artifact " + expectedDependency + " not found in Artifactory");
+            }
+        }
+        if (result.isEmpty()) {
+            throw new FileNotFoundException("Artifact " + expectedDependency
+                    + " not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts");
+        }
+        return result;
+    }
+
+    /**
+     * Validate the FileImpl result for usability as a dependency.
+     * <br/>
+     * Checks that the actually matches all known hashes and the path appears to match a maven repository G/A/V pattern.
+     *
+     * @param file The FileImpl from an Artifactory search response
+     * @return An Optional with the Matcher for the file path to retrieve the Maven G/A/V coordinates in case result is usable for further
+     * processing, otherwise an empty Optional.
+     */
+    private Optional<Matcher> validateUsability(FileImpl file) {
+        final Optional<Matcher> result;
+        if (!checkHashes(file.getChecksums())) {
+            result = Optional.empty();
+        } else {
+            final Matcher pathMatcher = PATH_PATTERN.matcher(file.getPath());
+            if (!pathMatcher.matches()) {
+                LOGGER.debug("Cannot extract the Maven information from the path retrieved in Artifactory {}", file.getPath());
+                result = Optional.empty();
+            } else {
+                result = Optional.of(pathMatcher);
+            }
+        }
+        return result;
+    }
+}

--- a/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchResponseHandler.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchResponseHandler.java
@@ -148,6 +148,12 @@ class ArtifactorySearchResponseHandler implements HttpClientResponseHandler<List
                 do {
                     final FileImpl file = fileImplReader.readValue(parser);
 
+                    if (file.getChecksums() == null) {
+                        LOGGER.warn("No checksums found in artifactory search result of uri {}. Please make sure that header X-Result-Detail is retained on any (reverse)-proxy, loadbalancer or WebApplicationFirewall in the network path to your Artifactory Server",
+                                file.getUri());
+                        continue;
+                    }
+
                     final Optional<Matcher> validationResult = validateUsability(file);
                     if (validationResult.isEmpty()) {
                         continue;

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchResponseHandlerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchResponseHandlerTest.java
@@ -1,0 +1,456 @@
+/*
+ * This file is part of dependency-check-core.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2018 - 2024 Nicolas Henneaux; Hans Aikema. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.data.artifactory;
+
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
+import org.junit.Before;
+import org.junit.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.data.nexus.MavenArtifact;
+import org.owasp.dependencycheck.dependency.Dependency;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ArtifactorySearchResponseHandlerTest extends BaseTest {
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Test
+    public void shouldProcessCorrectlyArtifactoryAnswerWithoutSha256() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("2e66da15851f9f5b5079228f856c2f090ba98c38");
+        dependency.setMd5sum("3dbee72667f107b4f76f2d5aa33c5687");
+        final ClassicHttpResponse response = mock(ClassicHttpResponse.class);
+        final HttpEntity responseEntity = mock(HttpEntity.class);
+        final byte[] payload = ("{\n" +
+                "  \"results\" : [ {\n" +
+                "    \"repo\" : \"jcenter-cache\",\n" +
+                "    \"path\" : \"/com/google/code/gson/gson/2.1/gson-2.1.jar\",\n" +
+                "    \"created\" : \"2017-06-14T16:15:37.936+02:00\",\n" +
+                "    \"createdBy\" : \"anonymous\",\n" +
+                "    \"lastModified\" : \"2012-12-12T22:20:22.000+01:00\",\n" +
+                "    \"modifiedBy\" : \"anonymous\",\n" +
+                "    \"lastUpdated\" : \"2017-06-14T16:15:37.939+02:00\",\n" +
+                "    \"properties\" : {\n" +
+                "      \"artifactory.internal.etag\" : [ \"2e66da15851f9f5b5079228f856c2f090ba98c38\" ]\n" +
+                "    },\n" +
+                "    \"downloadUri\" : \"https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar\",\n" +
+                "    \"remoteUrl\" : \"http://jcenter.bintray.com/com/google/code/gson/gson/2.1/gson-2.1.jar\",\n" +
+                "    \"mimeType\" : \"application/java-archive\",\n" +
+                "    \"size\" : \"180110\",\n" +
+                "    \"checksums\" : {\n" +
+                "      \"sha1\" : \"2e66da15851f9f5b5079228f856c2f090ba98c38\",\n" +
+                "      \"md5\" : \"3dbee72667f107b4f76f2d5aa33c5687\"\n" +
+                "    },\n" +
+                "    \"originalChecksums\" : {\n" +
+                "      \"sha1\" : \"2e66da15851f9f5b5079228f856c2f090ba98c38\"\n" +
+                "    },\n" +
+                "    \"uri\" : \"https://artifactory.techno.ingenico.com/artifactory/api/storage/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar\"\n" +
+                "  } ]\n" +
+                "}").getBytes(StandardCharsets.UTF_8);
+        when(response.getEntity()).thenReturn(responseEntity);
+        when(responseEntity.getContent()).thenReturn(new ByteArrayInputStream(payload));
+
+
+        // When
+        final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
+        final List<MavenArtifact> mavenArtifacts = handler.handleResponse(response);
+
+        // Then
+
+        assertEquals(1, mavenArtifacts.size());
+        final MavenArtifact artifact = mavenArtifacts.get(0);
+        assertEquals("com.google.code.gson", artifact.getGroupId());
+        assertEquals("gson", artifact.getArtifactId());
+        assertEquals("2.1", artifact.getVersion());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar",
+                artifact.getArtifactUrl());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.pom",
+                artifact.getPomUrl());
+    }
+
+    @Test
+    public void shouldProcessCorrectlyArtifactoryAnswerWithMultipleMatches() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("94a9ce681a42d0352b3ad22659f67835e560d107");
+        dependency.setMd5sum("03dcfdd88502505cc5a805a128bfdd8d");
+        final ClassicHttpResponse response = mock(ClassicHttpResponse.class);
+        final HttpEntity responseEntity = mock(HttpEntity.class);
+        final byte[] payload = multipleMatchesPayload();
+        when(response.getEntity()).thenReturn(responseEntity);
+        when(responseEntity.getContent()).thenReturn(new ByteArrayInputStream(payload));
+
+
+        // When
+        final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
+        final List<MavenArtifact> mavenArtifacts = handler.handleResponse(response);
+
+        // Then
+
+        assertEquals(2, mavenArtifacts.size());
+        final MavenArtifact artifact1 = mavenArtifacts.get(0);
+        assertEquals("axis", artifact1.getGroupId());
+        assertEquals("axis", artifact1.getArtifactId());
+        assertEquals("1.4", artifact1.getVersion());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/axis/axis/1.4/axis-1.4.jar", artifact1.getArtifactUrl());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/axis/axis/1.4/axis-1.4.pom", artifact1.getPomUrl());
+        final MavenArtifact artifact2 = mavenArtifacts.get(1);
+        assertEquals("org.apache.axis", artifact2.getGroupId());
+        assertEquals("axis", artifact2.getArtifactId());
+        assertEquals("1.4", artifact2.getVersion());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/org/apache/axis/axis/1.4/axis-1.4.jar",
+                artifact2.getArtifactUrl());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/org/apache/axis/axis/1.4/axis-1.4.pom",
+                artifact2.getPomUrl());
+    }
+
+    @Test
+    public void shouldHandleNoMatches() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("94a9ce681a42d0352b3ad22659f67835e560d108");
+        final ClassicHttpResponse response = mock(ClassicHttpResponse.class);
+        final HttpEntity responseEntity = mock(HttpEntity.class);
+        final byte[] payload = ("{\n" +
+                "  \"results\" : [ ]}").getBytes(StandardCharsets.UTF_8);
+        when(response.getEntity()).thenReturn(responseEntity);
+        when(responseEntity.getContent()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
+        try {
+            handler.handleResponse(response);
+            fail("No Match found, should throw an exception!");
+        } catch (FileNotFoundException e) {
+            // Then
+            assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory",
+                    e.getMessage());
+        }
+    }
+
+    private byte[] multipleMatchesPayload() {
+        return ("{\n" +
+                "  \"results\" : [ {\n" +
+                "    \"repo\" : \"gradle-libs-cache\",\n" +
+                "    \"path\" : \"/axis/axis/1.4/axis-1.4.jar\",\n" +
+                "    \"created\" : \"2015-07-17T08:58:28.039+02:00\",\n" +
+                "    \"createdBy\" : \"loic\",\n" +
+                "    \"lastModified\" : \"2006-04-23T06:32:12.000+02:00\",\n" +
+                "    \"modifiedBy\" : \"loic\",\n" +
+                "    \"lastUpdated\" : \"2015-07-17T08:58:28.049+02:00\",\n" +
+                "    \"properties\" : {\n" +
+                "    },\n" +
+                "    \"downloadUri\" : \"https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/axis/axis/1.4/axis-1.4.jar\",\n" +
+                "    \"remoteUrl\" : \"http://gradle.artifactoryonline.com/gradle/libs/axis/axis/1.4/axis-1.4.jar\",\n" +
+                "    \"mimeType\" : \"application/java-archive\",\n" +
+                "    \"size\" : \"1599570\",\n" +
+                "    \"checksums\" : {\n" +
+                "      \"sha1\" : \"94a9ce681a42d0352b3ad22659f67835e560d107\",\n" +
+                "      \"md5\" : \"03dcfdd88502505cc5a805a128bfdd8d\"\n" +
+                "    },\n" +
+                "    \"originalChecksums\" : {\n" +
+                "      \"sha1\" : \"94a9ce681a42d0352b3ad22659f67835e560d107\",\n" +
+                "      \"md5\" : \"03dcfdd88502505cc5a805a128bfdd8d\"\n" +
+                "    },\n" +
+                "    \"uri\" : \"https://artifactory.techno.ingenico.com/artifactory/api/storage/gradle-libs-cache/axis/axis/1.4/axis-1.4.jar\"\n" +
+                "  }, {\n" +
+                "    \"repo\" : \"gradle-libs-cache\",\n" +
+                "    \"path\" : \"/org/apache/axis/axis/1.4/axis-1.4.jar\",\n" +
+                "    \"created\" : \"2015-07-09T10:09:43.074+02:00\",\n" +
+                "    \"createdBy\" : \"fabrizio\",\n" +
+                "    \"lastModified\" : \"2006-04-23T07:16:56.000+02:00\",\n" +
+                "    \"modifiedBy\" : \"fabrizio\",\n" +
+                "    \"lastUpdated\" : \"2015-07-09T10:09:43.082+02:00\",\n" +
+                "    \"properties\" : {\n" +
+                "    },\n" +
+                "    \"downloadUri\" : \"https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/org/apache/axis/axis/1.4/axis-1.4.jar\",\n" +
+                "    \"remoteUrl\" : \"http://gradle.artifactoryonline.com/gradle/libs/org/apache/axis/axis/1.4/axis-1.4.jar\",\n" +
+                "    \"mimeType\" : \"application/java-archive\",\n" +
+                "    \"size\" : \"1599570\",\n" +
+                "    \"checksums\" : {\n" +
+                "      \"sha1\" : \"94a9ce681a42d0352b3ad22659f67835e560d107\",\n" +
+                "      \"md5\" : \"03dcfdd88502505cc5a805a128bfdd8d\"\n" +
+                "    },\n" +
+                "    \"originalChecksums\" : {\n" +
+                "      \"sha1\" : \"94a9ce681a42d0352b3ad22659f67835e560d107\",\n" +
+                "      \"md5\" : \"03dcfdd88502505cc5a805a128bfdd8d\"\n" +
+                "    },\n" +
+                "    \"uri\" : \"https://artifactory.techno.ingenico.com/artifactory/api/storage/gradle-libs-cache/org/apache/axis/axis/1.4/axis-1.4.jar\"\n" +
+                "  } ]}").getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void shouldProcessCorrectlyArtifactoryAnswer() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
+        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
+        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
+        final ClassicHttpResponse response = mock(ClassicHttpResponse.class);
+        final HttpEntity responseEntity = mock(HttpEntity.class);
+        final byte[] payload = payloadWithSha256().getBytes(StandardCharsets.UTF_8);
+        when(response.getEntity()).thenReturn(responseEntity);
+        when(responseEntity.getContent()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
+        final List<MavenArtifact> mavenArtifacts = handler.handleResponse(response);
+
+        // Then
+
+        assertEquals(1, mavenArtifacts.size());
+        final MavenArtifact artifact = mavenArtifacts.get(0);
+        assertEquals("com.google.code.gson", artifact.getGroupId());
+        assertEquals("gson", artifact.getArtifactId());
+        assertEquals("2.8.5", artifact.getVersion());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar",
+                artifact.getArtifactUrl());
+        assertEquals("https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5.pom",
+                artifact.getPomUrl());
+    }
+
+    private String payloadMimicIssue5868() {
+        return "{\n" +
+                "  \"results\" : [ {\n" +
+                "    \"repo\" : \"web-download-cache\",\n" +
+                "    \"path\" : \"/download/gson-2.8.5-sources.jar\",\n" +
+                "    \"created\" : \"2018-06-20T12:05:23.295+02:00\",\n" +
+                "    \"createdBy\" : \"nhenneaux\",\n" +
+                "    \"lastModified\" : \"2018-05-22T05:09:01.000+02:00\",\n" +
+                "    \"modifiedBy\" : \"nhenneaux\",\n" +
+                "    \"lastUpdated\" : \"2018-06-20T12:05:23.302+02:00\",\n" +
+                "    \"properties\" : {\n" +
+                "      \"artifactory.internal.etag\" : [ \"\\\"2d1dd0fc21ee96bccfab4353d5379649\\\"\" ]\n" +
+                "    },\n" +
+                "    \"downloadUri\" : \"https://artifactory.techno.ingenico.com/artifactory/web-download-cache/download/gson-2.8.5-sources.jar\",\n" +
+                "    \"remoteUrl\" : \"http://example.com/download/gson-2.8.5-sources.jar\",\n" +
+                "    \"mimeType\" : \"application/java-archive\",\n" +
+                "    \"size\" : \"156280\",\n" +
+                "    \"checksums\" : {\n" +
+                "      \"sha1\" : \"c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f\",\n" +
+                "      \"md5\" : \"2d1dd0fc21ee96bccfab4353d5379649\",\n" +
+                "      \"sha256\" : \"512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e\"\n" +
+                "    },\n" +
+                "    \"originalChecksums\" : {\n" +
+                "      \"sha1\" : \"c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f\",\n" +
+                "      \"md5\" : \"2d1dd0fc21ee96bccfab4353d5379649\",\n" +
+                "      \"sha256\" : \"512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e\"\n" +
+                "    },\n" +
+                "    \"uri\" : \"https://artifactory.techno.ingenico.com/artifactory/api/storage/web-download-cache/download/gson-2.8.5-sources.jar\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"repo\" : \"repo1-cache\",\n" +
+                "    \"path\" : \"/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\",\n" +
+                "    \"created\" : \"2018-06-20T12:05:23.295+02:00\",\n" +
+                "    \"createdBy\" : \"nhenneaux\",\n" +
+                "    \"lastModified\" : \"2018-05-22T05:09:01.000+02:00\",\n" +
+                "    \"modifiedBy\" : \"nhenneaux\",\n" +
+                "    \"lastUpdated\" : \"2018-06-20T12:05:23.302+02:00\",\n" +
+                "    \"properties\" : {\n" +
+                "      \"artifactory.internal.etag\" : [ \"\\\"2d1dd0fc21ee96bccfab4353d5379649\\\"\" ]\n" +
+                "    },\n" +
+                "    \"downloadUri\" : \"https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\",\n" +
+                "    \"remoteUrl\" : \"http://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\",\n" +
+                "    \"mimeType\" : \"application/java-archive\",\n" +
+                "    \"size\" : \"156280\",\n" +
+                "    \"checksums\" : {\n" +
+                "      \"sha1\" : \"c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f\",\n" +
+                "      \"md5\" : \"2d1dd0fc21ee96bccfab4353d5379649\",\n" +
+                "      \"sha256\" : \"512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e\"\n" +
+                "    },\n" +
+                "    \"originalChecksums\" : {\n" +
+                "      \"sha1\" : \"c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f\",\n" +
+                "      \"md5\" : \"2d1dd0fc21ee96bccfab4353d5379649\",\n" +
+                "      \"sha256\" : \"512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e\"\n" +
+                "    },\n" +
+                "    \"uri\" : \"https://artifactory.techno.ingenico.com/artifactory/api/storage/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\"\n" +
+                "  } ]\n" +
+                "}";
+    }
+
+    private String payloadWithSha256() {
+        return "{\n" +
+                "  \"results\" : [ {\n" +
+                "    \"repo\" : \"repo1-cache\",\n" +
+                "    \"path\" : \"/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\",\n" +
+                "    \"created\" : \"2018-06-20T12:05:23.295+02:00\",\n" +
+                "    \"createdBy\" : \"nhenneaux\",\n" +
+                "    \"lastModified\" : \"2018-05-22T05:09:01.000+02:00\",\n" +
+                "    \"modifiedBy\" : \"nhenneaux\",\n" +
+                "    \"lastUpdated\" : \"2018-06-20T12:05:23.302+02:00\",\n" +
+                "    \"properties\" : {\n" +
+                "      \"artifactory.internal.etag\" : [ \"\\\"2d1dd0fc21ee96bccfab4353d5379649\\\"\" ]\n" +
+                "    },\n" +
+                "    \"downloadUri\" : \"https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\",\n" +
+                "    \"remoteUrl\" : \"http://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\",\n" +
+                "    \"mimeType\" : \"application/java-archive\",\n" +
+                "    \"size\" : \"156280\",\n" +
+                "    \"checksums\" : {\n" +
+                "      \"sha1\" : \"c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f\",\n" +
+                "      \"md5\" : \"2d1dd0fc21ee96bccfab4353d5379649\",\n" +
+                "      \"sha256\" : \"512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e\"\n" +
+                "    },\n" +
+                "    \"originalChecksums\" : {\n" +
+                "      \"sha1\" : \"c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f\",\n" +
+                "      \"md5\" : \"2d1dd0fc21ee96bccfab4353d5379649\",\n" +
+                "      \"sha256\" : \"512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e\"\n" +
+                "    },\n" +
+                "    \"uri\" : \"https://artifactory.techno.ingenico.com/artifactory/api/storage/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\"\n" +
+                "  } ]\n" +
+                "}";
+    }
+
+    @Test
+    public void shouldProcessCorrectlyArtifactoryAnswerMisMatchMd5() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
+        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
+        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379640");
+        final ClassicHttpResponse response = mock(ClassicHttpResponse.class);
+        final HttpEntity responseEntity = mock(HttpEntity.class);
+        final byte[] payload = payloadWithSha256().getBytes(StandardCharsets.UTF_8);
+        when(response.getEntity()).thenReturn(responseEntity);
+        when(responseEntity.getContent()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
+        try {
+            handler.handleResponse(response);
+            fail("MD5 mismatching should throw an exception!");
+        } catch (FileNotFoundException e) {
+            // Then
+            assertEquals("Artifact " + dependency.toString()
+                    + " not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts", e.getMessage());
+
+        }
+    }
+
+    @Test
+    public void shouldProcessCorrectlyArtifactoryAnswerMisMatchSha1() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0e");
+        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
+        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
+        final ClassicHttpResponse response = mock(ClassicHttpResponse.class);
+        final HttpEntity responseEntity = mock(HttpEntity.class);
+        final byte[] payload = payloadWithSha256().getBytes(StandardCharsets.UTF_8);
+        when(response.getEntity()).thenReturn(responseEntity);
+        when(responseEntity.getContent()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
+        try {
+            handler.handleResponse(response);
+            fail("SHA1 mismatching should throw an exception!");
+        } catch (FileNotFoundException e) {
+            // Then
+            assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts", e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldProcessCorrectlyArtifactoryAnswerMisMatchSha256() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
+        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068f");
+        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
+        final ClassicHttpResponse response = mock(ClassicHttpResponse.class);
+        final HttpEntity responseEntity = mock(HttpEntity.class);
+        final byte[] payload = payloadWithSha256().getBytes(StandardCharsets.UTF_8);
+        when(response.getEntity()).thenReturn(responseEntity);
+        when(responseEntity.getContent()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
+        try {
+            handler.handleResponse(response);
+            fail("SHA256 mismatching should throw an exception!");
+        } catch (FileNotFoundException e) {
+            // Then
+            assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts", e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldThrowNotFoundWhenPatternCannotBeParsed() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
+        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
+        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
+        final ClassicHttpResponse response = mock(ClassicHttpResponse.class);
+        final HttpEntity responseEntity = mock(HttpEntity.class);
+        final byte[] payload = payloadWithSha256().replace("/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar", "/2.8.5/gson-2.8.5-sources.jar")
+                .getBytes(StandardCharsets.UTF_8);
+        when(response.getEntity()).thenReturn(responseEntity);
+        when(responseEntity.getContent()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
+        try {
+            handler.handleResponse(response);
+            fail("Maven GAV pattern mismatch for filepath should throw a not found exception!");
+        } catch (FileNotFoundException e) {
+            // Then
+            assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts", e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldSkipResultsWherePatternCannotBeParsed() throws IOException {
+        // Given
+        Dependency dependency = new Dependency();
+        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
+        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
+        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
+        final ClassicHttpResponse response = mock(ClassicHttpResponse.class);
+        final HttpEntity responseEntity = mock(HttpEntity.class);
+        final byte[] payload = payloadMimicIssue5868().getBytes(StandardCharsets.UTF_8);
+        when(response.getEntity()).thenReturn(responseEntity);
+        when(responseEntity.getContent()).thenReturn(new ByteArrayInputStream(payload));
+
+        // When
+        final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
+        List<MavenArtifact> result = handler.handleResponse(response);
+        // Then
+        assertEquals(1, result.size());
+        MavenArtifact artifact = result.get(0);
+        assertEquals("com.google.code.gson", artifact.getGroupId());
+        assertEquals("gson", artifact.getArtifactId());
+        assertEquals("2.8.5", artifact.getVersion());
+    }
+}

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
@@ -22,26 +22,16 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.utils.Settings;
 
-import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ArtifactorySearchTest extends BaseTest {
-    private ArtifactorySearch searcher;
     private static String httpsProxyHostOrig;
     private static String httpsPortOrig;
 
@@ -73,7 +63,6 @@ public class ArtifactorySearchTest extends BaseTest {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        searcher = new ArtifactorySearch(getSettings());
     }
 
 
@@ -86,312 +75,16 @@ public class ArtifactorySearchTest extends BaseTest {
         dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
 
         final Settings settings = getSettings();
-        settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_URL, "https://artifactory.techno.ingenico.com.non-existing/artifactory");
+        settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_URL, "https://artifactory.techno.ingenico.com.invalid/artifactory");
         final ArtifactorySearch artifactorySearch = new ArtifactorySearch(settings);
         // When
         try {
             artifactorySearch.search(dependency);
-            fail();
+            fail("Should have thrown an UnknownHostException");
         } catch (UnknownHostException exception) {
             // Then
-            assertEquals("artifactory.techno.ingenico.com.non-existing", exception.getMessage());
-        } catch (SocketTimeoutException exception) {
-            // Then
-            assertEquals("connect timed out", exception.getMessage());
-        } catch (IOException ex) {
-            assertEquals("Connection refused (Connection refused)", ex.getMessage());
+            assertEquals("artifactory.techno.ingenico.com.invalid: nodename nor servname provided, or not known", exception.getMessage());
         }
     }
 
-
-    @Test
-    public void shouldProcessCorrectlyArtifactoryAnswerWithoutSha256() throws IOException {
-        // Given
-        Dependency dependency = new Dependency();
-        dependency.setSha1sum("2e66da15851f9f5b5079228f856c2f090ba98c38");
-        dependency.setMd5sum("3dbee72667f107b4f76f2d5aa33c5687");
-        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
-        final byte[] payload = ("{\n" +
-                "  \"results\" : [ {\n" +
-                "    \"repo\" : \"jcenter-cache\",\n" +
-                "    \"path\" : \"/com/google/code/gson/gson/2.1/gson-2.1.jar\",\n" +
-                "    \"created\" : \"2017-06-14T16:15:37.936+02:00\",\n" +
-                "    \"createdBy\" : \"anonymous\",\n" +
-                "    \"lastModified\" : \"2012-12-12T22:20:22.000+01:00\",\n" +
-                "    \"modifiedBy\" : \"anonymous\",\n" +
-                "    \"lastUpdated\" : \"2017-06-14T16:15:37.939+02:00\",\n" +
-                "    \"properties\" : {\n" +
-                "      \"artifactory.internal.etag\" : [ \"2e66da15851f9f5b5079228f856c2f090ba98c38\" ]\n" +
-                "    },\n" +
-                "    \"downloadUri\" : \"https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar\",\n" +
-                "    \"remoteUrl\" : \"http://jcenter.bintray.com/com/google/code/gson/gson/2.1/gson-2.1.jar\",\n" +
-                "    \"mimeType\" : \"application/java-archive\",\n" +
-                "    \"size\" : \"180110\",\n" +
-                "    \"checksums\" : {\n" +
-                "      \"sha1\" : \"2e66da15851f9f5b5079228f856c2f090ba98c38\",\n" +
-                "      \"md5\" : \"3dbee72667f107b4f76f2d5aa33c5687\"\n" +
-                "    },\n" +
-                "    \"originalChecksums\" : {\n" +
-                "      \"sha1\" : \"2e66da15851f9f5b5079228f856c2f090ba98c38\"\n" +
-                "    },\n" +
-                "    \"uri\" : \"https://artifactory.techno.ingenico.com/artifactory/api/storage/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar\"\n" +
-                "  } ]\n" +
-                "}").getBytes(StandardCharsets.UTF_8);
-        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
-
-        // When
-        final List<MavenArtifact> mavenArtifacts = searcher.processResponse(dependency, urlConnection);
-
-        // Then
-
-        assertEquals(1, mavenArtifacts.size());
-        final MavenArtifact artifact = mavenArtifacts.get(0);
-        assertEquals("com.google.code.gson", artifact.getGroupId());
-        assertEquals("gson", artifact.getArtifactId());
-        assertEquals("2.1", artifact.getVersion());
-        assertEquals("https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar", artifact.getArtifactUrl());
-        assertEquals("https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.pom", artifact.getPomUrl());
-    }
-
-    @Test
-    public void shouldProcessCorrectlyArtifactoryAnswerWithMultipleMatches() throws IOException {
-        // Given
-        Dependency dependency = new Dependency();
-        dependency.setSha1sum("94a9ce681a42d0352b3ad22659f67835e560d107");
-        dependency.setMd5sum("03dcfdd88502505cc5a805a128bfdd8d");
-        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
-        final byte[] payload = multipleMatchesPayload();
-        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
-
-        // When
-        final List<MavenArtifact> mavenArtifacts = searcher.processResponse(dependency, urlConnection);
-
-        // Then
-
-        assertEquals(2, mavenArtifacts.size());
-        final MavenArtifact artifact1 = mavenArtifacts.get(0);
-        assertEquals("axis", artifact1.getGroupId());
-        assertEquals("axis", artifact1.getArtifactId());
-        assertEquals("1.4", artifact1.getVersion());
-        assertEquals("https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/axis/axis/1.4/axis-1.4.jar", artifact1.getArtifactUrl());
-        assertEquals("https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/axis/axis/1.4/axis-1.4.pom", artifact1.getPomUrl());
-        final MavenArtifact artifact2 = mavenArtifacts.get(1);
-        assertEquals("org.apache.axis", artifact2.getGroupId());
-        assertEquals("axis", artifact2.getArtifactId());
-        assertEquals("1.4", artifact2.getVersion());
-        assertEquals("https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/org/apache/axis/axis/1.4/axis-1.4.jar", artifact2.getArtifactUrl());
-        assertEquals("https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/org/apache/axis/axis/1.4/axis-1.4.pom", artifact2.getPomUrl());
-    }
-
-    @Test
-    public void shouldHandleNoMatches() throws IOException {
-        // Given
-        Dependency dependency = new Dependency();
-        dependency.setSha1sum("94a9ce681a42d0352b3ad22659f67835e560d108");
-        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
-        final byte[] payload = ("{\n" +
-                "  \"results\" : [ ]}").getBytes(StandardCharsets.UTF_8);
-        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
-
-        // When
-        try {
-            searcher.processResponse(dependency, urlConnection);
-            fail("No Match found, should throw an exception!");
-        } catch (FileNotFoundException e) {
-            // Then
-            assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory", e.getMessage());
-        }
-    }
-
-    private byte[] multipleMatchesPayload() {
-        return ("{\n" +
-                "  \"results\" : [ {\n" +
-                "    \"repo\" : \"gradle-libs-cache\",\n" +
-                "    \"path\" : \"/axis/axis/1.4/axis-1.4.jar\",\n" +
-                "    \"created\" : \"2015-07-17T08:58:28.039+02:00\",\n" +
-                "    \"createdBy\" : \"loic\",\n" +
-                "    \"lastModified\" : \"2006-04-23T06:32:12.000+02:00\",\n" +
-                "    \"modifiedBy\" : \"loic\",\n" +
-                "    \"lastUpdated\" : \"2015-07-17T08:58:28.049+02:00\",\n" +
-                "    \"properties\" : {\n" +
-                "    },\n" +
-                "    \"downloadUri\" : \"https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/axis/axis/1.4/axis-1.4.jar\",\n" +
-                "    \"remoteUrl\" : \"http://gradle.artifactoryonline.com/gradle/libs/axis/axis/1.4/axis-1.4.jar\",\n" +
-                "    \"mimeType\" : \"application/java-archive\",\n" +
-                "    \"size\" : \"1599570\",\n" +
-                "    \"checksums\" : {\n" +
-                "      \"sha1\" : \"94a9ce681a42d0352b3ad22659f67835e560d107\",\n" +
-                "      \"md5\" : \"03dcfdd88502505cc5a805a128bfdd8d\"\n" +
-                "    },\n" +
-                "    \"originalChecksums\" : {\n" +
-                "      \"sha1\" : \"94a9ce681a42d0352b3ad22659f67835e560d107\",\n" +
-                "      \"md5\" : \"03dcfdd88502505cc5a805a128bfdd8d\"\n" +
-                "    },\n" +
-                "    \"uri\" : \"https://artifactory.techno.ingenico.com/artifactory/api/storage/gradle-libs-cache/axis/axis/1.4/axis-1.4.jar\"\n" +
-                "  }, {\n" +
-                "    \"repo\" : \"gradle-libs-cache\",\n" +
-                "    \"path\" : \"/org/apache/axis/axis/1.4/axis-1.4.jar\",\n" +
-                "    \"created\" : \"2015-07-09T10:09:43.074+02:00\",\n" +
-                "    \"createdBy\" : \"fabrizio\",\n" +
-                "    \"lastModified\" : \"2006-04-23T07:16:56.000+02:00\",\n" +
-                "    \"modifiedBy\" : \"fabrizio\",\n" +
-                "    \"lastUpdated\" : \"2015-07-09T10:09:43.082+02:00\",\n" +
-                "    \"properties\" : {\n" +
-                "    },\n" +
-                "    \"downloadUri\" : \"https://artifactory.techno.ingenico.com/artifactory/gradle-libs-cache/org/apache/axis/axis/1.4/axis-1.4.jar\",\n" +
-                "    \"remoteUrl\" : \"http://gradle.artifactoryonline.com/gradle/libs/org/apache/axis/axis/1.4/axis-1.4.jar\",\n" +
-                "    \"mimeType\" : \"application/java-archive\",\n" +
-                "    \"size\" : \"1599570\",\n" +
-                "    \"checksums\" : {\n" +
-                "      \"sha1\" : \"94a9ce681a42d0352b3ad22659f67835e560d107\",\n" +
-                "      \"md5\" : \"03dcfdd88502505cc5a805a128bfdd8d\"\n" +
-                "    },\n" +
-                "    \"originalChecksums\" : {\n" +
-                "      \"sha1\" : \"94a9ce681a42d0352b3ad22659f67835e560d107\",\n" +
-                "      \"md5\" : \"03dcfdd88502505cc5a805a128bfdd8d\"\n" +
-                "    },\n" +
-                "    \"uri\" : \"https://artifactory.techno.ingenico.com/artifactory/api/storage/gradle-libs-cache/org/apache/axis/axis/1.4/axis-1.4.jar\"\n" +
-                "  } ]}").getBytes(StandardCharsets.UTF_8);
-    }
-
-    @Test
-    public void shouldProcessCorrectlyArtifactoryAnswer() throws IOException {
-        // Given
-        Dependency dependency = new Dependency();
-        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
-        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
-        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
-        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
-        final byte[] payload = payloadWithSha256().getBytes(StandardCharsets.UTF_8);
-        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
-
-        // When
-        final List<MavenArtifact> mavenArtifacts = searcher.processResponse(dependency, urlConnection);
-
-        // Then
-
-        assertEquals(1, mavenArtifacts.size());
-        final MavenArtifact artifact = mavenArtifacts.get(0);
-        assertEquals("com.google.code.gson", artifact.getGroupId());
-        assertEquals("gson", artifact.getArtifactId());
-        assertEquals("2.8.5", artifact.getVersion());
-        assertEquals("https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar", artifact.getArtifactUrl());
-        assertEquals("https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5.pom", artifact.getPomUrl());
-    }
-
-    private String payloadWithSha256() {
-        return "{\n" +
-                "  \"results\" : [ {\n" +
-                "    \"repo\" : \"repo1-cache\",\n" +
-                "    \"path\" : \"/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\",\n" +
-                "    \"created\" : \"2018-06-20T12:05:23.295+02:00\",\n" +
-                "    \"createdBy\" : \"nhenneaux\",\n" +
-                "    \"lastModified\" : \"2018-05-22T05:09:01.000+02:00\",\n" +
-                "    \"modifiedBy\" : \"nhenneaux\",\n" +
-                "    \"lastUpdated\" : \"2018-06-20T12:05:23.302+02:00\",\n" +
-                "    \"properties\" : {\n" +
-                "      \"artifactory.internal.etag\" : [ \"\\\"2d1dd0fc21ee96bccfab4353d5379649\\\"\" ]\n" +
-                "    },\n" +
-                "    \"downloadUri\" : \"https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\",\n" +
-                "    \"remoteUrl\" : \"http://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\",\n" +
-                "    \"mimeType\" : \"application/java-archive\",\n" +
-                "    \"size\" : \"156280\",\n" +
-                "    \"checksums\" : {\n" +
-                "      \"sha1\" : \"c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f\",\n" +
-                "      \"md5\" : \"2d1dd0fc21ee96bccfab4353d5379649\",\n" +
-                "      \"sha256\" : \"512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e\"\n" +
-                "    },\n" +
-                "    \"originalChecksums\" : {\n" +
-                "      \"sha1\" : \"c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f\",\n" +
-                "      \"md5\" : \"2d1dd0fc21ee96bccfab4353d5379649\",\n" +
-                "      \"sha256\" : \"512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e\"\n" +
-                "    },\n" +
-                "    \"uri\" : \"https://artifactory.techno.ingenico.com/artifactory/api/storage/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar\"\n" +
-                "  } ]\n" +
-                "}";
-    }
-
-    @Test
-    public void shouldProcessCorrectlyArtifactoryAnswerMisMatchMd5() throws IOException {
-        // Given
-        Dependency dependency = new Dependency();
-        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
-        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
-        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379640");
-        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
-        final byte[] payload = payloadWithSha256().getBytes(StandardCharsets.UTF_8);
-        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
-
-        // When
-        try {
-            searcher.processResponse(dependency, urlConnection);
-            fail("MD5 mismatching should throw an exception!");
-        } catch (FileNotFoundException e) {
-            // Then
-            assertEquals("Artifact found by API is not matching the md5 of the artifact (repository hash is 2d1dd0fc21ee96bccfab4353d5379649 while actual is 2d1dd0fc21ee96bccfab4353d5379640) !", e.getMessage());
-        }
-    }
-
-    @Test
-    public void shouldProcessCorrectlyArtifactoryAnswerMisMatchSha1() throws IOException {
-        // Given
-        Dependency dependency = new Dependency();
-        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0e");
-        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
-        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
-        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
-        final byte[] payload = payloadWithSha256().getBytes(StandardCharsets.UTF_8);
-        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
-
-        // When
-        try {
-            searcher.processResponse(dependency, urlConnection);
-            fail("SHA1 mismatching should throw an exception!");
-        } catch (FileNotFoundException e) {
-            // Then
-            assertEquals("Artifact found by API is not matching the SHA1 of the artifact (repository hash is c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f while actual is c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0e) !", e.getMessage());
-        }
-    }
-
-    @Test
-    public void shouldProcessCorrectlyArtifactoryAnswerMisMatchSha256() throws IOException {
-        // Given
-        Dependency dependency = new Dependency();
-        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
-        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068f");
-        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
-        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
-        final byte[] payload = payloadWithSha256().getBytes(StandardCharsets.UTF_8);
-        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
-
-        // When
-        try {
-            searcher.processResponse(dependency, urlConnection);
-            fail("SHA256 mismatching should throw an exception!");
-        } catch (FileNotFoundException e) {
-            // Then
-            assertEquals("Artifact found by API is not matching the SHA-256 of the artifact (repository hash is 512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e while actual is 512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068f) !", e.getMessage());
-        }
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenPatternCannotBeParsed() throws IOException {
-        // Given
-        Dependency dependency = new Dependency();
-        dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
-        dependency.setSha256sum("512b4bf6927f4864acc419b8c5109c23361c30ed1f5798170248d33040de068e");
-        dependency.setMd5sum("2d1dd0fc21ee96bccfab4353d5379649");
-        final HttpURLConnection urlConnection = mock(HttpURLConnection.class);
-        final byte[] payload = payloadWithSha256().replace("/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar", "/2.8.5/gson-2.8.5-sources.jar").getBytes(StandardCharsets.UTF_8);
-        when(urlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(payload));
-
-        // When
-        try {
-            searcher.processResponse(dependency, urlConnection);
-            fail("SHA256 mismatching should throw an exception!");
-        } catch (IllegalStateException e) {
-            // Then
-            assertEquals("Cannot extract the Maven information from the path retrieved in Artifactory /2.8.5/gson-2.8.5-sources.jar", e.getMessage());
-        }
-    }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ArtifactorySearchTest extends BaseTest {
@@ -83,7 +85,8 @@ public class ArtifactorySearchTest extends BaseTest {
             fail("Should have thrown an UnknownHostException");
         } catch (UnknownHostException exception) {
             // Then
-            assertEquals("artifactory.techno.ingenico.com.invalid: nodename nor servname provided, or not known", exception.getMessage());
+            assertNotNull(exception.getMessage());
+            assertTrue(exception.getMessage().contains("artifactory.techno.ingenico.com.invalid"));
         }
     }
 

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
@@ -206,6 +206,7 @@ public final class Downloader {
         tryAddHostedSuppressionCredentials();
         tryAddKEVCredentials();
         tryAddNexusAnalyzerCredentials();
+        tryAddArtifactoryCredentials();
         tryAddCentralAnalyzerCredentials();
         tryAddCentralContentCredentials();
         tryAddNVDApiDatafeed();
@@ -254,6 +255,15 @@ public final class Downloader {
             configureCredentials(Settings.KEYS.ANALYZER_CENTRAL_URL, "Central Analyzer",
                     Settings.KEYS.ANALYZER_CENTRAL_USER, Settings.KEYS.ANALYZER_CENTRAL_PASSWORD,
                     Settings.KEYS.ANALYZER_CENTRAL_BEARER_TOKEN
+            );
+        }
+    }
+
+    private void tryAddArtifactoryCredentials() throws InvalidSettingException {
+        if (!settings.getString(Settings.KEYS.ANALYZER_ARTIFACTORY_URL, "").isBlank()) {
+            configureCredentials(Settings.KEYS.ANALYZER_ARTIFACTORY_URL, "Artifactory Analyzer",
+                    Settings.KEYS.ANALYZER_ARTIFACTORY_API_USERNAME, Settings.KEYS.ANALYZER_ARTIFACTORY_API_TOKEN,
+                    Settings.KEYS.ANALYZER_ARTIFACTORY_BEARER_TOKEN
             );
         }
     }


### PR DESCRIPTION
## Description of Change

Make ArtifactoryAnalyzer use the Downloader class to finalize the migration of HTTP-traffic to use the Apache HTTPClient5 finalizing the work still left after #6949 

Make ArtifactoryAnalyzer skip results that do not fit the expectations (matching hashes and a maven-like G/A/V path structure) and attempt to find further matches in the remaining search results instead of throwing an exception on a first unexpected result entry format.

## Related issues

Fixes #5868 
Fixes #7254 

## Have test cases been added to cover the new functionality?

yes a testcase was added for the fix of #5868