### PR TITLE
chore(docs): Remove experimental info from nugetconf and retirejs analyzers docs.

### DIFF
--- a/src/site/markdown/analyzers/nugetconf-analyzer.md
+++ b/src/site/markdown/analyzers/nugetconf-analyzer.md
@@ -1,10 +1,6 @@
 Nugetconf Analyzer
 ==============
 
-*Experimental*: This analyzer is considered experimental. While this analyzer may 
-be useful and provide valid results more testing must be completed to ensure that
-the false negative/false positive rates are acceptable. 
-
 OWASP dependency-check includes an analyzer that will scan NuGet's packages.config files to
 collect information about the component being used. The evidence collected
 is used by other analyzers to determine if there are any known vulnerabilities

--- a/src/site/markdown/analyzers/retirejs-analyzer.md
+++ b/src/site/markdown/analyzers/retirejs-analyzer.md
@@ -4,9 +4,6 @@ Retire JS Analyzer
 OWASP dependency-check includes a Retire JS Analyzer. This analyzer that will scan
 JavaScript files and utilize the Retire JS database to identify vulnerable libraries.
 
-This analyzer is currently considered Experimental - however, this is expected to be
-promoted very quickly.
-
 The ODC team would like to thank Steve Springett for his intial PR to introduce this analyzer, 
 [Philippe Arteau](https://github.com/h3xstream) for the [burp-retire-js plugin](https://github.com/h3xstream/burp-retire-js) which
 provides much of the core functionality to use the Retire JS analysis in a Java application,


### PR DESCRIPTION
## Description of Change

Both Nugetconf Analyzer and Retire JS Analyzer are no longer experimental. However their documents still have paragraphs about these analyzers are experimental. This PR removes these paragraphs from the documents.

## Related issues

N/A. Please let me know if I should open an issue first.

## Have test cases been added to cover the new functionality?

No, as there is no change to functionality.