### PR TITLE
build: add Spring Milestones repo to repos list

### DIFF
--- a/.github/workflows/files/maven-pom.middle
+++ b/.github/workflows/files/maven-pom.middle
@@ -13,7 +13,11 @@
             <id>itext</id>
             <url>https://repo.itextsupport.com/releases</url>
         </repository>
-
+        <repository>
+            <name>spring-milestones</name>
+            <id>springmilestones</id>
+            <url>https://repo.spring.io/milestone/</url>
+        </repository>
         <repository>
             <name>mavengoogle</name>
             <id>mavengoogle</id>


### PR DESCRIPTION
According to https://spring.io/blog/2022/12/14/notice-of-permissions-changes-to-repo-spring-io-january-2023 only the /snapshots and /milestones repos are OK for anonymous access, so this should be fine.

Should allow the automation to work for FPs like #7359