### PR TITLE
fix: #6819 handle invalid toml file

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzer.java
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Copyright (c) 2019 Nima Yahyazadeh. All Rights Reserved.
  */
 package org.owasp.dependencycheck.analyzer;
 

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzerTest.java
@@ -80,6 +80,13 @@ public class PoetryAnalyzerTest extends BaseTest {
         analyzer.analyze(result, engine);
     }
 
+    @Test
+    public void testNodeGypToml() throws AnalysisException {
+        final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "node-gyp-toml/pyproject.toml"));
+        //returns with no error.
+        analyzer.analyze(result, engine);
+    }
+
     @Test(expected = AnalysisException.class)
     public void testPoetryToml() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "python-poetry-toml/pyproject.toml"));

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzerTest.java
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Copyright (c) 2019 Nima Yahyazadeh. All Rights Reserved.
  */
 package org.owasp.dependencycheck.analyzer;
 

--- a/core/src/test/resources/node-gyp-toml/pyproject.toml
+++ b/core/src/test/resources/node-gyp-toml/pyproject.toml
@@ -1,0 +1,119 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gyp-next"
+version = "0.16.1"
+authors = [
+  { name="Node.js contributors", email="ryzokuken@disroot.org" },
+]
+description = "A fork of the GYP build system for use in the Node.js projects"
+readme = "README.md"
+license = { file="LICENSE" }
+requires-python = ">=3.8"
+# The Python module "packaging" is vendored in the "pylib/packaging" directory to support Python >= 3.12.
+# dependencies = ["packaging>=23.1"]  # Uncomment this line if the vendored version is removed.
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
+
+[project.optional-dependencies]
+dev = ["flake8", "ruff", "pytest"]
+
+[project.scripts]
+gyp = "gyp:script_main"
+
+[project.urls]
+"Homepage" = "https://github.com/nodejs/gyp-next"
+
+[tool.ruff]
+lint.select = [
+  "C4",   # flake8-comprehensions
+  "C90",  # McCabe cyclomatic complexity
+  "DTZ",  # flake8-datetimez
+  "E",    # pycodestyle
+  "F",    # Pyflakes
+  "G",    # flake8-logging-format
+  "ICN",  # flake8-import-conventions
+  "INT",  # flake8-gettext
+  "PL",   # Pylint
+  "PYI",  # flake8-pyi
+  "RSE",  # flake8-raise
+  "RUF",  # Ruff-specific rules
+  "T10",  # flake8-debugger
+  "TCH",  # flake8-type-checking
+  "TID",  # flake8-tidy-imports
+  "UP",   # pyupgrade
+  "W",    # pycodestyle
+  "YTT",  # flake8-2020
+  # "A",    # flake8-builtins
+  # "ANN",  # flake8-annotations
+  # "ARG",  # flake8-unused-arguments
+  # "B",    # flake8-bugbear
+  # "BLE",  # flake8-blind-except
+  # "COM",  # flake8-commas
+  # "D",    # pydocstyle
+  # "DJ",   # flake8-django
+  # "EM",   # flake8-errmsg
+  # "ERA",  # eradicate
+  # "EXE",  # flake8-executable
+  # "FBT",  # flake8-boolean-trap
+  # "I",    # isort
+  # "INP",  # flake8-no-pep420
+  # "ISC",  # flake8-implicit-str-concat
+  # "N",    # pep8-naming
+  # "NPY",  # NumPy-specific rules
+  # "PD",   # pandas-vet
+  # "PGH",  # pygrep-hooks
+  # "PIE",  # flake8-pie
+  # "PT",   # flake8-pytest-style
+  # "PTH",  # flake8-use-pathlib
+  # "Q",    # flake8-quotes
+  # "RET",  # flake8-return
+  # "S",    # flake8-bandit
+  # "SIM",  # flake8-simplify
+  # "SLF",  # flake8-self
+  # "T20",  # flake8-print
+  # "TRY",  # tryceratops
+]
+lint.ignore = [
+  "E721",
+  "PLC1901",
+  "PLR0402",
+  "PLR1714",
+  "PLR2004",
+  "PLR5501",
+  "PLW0603",
+  "PLW2901",
+  "PYI024",
+  "RUF005",
+  "RUF012",
+  "UP031",
+]
+extend-exclude = ["pylib/packaging"]
+line-length = 88
+target-version = "py37"
+
+[tool.ruff.lint.mccabe]
+max-complexity = 101
+
+[tool.ruff.lint.pylint]
+max-args = 11
+max-branches = 108
+max-returns = 10
+max-statements = 286
+
+[tool.setuptools]
+package-dir = {"" = "pylib"}
+packages = ["gyp", "gyp.generator"]


### PR DESCRIPTION
## Description of Change

The goal of this PR is to handle an unparsable toml file in case it does not respect the toml specification. As of now, the analysis fail in error when such a file is present.

This changes aims to provide a warning message telling the user the file could not be parsed and is therefore excluded from the analysis. The stack trace can be visible when debug logs are enabled.

Please note this PR also remove a copyright mention in both modified files, [as advised by the Apache foundation](https://www.apache.org/legal/src-headers.html#headers).

Comments are welcomed!

### Current behavior

```
[WARN] An unexpected error occurred during analysis of '/home/jtorres/experiments/base/demo-project/node_modules/node-gyp/gyp/pyproject.toml' (Poetry Analyzer): java.lang.IllegalStateException: Invalid key on line 41: lint.select
[ERROR]
java.lang.RuntimeException: java.lang.IllegalStateException: Invalid key on line 41: lint.select
        at com.moandjiezana.toml.Toml.read(Toml.java:74)
        at org.owasp.dependencycheck.analyzer.PoetryAnalyzer.analyzeDependency(PoetryAnalyzer.java:150)
        at org.owasp.dependencycheck.analyzer.AbstractAnalyzer.analyze(AbstractAnalyzer.java:131)
        at org.owasp.dependencycheck.AnalysisTask.call(AnalysisTask.java:88)
        at org.owasp.dependencycheck.AnalysisTask.call(AnalysisTask.java:37)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.IllegalStateException: Invalid key on line 41: lint.select
        at com.moandjiezana.toml.Toml.read(Toml.java:140)
        at com.moandjiezana.toml.Toml.read(Toml.java:107)
        at com.moandjiezana.toml.Toml.read(Toml.java:72)
        ... 8 common frames omitted
```

### Behavior introduced by this change

```
[DEBUG] Invalid toml file, cannot parse '/home/nhumblot/dev/wkspace/DependencyCheck/core/target/test-classes/node-gyp-toml/pyproject.toml'
java.lang.RuntimeException: java.lang.IllegalStateException: Invalid key on line 41: lint.select
	at com.moandjiezana.toml.Toml.read(Toml.java:74)
	at org.owasp.dependencycheck.analyzer.PoetryAnalyzer.parseDependencyFile(PoetryAnalyzer.java:212)
	at org.owasp.dependencycheck.analyzer.PoetryAnalyzer.analyzeDependency(PoetryAnalyzer.java:152)
	at org.owasp.dependencycheck.analyzer.AbstractAnalyzer.analyze(AbstractAnalyzer.java:131)
	at org.owasp.dependencycheck.analyzer.PoetryAnalyzerTest.testNodeGypToml(PoetryAnalyzerTest.java:87)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:232)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
Caused by: java.lang.IllegalStateException: Invalid key on line 41: lint.select
	at com.moandjiezana.toml.Toml.read(Toml.java:140)
	at com.moandjiezana.toml.Toml.read(Toml.java:107)
	at com.moandjiezana.toml.Toml.read(Toml.java:72)
	... 34 common frames omitted
[WARN] toml file skipped: /home/nhumblot/dev/wkspace/DependencyCheck/core/target/test-classes/node-gyp-toml/pyproject.toml could not be parsed
```

## Related issues

Fixes #6819 

## Have test cases been added to cover the new functionality?

*yes*