### PR TITLE
docs: sync the supported Maven version with the one stated in the system requirement section

### DIFF
--- a/maven/src/site/markdown/index.md.vm
+++ b/maven/src/site/markdown/index.md.vm
@@ -1,7 +1,7 @@
 Usage
 ======================
 Dependency-check-maven is very simple to utilize and can be used as a stand-alone
-plug-in or as part of the site plug-in. The plug-in requires Maven 3.1 or higher.
+plug-in or as part of the site plug-in. The plug-in requires Maven 3.6.3 or higher.
 
 It is important to understand that the first time this task is executed it may
 take 20 minutes or more as it downloads and processes the data from the National

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -31,7 +31,7 @@ OWASP dependency-check's core analysis engine can be used as:
 - [Command Line Tool](dependency-check-cli/index.html)
 - [Gradle Plugin](dependency-check-gradle/index.html)
 - [Jenkins Plugin](dependency-check-jenkins/index.html)
-- [Maven Plugin](dependency-check-maven/index.html) - Maven 3.1 or newer required
+- [Maven Plugin](dependency-check-maven/index.html) - Maven 3.6.3 or newer required
 - [SBT Plugin](https://github.com/albuch/sbt-dependency-check)
 
 For help with dependency-check the following resource can be used:


### PR DESCRIPTION
## Description of Change

This change is made when looking at #7566 and the documentation. The system requirements section of the Maven plugin documentation states that DependencyCheck supports Maven 3.6.3+, but the main documentation page and the plugin's usage documentation page mention Maven 3.1, which was the case up to major version 10.

This PR aims to sync these 2 obsoletes mentions in the documentation.

## Related issues

Relates to #7566 

## Have test cases been added to cover the new functionality?

*no*