### PR TITLE
fix: add product evidence as vendor to reduce FN

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
@@ -284,20 +284,24 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
 
         if (!StringUtils.isBlank(data.getCompanyName())) {
             dependency.addEvidence(EvidenceType.VENDOR, "grokassembly", "CompanyName", data.getCompanyName(), Confidence.HIGHEST);
+            dependency.addEvidence(EvidenceType.PRODUCT, "grokassembly", "CompanyName", data.getCompanyName(), Confidence.LOW);
             addMatchingValues(data.getNamespaces(), data.getCompanyName(), dependency, EvidenceType.VENDOR);
         }
         if (!StringUtils.isBlank(data.getProductName())) {
             dependency.addEvidence(EvidenceType.PRODUCT, "grokassembly", "ProductName", data.getProductName(), Confidence.HIGHEST);
+            dependency.addEvidence(EvidenceType.VENDOR, "grokassembly", "ProductName", data.getProductName(), Confidence.MEDIUM);
             addMatchingValues(data.getNamespaces(), data.getProductName(), dependency, EvidenceType.PRODUCT);
         }
         if (!StringUtils.isBlank(data.getFileDescription())) {
             dependency.addEvidence(EvidenceType.PRODUCT, "grokassembly", "FileDescription", data.getFileDescription(), Confidence.HIGH);
+            dependency.addEvidence(EvidenceType.VENDOR, "grokassembly", "FileDescription", data.getFileDescription(), Confidence.LOW);
             addMatchingValues(data.getNamespaces(), data.getFileDescription(), dependency, EvidenceType.PRODUCT);
         }
 
         final String internalName = data.getInternalName();
         if (!StringUtils.isBlank(internalName)) {
             dependency.addEvidence(EvidenceType.PRODUCT, "grokassembly", "InternalName", internalName, Confidence.MEDIUM);
+            dependency.addEvidence(EvidenceType.VENDOR, "grokassembly", "InternalName", internalName, Confidence.LOW);
             addMatchingValues(data.getNamespaces(), internalName, dependency, EvidenceType.PRODUCT);
             addMatchingValues(data.getNamespaces(), internalName, dependency, EvidenceType.VENDOR);
             if (dependency.getName() == null && StringUtils.containsIgnoreCase(dependency.getActualFile().getName(), internalName)) {
@@ -313,6 +317,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
         final String originalFilename = data.getOriginalFilename();
         if (!StringUtils.isBlank(originalFilename)) {
             dependency.addEvidence(EvidenceType.PRODUCT, "grokassembly", "OriginalFilename", originalFilename, Confidence.MEDIUM);
+            dependency.addEvidence(EvidenceType.VENDOR, "grokassembly", "OriginalFilename", originalFilename, Confidence.LOW);
             addMatchingValues(data.getNamespaces(), originalFilename, dependency, EvidenceType.PRODUCT);
             if (dependency.getName() == null && StringUtils.containsIgnoreCase(dependency.getActualFile().getName(), originalFilename)) {
                 final String ext = FileUtils.getFileExtension(originalFilename);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AutoconfAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AutoconfAnalyzer.java
@@ -195,12 +195,15 @@ public class AutoconfAnalyzer extends AbstractFileTypeAnalyzer {
             if (!value.isEmpty()) {
                 if (variable.endsWith("NAME")) {
                     dependency.addEvidence(EvidenceType.PRODUCT, name, variable, value, Confidence.HIGHEST);
+                    dependency.addEvidence(EvidenceType.VENDOR, name, variable, value, Confidence.MEDIUM);
                 } else if ("VERSION".equals(variable)) {
                     dependency.addEvidence(EvidenceType.VERSION, name, variable, value, Confidence.HIGHEST);
                 } else if ("BUGREPORT".equals(variable)) {
                     dependency.addEvidence(EvidenceType.VENDOR, name, variable, value, Confidence.HIGH);
+                    dependency.addEvidence(EvidenceType.PRODUCT, name, variable, value, Confidence.MEDIUM);
                 } else if ("URL".equals(variable)) {
                     dependency.addEvidence(EvidenceType.VENDOR, name, variable, value, Confidence.HIGH);
+                    dependency.addEvidence(EvidenceType.PRODUCT, name, variable, value, Confidence.MEDIUM);
                 }
             }
         }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CocoaPodsAnalyzer.java
@@ -260,6 +260,7 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
             final String summary = determineEvidence(contents, blockVariable, "summary");
             if (!summary.isEmpty()) {
                 dependency.addEvidence(EvidenceType.PRODUCT, PODSPEC, "summary", summary, Confidence.HIGHEST);
+                dependency.addEvidence(EvidenceType.VENDOR, PODSPEC, "summary", summary, Confidence.MEDIUM);
             }
 
             final String author = determineEvidence(contents, blockVariable, "authors?");
@@ -269,6 +270,7 @@ public class CocoaPodsAnalyzer extends AbstractFileTypeAnalyzer {
             final String homepage = determineEvidence(contents, blockVariable, "homepage");
             if (!homepage.isEmpty()) {
                 dependency.addEvidence(EvidenceType.VENDOR, PODSPEC, "homepage", homepage, Confidence.HIGHEST);
+                dependency.addEvidence(EvidenceType.PRODUCT, PODSPEC, "homepage", homepage, Confidence.LOW);
             }
             final String license = determineEvidence(contents, blockVariable, "licen[cs]es?");
             if (!license.isEmpty()) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzer.java
@@ -133,7 +133,9 @@ public class ComposerLockAnalyzer extends AbstractFileTypeAnalyzer {
                 d.setSha256sum(Checksum.getSHA256Checksum(filePath));
                 d.setMd5sum(Checksum.getMD5Checksum(filePath));
                 d.addEvidence(EvidenceType.VENDOR, COMPOSER_LOCK, "vendor", dep.getGroup(), Confidence.HIGHEST);
+                d.addEvidence(EvidenceType.PRODUCT, COMPOSER_LOCK, "vendor", dep.getGroup(), Confidence.MEDIUM);
                 d.addEvidence(EvidenceType.PRODUCT, COMPOSER_LOCK, "product", dep.getProject(), Confidence.HIGHEST);
+                d.addEvidence(EvidenceType.VENDOR, COMPOSER_LOCK, "product", dep.getProject(), Confidence.HIGH);
                 d.addEvidence(EvidenceType.VERSION, COMPOSER_LOCK, "version", dep.getVersion(), Confidence.HIGHEST);
                 return d;
             }).forEach((d) -> {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/LibmanAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/LibmanAnalyzer.java
@@ -208,8 +208,10 @@ public class LibmanAnalyzer extends AbstractFileTypeAnalyzer {
                 child.setName(name);
                 child.setVersion(version);
 
-                child.addEvidence(EvidenceType.VENDOR, FILE_NAME, "vendor", (vendor != null ? vendor : name),
-                        Confidence.HIGHEST);
+                if (vendor != null) {
+                    child.addEvidence(EvidenceType.VENDOR, FILE_NAME, "vendor", vendor, Confidence.HIGHEST);    
+                }
+                child.addEvidence(EvidenceType.VENDOR, FILE_NAME, "name", name, Confidence.HIGH);
                 child.addEvidence(EvidenceType.PRODUCT, FILE_NAME, "name", name, Confidence.HIGHEST);
                 child.addEvidence(EvidenceType.VERSION, FILE_NAME, "version", version, Confidence.HIGHEST);
 

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzer.java
@@ -185,6 +185,7 @@ public class MSBuildProjectAnalyzer extends AbstractFileTypeAnalyzer {
                 child.setMd5sum(Checksum.getMD5Checksum(String.format("%s:%s", id, version)));
 
                 child.addEvidence(EvidenceType.PRODUCT, "msbuild", "id", id, Confidence.HIGHEST);
+                child.addEvidence(EvidenceType.VENDOR, "msbuild", "id", id, Confidence.MEDIUM);
                 child.addEvidence(EvidenceType.VERSION, "msbuild", "version", version, Confidence.HIGHEST);
 
                 if (id.indexOf('.') > 0) {
@@ -193,10 +194,12 @@ public class MSBuildProjectAnalyzer extends AbstractFileTypeAnalyzer {
                     // example: Microsoft.EntityFrameworkCore
                     child.addEvidence(EvidenceType.VENDOR, "msbuild", "id", parts[0], Confidence.MEDIUM);
                     child.addEvidence(EvidenceType.PRODUCT, "msbuild", "id", parts[1], Confidence.MEDIUM);
+                    child.addEvidence(EvidenceType.VENDOR, "msbuild", "id", parts[1], Confidence.LOW);
 
                     if (parts.length > 2) {
                         final String rest = id.substring(id.indexOf('.') + 1);
                         child.addEvidence(EvidenceType.PRODUCT, "msbuild", "id", rest, Confidence.MEDIUM);
+                        child.addEvidence(EvidenceType.VENDOR, "msbuild", "id", rest, Confidence.LOW);
                     }
                 } else {
                     // example: jQuery

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzer.java
@@ -182,6 +182,7 @@ public class NugetconfAnalyzer extends AbstractFileTypeAnalyzer {
                 child.setMd5sum(Checksum.getMD5Checksum(String.format("%s:%s", id, version)));
                 child.addEvidence(EvidenceType.VERSION, "packages.config", "version", np.getVersion(), Confidence.HIGHEST);
                 child.addEvidence(EvidenceType.PRODUCT, "packages.config", "id", np.getId(), Confidence.HIGHEST);
+                child.addEvidence(EvidenceType.VENDOR, "packages.config", "id", np.getId(), Confidence.MEDIUM);
 
                 // handle package names the same way as the MSBuild analyzer
                 if (id.indexOf('.') > 0) {
@@ -190,10 +191,12 @@ public class NugetconfAnalyzer extends AbstractFileTypeAnalyzer {
                     // example: Microsoft.EntityFrameworkCore
                     child.addEvidence(EvidenceType.VENDOR, "packages.config", "id", parts[0], Confidence.MEDIUM);
                     child.addEvidence(EvidenceType.PRODUCT, "packages.config", "id", parts[1], Confidence.MEDIUM);
+                    child.addEvidence(EvidenceType.VENDOR, "packages.config", "id", parts[1], Confidence.LOW);
 
                     if (parts.length > 2) {
                         final String rest = id.substring(id.indexOf('.') + 1);
                         child.addEvidence(EvidenceType.PRODUCT, "packages.config", "id", rest, Confidence.MEDIUM);
+                        child.addEvidence(EvidenceType.VENDOR, "packages.config", "id", rest, Confidence.LOW);
                     }
                 } else {
                     // example: jQuery

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NuspecAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NuspecAnalyzer.java
@@ -158,6 +158,7 @@ public class NuspecAnalyzer extends AbstractFileTypeAnalyzer {
             dependency.addEvidence(EvidenceType.VENDOR, "nuspec", "authors", np.getAuthors(), Confidence.HIGH);
             dependency.addEvidence(EvidenceType.VERSION, "nuspec", "version", np.getVersion(), Confidence.HIGHEST);
             dependency.addEvidence(EvidenceType.PRODUCT, "nuspec", "id", np.getId(), Confidence.HIGHEST);
+            dependency.addEvidence(EvidenceType.VENDOR, "nuspec", "id", np.getId(), Confidence.HIGH);
             dependency.addEvidence(EvidenceType.VENDOR, "nuspec", "description", np.getDescription(), Confidence.LOW);
             dependency.addEvidence(EvidenceType.PRODUCT, "nuspec", "description", np.getDescription(), Confidence.LOW);
             dependency.setName(np.getId());
@@ -178,6 +179,7 @@ public class NuspecAnalyzer extends AbstractFileTypeAnalyzer {
             }
             if (np.getTitle() != null) {
                 dependency.addEvidence(EvidenceType.PRODUCT, "nuspec", "title", np.getTitle(), Confidence.MEDIUM);
+                dependency.addEvidence(EvidenceType.VENDOR, "nuspec", "title", np.getTitle(), Confidence.LOW);
             }
         } catch (Throwable e) {
             throw new AnalysisException(e);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PEAnalyzer.java
@@ -185,6 +185,7 @@ public class PEAnalyzer extends AbstractFileTypeAnalyzer {
                             break;
                         case "InternalName":
                             dependency.addEvidence(EvidenceType.PRODUCT, "PE Header", "InternalName", value, Confidence.MEDIUM);
+                            dependency.addEvidence(EvidenceType.VENDOR, "PE Header", "InternalName", value, Confidence.LOW);
                             determineDependencyName(dependency, value);
                             break;
                         case "LegalCopyright":
@@ -201,6 +202,7 @@ public class PEAnalyzer extends AbstractFileTypeAnalyzer {
                             break;
                         case "ProductName":
                             dependency.addEvidence(EvidenceType.PRODUCT, "PE Header", "ProductName", value, Confidence.HIGHEST);
+                            dependency.addEvidence(EvidenceType.VENDOR, "PE Header", "ProductName", value, Confidence.MEDIUM);
                             determineDependencyName(dependency, value);
                             break;
                         default:

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PinnedMavenInstallAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PinnedMavenInstallAnalyzer.java
@@ -207,6 +207,7 @@ public class PinnedMavenInstallAnalyzer extends AbstractFileTypeAnalyzer {
             d.setEcosystem(Ecosystem.JAVA);
             d.addEvidence(EvidenceType.VENDOR, "project", "groupid", group, Confidence.HIGHEST);
             d.addEvidence(EvidenceType.PRODUCT, "project", "artifactid", artifact, Confidence.HIGHEST);
+            d.addEvidence(EvidenceType.VENDOR, "project", "artifactid", artifact, Confidence.HIGH);
             d.addEvidence(EvidenceType.VERSION, "project", "version", version, Confidence.HIGHEST);
             d.setName(String.format("%s:%s", group, artifact));
             d.setFilePath(String.format("%s>>%s", dependency.getActualFile(), dep.getCoord()));

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzer.java
@@ -211,6 +211,7 @@ public class PythonPackageAnalyzer extends AbstractFileTypeAnalyzer {
             //"The __init__.py files are required to make Python treat the directories as containing packages"
             //see section "6.4 Packages" from https://docs.python.org/2/tutorial/modules.html;
             dependency.addEvidence(EvidenceType.PRODUCT, file.getName(), "PackageName", parentName, Confidence.HIGHEST);
+            dependency.addEvidence(EvidenceType.VENDOR, file.getName(), "PackageName", parentName, Confidence.MEDIUM);
             dependency.setName(parentName);
 
             final File[] fileList = parent.listFiles(PY_FILTER);

--- a/core/src/main/java/org/owasp/dependencycheck/processing/BundlerAuditProcessor.java
+++ b/core/src/main/java/org/owasp/dependencycheck/processing/BundlerAuditProcessor.java
@@ -319,6 +319,7 @@ public class BundlerAuditProcessor extends Processor<InputStream> {
         dependency.setSha1sum(Checksum.getSHA1Checksum(displayFileName));
         dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
         dependency.addEvidence(EvidenceType.PRODUCT, "bundler-audit", "Name", gem, Confidence.HIGHEST);
+        dependency.addEvidence(EvidenceType.VENDOR, "bundler-audit", "Name", gem, Confidence.HIGH);
         //TODO add package URL - note, this may require parsing the gemfile.lock and getting the version for each entry
 
         dependency.setDisplayFileName(displayFileName);

--- a/core/src/main/java/org/owasp/dependencycheck/processing/MixAuditProcessor.java
+++ b/core/src/main/java/org/owasp/dependencycheck/processing/MixAuditProcessor.java
@@ -166,6 +166,7 @@ public class MixAuditProcessor extends Processor<InputStream> {
 
         dep.addEvidence(EvidenceType.VERSION, "mix_audit", "Version", version, Confidence.HIGHEST);
         dep.addEvidence(EvidenceType.PRODUCT, "mix_audit", "Package", packageName, Confidence.HIGHEST);
+        dep.addEvidence(EvidenceType.VENDOR, "mix_audit", "Package", packageName, Confidence.HIGH);
 
         try {
             final PackageURL purl = PackageURLBuilder.aPackageURL().withType("hex").withName(packageName)

--- a/core/src/test/java/org/owasp/dependencycheck/EngineIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/EngineIT.java
@@ -120,6 +120,7 @@ public class EngineIT extends BaseDBTestCase {
                 allowedMessages.add("../tmp/evil.txt");
                 allowedMessages.add("malformed input off : 5, length : 1");
                 allowedMessages.add("Python `pyproject.toml` found and there is not a `poetry.lock` or `requirements.txt`");
+                allowedMessages.add("file from the NPM Audit API (PnpmAuditAnalyzer)");
                 for (Throwable t : ex.getExceptions()) {
                     boolean isOk = false;
                     if (t.getMessage() != null) {

--- a/core/src/test/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgentIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgentIT.java
@@ -80,6 +80,7 @@ public class DependencyCheckScanAgentIT extends BaseDBTestCase {
         }
         if (name != null) {
             dependency.addEvidence(EvidenceType.PRODUCT, "dependency-track", "name", name, Confidence.HIGHEST);
+            dependency.addEvidence(EvidenceType.VENDOR, "dependency-track", "name", name, Confidence.HIGH);
             dependency.addProductWeighting(name);
         }
         if (version != null) {


### PR DESCRIPTION
## Description of Change

Adds product evidence to the vendor for several analyzers that did not already do this.

## Related issues

- resolves #7269