### PR TITLE
build: remove repo.spring.io from workflows

### DIFF
--- a/.github/workflows/files/maven-pom.middle
+++ b/.github/workflows/files/maven-pom.middle
@@ -13,11 +13,6 @@
             <id>itext</id>
             <url>https://repo.itextsupport.com/releases</url>
         </repository>
-        <repository>
-            <id>spring</id>
-            <name>spring</name>
-            <url>https://repo.spring.io/release/</url>
-        </repository>
 
         <repository>
             <name>mavengoogle</name>


### PR DESCRIPTION
The FP workflows are failing due to this repo being unauthorised for access. Not sure how it was working before unless there was an (expired?) authentication token somewhere, as anonymous access I believe was blocked some time ago.

Do we need this here, or is Maven Central good enough?