### PR TITLE
chore: Manually add the suppressions from #7603 to the published suppressions

### DIFF
--- a/suppressions/publishedSuppressions.xml
+++ b/suppressions/publishedSuppressions.xml
@@ -2252,4 +2252,11 @@ FP per issue #7582
    <packageUrl regex="true">^pkg:composer/phpunit/php-text-template@.*$</packageUrl>
    <cpe>cpe:/a:phpunit_project:phpunit</cpe>
 </suppress>
+<suppress base="true">
+   <notes><![CDATA[
+   FP per issue #7602
+   ]]></notes>
+   <packageUrl regex="true">^pkg:composer/spatie/laravel-.*$</packageUrl>
+   <cpe>cpe:/a:laravel:laravel</cpe>
+</suppress>
 </suppressions>


### PR DESCRIPTION
## Description of Change

Composer suppressions are not automatically updated into the `gh-pages` branch, and must be updated manually.

This PR is similar to commit d881a086f4549b41081050ebd2aec26391d5d562.

## Related issues

- relates to #7603
- relates to #7602

## Have test cases been added to cover the new functionality?

*no*