### PR TITLE
feat: #7510 Display a dedicated message when receiving an HTTP 403

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
@@ -310,16 +310,16 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
             LOGGER.info("invalid sha1-hash on {}", dependency.getFileName());
         } catch (FileNotFoundException fnfe) {
             LOGGER.debug("Artifact not found in repository: '{}", dependency.getFileName());
-        } catch (IOException ioe) {
-            final String message = "Could not connect to Central search. Analysis failed.";
-            LOGGER.error(message, ioe);
-            throw new AnalysisException(message, ioe);
         } catch (ForbiddenException e) {
             final String message = "Connection to Central search refused. This is most likely not a problem with " +
                     "Dependency-Check itself and is related to network connectivity. Please check " +
                     "https://central.sonatype.org/faq/403-error-central/.";
             LOGGER.error(message);
             throw new AnalysisException(message, e);
+        } catch (IOException ioe) {
+            final String message = "Could not connect to Central search. Analysis failed.";
+            LOGGER.error(message, ioe);
+            throw new AnalysisException(message, ioe);
         }
     }
 
@@ -338,7 +338,7 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
      * requests.
      */
     protected List<MavenArtifact> fetchMavenArtifacts(Dependency dependency) throws IOException,
-            TooManyRequestsException, ForbiddenException {
+            TooManyRequestsException {
         IOException lastException = null;
         long sleepingTimeBetweenRetriesInMillis = BASE_RETRY_WAIT;
         int triesLeft = numberOfRetries;

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CentralAnalyzer.java
@@ -34,6 +34,7 @@ import org.owasp.dependencycheck.utils.DownloadFailedException;
 import org.owasp.dependencycheck.utils.Downloader;
 import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import org.owasp.dependencycheck.utils.FileUtils;
+import org.owasp.dependencycheck.utils.ForbiddenException;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.ResourceNotFoundException;
 import org.owasp.dependencycheck.utils.Settings;
@@ -313,6 +314,12 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
             final String message = "Could not connect to Central search. Analysis failed.";
             LOGGER.error(message, ioe);
             throw new AnalysisException(message, ioe);
+        } catch (ForbiddenException e) {
+            final String message = "Connection to Central search refused. This is most likely not a problem with " +
+                    "Dependency-Check itself and is related to network connectivity. Please check " +
+                    "https://central.sonatype.org/faq/403-error-central/.";
+            LOGGER.error(message);
+            throw new AnalysisException(message, e);
         }
     }
 
@@ -330,7 +337,8 @@ public class CentralAnalyzer extends AbstractFileTypeAnalyzer {
      * @throws TooManyRequestsException if Central has received too many
      * requests.
      */
-    protected List<MavenArtifact> fetchMavenArtifacts(Dependency dependency) throws IOException, TooManyRequestsException {
+    protected List<MavenArtifact> fetchMavenArtifacts(Dependency dependency) throws IOException,
+            TooManyRequestsException, ForbiddenException {
         IOException lastException = null;
         long sleepingTimeBetweenRetriesInMillis = BASE_RETRY_WAIT;
         int triesLeft = numberOfRetries;

--- a/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearch.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  * Class of methods to search Artifactory for hashes and determine Maven GAV
  * from there.
  *
- * Data classes copied from JFrog's artifactory-client-java project.
+ * <p>Data classes copied from JFrog's artifactory-client-java project.</p>
  *
  * @author nhenneaux
  */

--- a/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearch.java
@@ -33,6 +33,7 @@ import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.utils.Checksum;
 import org.owasp.dependencycheck.utils.Downloader;
+import org.owasp.dependencycheck.utils.ForbiddenException;
 import org.owasp.dependencycheck.utils.ResourceNotFoundException;
 import org.owasp.dependencycheck.utils.Settings;
 import org.owasp.dependencycheck.utils.TooManyRequestsException;
@@ -116,6 +117,8 @@ public class ArtifactorySearch {
             throw new IOException(msg.append(" (400): Invalid URL").toString(), e);
         } catch (ResourceNotFoundException e) {
             throw new IOException(msg.append(" (404): Not found").toString(), e);
+        } catch (ForbiddenException e) {
+            throw new IOException(msg.append(" (403): Forbidden").toString(), e);
         }
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
@@ -143,7 +143,7 @@ public class CentralSearch {
         if (cache != null) {
             final List<MavenArtifact> cached = cache.get(sha1);
             if (cached != null) {
-                LOGGER.debug("cache hit for Central: " + sha1);
+                LOGGER.debug("cache hit for Central: {}", sha1);
                 if (cached.isEmpty()) {
                     throw new FileNotFoundException("Artifact not found in Central");
                 }

--- a/core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
@@ -21,6 +21,7 @@ import org.apache.hc.client5.http.impl.classic.AbstractHttpClientResponseHandler
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.owasp.dependencycheck.utils.DownloadFailedException;
 import org.owasp.dependencycheck.utils.Downloader;
+import org.owasp.dependencycheck.utils.ForbiddenException;
 import org.owasp.dependencycheck.utils.ResourceNotFoundException;
 import org.owasp.dependencycheck.utils.TooManyRequestsException;
 import java.io.FileNotFoundException;
@@ -135,7 +136,7 @@ public class CentralSearch {
      * @throws TooManyRequestsException if Central has received too many
      * requests.
      */
-    public List<MavenArtifact> searchSha1(String sha1) throws IOException, TooManyRequestsException {
+    public List<MavenArtifact> searchSha1(String sha1) throws IOException, TooManyRequestsException, ForbiddenException {
         if (null == sha1 || !sha1.matches("^[0-9A-Fa-f]{40}$")) {
             throw new IllegalArgumentException("Invalid SHA1 format");
         }
@@ -180,6 +181,9 @@ public class CentralSearch {
         } catch (URISyntaxException e) {
             final String errorMessage = "Could not convert central search URL to a URI " + e.getMessage();
             throw new IOException(errorMessage, e);
+        } catch (ForbiddenException e) {
+            final String errorMessage = "Forbidden access to MavenCentral " + e.getMessage();
+            throw new ForbiddenException(errorMessage, e);
         }
         if (cache != null) {
             cache.put(sha1, result);

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV2Search.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV2Search.java
@@ -34,6 +34,7 @@ import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.owasp.dependencycheck.utils.DownloadFailedException;
 import org.owasp.dependencycheck.utils.Downloader;
+import org.owasp.dependencycheck.utils.ForbiddenException;
 import org.owasp.dependencycheck.utils.ResourceNotFoundException;
 import org.owasp.dependencycheck.utils.Settings;
 
@@ -147,7 +148,7 @@ public class NexusV2Search implements NexusSearch {
                 throw new IOException("Could not connect to Nexus");
         } catch (ResourceNotFoundException e) {
             throw new FileNotFoundException("Artifact not found in Nexus");
-        } catch (XPathExpressionException | URISyntaxException e) {
+        } catch (XPathExpressionException | URISyntaxException | ForbiddenException e) {
             throw new IOException(e.getMessage(), e);
         }
     }
@@ -163,7 +164,7 @@ public class NexusV2Search implements NexusSearch {
                 LOGGER.warn("Pre-flight request to Nexus failed; expected root node name of status, got {}", doc.getDocumentElement().getNodeName());
                 return false;
             }
-        } catch (IOException | TooManyRequestsException | ResourceNotFoundException | URISyntaxException e) {
+        } catch (IOException | TooManyRequestsException | ResourceNotFoundException | URISyntaxException | ForbiddenException e) {
             LOGGER.warn("Pre-flight request to Nexus failed: ", e);
             return false;
         }

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV2Search.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV2Search.java
@@ -164,7 +164,7 @@ public class NexusV2Search implements NexusSearch {
                 LOGGER.warn("Pre-flight request to Nexus failed; expected root node name of status, got {}", doc.getDocumentElement().getNodeName());
                 return false;
             }
-        } catch (IOException | TooManyRequestsException | ResourceNotFoundException | URISyntaxException | ForbiddenException e) {
+        } catch (IOException | TooManyRequestsException | ResourceNotFoundException | URISyntaxException e) {
             LOGGER.warn("Pre-flight request to Nexus failed: ", e);
             return false;
         }

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV3Search.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV3Search.java
@@ -27,6 +27,7 @@ import org.apache.hc.core5.http.message.BasicHeader;
 import org.jetbrains.annotations.Nullable;
 import org.owasp.dependencycheck.utils.DownloadFailedException;
 import org.owasp.dependencycheck.utils.Downloader;
+import org.owasp.dependencycheck.utils.ForbiddenException;
 import org.owasp.dependencycheck.utils.ResourceNotFoundException;
 import org.owasp.dependencycheck.utils.Settings;
 import org.owasp.dependencycheck.utils.TooManyRequestsException;
@@ -146,7 +147,7 @@ public class NexusV3Search implements NexusSearch {
         try {
             return Downloader.getInstance().fetchAndHandle(client, url, handler, List.of(new BasicHeader(HttpHeaders.ACCEPT,
                             ContentType.APPLICATION_JSON)));
-        } catch (TooManyRequestsException | ResourceNotFoundException | DownloadFailedException e) {
+        } catch (TooManyRequestsException | ResourceNotFoundException | DownloadFailedException | ForbiddenException e) {
             if (LOGGER.isDebugEnabled()) {
                 int responseCode = -1;
                 String responseMessage = "";

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/KnownExploitedDataSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/KnownExploitedDataSource.java
@@ -35,7 +35,6 @@ import org.owasp.dependencycheck.data.update.cisa.KnownExploitedVulnerabilityPar
 import org.owasp.dependencycheck.data.update.exception.CorruptedDatastreamException;
 import org.owasp.dependencycheck.data.update.exception.UpdateException;
 import org.owasp.dependencycheck.utils.Downloader;
-import org.owasp.dependencycheck.utils.ForbiddenException;
 import org.owasp.dependencycheck.utils.ResourceNotFoundException;
 import org.owasp.dependencycheck.utils.Settings;
 import org.owasp.dependencycheck.utils.TooManyRequestsException;
@@ -103,7 +102,7 @@ public class KnownExploitedDataSource implements CachedWebDataSource {
                 dbProperties.save(DatabaseProperties.KEV_LAST_CHECKED, Long.toString(System.currentTimeMillis() / 1000));
                 return true;
             } catch (TooManyRequestsException | ResourceNotFoundException | IOException | DatabaseException
-                     | SQLException | URISyntaxException | ForbiddenException ex) {
+                     | SQLException | URISyntaxException ex) {
                 throw new UpdateException(ex);
             }
         }

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/KnownExploitedDataSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/KnownExploitedDataSource.java
@@ -35,6 +35,7 @@ import org.owasp.dependencycheck.data.update.cisa.KnownExploitedVulnerabilityPar
 import org.owasp.dependencycheck.data.update.exception.CorruptedDatastreamException;
 import org.owasp.dependencycheck.data.update.exception.UpdateException;
 import org.owasp.dependencycheck.utils.Downloader;
+import org.owasp.dependencycheck.utils.ForbiddenException;
 import org.owasp.dependencycheck.utils.ResourceNotFoundException;
 import org.owasp.dependencycheck.utils.Settings;
 import org.owasp.dependencycheck.utils.TooManyRequestsException;
@@ -102,7 +103,7 @@ public class KnownExploitedDataSource implements CachedWebDataSource {
                 dbProperties.save(DatabaseProperties.KEV_LAST_CHECKED, Long.toString(System.currentTimeMillis() / 1000));
                 return true;
             } catch (TooManyRequestsException | ResourceNotFoundException | IOException | DatabaseException
-                     | SQLException | URISyntaxException ex) {
+                     | SQLException | URISyntaxException | ForbiddenException ex) {
                 throw new UpdateException(ex);
             }
         }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
@@ -21,6 +21,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.central.CentralSearch;
+import org.owasp.dependencycheck.utils.ForbiddenException;
 import org.owasp.dependencycheck.utils.TooManyRequestsException;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.dependency.Dependency;
@@ -50,7 +51,7 @@ public class CentralAnalyzerTest extends BaseTest {
 
     @Test
     @SuppressWarnings("PMD.NonStaticInitializer")
-    public void testFetchMavenArtifactsWithoutException() throws IOException, TooManyRequestsException {
+    public void testFetchMavenArtifactsWithoutException() throws IOException, TooManyRequestsException, ForbiddenException {
             CentralAnalyzer instance = new CentralAnalyzer();
             instance.setCentralSearch(centralSearch);
             when(dependency.getSha1sum()).thenReturn(SHA1_SUM);
@@ -64,7 +65,7 @@ public class CentralAnalyzerTest extends BaseTest {
     @Test(expected = FileNotFoundException.class)
     @SuppressWarnings("PMD.NonStaticInitializer")
     public void testFetchMavenArtifactsRethrowsFileNotFoundException()
-            throws IOException, TooManyRequestsException {
+            throws IOException, TooManyRequestsException, ForbiddenException {
         CentralAnalyzer instance = new CentralAnalyzer();
         instance.setCentralSearch(centralSearch);
         when(dependency.getSha1sum()).thenReturn(SHA1_SUM);
@@ -75,7 +76,7 @@ public class CentralAnalyzerTest extends BaseTest {
     @Test(expected = IOException.class)
     @SuppressWarnings("PMD.NonStaticInitializer")
     public void testFetchMavenArtifactsAlwaysThrowsIOException()
-            throws IOException, TooManyRequestsException {
+            throws IOException, TooManyRequestsException, ForbiddenException {
         getSettings().setInt(Settings.KEYS.ANALYZER_CENTRAL_RETRY_COUNT, 1);
         getSettings().setBoolean(Settings.KEYS.ANALYZER_CENTRAL_USE_CACHE, false);
         CentralAnalyzer instance = new CentralAnalyzer();

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/ForbiddenException.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/ForbiddenException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.owasp.dependencycheck.utils;
+
+public class ForbiddenException extends Exception {
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+
+    public ForbiddenException(String message, ForbiddenException cause) {
+        super(message, cause);
+    }
+}

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/ForbiddenException.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/ForbiddenException.java
@@ -18,7 +18,9 @@
  */
 package org.owasp.dependencycheck.utils;
 
-public class ForbiddenException extends Exception {
+import java.io.IOException;
+
+public class ForbiddenException extends IOException {
 
     public ForbiddenException(String message) {
         super(message);

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/ForbiddenException.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/ForbiddenException.java
@@ -4,7 +4,7 @@
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  * https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
## Description of Change

The proposed change aims to add a more explicit message to the user when it is facing an HTTP 403 status code from Maven central search.

The change introduces `ForbiddenException`, a subclass of `IOException`. This fully preserve the behavior of any code using the utils module as a dependency.

I am open to comments and discussions on this change proposal, thank you for your help!

## Related issues

Fixes #7510 

## Have test cases been added to cover the new functionality?

*no*