### PR TITLE
build: Add Splunk repository to repositories for Maven FP automation

### DIFF
--- a/.github/workflows/files/maven-pom.middle
+++ b/.github/workflows/files/maven-pom.middle
@@ -50,6 +50,11 @@
             <url>https://plugins.gradle.org/m2/</url>
         </repository>
         <repository>
+            <id>splunk-artifactory</id>
+            <name>Splunk Releases</name>
+            <url>https://splunk.jfrog.io/splunk/ext-releases-local</url>
+        </repository>
+        <repository>
             <id>vaadin-addon</id>
             <name>vaadin addons</name>
             <url>https://vaadin.com/nexus/content/repositories/vaadin-addons/</url>


### PR DESCRIPTION
Sadly the Splunk jars are not published to Maven central, this follows instructions from https://github.com/splunk/splunk-library-javalogging (same as listed at https://mvnrepository.com/artifact/com.splunk.logging/splunk-library-javalogging/1.11.8 ) so FP rules against them fail.