### PR TITLE
fix(fp): FP for phpunit/php-text-template

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -2237,3 +2237,10 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
    <packageUrl regex="true">^pkg:nuget/Microsoft\.AspNetCore\.Authentication\.OpenIdConnect@.*$</packageUrl>
    <cpe>cpe:/a:openid:openid_connect</cpe>
 </suppress>
+<suppress base="true">
+   <notes><![CDATA[
+   FP per issue #7582
+   ]]></notes>
+   <packageUrl regex="true">^pkg:composer/phpunit/php-text-template@.*$</packageUrl>
+   <cpe>cpe:/a:phpunit_project:phpunit</cpe>
+</suppress>


### PR DESCRIPTION
## Description of Change

[php-text-template](https://github.com/sebastianbergmann/php-text-template) is an independent project, with independent versioning structure (latest release on Feb 7 as version 5). [PHPUnit](https://github.com/sebastianbergmann/phpunit) framework released version 12 on Feb 7. Considering them both the same results in vulnerabilities being incorrectly identified.

## Related issues

- fixes #7582

## Have test cases been added to cover the new functionality?

*no*