### PR TITLE
fix: Downloader configuration in core module

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/DownloadTask.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/nvd/api/DownloadTask.java
@@ -85,6 +85,7 @@ public class DownloadTask implements Callable<Future<NvdApiProcessor>> {
             LOGGER.info("Download Started for NVD Cache - {}", url);
             final long startDownload = System.currentTimeMillis();
             final File outputFile = settings.getTempFile("nvd-datafeed-", "json.gz");
+            Downloader.getInstance().configure(settings);
             Downloader.getInstance().fetchFile(u, outputFile, true, Settings.KEYS.NVD_API_DATAFEED_USER, Settings.KEYS.NVD_API_DATAFEED_PASSWORD,
                     Settings.KEYS.NVD_API_DATAFEED_BEARER_TOKEN);
             if (this.processorService == null) {


### PR DESCRIPTION
## Description of Change

Configure the Downloader in `org.owasp.dependencycheck.data.update.nvd.api.DownloadTask` with the Settings set in the DownloadTask.

## Related issues

fixes #7452

## Have test cases been added to cover the new functionality?

Not yet. But I'm unsure how to do this.