### PR TITLE
ci: add Hazelcast repository to Maven FP automation

### DIFF
--- a/.github/workflows/files/maven-pom.middle
+++ b/.github/workflows/files/maven-pom.middle
@@ -64,6 +64,11 @@
             <url>https://vaadin.com/nexus/content/repositories/vaadin-addons/</url>
         </repository>
         <repository>
+            <id>hazelcast-release</id>
+            <name>Hazelcast Repository</name>
+            <url>https://repository.hazelcast.com/release/</url>
+        </repository>
+        <repository>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
As at https://mvnrepository.com/repos/hazelcast-release and https://github.com/dependency-check/DependencyCheck/issues/7403 would be useful to have this available.