### PR TITLE
chore(docs): Correct analyzers config example to use Gradle dot-syntax

### DIFF
--- a/src/site/markdown/dependency-check-gradle/configuration.md
+++ b/src/site/markdown/dependency-check-gradle/configuration.md
@@ -188,18 +188,14 @@ ossIndex     | warnOnlyOnRemoteErrors| Sets whether remote errors from the OSS I
 #### Example
 ```groovy
 dependencyCheck {
-    analyzers {
-        assemblyEnabled=false
-        artifactory {
-            enabled=true
-            url='https://internal.artifactory.url'
-        }
-        retirejs {
-            filters = ['(i)copyright Jeremy Long']
-        }
-        ossIndex {
-            username = 'example@gmail.com'
-            password = '42cc601cd7ff12a531a0b1eada8dcf56d777b336'
-    }
+    analyzers.assemblyEnabled=false
+
+    analyzers.artifactory.enabled=true
+    analyzers.artifactory.url='https://internal.artifactory.url'
+
+    analyzers.retirejs.filters = ['(i)copyright Jeremy Long']
+
+    analyzers.ossIndex.username = 'example@gmail.com'
+    analyzers.ossIndex.password = '42cc601cd7ff12a531a0b1eada8dcf56d777b336'
 }
 ```


### PR DESCRIPTION
The closure style has been deprecated as of https://github.com/dependency-check/dependency-check-gradle/issues/404

## Description of Change

Correct the gradle plugin documentation to consistently use non-deprectaed dot notation within Gradle-groovy examples.

See https://github.com/dependency-check/dependency-check-gradle/issues/404 and https://github.com/dependency-check/dependency-check-gradle/issues/187

## Have test cases been added to cover the new functionality?

N/A