### PR TITLE
feat: #7610 add a reference to NVD mirroring in getting started documentation

### DIFF
--- a/ant/src/site/markdown/index.md.vm
+++ b/ant/src/site/markdown/index.md.vm
@@ -35,7 +35,10 @@ Installation
 
 It is important to understand that the first time this task is executed it may
 take 10 minutes or more as it downloads and processes the data from the National
-Vulnerability Database (NVD) hosted by NIST: https://nvd.nist.gov
+Vulnerability Database (NVD) hosted by NIST: https://nvd.nist.gov.
 
 After the first batch download, as long as the task is executed at least once every
 seven days the update will only take a few seconds.
+
+The Dependency-Check team strongly recommends to [mirror the NVD database](../data/mirrornvd.html) for any operational
+integration. If not done, any service disruption of the NVD database will make the usage of Dependency-Check difficult.

--- a/maven/src/site/markdown/index.md.vm
+++ b/maven/src/site/markdown/index.md.vm
@@ -5,10 +5,13 @@ plug-in or as part of the site plug-in. The plug-in requires Maven 3.6.3 or high
 
 It is important to understand that the first time this task is executed it may
 take 20 minutes or more as it downloads and processes the data from the National
-Vulnerability Database (NVD) hosted by NIST: https://nvd.nist.gov
+Vulnerability Database (NVD) hosted by NIST: https://nvd.nist.gov.
 
 After the first batch download, as long as the plug-in is executed at least once every
 seven days the update will only take a few seconds.
+
+The Dependency-Check team strongly recommends to [mirror the NVD database](../data/mirrornvd.html) for any operational
+integration. If not done, any service disruption of the NVD database will make the usage of Dependency-Check difficult.
 
 ### Default Phase
 The dependency-check plugin is, by default, tied to the `verify` or `site` phase

--- a/src/site/markdown/data/mirrornvd.md
+++ b/src/site/markdown/data/mirrornvd.md
@@ -7,7 +7,7 @@ The NVD API and the Retire JS repository.
 Creating an offline cache for the NVD API
 ------------------------------------------------------------
 
-The Open Vulnerability Project's [vuln CLI](https://github.com/dependency-check/Open-Vulnerability-Project/tree/main/vulnz#caching-the-nvd-cve-data)
+The Open Vulnerability Project's [vuln CLI](https://github.com/jeremylong/open-vulnerability-cli/blob/main/README.md)
 can be used to create an offline copy of the data obtained from the NVD API.
 Then configure dependency-check to use the NVD Datafeed URL.
 

--- a/src/site/markdown/dependency-check-gradle/index.md.vm
+++ b/src/site/markdown/dependency-check-gradle/index.md.vm
@@ -5,10 +5,13 @@ libraries; creating a report of known vulnerable components that are included in
 
 It is important to understand that the first time this task is executed it may
 take 5-20 minutes as it downloads and processes the data from the National
-Vulnerability Database (NVD) hosted by NIST: https://nvd.nist.gov
+Vulnerability Database (NVD) hosted by NIST: https://nvd.nist.gov.
 
 After the first batch download, as long as the plugin is executed at least once every
 seven days the update will only take a few seconds.
+
+The Dependency-Check team strongly recommends to [mirror the NVD database](../data/mirrornvd.html) for any operational
+integration. If not done, any service disruption of the NVD database will make the usage of Dependency-Check difficult.
 
 #set( $H = '#' )
 


### PR DESCRIPTION
## Description of Change

This pull requests aims to fix a broken link in the documentation and add an explicit mention in the getting started/usage sections that it is strongly advised to mirror the NVD database when using Dependency-Check in an operational environment to have a more robust integration and prevent service disruption.

## Related issues

- fixes #7610 

## Have test cases been added to cover the new functionality?

*no*