### PR TITLE
fix: improve error message on improperly configured serverId credentials in settings.xml

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2578,9 +2578,10 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 settings.setStringIfNotEmpty(userKey, username);
                 settings.setStringIfNotEmpty(passwordKey, password);
             } else {
-                throw new InitializationException(
-                        "Basic type server authentication encountered in serverId " + serverId + ", but only Bearer authentication is supported for "
-                                + "the resource. For Bearer authentication tokens you should leave out the username in the server-entry in settings.xml");
+                getLog().warn("Basic type server authentication encountered in serverId " + serverId + ", but only Bearer authentication is "
+                        + "supported for the resource. For Bearer authentication tokens you should leave out the username in the server-entry in"
+                        + " settings.xml");
+                settings.setStringIfNotEmpty(tokenKey, password);
             }
         } else {
             if (tokenKey != null) {

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2579,14 +2579,16 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 settings.setStringIfNotEmpty(passwordKey, password);
             } else {
                 throw new InitializationException(
-                        "Basic type serverId encountered in " + serverId + ", but userKey or passwordKey is null");
+                        "Basic type server authentication encountered in serverId " + serverId + ", but only Bearer authentication is supported for "
+                                + "the resource. For Bearer authentication tokens you should leave out the username in the server-entry in settings.xml");
             }
         } else {
             if (tokenKey != null) {
                 settings.setStringIfNotEmpty(tokenKey, password);
             } else {
                 throw new InitializationException(
-                        "Bearer type serverId encountered in " + serverId + ", but tokenKey is null");
+                        "Bearer type server authentication encountered in serverId " + serverId + ", but only Basic authentication is supported for "
+                                + "the  resource. Looks like the username was forgotten to be added in the server-entry in settings.xml");
             }
         }
     }


### PR DESCRIPTION
## Description of Change

Improve the error-message to clarify that basic auth configuration was encountered when only bearer auth configuration is expected/supported and vice versa.

## Related issues

fixes #7309 by providing a clearer error-message.

## Have test cases been added to cover the new functionality?

no