### PR TITLE
chore: Add a serialVersionUID to serializable classes that don't have it

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/update/exception/CorruptedDatastreamException.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/exception/CorruptedDatastreamException.java
@@ -27,6 +27,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class CorruptedDatastreamException extends Exception {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Create a new CorruptedDatastreamException.
      */

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/ForbiddenException.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/ForbiddenException.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 
 public class ForbiddenException extends IOException {
 
+    private static final long serialVersionUID = 1L;
+
     public ForbiddenException(String message) {
         super(message);
     }


### PR DESCRIPTION
## Description of Change

Spotted warnings on missing serialVersionUID in the build output. This PR resolves these by adding an explicit serialVersionUID to those classes.

## Have test cases been added to cover the new functionality?

N/A