### PR TITLE
fix(yarn): protect against exotic version number of yarn

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzer.java
@@ -114,7 +114,7 @@ public class YarnAuditAnalyzer extends AbstractNpmAnalyzer {
     private int getYarnMajorVersion(Dependency dependency) {
         var yarnVersion = getYarnVersion(dependency);
         try {
-            var semver = new Semver(yarnVersion);
+            var semver = Semver.coerce(yarnVersion);
             return semver.getMajor();
         } catch (SemverException e) {
             throw new IllegalStateException("Invalid version string format", e);


### PR DESCRIPTION
## Description of Change

Changed how Semver lib is used to test Yarn version so it is protected against exotic version.

## Related issues

- fixes #7488 

## Have test cases been added to cover the new functionality?

*yes* (was already tested for nominal case of yarn)