### PR TITLE
fix: Avoid FPs for Symfony Polyfill as framework

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -385,6 +385,13 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
+        FP per #7542
+        ]]></notes>
+        <packageUrl regex="true">^pkg:composer/symfony/polyfill-.*$</packageUrl>
+        <cpe>cpe:/a:sensiolabs:symfony</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
         FP per #2957
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy/resteasy\-spring\-boot\-starter@.*$</packageUrl>


### PR DESCRIPTION
## Description of Change

Since package name matching change, [Symfony Polyfill](https://github.com/symfony/polyfill) is being matched lossy as [Symfony framework](https://github.com/symfony/symfony). However, it is an independent project, with an independent versioning scheme.

This can be observed in CVE-2022-23601 match. The advisory was patched in Symphony framework versions 5.3.15, 5.4.4 and 6.0.4. (Latest framework version is 7.2.4.) Meanwhile, Polyfill project has latest version as 1.31.0. This understandably is considered a vulnerable version number.

## Related issues

- fixes #7542
- relates to #7444
- caused by #7295

## Have test cases been added to cover the new functionality?

*no*