### PR TITLE
fix: Make HC5 Downloader honor the connection- and readTimeout settings that the old URLConnectionFactory based downloads observed

### DIFF
--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -1455,6 +1455,31 @@ public final class Settings {
     }
 
     /**
+     * Returns a long value from the properties file. If the value was specified
+     * as a system property or passed in via the -Dprop=value argument - this
+     * method will return the value from the system properties before the values
+     * in the contained configuration file.
+     *
+     * @param key the key to lookup within the properties file
+     * @param defaultValue the default value to return
+     * @return the property from the properties file or the defaultValue if the
+     * property does not exist or cannot be converted to an integer
+     */
+    public long getLong(@NotNull final String key, long defaultValue) {
+        long value;
+        try {
+            value = Long.parseLong(getString(key));
+        } catch (NumberFormatException ex) {
+            if (!getString(key, "").isEmpty()) {
+                LOGGER.debug("Could not convert property '{}={}' to a long; using {} instead.",
+                        key, getPrintableValue(key, getString(key)), defaultValue);
+            }
+            value = defaultValue;
+        }
+        return value;
+    }
+
+    /**
      * Returns a boolean value from the properties file. If the value was
      * specified as a system property or passed in via the
      * <code>-Dprop=value</code> argument this method will return the value from


### PR DESCRIPTION
## Description of Change

Restores the timeouts (read and connect), including their configurability, that applied to the old UrlConnectionFactory based downloads also for the traffic that now uses the apache HttpClient5 based http clients.

## Related issues

- relates to #7418 in that the HC5 based Downloader of DependencyCheck itself, similar to the NVD-API-client of the open-vulnerability-clients library, missed out on setting read-timeout.


## Have test cases been added to cover the new functionality?

no