### PR TITLE
fix: Ignore require-bundle MANIFEST.MF entry for evidence

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -160,7 +160,8 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
             "dstamp",
             "eclipse-sourcereferences",
             "kotlin-version",
-            "require-capability");
+            "require-capability",
+            "require-bundle");
     /**
      * Deprecated Jar manifest attribute, that is, nonetheless, useful for
      * analysis.


### PR DESCRIPTION
Fixes #7518

## Description of Change

Add the require-bundle key to the Manifest keys that are ignored during evidence-gathering

## Related issues

- fixes #7518 

## Have test cases been added to cover the new functionality?

no