### PR TITLE
fix: Use unscored severity only in absence of any CVSS baseScore

### DIFF
--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -1524,12 +1524,23 @@ public class Check extends Update {
         for (Dependency d : dependencies) {
             boolean addName = true;
             for (Vulnerability v : d.getVulnerabilities()) {
-                if ((v.getCvssV2() != null && v.getCvssV2().getCvssData().getBaseScore() >= failBuildOnCVSS)
-                        || (v.getCvssV3() != null && v.getCvssV3().getCvssData().getBaseScore() >= failBuildOnCVSS)
-                        || (v.getCvssV4() != null && v.getCvssV4().getCvssData().getBaseScore() >= failBuildOnCVSS)
-                        || (v.getUnscoredSeverity() != null && SeverityUtil.estimateCvssV2(v.getUnscoredSeverity()) >= failBuildOnCVSS)
+                final double cvssV2 = v.getCvssV2() != null && v.getCvssV2().getCvssData() != null
+                        && v.getCvssV2().getCvssData().getBaseScore() != null ? v.getCvssV2().getCvssData().getBaseScore() : -1;
+                final double cvssV3 = v.getCvssV3() != null && v.getCvssV3().getCvssData() != null
+                        && v.getCvssV3().getCvssData().getBaseScore() != null ? v.getCvssV3().getCvssData().getBaseScore() : -1;
+                final double cvssV4 = v.getCvssV4() != null && v.getCvssV4().getCvssData() != null
+                        && v.getCvssV4().getCvssData().getBaseScore() != null ? v.getCvssV4().getCvssData().getBaseScore() : -1;
+                final boolean useUnscored = cvssV2 == -1 && cvssV3 == -1 && cvssV4 == -1;
+                final double unscoredCvss =
+                        useUnscored && v.getUnscoredSeverity() != null ? SeverityUtil.estimateCvssV2(v.getUnscoredSeverity()) : -1;
+
+                if (cvssV2 >= failBuildOnCVSS
+                        || cvssV3 >= failBuildOnCVSS
+                        || cvssV4 >= failBuildOnCVSS
+                        || unscoredCvss >= failBuildOnCVSS
                         //safety net to fail on any if for some reason the above misses on 0
-                        || (failBuildOnCVSS <= 0.0f)) {
+                        || failBuildOnCVSS <= 0.0f
+                ) {
                     if (addName) {
                         addName = false;
                         ids.append(NEW_LINE).append(d.getFileName()).append(" (")

--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -313,13 +313,14 @@ public class App {
         for (Dependency d : engine.getDependencies()) {
             boolean addName = true;
             for (Vulnerability v : d.getVulnerabilities()) {
-                final Double cvssV2 = v.getCvssV2() != null && v.getCvssV2().getCvssData() != null
+                final double cvssV2 = v.getCvssV2() != null && v.getCvssV2().getCvssData() != null
                         && v.getCvssV2().getCvssData().getBaseScore() != null ? v.getCvssV2().getCvssData().getBaseScore() : -1;
-                final Double cvssV3 = v.getCvssV3() != null && v.getCvssV3().getCvssData() != null
+                final double cvssV3 = v.getCvssV3() != null && v.getCvssV3().getCvssData() != null
                         && v.getCvssV3().getCvssData().getBaseScore() != null ? v.getCvssV3().getCvssData().getBaseScore() : -1;
-                final Double cvssV4 = v.getCvssV4() != null && v.getCvssV4().getCvssData() != null
+                final double cvssV4 = v.getCvssV4() != null && v.getCvssV4().getCvssData() != null
                         && v.getCvssV4().getCvssData().getBaseScore() != null ? v.getCvssV4().getCvssData().getBaseScore() : -1;
-                final Double unscoredCvss = v.getUnscoredSeverity() != null ? SeverityUtil.estimateCvssV2(v.getUnscoredSeverity()) : -1;
+                final boolean useUnscored = cvssV2 == -1 && cvssV3 == -1 && cvssV4 == -1;
+                final double unscoredCvss = (useUnscored && v.getUnscoredSeverity() != null) ? SeverityUtil.estimateCvssV2(v.getUnscoredSeverity()) : -1;
 
                 if (cvssV2 >= cvssFailScore
                         || cvssV3 >= cvssFailScore

--- a/core/src/main/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgent.java
+++ b/core/src/main/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgent.java
@@ -1027,12 +1027,21 @@ public class DependencyCheckScanAgent {
         for (Dependency d : dependencies) {
             boolean addName = true;
             for (Vulnerability v : d.getVulnerabilities()) {
-                if ((v.getCvssV2() != null && v.getCvssV2().getCvssData().getBaseScore() >= failBuildOnCVSS)
-                        || (v.getCvssV3() != null && v.getCvssV3().getCvssData().getBaseScore() >= failBuildOnCVSS)
-                        || (v.getCvssV4() != null && v.getCvssV4().getCvssData().getBaseScore() >= failBuildOnCVSS)
-                        || (v.getUnscoredSeverity() != null && SeverityUtil.estimateCvssV2(v.getUnscoredSeverity()) >= failBuildOnCVSS)
+                final double cvssV2 = v.getCvssV2() != null && v.getCvssV2().getCvssData() != null
+                        && v.getCvssV2().getCvssData().getBaseScore() != null ? v.getCvssV2().getCvssData().getBaseScore() : -1;
+                final double cvssV3 = v.getCvssV3() != null && v.getCvssV3().getCvssData() != null
+                        && v.getCvssV3().getCvssData().getBaseScore() != null ? v.getCvssV3().getCvssData().getBaseScore() : -1;
+                final double cvssV4 = v.getCvssV4() != null && v.getCvssV4().getCvssData() != null
+                        && v.getCvssV4().getCvssData().getBaseScore() != null ? v.getCvssV4().getCvssData().getBaseScore() : -1;
+                final boolean useUnscored = cvssV2 == -1 && cvssV3 == -1 && cvssV4 == -1;
+                final double unscoredCvss = (useUnscored && v.getUnscoredSeverity() != null) ? SeverityUtil.estimateCvssV2(v.getUnscoredSeverity()) : -1;
+                if (cvssV2 >= failBuildOnCVSS
+                        || cvssV3 >= failBuildOnCVSS
+                        || cvssV4 >= failBuildOnCVSS
+                        || unscoredCvss >= failBuildOnCVSS
                         //safety net to fail on any if for some reason the above misses on 0
-                        || (failBuildOnCVSS <= 0.0f)) {
+                        || failBuildOnCVSS <= 0.0f
+                ) {
                     if (addName) {
                         addName = false;
                         ids.append(NEW_LINE).append(d.getFileName()).append(" (")

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2838,17 +2838,20 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         for (Dependency d : dependencies) {
             boolean addName = true;
             for (Vulnerability v : d.getVulnerabilities()) {
-                final Double cvssV2 = v.getCvssV2() != null && v.getCvssV2().getCvssData() != null && v.getCvssV2().getCvssData().getBaseScore() != null ? v.getCvssV2().getCvssData().getBaseScore() : -1;
-                final Double cvssV3 = v.getCvssV3() != null && v.getCvssV3().getCvssData() != null && v.getCvssV3().getCvssData().getBaseScore() != null ? v.getCvssV3().getCvssData().getBaseScore() : -1;
-                final Double cvssV4 = v.getCvssV4() != null && v.getCvssV4().getCvssData() != null && v.getCvssV4().getCvssData().getBaseScore() != null ? v.getCvssV4().getCvssData().getBaseScore() : -1;
-                final Double unscoredCvss = v.getUnscoredSeverity() != null ? SeverityUtil.estimateCvssV2(v.getUnscoredSeverity()) : -1;
+                final double cvssV2 = v.getCvssV2() != null && v.getCvssV2().getCvssData() != null && v.getCvssV2().getCvssData().getBaseScore() != null ? v.getCvssV2().getCvssData().getBaseScore() : -1;
+                final double cvssV3 = v.getCvssV3() != null && v.getCvssV3().getCvssData() != null && v.getCvssV3().getCvssData().getBaseScore() != null ? v.getCvssV3().getCvssData().getBaseScore() : -1;
+                final double cvssV4 = v.getCvssV4() != null && v.getCvssV4().getCvssData() != null && v.getCvssV4().getCvssData().getBaseScore() != null ? v.getCvssV4().getCvssData().getBaseScore() : -1;
+                final boolean useUnscored = cvssV2 == -1 && cvssV3 == -1 && cvssV4 == -1;
+                final double unscoredCvss = (useUnscored && v.getUnscoredSeverity() != null) ? SeverityUtil.estimateCvssV2(v.getUnscoredSeverity()) : -1;
 
-                if (failBuildOnAnyVulnerability || cvssV2 >= failBuildOnCVSS
+                if (failBuildOnAnyVulnerability
+                        || cvssV2 >= failBuildOnCVSS
                         || cvssV3 >= failBuildOnCVSS
                         || cvssV4 >= failBuildOnCVSS
                         || unscoredCvss >= failBuildOnCVSS
                         //safety net to fail on any if for some reason the above misses on 0
-                        || (failBuildOnCVSS <= 0.0)) {
+                        || failBuildOnCVSS <= 0.0
+                ) {
                     String name = v.getName();
                     if (cvssV4 >= 0.0) {
                         name += "(" + cvssV4 + ")";


### PR DESCRIPTION
fixes #7528


## Description of Change

Only use the fabricated high-watermark guestimated CVSSv2 score for breaking the build when there is not any datasource that has published a CVSS basescore for the vulnerability.

- fixes #7528 

## Have test cases been added to cover the new functionality?

no