### PR TITLE
fix: some compatability issues in the gitlab report

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
+++ b/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.text.WordUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.context.Context;
@@ -273,6 +274,7 @@ public class ReportGenerator {
         ctxt.put("rpt", new ReportTool());
         ctxt.put("checksum", Checksum.class);
         ctxt.put("WordUtils", new WordUtils());
+        ctxt.put("StringUtils", new StringUtils());
         ctxt.put("VENDOR", EvidenceType.VENDOR);
         ctxt.put("PRODUCT", EvidenceType.PRODUCT);
         ctxt.put("VERSION", EvidenceType.VERSION);

--- a/core/src/main/resources/templates/gitlabReport.vsl
+++ b/core/src/main/resources/templates/gitlabReport.vsl
@@ -98,8 +98,10 @@
                         },
 
                         ## optional properties
-                        "name": "$enc.json($vulnerability.name)",
+                        "name": "$enc.json($StringUtils.truncate($vulnerability.name, 255))",
+                        #if($vulnerability.description)
                         "description": "$enc.json($vulnerability.description)",
+                        #end
                         #if($vulnerability.unscoredSeverity)
                             #if($vulnerability.unscoredSeverity.equals("0.0"))
                                 #set($severity = "Unknown")
@@ -116,15 +118,24 @@
                         "severity": "$severity.substring(0,1).toUpperCase()$severity.substring(1)",
                         ## "solution": "" --> not implemented
                         "links": [
+                            #set($prepend_comma = false)
                             #foreach( $ref in $vulnerability.getReferences(true) )
-                                {
-                                #if($ref.name)
-                                    ## optional property
-                                    "name": "$enc.json($ref.name)",
+                                #if($ref.url)
+                                    #if($prepend_comma) 
+                                        ,
+                                        #set($prepend_comma = false)
+                                    #end
+                                    {
+                                    #if($ref.name)
+                                        ## optional property
+                                        "name": "$enc.json($ref.name)",
+                                    #end
+                                        "url": "$enc.json($ref.url)"
+                                    }
+                                    #if( $foreach.hasNext )
+                                        #set($prepend_comma = true)
+                                    #end
                                 #end
-                                    "url": "$enc.json($ref.url)"
-                                }
-                                #if( $foreach.hasNext ),#end
                             #end
                         ]
                         ## "details": [], --> not implemented


### PR DESCRIPTION
* truncated vulnerability names
* made vulnerability descriptions optional
* no longer attempt to render links without urls

## Description of Change

1. Added StringUtils to Velocity content in ReportGenerator
2. Updated gitlabReport.vsl with the relevant changes
a. vulnerability name is truncated to 255 characters
b. vulnerability description is only rendered if present
c. links are only rendered if present

## Related issues

- fixes #7347

## Have test cases been added to cover the new functionality?

*no*