### PR TITLE
fix: Avoid FPs for Symfony Contracts as framework

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -392,6 +392,13 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
+        FP per #7545
+        ]]></notes>
+        <packageUrl regex="true">^pkg:composer/symfony/.*-contracts@.*$</packageUrl>
+        <cpe>cpe:/a:sensiolabs:symfony</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
         FP per #2957
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy/resteasy\-spring\-boot\-starter@.*$</packageUrl>


### PR DESCRIPTION
## Description of Change

[Symfony Contracts](https://github.com/symfony/contracts) are being matched as [Symphony framework](https://github.com/symfony/symfony). However, they are different projects with independent versioning schemes. For example, CVE-2022-23601 for Symfony is resolved in versions 5.3.15, 5.4.4 and 6.0.4. However, Contracts project's latest version is v3.5.2.

## Related issues

- fixes #7545
- relates to #7444
- caused by #7295

## Have test cases been added to cover the new functionality?

*no*