### PR TITLE
fix: remove duplicate dependency declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@ Copyright (c) 2012 - Jeremy Long
         <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
         <maven-surefire-report-plugin.version>3.5.3</maven-surefire-report-plugin.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
-        <spotbugs.version>4.9.3</spotbugs.version>
         <spotbugs.maven.plugin.version>4.9.3.0</spotbugs.maven.plugin.version>
         <taglist-maven-plugin.version>3.2.1</taglist-maven-plugin.version>
         <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
@@ -1004,13 +1003,6 @@ Copyright (c) 2012 - Jeremy Long
                 <version>3.0.0</version>
             </dependency>
             <dependency>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-annotations</artifactId>
-                <version>${spotbugs.version}</version>
-                <scope>compile</scope>
-                <optional>true</optional>
-            </dependency>
-            <dependency>
                 <groupId>org.whitesource</groupId>
                 <artifactId>pecoff4j</artifactId>
                 <version>0.0.2.1</version>
@@ -1344,12 +1336,6 @@ Copyright (c) 2012 - Jeremy Long
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <scope>compile</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
## Description of Change

This PR aims to remove a duplicate declaration of the `com.github.spotbugs:spotbugs-annotations` dependency, whose declaration is duplicated both in `<dependencyManagement>` and `<dependencies>` of the parent pom.

This duplicate declaration generates a warning when using Apache Maven:

```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.owasp:dependency-check-utils:jar:12.1.2-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: com.github.spotbugs:spotbugs-annotations:jar -> duplicate declaration of version (?) @ org.owasp:dependency-check-parent:12.1.2-SNAPSHOT, /home/nhumblot/dev/wkspace/DependencyCheck/pom.xml, line 1356, column 21
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: com.github.spotbugs:spotbugs-annotations:jar -> version ${spotbugs.version} vs ${findbugs.spotbugs.version} @ org.owasp:dependency-check-parent:12.1.2-SNAPSHOT, /home/nhumblot/dev/wkspace/DependencyCheck/pom.xml, line 1275, column 25
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.owasp:dependency-check-parent:pom:12.1.2-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: com.github.spotbugs:spotbugs-annotations:jar -> duplicate declaration of version (?) @ line 1356, column 21
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: com.github.spotbugs:spotbugs-annotations:jar -> version ${spotbugs.version} vs ${findbugs.spotbugs.version} @ line 1275, column 25
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

## Related 

None

## Have test cases been added to cover the new functionality?

*no*