### PR TITLE
fix: #7591 tell the stage goal has to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Building the documentation
 
 The documentation on the [github pages](https://dependency-check.github.io/DependencyCheck/) is generated from this repository:
 
-    mvn -s settings.xml site  site:staging
+    mvn -s settings.xml site site:stage
 
 Once done, point your browser to `./target/staging/index.html`.
 


### PR DESCRIPTION
## Description of Change

This PR aims to fix the readme documentation explaining how to build and test the site documentation. When following the documented instruction, Apache Maven fails with the following error message:

```
[ERROR] Could not find goal 'staging' in plugin org.apache.maven.plugins:maven-site-plugin:3.21.0 among available goals attach-descriptor, deploy, effective-site, help, jar, run, site, stage, stage-deploy -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoNotFoundException
```

The current change just update the README, advising to use the `stage` goal instead.

## Related

- relates to #7591 (I wanted to check how to improve the current licenses documentation page)

## Have test cases been added to cover the new functionality?

*no*