### PR TITLE
fix: prevent rogue base suppression files

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
@@ -205,18 +205,16 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
             return;
         }
         URL jarLocation = AbstractSuppressionAnalyzer.class.getProtectionDomain().getCodeSource().getLocation();
-
+        String expectedUrl = jarLocation.getFile();
+        if (expectedUrl.endsWith(".jar")) {
+            expectedUrl = "jar:file:" + expectedUrl + "!/dependencycheck-base-suppression.xml";
+        } else {
+            expectedUrl = "file:" + expectedUrl + "dependencycheck-base-suppression.xml";
+        }
         URL validUrl = null;
         while (urls.hasNext()) {
-            String validationBase = jarLocation.getFile();
             URL url = urls.next();
-            String path = url.toString();
-            if (path.startsWith("file:")) {
-                validationBase = "file:" + validationBase + "dependencycheck-base-suppression.xml";
-            } else {
-                validationBase = "jar:file:" + validationBase + "!/dependencycheck-base-suppression.xml";
-            }
-            if (validationBase.equals(path)) {
+            if (expectedUrl.equals(url.toString())) {
                 validUrl = url;
                 break;
             }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
@@ -207,9 +207,9 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
         URL jarLocation = AbstractSuppressionAnalyzer.class.getProtectionDomain().getCodeSource().getLocation();
         String expectedUrl = jarLocation.getFile();
         if (expectedUrl.endsWith(".jar")) {
-            expectedUrl = "jar:file:" + expectedUrl + "!/dependencycheck-base-suppression.xml";
+            expectedUrl = "jar:file:" + expectedUrl + "!/" + BASE_SUPPRESSION_FILE;
         } else {
-            expectedUrl = "file:" + expectedUrl + "dependencycheck-base-suppression.xml";
+            expectedUrl = "file:" + expectedUrl + BASE_SUPPRESSION_FILE;
         }
         URL validUrl = null;
         while (urls.hasNext()) {

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
@@ -27,7 +27,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -172,20 +171,6 @@ public final class FileUtils {
             return new FileInputStream(resource);
         }
         return inputStream;
-    }
-
-
-    /** Gets the {@link java.util.Iterator<java.net.URL>} for this resource
-     *
-     * @param resource path
-     * @return iterator of each resource URL
-     * @throws IOException if I/O error occurs
-     */
-    public static Iterator<URL> getResources(@NotNull String resource) throws IOException {
-        final ClassLoader classLoader = FileUtils.class.getClassLoader();
-        return classLoader != null
-                ? classLoader.getResources(resource).asIterator()
-                : ClassLoader.getSystemResources(resource).asIterator();
     }
 
     /**

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -171,6 +172,20 @@ public final class FileUtils {
             return new FileInputStream(resource);
         }
         return inputStream;
+    }
+
+
+    /** Gets the {@link java.util.Iterator<java.net.URL>} for this resource
+     *
+     * @param resource path
+     * @return iterator of each resource URL
+     * @throws IOException if I/O error occurs
+     */
+    public static Iterator<URL> getResources(@NotNull String resource) throws IOException {
+        final ClassLoader classLoader = FileUtils.class.getClassLoader();
+        return classLoader != null
+                ? classLoader.getResources(resource).asIterator()
+                : ClassLoader.getSystemResources(resource).asIterator();
     }
 
     /**


### PR DESCRIPTION
## Description of Change

PR #7541 showed the maintainers that it was possible for a rogue library to add a suppression file

## Have test cases been added to cover the new functionality?

No, existing test cases appropriately load the suppression file. A negative test case was not added.