### PR TITLE
feat: Allow multiple base suppression files coming from several dependencies

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -195,15 +196,24 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
      * @throws SuppressionParseException thrown if the XML cannot be parsed.
      */
     private void loadPackagedSuppressionBaseData(final SuppressionParser parser, final Engine engine) throws SuppressionParseException {
-        final List<SuppressionRule> ruleList;
-        try (InputStream in = FileUtils.getResourceAsStream(BASE_SUPPRESSION_FILE)) {
-            if (in == null) {
-                throw new SuppressionParseException("Suppression rules `" + BASE_SUPPRESSION_FILE + "` could not be found");
+        final List<SuppressionRule> ruleList = new ArrayList<>();
+        try {
+            Iterator<URL> urls = FileUtils.getResources(BASE_SUPPRESSION_FILE);
+            while (urls.hasNext()) {
+                URL url = urls.next();
+                try (InputStream in = url.openStream()) {
+                    if (in == null) {
+                        throw new SuppressionParseException("Suppression rules `" + url + "` could not be found");
+                    }
+                    ruleList.addAll(parser.parseSuppressionRules(in));
+                } catch (SAXException | IOException ex) {
+                    throw new SuppressionParseException("Unable to parse the base suppression data file", ex);
+                }
             }
-            ruleList = parser.parseSuppressionRules(in);
-        } catch (SAXException | IOException ex) {
-            throw new SuppressionParseException("Unable to parse the base suppression data file", ex);
+        } catch (IOException ex) {
+            throw new SuppressionParseException("Unable to find base suppression data files", ex);
         }
+
         if (!ruleList.isEmpty()) {
             if (engine.hasObject(SUPPRESSION_OBJECT_KEY)) {
                 @SuppressWarnings("unchecked")

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
@@ -27,6 +27,8 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.Iterator;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -151,6 +153,19 @@ public final class FileUtils {
                 LOGGER.trace("", ex);
             }
         }
+    }
+
+    /** Gets the {@link java.util.Iterator<java.net.URL>} for this resource
+     *
+     * @param resource path
+     * @return iterator of each resource URL
+     * @throws IOException if I/O error occurs
+     */
+    public static Iterator<URL> getResources(@NotNull String resource) throws IOException {
+        final ClassLoader classLoader = FileUtils.class.getClassLoader();
+        return classLoader != null
+            ? classLoader.getResources(resource).asIterator()
+            : ClassLoader.getSystemResources(resource).asIterator();
     }
 
     /**


### PR DESCRIPTION
## Description of Change

By allowing multiple packaged base suppression files, projects can export their suppressions so other downstream projects can reuse these suppressions.

On our project we follow an approach where we've a "commons" library pulls most of the dependencies that will be used transitively. In order to avoid duplicating the suppression file on each downstream project, we package the "commons" suppression file, and we aggregate it with any other suppressions on the downstream projects.

There is at least one potential downside to this, in that some library could suppress a vulnerability that we as users disagree with. This is nonetheless the current case with the packaged suppression, as there is no way to disable them.

Please let me know if this PR would be a desirable feature, otherwise feel free to close it.

There is one issue with the implementation though. In order to keep the base/non-base status of the suppression depending where it's used (ie. if it's packaged or if it's used by the project that defined it), it's possible for force the "base" attribute when loading the packaged suppressions with "setBase(true)". If the feature is desirable, I can make an update to the PR.

## Have test cases been added to cover the new functionality?

**no**