### PR TITLE
fix: cli not honoring window paths correctly

### DIFF
--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -380,6 +380,10 @@ public class App {
             final File baseDir;
             final int pos = getLastFileSeparator(include);
             final String tmpBase = include.substring(0, pos);
+            //fix for windows style paths scanning c:/temp.
+            if (tmpBase.endsWith(':')) {
+                tmpBase += '/';
+            }
             final String tmpInclude = include.substring(pos + 1);
             if (tmpInclude.indexOf('*') >= 0 || tmpInclude.indexOf('?') >= 0
                     || new File(include).isFile()) {

--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -379,7 +379,7 @@ public class App {
             String include = file.replace('\\', '/');
             final File baseDir;
             final int pos = getLastFileSeparator(include);
-            final String tmpBase = include.substring(0, pos);
+            String tmpBase = include.substring(0, pos);
             //fix for windows style paths scanning c:/temp.
             if (tmpBase.endsWith(":")) {
                 tmpBase += "/";

--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -381,8 +381,8 @@ public class App {
             final int pos = getLastFileSeparator(include);
             final String tmpBase = include.substring(0, pos);
             //fix for windows style paths scanning c:/temp.
-            if (tmpBase.endsWith(':')) {
-                tmpBase += '/';
+            if (tmpBase.endsWith(":")) {
+                tmpBase += "/";
             }
             final String tmpInclude = include.substring(pos + 1);
             if (tmpInclude.indexOf('*') >= 0 || tmpInclude.indexOf('?') >= 0


### PR DESCRIPTION
Minor fix to how the CLI handles paths in Windows. Resolves #7152.
