### PR TITLE
fix: Also apply muteNoisyLoggers to UpdateMojo

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2703,7 +2703,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     /**
      * Hacky method of muting the noisy logging from JCS
      */
-    private void muteNoisyLoggers() {
+    protected void muteNoisyLoggers() {
         System.setProperty("jcs.logSystem", "slf4j");
         if (!getLog().isDebugEnabled()) {
             Slf4jAdapter.muteLogging(true);

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/UpdateMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/UpdateMojo.java
@@ -67,6 +67,7 @@ public class UpdateMojo extends BaseDependencyCheckMojo {
      */
     @Override
     protected void runCheck() throws MojoExecutionException, MojoFailureException {
+        muteNoisyLoggers();
         try (Engine engine = initializeEngine()) {
             try {
                 if (!engine.getSettings().getBoolean(Settings.KEYS.AUTO_UPDATE)) {


### PR DESCRIPTION
## Description of Change

The `update-only` mojo also has some log spamming that can be disabled by using `BaseDependencyCheckMojo.muteNoisyLoggers`

## Related issues

None as far as I know or found

## Have test cases been added to cover the new functionality?

Manually tested, not sure if there is a test for log spam