### PR TITLE
fix(fp): FP for spatie/laravel-*

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -2251,3 +2251,10 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
    <packageUrl regex="true">^pkg:composer/phpunit/php-text-template@.*$</packageUrl>
    <cpe>cpe:/a:phpunit_project:phpunit</cpe>
 </suppress>
+<suppress base="true">
+   <notes><![CDATA[
+   FP per issue #7602
+   ]]></notes>
+   <packageUrl regex="true">^pkg:composer/spatie/laravel-.*$</packageUrl>
+   <cpe>cpe:/a:laravel:laravel</cpe>
+</suppress>


### PR DESCRIPTION
## Description of Change

Spatie provides various Laravel (PHP) packages. Quoting their [website](https://spatie.be/open-source/packages):
> \[Spatie has] created more than 500 packages for Laravel and PHP. These packages have been downloaded a whopping 1.58 billion times!

Their naming scheme follows `spatie/laravel-project-name` format, where all project names are prefixed with `laravel`. This however results in a match for [laravel/framework](https://github.com/laravel/framework) project, even if it's really [spatie/laravel-sluggable](https://github.com/spatie/laravel-sluggable) or other. There is no shared versioning scheme, as the framework has latest version at v12.8.1, while the Sluggable extension by Spatie has latest version at 3.7.4.

## Related issues

- fixes #7602

## Have test cases been added to cover the new functionality?

*no*