### PR TITLE
build(deps): bump open-vulnerability-client from 7.3.1 to 7.3.2 

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -359,7 +359,7 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
                         availabilityImpact = CvssV2Data.CiaType.fromValue(tmp);
                     }
                     final String severity = Cvss2Severity.of((float) cvssScore).name().toUpperCase();
-                    final CvssV2Data cvssData = new CvssV2Data("2.0", source.getCvssVector(), accessVector,
+                    final CvssV2Data cvssData = new CvssV2Data(CvssV2Data.Version._2_0, source.getCvssVector(), accessVector,
                             accessComplexity, authentication, confidentialityImpact,
                             integrityImpact, availabilityImpact, cvssScore,
                             severity, null, null, null, null, null, null, null, null, null, null);

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -741,12 +741,7 @@ public final class CveDB implements AutoCloseable {
                                 integrityImpact == null ? "" : integrityImpact.value().substring(0, 1),
                                 availabilityImpact == null ? "" : availabilityImpact.value().substring(0, 1));
 
-                        //some older test data may not correctly have the version set.
-                        String cveVersion = "2.0";
-                        if (rsV.getString(18) != null) {
-                            cveVersion = rsV.getString(18);
-                        }
-                        final CvssV2Data cvssData = new CvssV2Data(cveVersion, vector, accessVector,
+                        final CvssV2Data cvssData = new CvssV2Data(CvssV2Data.Version._2_0, vector, accessVector,
                                 accessComplexity, authentication, confidentialityImpact,
                                 integrityImpact, availabilityImpact, rsV.getDouble(11), rsV.getString(3),
                                 null, null, null, null, null, null, null, null, null, null);

--- a/core/src/main/java/org/owasp/dependencycheck/processing/BundlerAuditProcessor.java
+++ b/core/src/main/java/org/owasp/dependencycheck/processing/BundlerAuditProcessor.java
@@ -242,7 +242,7 @@ public class BundlerAuditProcessor extends Processor<InputStream> {
                     score = 2.0;
                 }
                 LOGGER.debug("bundle-audit vulnerability missing CVSS data: {}", vulnerability.getName());
-                final CvssV2Data cvssData = new CvssV2Data("2.0", null, null, null, null, null, null, null, score, criticality.toUpperCase(),
+                final CvssV2Data cvssData = new CvssV2Data(CvssV2Data.Version._2_0, null, null, null, null, null, null, null, score, criticality.toUpperCase(),
                         null, null, null, null, null, null, null, null, null, null);
                 final CvssV2 cvssV2 = new CvssV2(null, null, cvssData, criticality.toUpperCase(), null, null, null, null, null, null, null);
                 vulnerability.setCvssV2(cvssV2);

--- a/core/src/main/java/org/owasp/dependencycheck/utils/CvssUtil.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/CvssUtil.java
@@ -115,7 +115,6 @@ public final class CvssUtil {
                             vectorString));
         }
 
-        final String version = CvssV2Data.Version._2_0.value();
         //"AV:L/AC:L/Au:N/C:N/I:N/A:C"
         final CvssV2Data.AccessVectorType accessVector = CvssV2Data.AccessVectorType.fromValue(metrics.get("AV"));
         final CvssV2Data.AccessComplexityType attackComplexity = CvssV2Data.AccessComplexityType.fromValue(metrics.get("AC"));
@@ -125,7 +124,7 @@ public final class CvssUtil {
         final CvssV2Data.CiaType availabilityImpact = CvssV2Data.CiaType.fromValue(metrics.get("A"));
 
         final String baseSeverity = cvssV2ScoreToSeverity(baseScore);
-        final CvssV2Data data = new CvssV2Data(version, vectorString, accessVector, attackComplexity,
+        final CvssV2Data data = new CvssV2Data(CvssV2Data.Version._2_0, vectorString, accessVector, attackComplexity,
                 authentication, confidentialityImpact, integrityImpact, availabilityImpact, baseScore, baseSeverity,
                 null, null, null, null, null, null, null, null, null, null);
         final CvssV2 cvss = new CvssV2(null, null, data, baseSeverity, null, null, null, null, null, null, null);

--- a/core/src/test/java/org/owasp/dependencycheck/data/nvd/ecosystem/UrlEcosystemMapperTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nvd/ecosystem/UrlEcosystemMapperTest.java
@@ -38,7 +38,7 @@ public class UrlEcosystemMapperTest {
         // Given
         UrlEcosystemMapper mapper = new UrlEcosystemMapper();
 
-        CveItem cveItem = new CveItem();
+        CveItem cveItem = new CveItem(null,null,null,null,null);
         DefCveItem defCveItem = new DefCveItem(cveItem);
 
         // When
@@ -53,7 +53,7 @@ public class UrlEcosystemMapperTest {
         // Given
         UrlEcosystemMapper mapper = new UrlEcosystemMapper();
 
-        DefCveItem cveItem = new DefCveItem();
+        DefCveItem cveItem = new DefCveItem(null);
 
         // When
         String output = mapper.getEcosystem(cveItem);

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/VulnerabilityTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/VulnerabilityTest.java
@@ -171,7 +171,7 @@ public class VulnerabilityTest extends BaseTest {
 
     
     private CvssV2 createCvssV2(double score, String severity) {
-        CvssV2Data v2Data = new CvssV2Data("2.0", severity, CvssV2Data.AccessVectorType.NETWORK, 
+        CvssV2Data v2Data = new CvssV2Data(CvssV2Data.Version._2_0, severity, CvssV2Data.AccessVectorType.NETWORK,
                 CvssV2Data.AccessComplexityType.MEDIUM, CvssV2Data.AuthenticationType.MULTIPLE, 
                 CvssV2Data.CiaType.PARTIAL, CvssV2Data.CiaType.PARTIAL, CvssV2Data.CiaType.PARTIAL, 
                 

--- a/pom.xml
+++ b/pom.xml
@@ -932,7 +932,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>io.github.jeremylong</groupId>
                 <artifactId>open-vulnerability-clients</artifactId>
-                <version>7.3.1</version>
+                <version>7.3.2</version>
             </dependency>
             <dependency>
                 <groupId>org.anarres.jdiagnostics</groupId>


### PR DESCRIPTION
Use the latest OVC library to resolve an issue with trailing commas in JSON returned from the NVD.