### PR TITLE
docs: drop redundant text in the Internet Access Required section

### DIFF
--- a/src/site/markdown/data/index.md
+++ b/src/site/markdown/data/index.md
@@ -1,6 +1,6 @@
 # Internet Access Required
 
-Dependency-check requires access, by default, to several externally
+Dependency-check, by default, requires access to several externally
 hosted resources.
 
 ## The NVD Database

--- a/src/site/markdown/data/index.md
+++ b/src/site/markdown/data/index.md
@@ -1,6 +1,6 @@
 # Internet Access Required
 
-Dependency-check requires access, by default, requires access to several externally
+Dependency-check requires access, by default, to several externally
 hosted resources.
 
 ## The NVD Database


### PR DESCRIPTION
## Description of Change

This pull request fixes a trivial writing error in the introductory text of the [Internet Access Required – dependency-check-maven](https://dependency-check.github.io/DependencyCheck/data/index.html) page.

Please take a look at the diff for the problem.

## Related issues

N/A

## Have test cases been added to cover the new functionality?

N/A