### PR TITLE
fix: Avoid FPs when Composer product name has php

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -361,8 +361,26 @@
     <suppress base="true">
         <notes><![CDATA[
         FP per #2972
+        hyphenated PHP library vendor names
         ]]></notes>
         <packageUrl regex="true">^pkg:composer/php\-.*$</packageUrl>
+        <cpe>cpe:/a:php:php</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per #2972 + #7444
+        hyphenated PHP library product names (prefix)
+        ]]></notes>
+        <packageUrl regex="true">^pkg:composer/[^/]+/php[\-_].*$</packageUrl>
+        <cpe>cpe:/a:php:php</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per #2972 + #7444
+        hyphenated PHP library product names (suffix)
+        including number suffix, e.g., `symfony/polyfill-php80`
+        ]]></notes>
+        <packageUrl regex="true">^pkg:composer/[^/]+/.*[\-_]php[0-9]*@.*$</packageUrl>
         <cpe>cpe:/a:php:php</cpe>
     </suppress>
     <suppress base="true">


### PR DESCRIPTION
## Description of Change

Previously, only PHP package's vendor (product URL's namespace) was considered as evidence. As of DependencyCheck v12, specifically change from #7295, the product (name) is also being considered as evidence.

This results in new false positives, as noticed in #7444. PHP Composer checks are affected, for example, considering package `pkg:composer/phpunit/php-timer@6.0.0` as `cpe:2.3:a:php:php:6.0:*:*:*:*:*:*:*` resulting in 17 CVEs (including Critical).

This commit adds two new suppression rules: one for php as the prefix, and one for php as the suffix. Both can be observed in the wild. Additionally, underscore is sometimes used instead of hyphen, and should be respected. Furthermore, there is `symfony/polyfill-php83` which adds number suffix, which should also be suppressed as it currently maps to the base `cpe:/a:php:php`.

## Related issues

- relates to #7444
- relates to #7295
- relates to #2972

## Have test cases been added to cover the new functionality?

no