### PR TITLE
fix: resolve NPE when processing CVE-2025-2682

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -1090,7 +1090,7 @@ public final class CveDB implements AutoCloseable {
         clearCache();
         final String cveId = cve.getCve().getId();
         try {
-            if (cve.getCve().getVulnStatus().toUpperCase().startsWith("REJECT")) {
+            if (cve.getCve().getVulnStatus() != null && cve.getCve().getVulnStatus().toUpperCase().startsWith("REJECT")) {
                 deleteVulnerability(cveId);
             } else {
                 if (cveItemConverter.testCveCpeStartWithFilter(cve)) {


### PR DESCRIPTION
Adds a null check to prevent NPE.

resolves #7557