### PR TITLE
test: Migrate tests to JUnit5

### DIFF
--- a/ant/src/test/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTaskIT.java
+++ b/ant/src/test/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTaskIT.java
@@ -29,7 +29,6 @@ import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
@@ -127,12 +126,11 @@ class DependencyCheckTaskIT extends BaseDBTestCase {
 
     @Test
     void testNestedBADReportFormat() {
-        try {
-            buildFileRule.executeTarget("test.formatBADNested");
-            fail("Should have had a buildExceotion for a bad format attribute");
-        } catch (BuildException e) {
-            assertTrue(e.getMessage().contains("BAD is not a legal value for this attribute"), "Message did not have BAD, unexpected exception: " + e.getMessage());
-        }
+        BuildException e = assertThrows(BuildException.class,
+                () -> buildFileRule.executeTarget("test.formatBADNested"),
+                "Should have had a buildException for a bad format attribute");
+        assertTrue(e.getMessage().contains("BAD is not a legal value for this attribute"),
+                "Message did not have BAD, unexpected exception: " + e.getMessage());
     }
 
     /**

--- a/ant/src/test/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTaskIT.java
+++ b/ant/src/test/java/org/owasp/dependencycheck/taskdefs/DependencyCheckTaskIT.java
@@ -49,12 +49,12 @@ class DependencyCheckTaskIT extends BaseDBTestCase {
     @AfterEach
     @Override
     public void tearDown() throws Exception {
-        super.tearDown();
         if (buildFileRule.getProject() != null) {
             if (this.buildFileRule.getProject().getTargets().containsKey("tearDown")) {
                 this.buildFileRule.getProject().executeTarget("tearDown");
             }
         }
+        super.tearDown();
     }
 
     /**

--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -39,7 +39,19 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.12.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.12.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <version>5.12.2</version>
             <scope>test</scope>
         </dependency>

--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -4,10 +4,10 @@
     <groupId>\${groupId}</groupId>
     <artifactId>\${artifactId}</artifactId>
     <version>\${version}</version>
-    
+
     <name>\${artifactId}</name>
     <packaging>jar</packaging>
-    
+
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.8.2</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/archetype/src/main/resources/archetype-resources/src/test/java/__analyzerName__Test.java
+++ b/archetype/src/main/resources/archetype-resources/src/test/java/__analyzerName__Test.java
@@ -13,43 +13,45 @@
  */
 package ${package};
 
-import java.io.File;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.AfterAll;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.AnalysisPhase;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.utils.Settings;
 
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 /**
  * Test cases for ${analyzerName}
  */
-public class ${analyzerName}Test {
-    
+class ${analyzerName}Test {
+
     Settings settings = null;
-	
-    public ${analyzerName}Test() {
+
+    ${analyzerName}Test() {
     }
-    
+
     @BeforeAll
-    public static void setUpClass() {
+    static void setUpClass() {
     }
-    
+
     @AfterAll
-    public static void tearDownClass() {
+    static void tearDownClass() {
     }
-    
+
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         settings = new Settings();
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         settings.cleanup();
     }
 
@@ -57,7 +59,7 @@ public class ${analyzerName}Test {
      * Test of accept method, of class ${analyzerName}.
      */
     @Test
-    public void testAccept() {
+    void testAccept() {
         File pathname = new File("test.file");
         ${analyzerName} instance = new ${analyzerName}();
         boolean expResult = true;
@@ -69,13 +71,13 @@ public class ${analyzerName}Test {
      * Test of analyze method, of class ${analyzerName}.
      */
     @Test
-    public void testAnalyze() throws Exception {
+    void testAnalyze() throws Exception {
         //The engine is generally null for most analyzer test cases but can be instantiated if needed.
         Engine engine = null;
         ${analyzerName} instance = new ${analyzerName}();
         instance.initialize(settings);
         instance.prepare(engine);
-		
+
         File file = new File(${analyzerName}.class.getClassLoader().getResource("test.file").toURI().getPath());
         Dependency dependency = new Dependency(file);
 
@@ -87,7 +89,7 @@ public class ${analyzerName}Test {
      * Test of getName method, of class ${analyzerName}.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         ${analyzerName} instance = new ${analyzerName}();
         String expResult = "${analyzerName}";
         String result = instance.getName();
@@ -98,7 +100,7 @@ public class ${analyzerName}Test {
      * Test of getAnalysisPhase method, of class ${analyzerName}.
      */
     @Test
-    public void testGetAnalysisPhase() {
+    void testGetAnalysisPhase() {
         ${analyzerName} instance = new ${analyzerName}();
         AnalysisPhase expResult = AnalysisPhase.INFORMATION_COLLECTION;
         AnalysisPhase result = instance.getAnalysisPhase();
@@ -109,7 +111,7 @@ public class ${analyzerName}Test {
      * Test of initialize method, of class ${analyzerName}.
      */
     @Test
-    public void testInitialize() throws Exception {
+    void testInitialize() throws Exception {
         ${analyzerName} instance = new ${analyzerName}();
         instance.initialize(settings);
     }
@@ -118,7 +120,7 @@ public class ${analyzerName}Test {
      * Test of close method, of class ${analyzerName}.
      */
     @Test
-    public void testClose() throws Exception {
+    void testClose() throws Exception {
         ${analyzerName} instance = new ${analyzerName}();
         instance.close();
     }
@@ -127,7 +129,7 @@ public class ${analyzerName}Test {
      * Test of supportsParallelProcessing method, of class ${analyzerName}.
      */
     @Test
-    public void testSupportsParallelProcessing() {
+    void testSupportsParallelProcessing() {
         ${analyzerName} instance = new ${analyzerName}();
         boolean expResult = true;
         boolean result = instance.supportsParallelProcessing();
@@ -138,7 +140,7 @@ public class ${analyzerName}Test {
      * Test of isEnabled method, of class ${analyzerName}.
      */
     @Test
-    public void testIsEnabled() {
+    void testIsEnabled() {
         ${analyzerName} instance = new ${analyzerName}();
         boolean expResult = true;
         boolean result = instance.isEnabled();

--- a/cli/src/test/java/org/owasp/dependencycheck/AppTest.java
+++ b/cli/src/test/java/org/owasp/dependencycheck/AppTest.java
@@ -17,35 +17,34 @@
  */
 package org.owasp.dependencycheck;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.net.URISyntaxException;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.UnrecognizedOptionException;
-import static org.hamcrest.MatcherAssert.assertThat;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
 import org.owasp.dependencycheck.utils.Settings.KEYS;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * Tests for the {@link AppTest} class.
  */
-public class AppTest extends BaseTest {
+class AppTest extends BaseTest {
 
     /**
      * Test of ensureCanonicalPath method, of class App.
      */
     @Test
-    public void testEnsureCanonicalPath() {
+    void testEnsureCanonicalPath() {
         String file = "../*.jar";
         App instance = new App(getSettings());
         String result = instance.ensureCanonicalPath(file);
@@ -55,7 +54,7 @@ public class AppTest extends BaseTest {
         file = "../some/skip/../path/file.txt";
         String expResult = "/some/path/file.txt";
         result = instance.ensureCanonicalPath(file);
-        assertTrue("result=" + result, result.endsWith(expResult));
+        assertTrue(result.endsWith(expResult), "result=" + result);
     }
 
     /**
@@ -65,7 +64,7 @@ public class AppTest extends BaseTest {
      * @throws Exception the unexpected {@link Exception}.
      */
     @Test
-    public void testPopulateSettings() throws Exception {
+    void testPopulateSettings() throws Exception {
         File prop = new File(this.getClass().getClassLoader().getResource("sample.properties").toURI().getPath());
         String[] args = {"-P", prop.getAbsolutePath()};
         Map<String, Boolean> expected = new HashMap<>();
@@ -115,13 +114,12 @@ public class AppTest extends BaseTest {
      * Assert that an {@link UnrecognizedOptionException} is thrown when a
      * property that is not supported is specified on the CLI.
      *
-     * @throws Exception the unexpected {@link Exception}.
      */
     @Test
-    public void testPopulateSettingsException() throws Exception {
+    void testPopulateSettingsException() {
         String[] args = {"-invalidPROPERTY"};
-        Exception exception = Assert.assertThrows(UnrecognizedOptionException.class, () -> testBooleanProperties(args, null));
-        Assert.assertTrue(exception.getMessage().contains("Unrecognized option: -invalidPROPERTY"));
+        Exception exception = assertThrows(UnrecognizedOptionException.class, () -> testBooleanProperties(args, null));
+        assertTrue(exception.getMessage().contains("Unrecognized option: -invalidPROPERTY"));
     }
 
     /**
@@ -130,7 +128,7 @@ public class AppTest extends BaseTest {
      * @throws Exception the unexpected {@link Exception}.
      */
     @Test
-    public void testPopulatingSuppressionSettingsWithASingleFile() throws Exception {
+    void testPopulatingSuppressionSettingsWithASingleFile() throws Exception {
         // GIVEN CLI properties with the mandatory arguments
         File prop = new File(this.getClass().getClassLoader().getResource("sample.properties").toURI().getPath());
 
@@ -154,7 +152,7 @@ public class AppTest extends BaseTest {
      * @throws Exception the unexpected {@link Exception}.
      */
     @Test
-    public void testPopulatingSuppressionSettingsWithMultipleFiles() throws Exception {
+    void testPopulatingSuppressionSettingsWithMultipleFiles() throws Exception {
         // GIVEN CLI properties with the mandatory arguments
         File prop = new File(this.getClass().getClassLoader().getResource("sample.properties").toURI().getPath());
 
@@ -172,7 +170,7 @@ public class AppTest extends BaseTest {
     }
 
 
-    private boolean testBooleanProperties(String[] args, Map<String, Boolean> expected) throws URISyntaxException, FileNotFoundException, ParseException, InvalidSettingException {
+    private boolean testBooleanProperties(String[] args, Map<String, Boolean> expected) throws FileNotFoundException, ParseException, InvalidSettingException {
         this.reloadSettings();
         final CliParser cli = new CliParser(getSettings());
         cli.parse(args);

--- a/cli/src/test/java/org/owasp/dependencycheck/AppTest.java
+++ b/cli/src/test/java/org/owasp/dependencycheck/AppTest.java
@@ -118,7 +118,7 @@ class AppTest extends BaseTest {
     @Test
     void testPopulateSettingsException() {
         String[] args = {"-invalidPROPERTY"};
-        Exception exception = assertThrows(UnrecognizedOptionException.class, () -> testBooleanProperties(args, null));
+        UnrecognizedOptionException exception = assertThrows(UnrecognizedOptionException.class, () -> testBooleanProperties(args, null));
         assertTrue(exception.getMessage().contains("Unrecognized option: -invalidPROPERTY"));
     }
 

--- a/cli/src/test/java/org/owasp/dependencycheck/BaseTest.java
+++ b/cli/src/test/java/org/owasp/dependencycheck/BaseTest.java
@@ -15,8 +15,8 @@
  */
 package org.owasp.dependencycheck;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.owasp.dependencycheck.utils.Settings;
 
 /**
@@ -33,7 +33,7 @@ public abstract class BaseTest {
     /**
      * Initialize the {@link Settings}.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         settings = new Settings();
     }
@@ -41,7 +41,7 @@ public abstract class BaseTest {
     /**
      * Clean the {@link Settings}.
      */
-    @After
+    @AfterEach
     public void tearDown() {
         settings.cleanup(true);
     }

--- a/cli/src/test/java/org/owasp/dependencycheck/CliParserTest.java
+++ b/cli/src/test/java/org/owasp/dependencycheck/CliParserTest.java
@@ -30,6 +30,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -99,20 +100,17 @@ class CliParserTest extends BaseTest {
     /**
      * Test of parse method with failOnCVSS without an argument
      *
-     * @throws Exception thrown when an exception occurs.
      */
     @Test
-    void testParse_failOnCVSSNoArg() throws Exception {
+    void testParse_failOnCVSSNoArg() {
 
         String[] args = {"--failOnCVSS"};
 
         CliParser instance = new CliParser(getSettings());
-        try {
-            instance.parse(args);
-            fail("an argument for failOnCVSS was missing and an exception was not thrown");
-        } catch (ParseException ex) {
-            assertTrue(ex.getMessage().contains("Missing argument"));
-        }
+        ParseException ex = assertThrows(ParseException.class, () -> instance.parse(args),
+                "an argument for failOnCVSS was missing and an exception was not thrown");
+        assertTrue(ex.getMessage().contains("Missing argument"));
+
         assertFalse(instance.isGetVersion());
         assertFalse(instance.isGetHelp());
         assertFalse(instance.isRunScan());
@@ -159,10 +157,9 @@ class CliParserTest extends BaseTest {
     /**
      * Test of parse method with jar and cpe args, of class CliParser.
      *
-     * @throws Exception thrown when an exception occurs.
      */
     @Test
-    void testParse_unknown() throws Exception {
+    void testParse_unknown() {
 
         String[] args = {"-unknown"};
 
@@ -173,12 +170,10 @@ class CliParserTest extends BaseTest {
 
         CliParser instance = new CliParser(getSettings());
 
-        try {
-            instance.parse(args);
-            fail("Unrecognized option should have caused an exception");
-        } catch (ParseException ex) {
-            assertTrue(ex.getMessage().contains("Unrecognized option"));
-        }
+        ParseException ex = assertThrows(ParseException.class, () -> instance.parse(args) ,
+                "Unrecognized option should have caused an exception");
+        assertTrue(ex.getMessage().contains("Unrecognized option"));
+
         assertFalse(instance.isGetVersion());
         assertFalse(instance.isGetHelp());
         assertFalse(instance.isRunScan());
@@ -187,21 +182,17 @@ class CliParserTest extends BaseTest {
     /**
      * Test of parse method with scan arg, of class CliParser.
      *
-     * @throws Exception thrown when an exception occurs.
      */
     @Test
-    void testParse_scan() throws Exception {
+    void testParse_scan() {
 
         String[] args = {"-scan"};
 
         CliParser instance = new CliParser(getSettings());
 
-        try {
-            instance.parse(args);
-            fail("Missing argument should have caused an exception");
-        } catch (ParseException ex) {
-            assertTrue(ex.getMessage().contains("Missing argument"));
-        }
+        ParseException ex = assertThrows(ParseException.class, () -> instance.parse(args),
+                "Missing argument should have caused an exception");
+        assertTrue(ex.getMessage().contains("Missing argument"));
 
         assertFalse(instance.isGetVersion());
         assertFalse(instance.isGetHelp());
@@ -211,20 +202,17 @@ class CliParserTest extends BaseTest {
     /**
      * Test of parse method with jar arg, of class CliParser.
      *
-     * @throws Exception thrown when an exception occurs.
      */
     @Test
-    void testParse_scan_unknownFile() throws Exception {
+    void testParse_scan_unknownFile() {
 
         String[] args = {"-scan", "jar.that.does.not.exist", "--project", "test"};
 
         CliParser instance = new CliParser(getSettings());
-        try {
-            instance.parse(args);
-            fail("An exception should have been thrown");
-        } catch (FileNotFoundException ex) {
-            assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
-        }
+
+        FileNotFoundException ex = assertThrows(FileNotFoundException.class, () -> instance.parse(args),
+                "An exception should have been thrown");
+        assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
 
         assertFalse(instance.isGetVersion());
         assertFalse(instance.isGetHelp());
@@ -274,7 +262,7 @@ class CliParserTest extends BaseTest {
             assertFalse(text.contains("unknown"));
         } catch (IOException ex) {
             System.setOut(out);
-            fail("CliParser.printVersionInfo did not write anything to system.out.");
+            fail("CliParser.printVersionInfo did not write anything to system.out.", ex);
         } finally {
             System.setOut(out);
         }
@@ -318,16 +306,15 @@ class CliParserTest extends BaseTest {
      * Test of getBooleanArgument method, of class CliParser.
      */
     @Test
-    void testGetBooleanArgument() throws ParseException {
+    void testGetBooleanArgument() {
         String[] args = {"--scan", "missing.file", "--artifactoryUseProxy", "false", "--artifactoryParallelAnalysis", "true", "--project", "test"};
 
         CliParser instance = new CliParser(getSettings());
-        try {
-            instance.parse(args);
-            fail("invalid scan should have caused an error");
-        } catch (FileNotFoundException ex) {
-            assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
-        }
+
+        FileNotFoundException ex = assertThrows(FileNotFoundException.class, () -> instance.parse(args),
+                "invalid scan should have caused an error");
+        assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
+
         boolean expResult;
         Boolean result = instance.getBooleanArgument("missingArgument");
         assertNull(result);
@@ -344,17 +331,16 @@ class CliParserTest extends BaseTest {
      * Test of getStringArgument method, of class CliParser.
      */
     @Test
-    void testGetStringArgument() throws ParseException {
+    void testGetStringArgument() {
 
         String[] args = {"--scan", "missing.file", "--artifactoryUsername", "blue42", "--project", "test"};
 
         CliParser instance = new CliParser(getSettings());
-        try {
-            instance.parse(args);
-            fail("invalid scan argument should have caused an exception");
-        } catch (FileNotFoundException ex) {
-            assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
-        }
+
+        FileNotFoundException ex = assertThrows(FileNotFoundException.class, () -> instance.parse(args),
+                "invalid scan argument should have caused an exception");
+        assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
+
         String expResult;
         String result = instance.getStringArgument("missingArgument");
         assertNull(result);
@@ -365,17 +351,15 @@ class CliParserTest extends BaseTest {
     }
 
     @Test
-    void testHasOption() throws ParseException {
+    void testHasOption() {
 
         String[] args = {"--scan", "missing.file", "--artifactoryUsername", "blue42", "--project", "test"};
 
         CliParser instance = new CliParser(getSettings());
-        try {
-            instance.parse(args);
-            fail("invalid scan argument should have caused an exception");
-        } catch (FileNotFoundException ex) {
-            assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
-        }
+
+        FileNotFoundException ex = assertThrows(FileNotFoundException.class, () -> instance.parse(args),
+                "invalid scan argument should have caused an exception");
+        assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
 
         Boolean result = instance.hasOption("missingOption");
         assertNull(result);

--- a/cli/src/test/java/org/owasp/dependencycheck/CliParserTest.java
+++ b/cli/src/test/java/org/owasp/dependencycheck/CliParserTest.java
@@ -17,21 +17,27 @@
  */
 package org.owasp.dependencycheck;
 
+import org.apache.commons.cli.ParseException;
+import org.junit.jupiter.api.Test;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
-import org.apache.commons.cli.ParseException;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
  * @author Jeremy Long
  */
-public class CliParserTest extends BaseTest {
+class CliParserTest extends BaseTest {
 
     /**
      * Test of parse method, of class CliParser.
@@ -39,7 +45,7 @@ public class CliParserTest extends BaseTest {
      * @throws Exception thrown when an exception occurs.
      */
     @Test
-    public void testParse() throws Exception {
+    void testParse() throws Exception {
 
         String[] args = {};
 
@@ -49,9 +55,9 @@ public class CliParserTest extends BaseTest {
         CliParser instance = new CliParser(getSettings());
         instance.parse(args);
 
-        Assert.assertFalse(instance.isGetVersion());
-        Assert.assertFalse(instance.isGetHelp());
-        Assert.assertFalse(instance.isRunScan());
+        assertFalse(instance.isGetVersion());
+        assertFalse(instance.isGetHelp());
+        assertFalse(instance.isRunScan());
     }
 
     /**
@@ -60,16 +66,16 @@ public class CliParserTest extends BaseTest {
      * @throws Exception thrown when an exception occurs.
      */
     @Test
-    public void testParse_help() throws Exception {
+    void testParse_help() throws Exception {
 
         String[] args = {"-help"};
 
         CliParser instance = new CliParser(getSettings());
         instance.parse(args);
 
-        Assert.assertFalse(instance.isGetVersion());
-        Assert.assertTrue(instance.isGetHelp());
-        Assert.assertFalse(instance.isRunScan());
+        assertFalse(instance.isGetVersion());
+        assertTrue(instance.isGetHelp());
+        assertFalse(instance.isRunScan());
     }
 
     /**
@@ -78,15 +84,15 @@ public class CliParserTest extends BaseTest {
      * @throws Exception thrown when an exception occurs.
      */
     @Test
-    public void testParse_version() throws Exception {
+    void testParse_version() throws Exception {
 
         String[] args = {"-version"};
 
         CliParser instance = new CliParser(getSettings());
         instance.parse(args);
-        Assert.assertTrue(instance.isGetVersion());
-        Assert.assertFalse(instance.isGetHelp());
-        Assert.assertFalse(instance.isRunScan());
+        assertTrue(instance.isGetVersion());
+        assertFalse(instance.isGetHelp());
+        assertFalse(instance.isRunScan());
 
     }
 
@@ -96,20 +102,20 @@ public class CliParserTest extends BaseTest {
      * @throws Exception thrown when an exception occurs.
      */
     @Test
-    public void testParse_failOnCVSSNoArg() throws Exception {
+    void testParse_failOnCVSSNoArg() throws Exception {
 
         String[] args = {"--failOnCVSS"};
 
         CliParser instance = new CliParser(getSettings());
         try {
             instance.parse(args);
-            Assert.fail("an argument for failOnCVSS was missing and an exception was not thrown");
+            fail("an argument for failOnCVSS was missing and an exception was not thrown");
         } catch (ParseException ex) {
-            Assert.assertTrue(ex.getMessage().contains("Missing argument"));
+            assertTrue(ex.getMessage().contains("Missing argument"));
         }
-        Assert.assertFalse(instance.isGetVersion());
-        Assert.assertFalse(instance.isGetHelp());
-        Assert.assertFalse(instance.isRunScan());
+        assertFalse(instance.isGetVersion());
+        assertFalse(instance.isGetHelp());
+        assertFalse(instance.isRunScan());
     }
 
     /**
@@ -119,16 +125,16 @@ public class CliParserTest extends BaseTest {
      * @throws Exception thrown when an exception occurs.
      */
     @Test
-    public void testParse_failOnCVSSInvalidArgument() throws Exception {
+    void testParse_failOnCVSSInvalidArgument() throws Exception {
 
         String[] args = {"--failOnCVSS", "bad"};
 
         CliParser instance = new CliParser(getSettings());
         instance.parse(args);
-        Assert.assertEquals("Default should be 11", 11.0, instance.getFailOnCVSS(), 0);
-        Assert.assertFalse(instance.isGetVersion());
-        Assert.assertFalse(instance.isGetHelp());
-        Assert.assertFalse(instance.isRunScan());
+        assertEquals(11.0, instance.getFailOnCVSS(), 0, "Default should be 11");
+        assertFalse(instance.isGetVersion());
+        assertFalse(instance.isGetHelp());
+        assertFalse(instance.isRunScan());
     }
 
     /**
@@ -138,16 +144,16 @@ public class CliParserTest extends BaseTest {
      * @throws Exception thrown when an exception occurs.
      */
     @Test
-    public void testParse_failOnCVSSValidArgument() throws Exception {
+    void testParse_failOnCVSSValidArgument() throws Exception {
 
         String[] args = {"--failOnCVSS", "6"};
 
         CliParser instance = new CliParser(getSettings());
         instance.parse(args);
-        Assert.assertEquals(6.0, instance.getFailOnCVSS(), 0);
-        Assert.assertFalse(instance.isGetVersion());
-        Assert.assertFalse(instance.isGetHelp());
-        Assert.assertFalse(instance.isRunScan());
+        assertEquals(6.0, instance.getFailOnCVSS(), 0);
+        assertFalse(instance.isGetVersion());
+        assertFalse(instance.isGetHelp());
+        assertFalse(instance.isRunScan());
     }
 
     /**
@@ -156,7 +162,7 @@ public class CliParserTest extends BaseTest {
      * @throws Exception thrown when an exception occurs.
      */
     @Test
-    public void testParse_unknown() throws Exception {
+    void testParse_unknown() throws Exception {
 
         String[] args = {"-unknown"};
 
@@ -169,13 +175,13 @@ public class CliParserTest extends BaseTest {
 
         try {
             instance.parse(args);
-            Assert.fail("Unrecognized option should have caused an exception");
+            fail("Unrecognized option should have caused an exception");
         } catch (ParseException ex) {
-            Assert.assertTrue(ex.getMessage().contains("Unrecognized option"));
+            assertTrue(ex.getMessage().contains("Unrecognized option"));
         }
-        Assert.assertFalse(instance.isGetVersion());
-        Assert.assertFalse(instance.isGetHelp());
-        Assert.assertFalse(instance.isRunScan());
+        assertFalse(instance.isGetVersion());
+        assertFalse(instance.isGetHelp());
+        assertFalse(instance.isRunScan());
     }
 
     /**
@@ -184,7 +190,7 @@ public class CliParserTest extends BaseTest {
      * @throws Exception thrown when an exception occurs.
      */
     @Test
-    public void testParse_scan() throws Exception {
+    void testParse_scan() throws Exception {
 
         String[] args = {"-scan"};
 
@@ -192,14 +198,14 @@ public class CliParserTest extends BaseTest {
 
         try {
             instance.parse(args);
-            Assert.fail("Missing argument should have caused an exception");
+            fail("Missing argument should have caused an exception");
         } catch (ParseException ex) {
-            Assert.assertTrue(ex.getMessage().contains("Missing argument"));
+            assertTrue(ex.getMessage().contains("Missing argument"));
         }
 
-        Assert.assertFalse(instance.isGetVersion());
-        Assert.assertFalse(instance.isGetHelp());
-        Assert.assertFalse(instance.isRunScan());
+        assertFalse(instance.isGetVersion());
+        assertFalse(instance.isGetHelp());
+        assertFalse(instance.isRunScan());
     }
 
     /**
@@ -208,21 +214,21 @@ public class CliParserTest extends BaseTest {
      * @throws Exception thrown when an exception occurs.
      */
     @Test
-    public void testParse_scan_unknownFile() throws Exception {
+    void testParse_scan_unknownFile() throws Exception {
 
         String[] args = {"-scan", "jar.that.does.not.exist", "--project", "test"};
 
         CliParser instance = new CliParser(getSettings());
         try {
             instance.parse(args);
-            Assert.fail("An exception should have been thrown");
+            fail("An exception should have been thrown");
         } catch (FileNotFoundException ex) {
-            Assert.assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
+            assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
         }
 
-        Assert.assertFalse(instance.isGetVersion());
-        Assert.assertFalse(instance.isGetHelp());
-        Assert.assertFalse(instance.isRunScan());
+        assertFalse(instance.isGetVersion());
+        assertFalse(instance.isGetHelp());
+        assertFalse(instance.isRunScan());
     }
 
     /**
@@ -231,28 +237,27 @@ public class CliParserTest extends BaseTest {
      * @throws Exception thrown when an exception occurs.
      */
     @Test
-    public void testParse_scan_withFileExists() throws Exception {
+    void testParse_scan_withFileExists() throws Exception {
         File path = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").toURI().getPath());
         String[] args = {"--scan", path.getCanonicalPath(), "--out", "./", "--project", "test"};
 
         CliParser instance = new CliParser(getSettings());
         instance.parse(args);
 
-        Assert.assertEquals(path.getCanonicalPath(), instance.getScanFiles()[0]);
+        assertEquals(path.getCanonicalPath(), instance.getScanFiles()[0]);
 
-        Assert.assertFalse(instance.isGetVersion());
-        Assert.assertFalse(instance.isGetHelp());
-        Assert.assertTrue(instance.isRunScan());
+        assertFalse(instance.isGetVersion());
+        assertFalse(instance.isGetHelp());
+        assertTrue(instance.isRunScan());
     }
 
     /**
      * Test of printVersionInfo, of class CliParser.
      *
-     * @throws Exception thrown when an exception occurs.
      */
     @Test
     @SuppressWarnings("StringSplitter")
-    public void testParse_printVersionInfo() throws Exception {
+    void testParse_printVersionInfo() {
 
         PrintStream out = System.out;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -262,14 +267,14 @@ public class CliParserTest extends BaseTest {
         instance.printVersionInfo();
         try {
             baos.flush();
-            String text = new String(baos.toByteArray(), UTF_8).toLowerCase();
-            String[] lines = text.split(System.getProperty("line.separator"));
-            Assert.assertTrue(lines.length >= 1);
-            Assert.assertTrue(text.contains("version"));
-            Assert.assertFalse(text.contains("unknown"));
+            String text = baos.toString(UTF_8).toLowerCase();
+            String[] lines = text.split(System.lineSeparator());
+            assertTrue(lines.length >= 1);
+            assertTrue(text.contains("version"));
+            assertFalse(text.contains("unknown"));
         } catch (IOException ex) {
             System.setOut(out);
-            Assert.fail("CliParser.printVersionInfo did not write anything to system.out.");
+            fail("CliParser.printVersionInfo did not write anything to system.out.");
         } finally {
             System.setOut(out);
         }
@@ -282,7 +287,7 @@ public class CliParserTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("StringSplitter")
-    public void testParse_printHelp() throws Exception {
+    void testParse_printHelp() throws Exception {
 
         PrintStream out = System.out;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -297,13 +302,13 @@ public class CliParserTest extends BaseTest {
         instance.printHelp();
         try {
             baos.flush();
-            String text = (new String(baos.toByteArray(), UTF_8));
-            String[] lines = text.split(System.getProperty("line.separator"));
-            Assert.assertTrue(lines[0].startsWith("usage: "));
-            Assert.assertTrue((lines.length > 2));
+            String text = (baos.toString(UTF_8));
+            String[] lines = text.split(System.lineSeparator());
+            assertTrue(lines[0].startsWith("usage: "));
+            assertTrue((lines.length > 2));
         } catch (IOException ex) {
             System.setOut(out);
-            Assert.fail("CliParser.printVersionInfo did not write anything to system.out.");
+            fail("CliParser.printVersionInfo did not write anything to system.out.");
         } finally {
             System.setOut(out);
         }
@@ -313,70 +318,70 @@ public class CliParserTest extends BaseTest {
      * Test of getBooleanArgument method, of class CliParser.
      */
     @Test
-    public void testGetBooleanArgument() throws ParseException {
+    void testGetBooleanArgument() throws ParseException {
         String[] args = {"--scan", "missing.file", "--artifactoryUseProxy", "false", "--artifactoryParallelAnalysis", "true", "--project", "test"};
 
         CliParser instance = new CliParser(getSettings());
         try {
             instance.parse(args);
-            Assert.fail("invalid scan should have caused an error");
+            fail("invalid scan should have caused an error");
         } catch (FileNotFoundException ex) {
-            Assert.assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
+            assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
         }
         boolean expResult;
         Boolean result = instance.getBooleanArgument("missingArgument");
-        Assert.assertNull(result);
+        assertNull(result);
 
         expResult = false;
         result = instance.getBooleanArgument(CliParser.ARGUMENT.ARTIFACTORY_USES_PROXY);
-        Assert.assertEquals(expResult, result);
+        assertEquals(expResult, result);
         expResult = true;
         result = instance.getBooleanArgument(CliParser.ARGUMENT.ARTIFACTORY_PARALLEL_ANALYSIS);
-        Assert.assertEquals(expResult, result);
+        assertEquals(expResult, result);
     }
 
     /**
      * Test of getStringArgument method, of class CliParser.
      */
     @Test
-    public void testGetStringArgument() throws ParseException {
+    void testGetStringArgument() throws ParseException {
 
         String[] args = {"--scan", "missing.file", "--artifactoryUsername", "blue42", "--project", "test"};
 
         CliParser instance = new CliParser(getSettings());
         try {
             instance.parse(args);
-            Assert.fail("invalid scan argument should have caused an exception");
+            fail("invalid scan argument should have caused an exception");
         } catch (FileNotFoundException ex) {
-            Assert.assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
+            assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
         }
         String expResult;
         String result = instance.getStringArgument("missingArgument");
-        Assert.assertNull(result);
+        assertNull(result);
 
         expResult = "blue42";
         result = instance.getStringArgument(CliParser.ARGUMENT.ARTIFACTORY_USERNAME);
-        Assert.assertEquals(expResult, result);
+        assertEquals(expResult, result);
     }
 
     @Test
-    public void testHasOption() throws ParseException {
+    void testHasOption() throws ParseException {
 
         String[] args = {"--scan", "missing.file", "--artifactoryUsername", "blue42", "--project", "test"};
 
         CliParser instance = new CliParser(getSettings());
         try {
             instance.parse(args);
-            Assert.fail("invalid scan argument should have caused an exception");
+            fail("invalid scan argument should have caused an exception");
         } catch (FileNotFoundException ex) {
-            Assert.assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
+            assertTrue(ex.getMessage().contains("Invalid 'scan' argument"));
         }
 
         Boolean result = instance.hasOption("missingOption");
-        Assert.assertNull(result);
+        assertNull(result);
 
         Boolean expResult = true;
         result = instance.hasOption(CliParser.ARGUMENT.PROJECT);
-        Assert.assertEquals(expResult, result);
+        assertEquals(expResult, result);
     }
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -335,7 +335,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/src/test/java/org/owasp/dependencycheck/AnalysisTaskTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/AnalysisTaskTest.java
@@ -1,23 +1,23 @@
 package org.owasp.dependencycheck;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.owasp.dependencycheck.analyzer.FileTypeAnalyzer;
 import org.owasp.dependencycheck.analyzer.HintAnalyzer;
 import org.owasp.dependencycheck.dependency.Dependency;
 
 import java.io.File;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class AnalysisTaskTest extends BaseTest {
+@ExtendWith(MockitoExtension.class)
+class AnalysisTaskTest extends BaseTest {
 
     @Mock
     private FileTypeAnalyzer fileTypeAnalyzer;
@@ -30,14 +30,14 @@ public class AnalysisTaskTest extends BaseTest {
 
 
     @Test
-    public void shouldAnalyzeReturnsTrueForNonFileTypeAnalyzers() {
+    void shouldAnalyzeReturnsTrueForNonFileTypeAnalyzers() {
         AnalysisTask instance = new AnalysisTask(new HintAnalyzer(), null, null, null);
         boolean shouldAnalyze = instance.shouldAnalyze();
         assertTrue(shouldAnalyze);
     }
 
     @Test
-    public void shouldAnalyzeReturnsTrueIfTheFileTypeAnalyzersAcceptsTheDependency() {
+    void shouldAnalyzeReturnsTrueIfTheFileTypeAnalyzersAcceptsTheDependency() {
         final File dependencyFile = new File("");
         when(dependency.getActualFile()).thenReturn(dependencyFile);
         when(fileTypeAnalyzer.accept(dependencyFile)).thenReturn(true);
@@ -49,7 +49,7 @@ public class AnalysisTaskTest extends BaseTest {
     }
 
     @Test
-    public void shouldAnalyzeReturnsFalseIfTheFileTypeAnalyzerDoesNotAcceptTheDependency() {
+    void shouldAnalyzeReturnsFalseIfTheFileTypeAnalyzerDoesNotAcceptTheDependency() {
         final File dependencyFile = new File("");
         when(dependency.getActualFile()).thenReturn(dependencyFile);
         when(fileTypeAnalyzer.accept(dependencyFile)).thenReturn(false);
@@ -61,7 +61,7 @@ public class AnalysisTaskTest extends BaseTest {
     }
 
     @Test
-    public void taskAnalyzes() throws Exception {
+    void taskAnalyzes() throws Exception {
         final AnalysisTask analysisTask = new AnalysisTask(fileTypeAnalyzer, dependency, engine, null);
         when(fileTypeAnalyzer.accept(dependency.getActualFile())).thenReturn(true);
 
@@ -71,7 +71,7 @@ public class AnalysisTaskTest extends BaseTest {
     }
 
     @Test
-    public void taskDoesNothingIfItShouldNotAnalyze() throws Exception {
+    void taskDoesNothingIfItShouldNotAnalyze() throws Exception {
         final AnalysisTask analysisTask = new AnalysisTask(fileTypeAnalyzer, dependency, engine, null);
         when(fileTypeAnalyzer.accept(dependency.getActualFile())).thenReturn(false);
 

--- a/core/src/test/java/org/owasp/dependencycheck/BaseDBTestCase.java
+++ b/core/src/test/java/org/owasp/dependencycheck/BaseDBTestCase.java
@@ -17,6 +17,14 @@
  */
 package org.owasp.dependencycheck;
 
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.owasp.dependencycheck.data.nvdcve.DatabaseManager;
+import org.owasp.dependencycheck.utils.Settings;
+import org.owasp.dependencycheck.utils.WriteLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -24,13 +32,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.owasp.dependencycheck.data.nvdcve.DatabaseManager;
-import org.owasp.dependencycheck.utils.WriteLock;
-import org.owasp.dependencycheck.utils.Settings;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * An abstract database test case that is used to ensure the H2 DB exists prior
@@ -40,11 +41,11 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class BaseDBTestCase extends BaseTest {
 
-    protected final static int BUFFER_SIZE = 2048;
+    protected static final int BUFFER_SIZE = 2048;
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(BaseDBTestCase.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseDBTestCase.class);
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();

--- a/core/src/test/java/org/owasp/dependencycheck/BaseTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/BaseTest.java
@@ -16,15 +16,16 @@
 package org.owasp.dependencycheck;
 
 import io.github.jeremylong.jcs3.slf4j.Slf4jAdapter;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.owasp.dependencycheck.utils.Settings;
+
 import java.io.File;
 import java.io.InputStream;
 import java.net.URISyntaxException;
-import org.junit.After;
 
-import org.junit.AfterClass;
-import org.junit.Assume;
-import org.junit.Before;
-import org.owasp.dependencycheck.utils.Settings;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  *
@@ -40,7 +41,7 @@ public abstract class BaseTest {
     /**
      * Initialize the {@link Settings}.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         System.setProperty("jcs.logSystem", "slf4j");
         Slf4jAdapter.muteLogging(true);
@@ -50,13 +51,13 @@ public abstract class BaseTest {
     /**
      * Clean the {@link Settings}.
      */
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         settings.cleanup(true);
     }
 
-    @AfterClass
-    public static void tearDownClass() throws Exception {
+    @AfterAll
+    public static void tearDownClass() {
         File f = new File("./target/data/odc.mv.db");
         if (f.exists() && f.isFile() && f.length() < 71680) {
             System.err.println("------------------------------------------------");
@@ -93,7 +94,7 @@ public abstract class BaseTest {
     public static File getResourceAsFile(Object o, String resource) {
         try {
             File f = new File(o.getClass().getClassLoader().getResource(resource).toURI().getPath());
-            Assume.assumeTrue(String.format("%n%n[SEVERE] Unable to load resource for test case: %s%n%n", resource), f.exists());
+            assumeTrue(f.exists(), String.format("%n%n[SEVERE] Unable to load resource for test case: %s%n%n", resource));
             return f;
         } catch (URISyntaxException e) {
             throw new UnsupportedOperationException(e);

--- a/core/src/test/java/org/owasp/dependencycheck/EngineIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/EngineIT.java
@@ -36,8 +36,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -72,9 +72,9 @@ class EngineIT extends BaseDBTestCase {
              when(instance.getExecutorService(analyzer)).thenReturn(executorService);
              doReturn(failingAnalysisTask).when(instance).getAnalysisTasks(analyzer, exceptions);
 
-             instance.executeAnalysisTasks(analyzer, exceptions);
-             fail("ExceptionCollection exception was expected");
-         } catch (ExceptionCollection expected) {
+             ExceptionCollection expected = assertThrows(ExceptionCollection.class,
+                     () -> instance.executeAnalysisTasks(analyzer, exceptions),
+                     "ExceptionCollection exception was expected");
              List<Throwable> collected = expected.getExceptions();
              assertEquals(1, collected.size());
              assertEquals(java.util.concurrent.ExecutionException.class, collected.get(0).getClass());

--- a/core/src/test/java/org/owasp/dependencycheck/EngineIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/EngineIT.java
@@ -17,8 +17,17 @@
  */
 package org.owasp.dependencycheck;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.owasp.dependencycheck.analyzer.Analyzer;
+import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
+import org.owasp.dependencycheck.exception.ExceptionCollection;
+import org.owasp.dependencycheck.exception.ReportException;
+import org.owasp.dependencycheck.utils.Settings;
+
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -26,31 +35,20 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
-import org.owasp.dependencycheck.exception.ExceptionCollection;
-import org.owasp.dependencycheck.exception.ReportException;
-import org.owasp.dependencycheck.utils.InvalidSettingException;
-import org.owasp.dependencycheck.utils.Settings;
-import org.owasp.dependencycheck.analyzer.Analyzer;
-
 /**
  *
  * @author Jeremy Long
  */
-@RunWith(MockitoJUnitRunner.class)
-public class EngineIT extends BaseDBTestCase {
+@ExtendWith(MockitoExtension.class)
+class EngineIT extends BaseDBTestCase {
 
     @Mock
     private Analyzer analyzer;
@@ -60,7 +58,7 @@ public class EngineIT extends BaseDBTestCase {
 
 
     @Test
-    public void exceptionDuringAnalysisTaskExecutionIsFatal() throws DatabaseException, ExceptionCollection {
+    void exceptionDuringAnalysisTaskExecutionIsFatal() throws DatabaseException {
          final ExecutorService executorService = Executors.newFixedThreadPool(3);
          try (Engine instance = spy(new Engine(new Settings()))) {
              final List<Throwable> exceptions = new ArrayList<>();
@@ -88,14 +86,12 @@ public class EngineIT extends BaseDBTestCase {
     /**
      * Test running the entire engine.
      *
-     * @throws java.io.IOException
-     * @throws org.owasp.dependencycheck.utils.InvalidSettingException
      * @throws org.owasp.dependencycheck.data.nvdcve.DatabaseException
      * @throws org.owasp.dependencycheck.exception.ReportException
      * @throws org.owasp.dependencycheck.exception.ExceptionCollection
      */
     @Test
-    public void testEngine() throws IOException, InvalidSettingException, DatabaseException, ReportException, ExceptionCollection {
+    void testEngine() throws DatabaseException, ReportException, ExceptionCollection {
         String testClasses = "target/test-classes";
         getSettings().setBoolean(Settings.KEYS.AUTO_UPDATE, false);
         getSettings().setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);

--- a/core/src/test/java/org/owasp/dependencycheck/EngineTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/EngineTest.java
@@ -17,20 +17,19 @@
  */
 package org.owasp.dependencycheck;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.analyzer.JarAnalyzer;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
 import org.owasp.dependencycheck.dependency.Dependency;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Jeremy Long
  */
-public class EngineTest extends BaseDBTestCase {
-
+class EngineTest extends BaseDBTestCase {
 
 
     /**
@@ -40,7 +39,7 @@ public class EngineTest extends BaseDBTestCase {
      * there is an exception
      */
     @Test
-    public void testScanFile() throws DatabaseException {
+    void testScanFile() throws DatabaseException {
         try (Engine instance = new Engine(getSettings())) {
             instance.addFileTypeAnalyzer(new JarAnalyzer());
             File file = BaseTest.getResourceAsFile(this, "dwr.jar");

--- a/core/src/test/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgentIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/agent/DependencyCheckScanAgentIT.java
@@ -17,32 +17,35 @@
  */
 package org.owasp.dependencycheck.agent;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.reporting.ReportGenerator;
 import org.owasp.dependencycheck.utils.FileUtils;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import org.owasp.dependencycheck.BaseDBTestCase;
 
-public class DependencyCheckScanAgentIT extends BaseDBTestCase {
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DependencyCheckScanAgentIT extends BaseDBTestCase {
 
     private static final File REPORT_DIR = new File("target/test-scan-agent/report");
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    static void beforeClass() {
         if (!REPORT_DIR.exists()) {
             REPORT_DIR.mkdirs();
         }
     }
 
     @Test
-    public void testComponentMetadata() throws Exception {
+    void testComponentMetadata() throws Exception {
         List<Dependency> dependencies = new ArrayList<>();
         dependencies.add(createDependency("apache", "tomcat", "5.0.5"));
         DependencyCheckScanAgent scanAgent = createScanAgent();
@@ -50,10 +53,10 @@ public class DependencyCheckScanAgentIT extends BaseDBTestCase {
         scanAgent.execute();
 
         Dependency tomcat = scanAgent.getDependencies().get(0);
-        Assert.assertTrue(tomcat.getVulnerableSoftwareIdentifiers().size() >= 1);
+        assertFalse(tomcat.getVulnerableSoftwareIdentifiers().isEmpty());
 
         // This will change over time
-        Assert.assertTrue(tomcat.getVulnerabilities().size() > 5);
+        assertTrue(tomcat.getVulnerabilities().size() > 5);
     }
 
     private DependencyCheckScanAgent createScanAgent() {

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractFileTypeAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractFileTypeAnalyzerTest.java
@@ -17,23 +17,25 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.util.Set;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class AbstractFileTypeAnalyzerTest extends BaseTest {
+class AbstractFileTypeAnalyzerTest extends BaseTest {
 
     /**
      * Test of newHashSet method, of class AbstractAnalyzer.
      */
     @Test
-    public void testNewHashSet() {
+    void testNewHashSet() {
         Set<String> result = AbstractFileTypeAnalyzer.newHashSet("one", "two");
         assertEquals(2, result.size());
         assertTrue(result.contains("one"));

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzerIT.java
@@ -17,22 +17,24 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.ArrayList;
 import java.util.Collection;
-import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author jeremy long
  */
-public class AbstractNpmAnalyzerIT {
+class AbstractNpmAnalyzerIT {
 
     /**
      * Test of determineVersionFromMap method, of class AbstractNpmAnalyzer.
      */
     @Test
-    public void testDetermineVersionFromMap() {
+    void testDetermineVersionFromMap() {
         String versionRange = ">2.1.1 <5.0.1";
         Collection<String> availableVersions = new ArrayList<>();
         availableVersions.add("2.0.2");
@@ -49,7 +51,7 @@ public class AbstractNpmAnalyzerIT {
     }
 
     @Test
-    public void testDetermineVersionFromMap_1() {
+    void testDetermineVersionFromMap_1() {
         String versionRange = ">2.1.1 <5.0.1";
         Collection<String> availableVersions = new ArrayList<>();
         availableVersions.add("10.1.0");
@@ -59,7 +61,7 @@ public class AbstractNpmAnalyzerIT {
     }
 
     @Test
-    public void testDetermineVersionFromMap_2() {
+    void testDetermineVersionFromMap_2() {
         String versionRange = ">2.1.1 <5.0.1";
         Collection<String> availableVersions = new ArrayList<>();
         availableVersions.add("2.0.2");

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzerTest.java
@@ -17,19 +17,11 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import java.util.Set;
-
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.Engine.Mode;
-import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.Downloader;
@@ -37,10 +29,18 @@ import org.owasp.dependencycheck.utils.Settings;
 import org.owasp.dependencycheck.utils.Settings.KEYS;
 import org.owasp.dependencycheck.xml.suppression.SuppressionRule;
 
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 /**
  * @author Jeremy Long
  */
-public class AbstractSuppressionAnalyzerTest extends BaseTest {
+class AbstractSuppressionAnalyzerTest extends BaseTest {
 
     /**
      * A second suppression file to test with.
@@ -54,8 +54,8 @@ public class AbstractSuppressionAnalyzerTest extends BaseTest {
 
     private AbstractSuppressionAnalyzer instance;
 
-    @Before
-    public void createObjectUnderTest() throws Exception {
+    @BeforeEach
+    void createObjectUnderTest() {
         instance = new AbstractSuppressionAnalyzerImpl();
     }
 
@@ -64,7 +64,7 @@ public class AbstractSuppressionAnalyzerTest extends BaseTest {
      * AbstractSuppressionAnalyzer.
      */
     @Test
-    public void testGetSupportedExtensions() {
+    void testGetSupportedExtensions() {
         Set<String> result = instance.getSupportedExtensions();
         assertNull(result);
     }
@@ -74,10 +74,10 @@ public class AbstractSuppressionAnalyzerTest extends BaseTest {
      * suppression file declared as URL.
      */
     @Test
-    public void testGetRulesFromSuppressionFileFromURL() throws Exception {
+    void testGetRulesFromSuppressionFileFromURL() throws Exception {
         final String fileUrl = getClass().getClassLoader().getResource(SUPPRESSIONS_FILE).toURI().toURL().toString();
         final int numberOfExtraLoadedRules = getNumberOfRulesLoadedFromPath(fileUrl) - getNumberOfRulesLoadedInCoreFile();
-        assertEquals("Expected 5 extra rules in the given path", 5, numberOfExtraLoadedRules);
+        assertEquals(5, numberOfExtraLoadedRules, "Expected 5 extra rules in the given path");
     }
 
     /**
@@ -85,9 +85,9 @@ public class AbstractSuppressionAnalyzerTest extends BaseTest {
      * suppression file on the class path.
      */
     @Test
-    public void testGetRulesFromSuppressionFileInClasspath() throws Exception {
+    void testGetRulesFromSuppressionFileInClasspath() throws Exception {
         final int numberOfExtraLoadedRules = getNumberOfRulesLoadedFromPath(SUPPRESSIONS_FILE) - getNumberOfRulesLoadedInCoreFile();
-        assertEquals("Expected 5 extra rules in the given file", 5, numberOfExtraLoadedRules);
+        assertEquals(5, numberOfExtraLoadedRules, "Expected 5 extra rules in the given file");
     }
 
     /**
@@ -95,7 +95,7 @@ public class AbstractSuppressionAnalyzerTest extends BaseTest {
      * defined in the {@link Settings}.
      */
     @Test
-    public void testGetRulesFromMultipleSuppressionFiles() throws Exception {
+    void testGetRulesFromMultipleSuppressionFiles() throws Exception {
         final int rulesInCoreFile = getNumberOfRulesLoadedInCoreFile();
 
         // GIVEN suppression rules from one file
@@ -116,12 +116,13 @@ public class AbstractSuppressionAnalyzerTest extends BaseTest {
         assertThat("Expected suppressions from both files", instance.getRuleCount(engine), is(expectedSize));
     }
 
-    @Test(expected = InitializationException.class)
-    public void testFailureToLocateSuppressionFileAnywhere() throws Exception {
+    @Test
+    void testFailureToLocateSuppressionFileAnywhere() {
         getSettings().setString(Settings.KEYS.SUPPRESSION_FILE, "doesnotexist.xml");
         instance.initialize(getSettings());
         Engine engine = new Engine(Mode.EVIDENCE_COLLECTION, getSettings());
-        instance.prepare(engine);
+        assertThrows(InitializationException.class, () ->
+            instance.prepare(engine));
     }
 
     /**
@@ -163,7 +164,7 @@ public class AbstractSuppressionAnalyzerTest extends BaseTest {
     public static class AbstractSuppressionAnalyzerImpl extends AbstractSuppressionAnalyzer {
 
         @Override
-        public void analyzeDependency(Dependency dependency, Engine engine) throws AnalysisException {
+        public void analyzeDependency(Dependency dependency, Engine engine) {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
 

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/AnalyzerServiceTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/AnalyzerServiceTest.java
@@ -17,15 +17,15 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.utils.Settings;
 
 import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.owasp.dependencycheck.analyzer.AnalysisPhase.FINAL;
 import static org.owasp.dependencycheck.analyzer.AnalysisPhase.INITIAL;
 
@@ -33,13 +33,13 @@ import static org.owasp.dependencycheck.analyzer.AnalysisPhase.INITIAL;
  *
  * @author Jeremy Long
  */
-public class AnalyzerServiceTest extends BaseDBTestCase {
+class AnalyzerServiceTest extends BaseDBTestCase {
 
     /**
      * Test of getAnalyzers method, of class AnalyzerService.
      */
     @Test
-    public void testGetAnalyzers() {
+    void testGetAnalyzers() {
         AnalyzerService instance = new AnalyzerService(Thread.currentThread().getContextClassLoader(), getSettings());
         List<Analyzer> result = instance.getAnalyzers();
 
@@ -50,14 +50,14 @@ public class AnalyzerServiceTest extends BaseDBTestCase {
                 break;
             }
         }
-        assertTrue("JarAnalyzer loaded", found);
+        assertTrue(found, "JarAnalyzer loaded");
     }
 
     /**
      * Test of getAnalyzers method, of class AnalyzerService.
      */
     @Test
-    public void testGetAnalyzers_SpecificPhases() throws Exception {
+    void testGetAnalyzers_SpecificPhases() {
         AnalyzerService instance = new AnalyzerService(Thread.currentThread().getContextClassLoader(), getSettings());
         List<Analyzer> result = instance.getAnalyzers(INITIAL, FINAL);
 
@@ -72,7 +72,7 @@ public class AnalyzerServiceTest extends BaseDBTestCase {
      * Test of getAnalyzers method, of class AnalyzerService.
      */
     @Test
-    public void testGetExperimentalAnalyzers() {
+    void testGetExperimentalAnalyzers() {
         AnalyzerService instance = new AnalyzerService(Thread.currentThread().getContextClassLoader(), getSettings());
         List<Analyzer> result = instance.getAnalyzers();
         String experimental = "CMake Analyzer";
@@ -83,8 +83,8 @@ public class AnalyzerServiceTest extends BaseDBTestCase {
                 found = true;
             }
         }
-        assertFalse("Experimental analyzer loaded when set to false", found);
-        assertFalse("Retired analyzer loaded when set to false", retiredFound);
+        assertFalse(found, "Experimental analyzer loaded when set to false");
+        assertFalse(retiredFound, "Retired analyzer loaded when set to false");
 
         getSettings().setBoolean(Settings.KEYS.ANALYZER_EXPERIMENTAL_ENABLED, true);
         instance = new AnalyzerService(Thread.currentThread().getContextClassLoader(), getSettings());
@@ -96,8 +96,8 @@ public class AnalyzerServiceTest extends BaseDBTestCase {
                 found = true;
             }
         }
-        assertTrue("Experimental analyzer not loaded when set to true", found);
-        assertFalse("Retired analyzer loaded when set to false", retiredFound);
+        assertTrue(found, "Experimental analyzer not loaded when set to true");
+        assertFalse(retiredFound, "Retired analyzer loaded when set to false");
 
         getSettings().setBoolean(Settings.KEYS.ANALYZER_EXPERIMENTAL_ENABLED, false);
         getSettings().setBoolean(Settings.KEYS.ANALYZER_RETIRED_ENABLED, true);
@@ -109,6 +109,6 @@ public class AnalyzerServiceTest extends BaseDBTestCase {
                 found = true;
             }
         }
-        assertFalse("Experimental analyzer loaded when set to false", found);
+        assertFalse(found, "Experimental analyzer loaded when set to false");
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzerIT.java
@@ -22,7 +22,6 @@ import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.dependency.Dependency;
-import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.Settings;
 
 import java.io.File;
@@ -34,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
@@ -113,9 +111,7 @@ class ArchiveAnalyzerIT extends BaseDBTestCase {
         try {
             instance.setEnabled(true);
             instance.setFilesMatched(true);
-            instance.prepare(null);
-        } catch (InitializationException ex) {
-            fail(ex.getMessage());
+            assertDoesNotThrow(() -> instance.prepare(null));
         } finally {
             assertDoesNotThrow(instance::close);
         }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzerIT.java
@@ -17,29 +17,36 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.util.HashSet;
-import java.util.Set;
-import static org.junit.Assert.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
-import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.Settings;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
  * @author Jeremy Long
  */
-public class ArchiveAnalyzerIT extends BaseDBTestCase {
+class ArchiveAnalyzerIT extends BaseDBTestCase {
 
     /**
      * Test of getSupportedExtensions method, of class ArchiveAnalyzer.
      */
     @Test
-    public void testSupportsExtensions() {
+    void testSupportsExtensions() {
         ArchiveAnalyzer instance = new ArchiveAnalyzer();
         instance.initialize(getSettings());
         Set<String> expResult = new HashSet<>();
@@ -57,7 +64,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
         expResult.add("tbz2");
         expResult.add("rpm");
         for (String ext : expResult) {
-            assertTrue(ext, instance.accept(new File("test." + ext)));
+            assertTrue(instance.accept(new File("test." + ext)), ext);
         }
     }
 
@@ -65,7 +72,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
      * Test of getName method, of class ArchiveAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         ArchiveAnalyzer instance = new ArchiveAnalyzer();
         instance.initialize(getSettings());
         String expResult = "Archive Analyzer";
@@ -77,18 +84,18 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
      * Test of supportsExtension method, of class ArchiveAnalyzer.
      */
     @Test
-    public void testSupportsExtension() {
+    void testSupportsExtension() {
         String extension = "test.7z"; //not supported
         ArchiveAnalyzer instance = new ArchiveAnalyzer();
         instance.initialize(getSettings());
-        assertFalse(extension, instance.accept(new File(extension)));
+        assertFalse(instance.accept(new File(extension)), extension);
     }
 
     /**
      * Test of getAnalysisPhase method, of class ArchiveAnalyzer.
      */
     @Test
-    public void testGetAnalysisPhase() {
+    void testGetAnalysisPhase() {
         ArchiveAnalyzer instance = new ArchiveAnalyzer();
         instance.initialize(getSettings());
         AnalysisPhase expResult = AnalysisPhase.INITIAL;
@@ -100,7 +107,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
      * Test of prepare and close methods, of class ArchiveAnalyzer.
      */
     @Test
-    public void testInitialize() {
+    void testInitialize() {
         ArchiveAnalyzer instance = new ArchiveAnalyzer();
         instance.initialize(getSettings());
         try {
@@ -110,11 +117,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
         } catch (InitializationException ex) {
             fail(ex.getMessage());
         } finally {
-            try {
-                instance.close();
-            } catch (Exception ex) {
-                fail(ex.getMessage());
-            }
+            assertDoesNotThrow(instance::close);
         }
     }
 
@@ -124,7 +127,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
      * @throws java.lang.Exception when an error occurs
      */
     @Test
-    public void testAnalyze() throws Exception {
+    void testAnalyze() throws Exception {
         Settings settings = getSettings();
         settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
         settings.setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
@@ -154,7 +157,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
      * Test of analyze method, of class ArchiveAnalyzer, with an executable jar.
      */
     @Test
-    public void testAnalyzeExecutableJar() throws Exception {
+    void testAnalyzeExecutableJar() throws Exception {
         Settings settings = getSettings();
         settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
         settings.setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
@@ -181,7 +184,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
     }
 
     @Test
-    public void testAnalyzeJarStaticResources() throws Exception {
+    void testAnalyzeJarStaticResources() throws Exception {
         Settings settings = getSettings();
         settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
         settings.setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
@@ -217,7 +220,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
      * Test of analyze method, of class ArchiveAnalyzer.
      */
     @Test
-    public void testAnalyzeTar() throws Exception {
+    void testAnalyzeTar() throws Exception {
         Settings settings = getSettings();
         settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
         settings.setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
@@ -249,7 +252,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
      * Test of analyze method, of class ArchiveAnalyzer.
      */
     @Test
-    public void testAnalyzeTarGz() throws Exception {
+    void testAnalyzeTarGz() throws Exception {
         Settings settings = getSettings();
         settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
         settings.setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
@@ -282,7 +285,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
      * Test of analyze method, of class ArchiveAnalyzer.
      */
     @Test
-    public void testAnalyzeTarBz2() throws Exception {
+    void testAnalyzeTarBz2() throws Exception {
         Settings settings = getSettings();
         settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
         settings.setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
@@ -310,7 +313,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
      * Test of analyze method, of class ArchiveAnalyzer.
      */
     @Test
-    public void testAnalyzeTgz() throws Exception {
+    void testAnalyzeTgz() throws Exception {
         Settings settings = getSettings();
         settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
         settings.setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
@@ -340,7 +343,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
      * Test of analyze method, of class ArchiveAnalyzer.
      */
     @Test
-    public void testAnalyzeTbz2() throws Exception {
+    void testAnalyzeTbz2() throws Exception {
         Settings settings = getSettings();
         settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
         settings.setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
@@ -367,7 +370,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
      * Test of analyze method, of class ArchiveAnalyzer.
      */
     @Test
-    public void testAnalyzeRpm() throws Exception {
+    void testAnalyzeRpm() throws Exception {
         Settings settings = getSettings();
         settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
         settings.setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);
@@ -380,7 +383,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
         instance.accept(new File("struts-1.2.9-162.35.1.uyuni.noarch.rpm"));
         try (Engine engine = new Engine(settings)) {
             instance.prepare(null);
-            
+
             File file = BaseTest.getResourceAsFile(this, "xmlsec-2.0.7-3.7.uyuni.noarch.rpm");
             Dependency dependency = new Dependency(file);
 
@@ -397,7 +400,7 @@ public class ArchiveAnalyzerIT extends BaseDBTestCase {
      * Test of analyze method, of class ArchiveAnalyzer.
      */
     @Test
-    public void testAnalyze_badZip() throws Exception {
+    void testAnalyze_badZip() throws Exception {
         Settings settings = getSettings();
         settings.setBoolean(Settings.KEYS.AUTO_UPDATE, false);
         settings.setBoolean(Settings.KEYS.ANALYZER_NEXUS_ENABLED, false);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/ArchiveAnalyzerTest.java
@@ -15,27 +15,23 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.utils.Settings;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author jeremy long
  */
-public class ArchiveAnalyzerTest extends BaseTest {
+class ArchiveAnalyzerTest extends BaseTest {
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -46,7 +42,7 @@ public class ArchiveAnalyzerTest extends BaseTest {
      * Test of analyzeDependency method, of class ArchiveAnalyzer.
      */
     @Test
-    public void testZippableExtensions() throws Exception {
+    void testZippableExtensions() {
         ArchiveAnalyzer instance = new ArchiveAnalyzer();
         instance.initialize(getSettings());
         assertTrue(instance.getFileFilter().accept(new File("c:/test.zip")));
@@ -59,7 +55,7 @@ public class ArchiveAnalyzerTest extends BaseTest {
      * Test of analyzeDependency method, of class ArchiveAnalyzer.
      */
     @Test
-    public void testRpmExtension() throws Exception {
+    void testRpmExtension() {
         ArchiveAnalyzer instance = new ArchiveAnalyzer();
         instance.initialize(getSettings());
         assertTrue(instance.getFileFilter().accept(new File("/srv/struts-1.2.9-162.35.1.uyuni.noarch.rpm")));

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzerTest.java
@@ -17,18 +17,9 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.io.IOException;
-import org.junit.After;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import org.junit.Assume;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeNotNull;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException;
@@ -41,13 +32,21 @@ import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 /**
  * Tests for the AssemblyAnalyzer.
  *
  * @author colezlaw
  *
  */
-public class AssemblyAnalyzerTest extends BaseTest {
+class AssemblyAnalyzerTest extends BaseTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AssemblyAnalyzerTest.class);
 
@@ -60,7 +59,7 @@ public class AssemblyAnalyzerTest extends BaseTest {
      *
      * @throws Exception if anything goes sideways
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -76,28 +75,28 @@ public class AssemblyAnalyzerTest extends BaseTest {
             } else {
                 LOGGER.warn("Exception setting up AssemblyAnalyzer. Tests will be incomplete");
             }
-            Assume.assumeNoException("Is dotnet installed? TESTS WILL BE INCOMPLETE", e);
+            assumeTrue(false, "Is dotnet installed? TESTS WILL BE INCOMPLETE: " + e);
         }
     }
 
-    private void assertGrokAssembly() throws IOException {
+    private void assertGrokAssembly() {
         // There must be an .exe and a .config files created in the temp
         // directory and they must match the resources they were created from.
         File grokAssemblyExeFile = analyzer.getGrokAssemblyPath();
-        assertTrue("The GrokAssembly executable was not created.", grokAssemblyExeFile.isFile());
+        assertTrue(grokAssemblyExeFile.isFile(), "The GrokAssembly executable was not created.");
     }
 
     /**
      * Tests to make sure the name is correct.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertEquals("Assembly Analyzer", analyzer.getName());
     }
 
     @Test
-    public void testAnalysis() throws Exception {
-        assumeNotNull(analyzer.buildArgumentList());
+    void testAnalysis() throws Exception {
+        assumeTrue(analyzer.buildArgumentList() != null);
         File f = analyzer.getGrokAssemblyPath();
         Dependency d = new Dependency(f);
         analyzer.analyze(d, null);
@@ -106,8 +105,8 @@ public class AssemblyAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testLog4Net() throws Exception {
-        assumeNotNull(analyzer.buildArgumentList());
+    void testLog4Net() throws Exception {
+        assumeTrue(analyzer.buildArgumentList() != null);
         File f = BaseTest.getResourceAsFile(this, "log4net.dll");
 
         Dependency d = new Dependency(f);
@@ -120,8 +119,8 @@ public class AssemblyAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testNonexistent() {
-        assumeNotNull(analyzer.buildArgumentList());
+    void testNonexistent() {
+        assumeTrue(analyzer.buildArgumentList() != null);
 
         // Tweak the log level so the warning doesn't show in the console
         String oldProp = System.getProperty(LOG_KEY, "info");
@@ -140,7 +139,7 @@ public class AssemblyAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testWithSettingMono() throws Exception {
+    void testWithSettingMono() {
 
         //This test doesn't work on Windows.
         assumeFalse(System.getProperty("os.name").startsWith("Windows"));
@@ -177,7 +176,7 @@ public class AssemblyAnalyzerTest extends BaseTest {
         }
     }
 
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         try {

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzerTest.java
@@ -35,8 +35,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -129,9 +129,8 @@ class AssemblyAnalyzerTest extends BaseTest {
         Dependency d = new Dependency(test);
 
         try {
-            analyzer.analyze(d, null);
-            fail("Expected an AnalysisException");
-        } catch (AnalysisException ae) {
+            AnalysisException ae = assertThrows(AnalysisException.class, () -> analyzer.analyze(d, null),
+                "Expected an AnalysisException");
             assertTrue(ae.getMessage().contains("nonexistent.dll does not exist and cannot be analyzed by dependency-check"));
         } finally {
             System.setProperty(LOG_KEY, oldProp);
@@ -159,9 +158,9 @@ class AssemblyAnalyzerTest extends BaseTest {
             AssemblyAnalyzer aanalyzer = new AssemblyAnalyzer();
             aanalyzer.initialize(getSettings());
             aanalyzer.accept(new File("test.dll")); // trick into "thinking it is active"
-            aanalyzer.prepare(null);
-            fail("Expected an InitializationException");
-        } catch (InitializationException ae) {
+
+            InitializationException ae = assertThrows(InitializationException.class, () -> aanalyzer.prepare(null),
+                    "Expected an InitializationException");
             assertEquals("An error occurred with the .NET AssemblyAnalyzer, is the dotnet 8.0 runtime or sdk installed?", ae.getMessage());
         } finally {
             System.setProperty(LOG_KEY, oldProp);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/AutoconfAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/AutoconfAnalyzerTest.java
@@ -17,20 +17,20 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.Evidence;
+import org.owasp.dependencycheck.dependency.EvidenceType;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import org.owasp.dependencycheck.dependency.Confidence;
-import org.owasp.dependencycheck.dependency.Evidence;
-import org.owasp.dependencycheck.dependency.EvidenceType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for AutoconfAnalyzer. The test resources under autoconf/ were
@@ -43,7 +43,7 @@ import org.owasp.dependencycheck.dependency.EvidenceType;
  * @see <a href="https://gnu.org/software/binutils/">GNU Binutils</a>
  * @see <a href="https://gnu.org/software/ghostscript/">GNU Ghostscript</a>
  */
-public class AutoconfAnalyzerTest extends BaseTest {
+class AutoconfAnalyzerTest extends BaseTest {
 
     /**
      * The analyzer to test.
@@ -55,7 +55,7 @@ public class AutoconfAnalyzerTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -70,7 +70,7 @@ public class AutoconfAnalyzerTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         analyzer.close();
@@ -84,7 +84,7 @@ public class AutoconfAnalyzerTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzeConfigureAC1() throws AnalysisException {
+    void testAnalyzeConfigureAC1() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                 this, "autoconf/ghostscript/configure.ac"));
         analyzer.analyze(result, null);
@@ -100,7 +100,7 @@ public class AutoconfAnalyzerTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzeConfigureAC2() throws AnalysisException {
+    void testAnalyzeConfigureAC2() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                 this, "autoconf/readable-code/configure.ac"));
         analyzer.analyze(result, null);
@@ -117,7 +117,7 @@ public class AutoconfAnalyzerTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzeConfigureScript() throws AnalysisException {
+    void testAnalyzeConfigureScript() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                 this, "autoconf/binutils/configure"));
         analyzer.analyze(result, null);
@@ -133,7 +133,7 @@ public class AutoconfAnalyzerTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzeReadableConfigureScript() throws AnalysisException {
+    void testAnalyzeReadableConfigureScript() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                 this, "autoconf/readable-code/configure"));
         analyzer.analyze(result, null);
@@ -148,21 +148,22 @@ public class AutoconfAnalyzerTest extends BaseTest {
      * Test of getName method, of {@link AutoconfAnalyzer}.
      */
     @Test
-    public void testGetName() {
-        assertEquals("Analyzer name wrong.", "Autoconf Analyzer",
-                analyzer.getName());
+    void testGetName() {
+        assertEquals("Autoconf Analyzer",
+                analyzer.getName(),
+                "Analyzer name wrong.");
     }
 
     /**
      * Test of {@link AutoconfAnalyzer#accept(File)}.
      */
     @Test
-    public void testSupportsFileExtension() {
-        assertTrue("Should support \"ac\" extension.",
-                analyzer.accept(new File("configure.ac")));
-        assertTrue("Should support \"in\" extension.",
-                analyzer.accept(new File("configure.in")));
-        assertTrue("Should support \"configure\" extension.",
-                analyzer.accept(new File("configure")));
+    void testSupportsFileExtension() {
+        assertTrue(analyzer.accept(new File("configure.ac")),
+                "Should support \"ac\" extension.");
+        assertTrue(analyzer.accept(new File("configure.in")),
+                "Should support \"in\" extension.");
+        assertTrue(analyzer.accept(new File("configure")),
+                "Should support \"configure\" extension.");
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/CMakeAnalyzerTest.java
@@ -17,15 +17,17 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.Evidence;
+import org.owasp.dependencycheck.dependency.EvidenceType;
 
 import java.io.File;
 import java.util.HashMap;
@@ -34,20 +36,17 @@ import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import org.owasp.dependencycheck.dependency.Evidence;
-import org.owasp.dependencycheck.dependency.EvidenceType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for CmakeAnalyzer.
  *
  * @author Dale Visser
  */
-public class CMakeAnalyzerTest extends BaseDBTestCase {
+class CMakeAnalyzerTest extends BaseDBTestCase {
 
     /**
      * The package analyzer to test.
@@ -59,7 +58,7 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
      *
      * @throws Exception if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -74,7 +73,7 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
      *
      * @throws Exception if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         try {
@@ -88,7 +87,7 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
      * Test of getName method, of class PythonPackageAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertThat(analyzer.getName(), is(equalTo("CMake Analyzer")));
     }
 
@@ -96,11 +95,11 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
      * Test of supportsExtension method, of class PythonPackageAnalyzer.
      */
     @Test
-    public void testAccept() {
-        assertTrue("Should support \"CMakeLists.txt\" name.",
-                analyzer.accept(new File("CMakeLists.txt")));
-        assertTrue("Should support \"cmake\" extension.",
-                analyzer.accept(new File("test.cmake")));
+    void testAccept() {
+        assertTrue(analyzer.accept(new File("CMakeLists.txt")),
+                "Should support \"CMakeLists.txt\" name.");
+        assertTrue(analyzer.accept(new File("test.cmake")),
+                "Should support \"cmake\" extension.");
     }
 
     /**
@@ -109,7 +108,7 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzeCMakeListsOpenCV() throws AnalysisException {
+    void testAnalyzeCMakeListsOpenCV() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                 this, "cmake/opencv/CMakeLists.txt"));
         analyzer.analyze(result, null);
@@ -123,7 +122,7 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzeCMakeListsZlib() throws AnalysisException {
+    void testAnalyzeCMakeListsZlib() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                 this, "cmake/zlib/CMakeLists.txt"));
         analyzer.analyze(result, null);
@@ -137,7 +136,7 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzeCMakeListsPython() throws AnalysisException {
+    void testAnalyzeCMakeListsPython() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                 this, "cmake/opencv/cmake/OpenCVDetectPython.cmake"));
         analyzer.analyze(result, null);
@@ -154,7 +153,7 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
                 break;
             }
         }
-        assertTrue("Expected product evidence to contain \"" + product + "\".", found);
+        assertTrue(found, "Expected product evidence to contain \"" + product + "\".");
     }
 
     /**
@@ -164,7 +163,7 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzeCMakeListsOpenCV3rdParty() throws AnalysisException, DatabaseException {
+    void testAnalyzeCMakeListsOpenCV3rdParty() throws AnalysisException, DatabaseException {
         try (Engine engine = new Engine(getSettings())) {
             final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                     this, "cmake/opencv/3rdparty/ffmpeg/ffmpeg_version.cmake"));
@@ -172,10 +171,10 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
             analyzer.analyze(result, engine);
             assertProductEvidence(result, "libavcodec");
             assertVersionEvidence(result, "55.18.102");
-            assertFalse("ALIASOF_ prefix shouldn't be present.",
-                    Pattern.compile("\\bALIASOF_\\w+").matcher(result.getEvidence(EvidenceType.PRODUCT).toString()).find());
+            assertFalse(Pattern.compile("\\bALIASOF_\\w+").matcher(result.getEvidence(EvidenceType.PRODUCT).toString()).find(),
+                    "ALIASOF_ prefix shouldn't be present.");
             final Dependency[] dependencies = engine.getDependencies();
-            assertEquals("Number of additional dependencies should be 4.", 4, dependencies.length);
+            assertEquals(4, dependencies.length, "Number of additional dependencies should be 4.");
             final Dependency last = dependencies[3];
             assertProductEvidence(last, "libavresample");
             assertVersionEvidence(last, "1.0.1");
@@ -190,11 +189,11 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
                 break;
             }
         }
-        assertTrue("Expected version evidence to contain \"" + version + "\".", found);
+        assertTrue(found, "Expected version evidence to contain \"" + version + "\".");
     }
 
     @Test
-    public void testRemoveSelfReferences() {
+    void testRemoveSelfReferences() {
         // Given
         Map<String, String> input = new HashMap<>();
         input.put("Deflate_OLD_FIND_LIBRARY_PREFIXES", "${CMAKE_FIND_LIBRARY_PREFIXES}");
@@ -220,7 +219,7 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
     }
 
     @Test
-    public void testRemoveSelfReferences2() {
+    void testRemoveSelfReferences2() {
         // Given
         Map<String, String> input = new HashMap<>();
         input.put("FLTK2_DIR", "${FLTK2_INCLUDE_DIR}");
@@ -274,7 +273,7 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzeCMakeTempVariable() throws AnalysisException {
+    void testAnalyzeCMakeTempVariable() throws AnalysisException {
         try (Engine engine = new Engine(getSettings())) {
             final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                     this, "cmake/libtiff/FindDeflate.cmake"));
@@ -285,7 +284,7 @@ public class CMakeAnalyzerTest extends BaseDBTestCase {
     }
 
     @Test
-    public void testAnalyzeCMakeInfiniteLoop() throws AnalysisException {
+    void testAnalyzeCMakeInfiniteLoop() throws AnalysisException {
         try (Engine engine = new Engine(getSettings())) {
             final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                     this, "cmake/cmake-modules/FindFLTK2.cmake"));

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/CPEAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/CPEAnalyzerIT.java
@@ -159,7 +159,7 @@ class CPEAnalyzerIT extends BaseDBTestCase {
             }
             assertTrue(found, "Match not found: { dep:'" + dep.getFileName() + "', exp:'" + expResult + "' }");
         } else {
-            dep.getVulnerableSoftwareIdentifiers().forEach((id) -> fail("Unexpected match found: { dep:'" + dep.getFileName() + "', found:'" + id + "' }"));
+            dep.getVulnerableSoftwareIdentifiers().forEach(id -> fail("Unexpected match found: { dep:'" + dep.getFileName() + "', found:'" + id + "' }"));
         }
     }
 
@@ -222,7 +222,7 @@ class CPEAnalyzerIT extends BaseDBTestCase {
             instance.close();
 
             suppressionAnalyzer.analyze(commonValidator, engine);
-            commonValidator.getVulnerableSoftwareIdentifiers().forEach((i) -> fail("Apache Common Validator found an unexpected CPE identifier - " + i.getValue()));
+            commonValidator.getVulnerableSoftwareIdentifiers().forEach(i -> fail("Apache Common Validator found an unexpected CPE identifier - " + i.getValue()));
 
             String expResult = "cpe:2.3:a:apache:struts:2.1.2:*:*:*:*:*:*:*";
             assertFalse(struts.getVulnerableSoftwareIdentifiers().isEmpty(), "Incorrect match size - struts");

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/CPEAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/CPEAnalyzerTest.java
@@ -17,30 +17,34 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.dependency.Confidence;
+import org.owasp.dependencycheck.dependency.Evidence;
+import org.owasp.dependencycheck.utils.Settings;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang3.mutable.MutableInt;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.owasp.dependencycheck.dependency.Confidence;
-import org.owasp.dependencycheck.dependency.Evidence;
-import org.owasp.dependencycheck.utils.Settings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author jeremy long
  */
-public class CPEAnalyzerTest {
+class CPEAnalyzerTest {
 
     /**
      * Test of getName method, of class CPEAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         CPEAnalyzer instance = new CPEAnalyzer();
         String expResult = "CPE Analyzer";
         String result = instance.getName();
@@ -51,7 +55,7 @@ public class CPEAnalyzerTest {
      * Test of getAnalysisPhase method, of class CPEAnalyzer.
      */
     @Test
-    public void testGetAnalysisPhase() {
+    void testGetAnalysisPhase() {
         CPEAnalyzer instance = new CPEAnalyzer();
         AnalysisPhase expResult = AnalysisPhase.IDENTIFIER_ANALYSIS;
         AnalysisPhase result = instance.getAnalysisPhase();
@@ -62,7 +66,7 @@ public class CPEAnalyzerTest {
      * Test of getAnalyzerEnabledSettingKey method, of class CPEAnalyzer.
      */
     @Test
-    public void testGetAnalyzerEnabledSettingKey() {
+    void testGetAnalyzerEnabledSettingKey() {
         CPEAnalyzer instance = new CPEAnalyzer();
         String expResult = Settings.KEYS.ANALYZER_CPE_ENABLED;
         String result = instance.getAnalyzerEnabledSettingKey();
@@ -73,7 +77,7 @@ public class CPEAnalyzerTest {
      * Test of collectTerms method, of class CPEAnalyzer.
      */
     @Test
-    public void testAddEvidenceWithoutDuplicateTerms() {
+    void testAddEvidenceWithoutDuplicateTerms() {
         Map<String, MutableInt> terms = new HashMap<>();
         List<Evidence> evidence = new ArrayList<>();
         evidence.add(new Evidence("test case", "value", "test", Confidence.HIGHEST));
@@ -191,7 +195,7 @@ public class CPEAnalyzerTest {
     }
 
     @Test
-    public void testCollectTerms() {
+    void testCollectTerms() {
         Map<String, MutableInt> terms = new HashMap<>();
         List<Evidence> evidence = new ArrayList<>();
         evidence.add(new Evidence("\\@", "\\*", "\\+", Confidence.HIGHEST));
@@ -204,7 +208,7 @@ public class CPEAnalyzerTest {
      * Test of buildSearch method, of class CPEAnalyzer.
      */
     @Test
-    public void testBuildSearch() {
+    void testBuildSearch() {
         Map<String, MutableInt> vendor = new HashMap<>();
         Map<String, MutableInt> product = new HashMap<>();
         vendor.put("apache software foundation", new MutableInt(1));
@@ -279,7 +283,7 @@ public class CPEAnalyzerTest {
     }
 
     @Test
-    public void testBuildSearchBlank() {
+    void testBuildSearchBlank() {
         Map<String, MutableInt> vendor = new HashMap<>();
         Map<String, MutableInt> product = new HashMap<>();
         vendor.put("   ", new MutableInt(1));

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/CentralAnalyzerTest.java
@@ -17,33 +17,28 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.data.central.CentralSearch;
-import org.owasp.dependencycheck.utils.ForbiddenException;
-import org.owasp.dependencycheck.utils.TooManyRequestsException;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.utils.Settings;
+import org.owasp.dependencycheck.utils.TooManyRequestsException;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import org.apache.commons.lang3.StringUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import org.junit.Assume;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.utils.Settings;
 
 /**
  * Tests for the CentralAnalyzer.
  */
-public class CentralAnalyzerTest extends BaseTest {
+class CentralAnalyzerTest extends BaseTest {
 
     private static final String SHA1_SUM = "my-sha1-sum";
     final CentralSearch centralSearch = mock(CentralSearch.class);
@@ -51,7 +46,7 @@ public class CentralAnalyzerTest extends BaseTest {
 
     @Test
     @SuppressWarnings("PMD.NonStaticInitializer")
-    public void testFetchMavenArtifactsWithoutException() throws IOException, TooManyRequestsException, ForbiddenException {
+    void testFetchMavenArtifactsWithoutException() throws IOException, TooManyRequestsException {
             CentralAnalyzer instance = new CentralAnalyzer();
             instance.setCentralSearch(centralSearch);
             when(dependency.getSha1sum()).thenReturn(SHA1_SUM);
@@ -62,30 +57,28 @@ public class CentralAnalyzerTest extends BaseTest {
             assertTrue(actualMavenArtifacts.isEmpty());
     }
 
-    @Test(expected = FileNotFoundException.class)
+    @Test
     @SuppressWarnings("PMD.NonStaticInitializer")
-    public void testFetchMavenArtifactsRethrowsFileNotFoundException()
-            throws IOException, TooManyRequestsException, ForbiddenException {
+    void testFetchMavenArtifactsRethrowsFileNotFoundException() throws Exception {
         CentralAnalyzer instance = new CentralAnalyzer();
         instance.setCentralSearch(centralSearch);
         when(dependency.getSha1sum()).thenReturn(SHA1_SUM);
         when(centralSearch.searchSha1(SHA1_SUM)).thenThrow(FileNotFoundException.class);
-        instance.fetchMavenArtifacts(dependency);
+        assertThrows(FileNotFoundException.class, () ->
+            instance.fetchMavenArtifacts(dependency));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     @SuppressWarnings("PMD.NonStaticInitializer")
-    public void testFetchMavenArtifactsAlwaysThrowsIOException()
-            throws IOException, TooManyRequestsException, ForbiddenException {
+    void testFetchMavenArtifactsAlwaysThrowsIOException() throws Exception {
         getSettings().setInt(Settings.KEYS.ANALYZER_CENTRAL_RETRY_COUNT, 1);
         getSettings().setBoolean(Settings.KEYS.ANALYZER_CENTRAL_USE_CACHE, false);
         CentralAnalyzer instance = new CentralAnalyzer();
         instance.initialize(getSettings());
-        
         instance.setCentralSearch(centralSearch);
         when(dependency.getSha1sum()).thenReturn(SHA1_SUM);
         when(centralSearch.searchSha1(SHA1_SUM)).thenThrow(IOException.class);
-
-        instance.fetchMavenArtifacts(dependency);
+        assertThrows(IOException.class, () ->
+            instance.fetchMavenArtifacts(dependency));
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/ComposerLockAnalyzerTest.java
@@ -17,9 +17,10 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
@@ -27,20 +28,19 @@ import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 
 import java.io.File;
-import org.apache.commons.lang3.ArrayUtils;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for NodePackageAnalyzer.
  *
  * @author Dale Visser
  */
-public class ComposerLockAnalyzerTest extends BaseDBTestCase {
+class ComposerLockAnalyzerTest extends BaseDBTestCase {
 
     /**
      * The analyzer to test.
@@ -52,7 +52,7 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
      *
      * @throws Exception thrown if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -67,7 +67,7 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         analyzer.close();
@@ -78,7 +78,7 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
      * Test of getName method, of class ComposerLockAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertEquals("Composer.lock analyzer", analyzer.getName());
     }
 
@@ -86,7 +86,7 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
      * Test of supportsExtension method, of class ComposerLockAnalyzer.
      */
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         assertTrue(analyzer.accept(new File("composer.lock")));
     }
 
@@ -96,7 +96,7 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzePackageJson() throws Exception {
+    void testAnalyzePackageJson() throws Exception {
         try (Engine engine = new Engine(getSettings())) {
             final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                     "composer.lock"));
@@ -115,7 +115,7 @@ public class ComposerLockAnalyzerTest extends BaseDBTestCase {
                     assertEquals(ComposerLockAnalyzer.DEPENDENCY_ECOSYSTEM, d.getEcosystem());
                 }
             }
-            assertTrue("Expeced to find classpreloader", found);
+            assertTrue(found, "Expeced to find classpreloader");
         }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/CpeSuppressionAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/CpeSuppressionAnalyzerIT.java
@@ -17,28 +17,30 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.utils.Settings;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Testing the CPE suppression analyzer.
  *
  * @author Jeremy Long
  */
-public class CpeSuppressionAnalyzerIT extends BaseDBTestCase {
+class CpeSuppressionAnalyzerIT extends BaseDBTestCase {
 
     /**
      * Test of getName method, of class CpeSuppressionAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         CpeSuppressionAnalyzer instance = new CpeSuppressionAnalyzer();
         instance.initialize(getSettings());
         String expResult = "Cpe Suppression Analyzer";
@@ -50,7 +52,7 @@ public class CpeSuppressionAnalyzerIT extends BaseDBTestCase {
      * Test of getAnalysisPhase method, of class CpeSuppressionAnalyzer.
      */
     @Test
-    public void testGetAnalysisPhase() {
+    void testGetAnalysisPhase() {
         CpeSuppressionAnalyzer instance = new CpeSuppressionAnalyzer();
         instance.initialize(getSettings());
         AnalysisPhase expResult = AnalysisPhase.POST_IDENTIFIER_ANALYSIS;
@@ -62,7 +64,7 @@ public class CpeSuppressionAnalyzerIT extends BaseDBTestCase {
      * Test of analyze method, of class CpeSuppressionAnalyzer.
      */
     @Test
-    public void testAnalyze() throws Exception {
+    void testAnalyze() throws Exception {
 
         File file = BaseTest.getResourceAsFile(this, "commons-fileupload-1.2.1.jar");
         File suppression = BaseTest.getResourceAsFile(this, "commons-fileupload-1.2.1.suppression.xml");

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DartAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DartAnalyzerTest.java
@@ -1,30 +1,29 @@
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
-import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.dependency.naming.GenericIdentifier;
 import org.owasp.dependencycheck.dependency.naming.Identifier;
 import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
 
 import java.io.File;
-import java.util.Set;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for DartAnalyzer
  *
  * @author Marc Rödder
  */
-public class DartAnalyzerTest extends BaseTest {
+class DartAnalyzerTest extends BaseTest {
 
     /**
      * The analyzer to test.
@@ -36,7 +35,7 @@ public class DartAnalyzerTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -51,7 +50,7 @@ public class DartAnalyzerTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         dartAnalyzer.close();
@@ -64,7 +63,7 @@ public class DartAnalyzerTest extends BaseTest {
      * Test of getName method, of class DartAnalyzer.
      */
     @Test
-    public void testDartAnalyzerGetName() {
+    void testDartAnalyzerGetName() {
         assertThat(dartAnalyzer.getName(), is("Dart Package Analyzer"));
     }
 
@@ -73,7 +72,7 @@ public class DartAnalyzerTest extends BaseTest {
      * Test of supportsFiles method, of class DartAnalyzer.
      */
     @Test
-    public void testAnalyzerSupportsFiles() {
+    void testAnalyzerSupportsFiles() {
         assertThat(dartAnalyzer.accept(new File("pubspec.yaml")), is(true));
         assertThat(dartAnalyzer.accept(new File("pubspec.lock")), is(true));
     }
@@ -84,7 +83,7 @@ public class DartAnalyzerTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testDartPubspecLockAnalyzer() throws AnalysisException {
+    void testDartPubspecLockAnalyzer() throws AnalysisException {
         final Engine engine = new Engine(getSettings());
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "dart/pubspec.lock"));
@@ -123,7 +122,7 @@ public class DartAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testDartPubspecYamlAnalyzer() throws AnalysisException {
+    void testDartPubspecYamlAnalyzer() throws AnalysisException {
         final Engine engine = new Engine(getSettings());
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "dart.yaml/pubspec.yaml"));
@@ -187,10 +186,10 @@ public class DartAnalyzerTest extends BaseTest {
 
     /**
      * Test case for issue #5008.
-     * @throws AnalysisException 
+     * @throws AnalysisException
      */
     @Test
-    public void testDartPubspecYamlAnalyzerAddressbook() throws AnalysisException {
+    void testDartPubspecYamlAnalyzerAddressbook() throws AnalysisException {
         final Engine engine = new Engine(getSettings());
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "dart.addressbook/pubspec.yaml"));
@@ -199,13 +198,13 @@ public class DartAnalyzerTest extends BaseTest {
         assertThat(engine.getDependencies().length, equalTo(1));
 
         Dependency dependency1 = engine.getDependencies()[0];
-       
+
         assertThat(dependency1.getName(), equalTo("protobuf"));
         assertThat(dependency1.getVersion(), equalTo(""));
     }
-    
+
     @Test
-    public void testIsEnabledIsTrueByDefault() {
+    void testIsEnabledIsTrueByDefault() {
         assertTrue(dartAnalyzer.isEnabled());
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzerIT.java
@@ -17,20 +17,20 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 
 /**
  *
  * @author Jeremy Long
  */
-public class DependencyBundlingAnalyzerIT extends BaseDBTestCase {
+class DependencyBundlingAnalyzerIT extends BaseDBTestCase {
 
     /**
      * Test of analyze method, of class DependencyBundlingAnalyzer.
      */
     @Test
-    public void testAnalyze() throws Exception {
+    void testAnalyze() {
 //        Engine engine = null;
 //        JarAnalyzer ja = null;
 //        FileNameAnalyzer fna = null;

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyBundlingAnalyzerTest.java
@@ -18,30 +18,30 @@
 package org.owasp.dependencycheck.analyzer;
 
 import com.github.packageurl.MalformedPackageURLException;
-import java.io.File;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
-import org.owasp.dependencycheck.dependency.Confidence;
-import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
 
 /**
  * @author Jeremy Long
  */
-@RunWith(MockitoJUnitRunner.class)
-public class DependencyBundlingAnalyzerTest extends BaseTest {
+@ExtendWith(MockitoExtension.class)
+class DependencyBundlingAnalyzerTest extends BaseTest {
 
     @Mock(answer = Answers.RETURNS_SMART_NULLS)
     private Engine engineMock;
@@ -50,7 +50,7 @@ public class DependencyBundlingAnalyzerTest extends BaseTest {
      * Test of getName method, of class DependencyBundlingAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         DependencyBundlingAnalyzer instance = new DependencyBundlingAnalyzer();
         String expResult = "Dependency Bundling Analyzer";
         String result = instance.getName();
@@ -61,7 +61,7 @@ public class DependencyBundlingAnalyzerTest extends BaseTest {
      * Test of getAnalysisPhase method, of class DependencyBundlingAnalyzer.
      */
     @Test
-    public void testGetAnalysisPhase() {
+    void testGetAnalysisPhase() {
         DependencyBundlingAnalyzer instance = new DependencyBundlingAnalyzer();
         AnalysisPhase expResult = AnalysisPhase.FINAL;
         AnalysisPhase result = instance.getAnalysisPhase();
@@ -73,7 +73,7 @@ public class DependencyBundlingAnalyzerTest extends BaseTest {
      * passed dependency does not matter. The analyzer only runs once.
      */
     @Test
-    public void testAnalyze() throws Exception {
+    void testAnalyze() throws Exception {
         DependencyBundlingAnalyzer instance = new DependencyBundlingAnalyzer();
 
         // the actual dependency does not matter
@@ -93,7 +93,7 @@ public class DependencyBundlingAnalyzerTest extends BaseTest {
      * Test of isCore method, of class DependencyBundlingAnalyzer.
      */
     @Test
-    public void testIsCore() {
+    void testIsCore() {
         Dependency left = new Dependency();
         Dependency right = new Dependency();
 
@@ -120,7 +120,7 @@ public class DependencyBundlingAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testFirstPathIsShortest() {
+    void testFirstPathIsShortest() {
         String left = "./a/c.jar";
         String right = "./d/e/f.jar";
         boolean expResult = true;
@@ -153,7 +153,7 @@ public class DependencyBundlingAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testIsShaded() throws MalformedPackageURLException {
+    void testIsShaded() throws MalformedPackageURLException {
         DependencyBundlingAnalyzer instance = new DependencyBundlingAnalyzer();
 
         Dependency left = null;
@@ -221,7 +221,7 @@ public class DependencyBundlingAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testIsWebJar() throws MalformedPackageURLException {
+    void testIsWebJar() throws MalformedPackageURLException {
         DependencyBundlingAnalyzer instance = new DependencyBundlingAnalyzer();
 
         Dependency left = null;
@@ -273,8 +273,8 @@ public class DependencyBundlingAnalyzerTest extends BaseTest {
         expResult = true;
         result = instance.isWebJar(left, right);
         assertEquals(expResult, result);
-        
-        
+
+
         left = new Dependency(new File("/path/spring-core.jar"), true);
         left.addSoftwareIdentifier(new PurlIdentifier("maven", "org.springframework", "spring-core", "3.0.0", Confidence.HIGHEST));
         expResult = false;

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyCheckPropertiesTest.java
@@ -1,10 +1,8 @@
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,10 +20,13 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class DependencyCheckPropertiesTest {
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DependencyCheckPropertiesTest {
 
     @Test
-    public void should_each_analyzer_have_default_enabled_property()
+    void should_each_analyzer_have_default_enabled_property()
             throws IOException, InstantiationException, IllegalAccessException {
         String packageName = "org.owasp.dependencycheck.analyzer";
         Set<Class<AbstractAnalyzer>> analyzerImplementations = findAllAnalyzerImplementations(packageName);
@@ -45,16 +46,16 @@ public class DependencyCheckPropertiesTest {
             properties.load(fis);
         }
 
-        Assert.assertFalse(analyzerEnabledSettingKeys.isEmpty());
+        assertFalse(analyzerEnabledSettingKeys.isEmpty());
 
         Set<String> absentKeys = analyzerEnabledSettingKeys.stream()
                 .filter(key -> !properties.containsKey(key))
                 .collect(Collectors.toSet());
 
-        Assert.assertTrue(absentKeys.isEmpty());
+        assertTrue(absentKeys.isEmpty());
     }
 
-    public Set<Class<AbstractAnalyzer>> findAllAnalyzerImplementations(String packageName)
+    private Set<Class<AbstractAnalyzer>> findAllAnalyzerImplementations(String packageName)
             throws IOException {
 
         Set<Class<?>> packageClasses = findAllClasses(packageName);
@@ -88,7 +89,7 @@ public class DependencyCheckPropertiesTest {
         return clazz == AbstractSuppressionAnalyzerTest.AbstractSuppressionAnalyzerImpl.class;
     }
 
-    public Set<Class<?>> findAllClasses(String packageName) throws IOException {
+    private Set<Class<?>> findAllClasses(String packageName) throws IOException {
         String parsedPackageName = packageName.replaceAll("[.]", "/");
 
         Set<Class<?>> classes = new HashSet<>();

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyMergingAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/DependencyMergingAnalyzerTest.java
@@ -17,11 +17,7 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.util.HashSet;
-import java.util.Set;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.data.nvd.ecosystem.Ecosystem;
@@ -30,17 +26,25 @@ import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.utils.Settings;
 
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  *
  * @author Jeremy Long
  */
-public class DependencyMergingAnalyzerTest extends BaseTest {
+class DependencyMergingAnalyzerTest extends BaseTest {
 
     /**
      * Test of getName method, of class DependencyMergingAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         DependencyMergingAnalyzer instance = new DependencyMergingAnalyzer();
         String expResult = "Dependency Merging Analyzer";
         String result = instance.getName();
@@ -51,7 +55,7 @@ public class DependencyMergingAnalyzerTest extends BaseTest {
      * Test of getAnalysisPhase method, of class DependencyMergingAnalyzer.
      */
     @Test
-    public void testGetAnalysisPhase() {
+    void testGetAnalysisPhase() {
         DependencyMergingAnalyzer instance = new DependencyMergingAnalyzer();
         AnalysisPhase expResult = AnalysisPhase.POST_INFORMATION_COLLECTION1;
         AnalysisPhase result = instance.getAnalysisPhase();
@@ -63,7 +67,7 @@ public class DependencyMergingAnalyzerTest extends BaseTest {
      * DependencyMergingAnalyzer.
      */
     @Test
-    public void testGetAnalyzerEnabledSettingKey() {
+    void testGetAnalyzerEnabledSettingKey() {
         DependencyMergingAnalyzer instance = new DependencyMergingAnalyzer();
         String expResult = Settings.KEYS.ANALYZER_DEPENDENCY_MERGING_ENABLED;
         String result = instance.getAnalyzerEnabledSettingKey();
@@ -74,7 +78,7 @@ public class DependencyMergingAnalyzerTest extends BaseTest {
      * Test of evaluateDependencies method, of class DependencyMergingAnalyzer.
      */
     @Test
-    public void testEvaluateDependencies() {
+    void testEvaluateDependencies() {
 //        Dependency dependency = null;
 //        Dependency nextDependency = null;
 //        Set<Dependency> dependenciesToRemove = null;
@@ -88,7 +92,7 @@ public class DependencyMergingAnalyzerTest extends BaseTest {
      * Test of mergeDependencies method, of class DependencyMergingAnalyzer.
      */
     @Test
-    public void testMergeDependencies() {
+    void testMergeDependencies() {
         Dependency dependency = new Dependency(true);
         dependency.setName("main");
         dependency.addEvidence(EvidenceType.VENDOR, "test", "vendor", "main", Confidence.HIGHEST);
@@ -114,7 +118,7 @@ public class DependencyMergingAnalyzerTest extends BaseTest {
      * Test of isSameRubyGem method, of class DependencyMergingAnalyzer.
      */
     @Test
-    public void testIsSameRubyGem() {
+    void testIsSameRubyGem() {
         Dependency dependency1 = new Dependency(new File("some.gemspec"), true);
         Dependency dependency2 = new Dependency(new File("another.gemspec"), true);
         dependency1.setPackagePath("path1");
@@ -135,7 +139,7 @@ public class DependencyMergingAnalyzerTest extends BaseTest {
      * DependencyMergingAnalyzer.
      */
     @Test
-    public void testGetMainGemspecDependency() {
+    void testGetMainGemspecDependency() {
         Dependency dependency1 = null;
         Dependency dependency2 = null;
         DependencyMergingAnalyzer instance = new DependencyMergingAnalyzer();
@@ -168,7 +172,7 @@ public class DependencyMergingAnalyzerTest extends BaseTest {
      * Test of isSameSwiftPackage method, of class DependencyMergingAnalyzer.
      */
     @Test
-    public void testIsSameSwiftPackage() {
+    void testIsSameSwiftPackage() {
         Dependency dependency1 = new Dependency(new File("Package.swift"), true);
         Dependency dependency2 = new Dependency(new File("Package.swift"), true);
         dependency1.setPackagePath("path1");
@@ -189,7 +193,7 @@ public class DependencyMergingAnalyzerTest extends BaseTest {
      * DependencyMergingAnalyzer.
      */
     @Test
-    public void testGetMainSwiftDependency() {
+    void testGetMainSwiftDependency() {
 
         Dependency dependency1 = null;
         Dependency dependency2 = null;
@@ -226,7 +230,7 @@ public class DependencyMergingAnalyzerTest extends BaseTest {
      * @throws Exception thrown if there is an analysis exception
      */
     @Test
-    public void testGetMainAndroidDependency() throws Exception {
+    void testGetMainAndroidDependency() throws Exception {
         ArchiveAnalyzer aa = null;
         try (Engine engine = new Engine(Engine.Mode.EVIDENCE_COLLECTION, getSettings())) {
             Dependency dependency1 = new Dependency(BaseTest.getResourceAsFile(this, "aar-1.0.0.aar"));
@@ -245,7 +249,7 @@ public class DependencyMergingAnalyzerTest extends BaseTest {
                     break;
                 }
             }
-            assertNotNull("classes.jar was not found", dependency2);
+            assertNotNull(dependency2, "classes.jar was not found");
             dependency2.setEcosystem(Ecosystem.JAVA);
             DependencyMergingAnalyzer instance = new DependencyMergingAnalyzer();
             Dependency expResult = dependency1;
@@ -263,7 +267,7 @@ public class DependencyMergingAnalyzerTest extends BaseTest {
      * DependencyMergingAnalyzer.
      */
     @Test
-    public void testGetMainDotnetDependency() {
+    void testGetMainDotnetDependency() {
         Dependency dependency1 = new Dependency(BaseTest.getResourceAsFile(this, "log4net.dll"));
         dependency1.setEcosystem(AssemblyAnalyzer.DEPENDENCY_ECOSYSTEM);
         dependency1.setName("log4net");

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/ElixirMixAuditAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/ElixirMixAuditAnalyzerTest.java
@@ -1,20 +1,9 @@
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
-import org.owasp.dependencycheck.BaseDBTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.Engine;
-import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
-import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
-import org.owasp.dependencycheck.data.update.exception.UpdateException;
-import org.owasp.dependencycheck.dependency.Dependency;
-import org.owasp.dependencycheck.dependency.EvidenceType;
-import org.owasp.dependencycheck.dependency.Vulnerability;
-import org.owasp.dependencycheck.exception.ExceptionCollection;
-import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,14 +12,13 @@ import java.io.File;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
 
-public class ElixirMixAuditAnalyzerTest extends BaseTest {
+class ElixirMixAuditAnalyzerTest extends BaseTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ElixirMixAuditAnalyzerTest.class);
     private ElixirMixAuditAnalyzer analyzer;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         getSettings().setBoolean(Settings.KEYS.AUTO_UPDATE, false);
@@ -39,7 +27,7 @@ public class ElixirMixAuditAnalyzerTest extends BaseTest {
         analyzer.setFilesMatched(true);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (analyzer != null) {
             analyzer.close();
@@ -48,12 +36,12 @@ public class ElixirMixAuditAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertThat(analyzer.getName(), is("Elixir Mix Audit Analyzer"));
     }
 
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         assertThat(analyzer.accept(new File("mix.lock")), is(true));
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/FalsePositiveAnalyzerTest.java
@@ -15,9 +15,7 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.dependency.Confidence;
@@ -29,11 +27,14 @@ import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.CpeBuilder;
 import us.springett.parsers.cpe.values.Part;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  *
  * @author Jeremy Long
  */
-public class FalsePositiveAnalyzerTest extends BaseTest {
+class FalsePositiveAnalyzerTest extends BaseTest {
 
     /**
      * A CPE builder object.
@@ -44,7 +45,7 @@ public class FalsePositiveAnalyzerTest extends BaseTest {
      * Test of getName method, of class FalsePositiveAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         FalsePositiveAnalyzer instance = new FalsePositiveAnalyzer();
         String expResult = "False Positive Analyzer";
         String result = instance.getName();
@@ -55,7 +56,7 @@ public class FalsePositiveAnalyzerTest extends BaseTest {
      * Test of getAnalysisPhase method, of class FalsePositiveAnalyzer.
      */
     @Test
-    public void testGetAnalysisPhase() {
+    void testGetAnalysisPhase() {
         FalsePositiveAnalyzer instance = new FalsePositiveAnalyzer();
         AnalysisPhase expResult = AnalysisPhase.POST_IDENTIFIER_ANALYSIS;
         AnalysisPhase result = instance.getAnalysisPhase();
@@ -67,7 +68,7 @@ public class FalsePositiveAnalyzerTest extends BaseTest {
      * FalsePositiveAnalyzer.
      */
     @Test
-    public void testGetAnalyzerEnabledSettingKey() {
+    void testGetAnalyzerEnabledSettingKey() {
         FalsePositiveAnalyzer instance = new FalsePositiveAnalyzer();
         String expResult = Settings.KEYS.ANALYZER_FALSE_POSITIVE_ENABLED;
         String result = instance.getAnalyzerEnabledSettingKey();
@@ -78,7 +79,7 @@ public class FalsePositiveAnalyzerTest extends BaseTest {
      * Test of analyzeDependency method, of class FalsePositiveAnalyzer.
      */
     @Test
-    public void testAnalyzeDependency() throws Exception {
+    void testAnalyzeDependency() throws Exception {
         Dependency dependency = new Dependency();
         dependency.setFileName("pom.xml");
         dependency.setFilePath("pom.xml");
@@ -97,7 +98,7 @@ public class FalsePositiveAnalyzerTest extends BaseTest {
      * Test of removeBadMatches method, of class FalsePositiveAnalyzer.
      */
     @Test
-    public void testRemoveBadMatches() throws Exception {
+    void testRemoveBadMatches() throws Exception {
         Dependency dependency = new Dependency();
         dependency.setFileName("some.jar");
         dependency.setFilePath("some.jar");

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/FileNameAnalyzerTest.java
@@ -17,27 +17,28 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.EvidenceType;
-import org.owasp.dependencycheck.exception.InitializationException;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class FileNameAnalyzerTest extends BaseTest {
+class FileNameAnalyzerTest extends BaseTest {
 
     /**
      * Test of getName method, of class FileNameAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         FileNameAnalyzer instance = new FileNameAnalyzer();
         String expResult = "File Name Analyzer";
         String result = instance.getName();
@@ -48,7 +49,7 @@ public class FileNameAnalyzerTest extends BaseTest {
      * Test of getAnalysisPhase method, of class FileNameAnalyzer.
      */
     @Test
-    public void testGetAnalysisPhase() {
+    void testGetAnalysisPhase() {
         FileNameAnalyzer instance = new FileNameAnalyzer();
         AnalysisPhase expResult = AnalysisPhase.INFORMATION_COLLECTION;
         AnalysisPhase result = instance.getAnalysisPhase();
@@ -59,7 +60,7 @@ public class FileNameAnalyzerTest extends BaseTest {
      * Test of analyze method, of class FileNameAnalyzer.
      */
     @Test
-    public void testAnalyze() throws Exception {
+    void testAnalyze() throws Exception {
         //File struts = new File(this.getClass().getClassLoader().getResource("struts2-core-2.1.2.jar").getPath());
         File struts = BaseTest.getResourceAsFile(this, "struts2-core-2.1.2.jar");
         Dependency resultStruts = new Dependency(struts);
@@ -79,14 +80,12 @@ public class FileNameAnalyzerTest extends BaseTest {
      * Test of prepare method, of class FileNameAnalyzer.
      */
     @Test
-    public void testInitialize() {
+    void testInitialize() {
         FileNameAnalyzer instance = new FileNameAnalyzer();
-        try {
+        assertDoesNotThrow(() -> {
             instance.initialize(getSettings());
             instance.prepare(null);
-        } catch (InitializationException ex) {
-            fail(ex.getMessage());
-        }
+        });
         assertTrue(instance.isEnabled());
     }
 
@@ -94,12 +93,8 @@ public class FileNameAnalyzerTest extends BaseTest {
      * Test of close method, of class FileNameAnalyzer.
      */
     @Test
-    public void testClose() {
+    void testClose() {
         FileNameAnalyzer instance = new FileNameAnalyzer();
-        try {
-            instance.close();
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
+        assertDoesNotThrow(instance::close);
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/GolangDepAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/GolangDepAnalyzerTest.java
@@ -17,26 +17,26 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import java.io.File;
-
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 
-public class GolangDepAnalyzerTest extends BaseTest {
+import java.io.File;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GolangDepAnalyzerTest extends BaseTest {
 
     private GolangDepAnalyzer analyzer;
     private Engine engine;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         analyzer = new GolangDepAnalyzer();
@@ -44,18 +44,19 @@ public class GolangDepAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testName() {
-        assertEquals("Analyzer name wrong.", "Golang Dep Analyzer",
-                analyzer.getName());
+    void testName() {
+        assertEquals("Golang Dep Analyzer",
+                analyzer.getName(),
+                "Analyzer name wrong.");
     }
 
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         assertThat(analyzer.accept(new File("Gopkg.lock")), is(true));
     }
 
     @Test
-    public void testGopkgLock() throws AnalysisException {
+    void testGopkgLock() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "golang/Gopkg.lock"));
         analyzer.analyze(result, engine);
         assertEquals(12, engine.getDependencies().length);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/GolangModAnalyzerTest.java
@@ -17,36 +17,36 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.exception.InitializationException;
+import org.owasp.dependencycheck.utils.Settings;
 
 import java.io.File;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import org.owasp.dependencycheck.utils.Settings;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for GolangModAnalyzer.
  *
  * @author Matthijs van den Bos
  */
-public class GolangModAnalyzerTest extends BaseTest {
+class GolangModAnalyzerTest extends BaseTest {
 
     private GolangModAnalyzer analyzer;
     private Engine engine;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         getSettings().setBoolean(Settings.KEYS.AUTO_UPDATE, false);
@@ -71,7 +71,7 @@ public class GolangModAnalyzerTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         if (analyzer != null) {
@@ -82,18 +82,19 @@ public class GolangModAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testName() {
-        assertEquals("Analyzer name wrong.", "Golang Mod Analyzer",
-                analyzer.getName());
+    void testName() {
+        assertEquals("Golang Mod Analyzer",
+                analyzer.getName(),
+                "Analyzer name wrong.");
     }
 
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         assertThat(analyzer.accept(new File("go.mod")), is(true));
     }
 
     @Test
-    public void testGoMod() throws AnalysisException, InitializationException {
+    void testGoMod() throws AnalysisException, InitializationException {
         analyzer.prepare(engine);
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "golang/go.mod"));
         analyzer.analyze(result, engine);
@@ -112,6 +113,6 @@ public class GolangModAnalyzerTest extends BaseTest {
                 assertTrue(d.getEvidence(EvidenceType.VERSION).toString().toLowerCase().contains("1.5.0"));
             }
         }
-        assertTrue("Expected to find gitea/gitea", found);
+        assertTrue(found, "Expected to find gitea/gitea");
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/HintAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/HintAnalyzerTest.java
@@ -15,33 +15,33 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import java.util.Set;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
-import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.utils.Settings;
 
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  *
  * @author Jeremy Long
  */
-public class HintAnalyzerTest extends BaseDBTestCase {
+class HintAnalyzerTest extends BaseDBTestCase {
 
     /**
      * Test of getName method, of class HintAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         HintAnalyzer instance = new HintAnalyzer();
         String expResult = "Hint Analyzer";
         String result = instance.getName();
@@ -52,7 +52,7 @@ public class HintAnalyzerTest extends BaseDBTestCase {
      * Test of getAnalysisPhase method, of class HintAnalyzer.
      */
     @Test
-    public void testGetAnalysisPhase() {
+    void testGetAnalysisPhase() {
         HintAnalyzer instance = new HintAnalyzer();
         AnalysisPhase expResult = AnalysisPhase.POST_INFORMATION_COLLECTION2;
         AnalysisPhase result = instance.getAnalysisPhase();
@@ -63,7 +63,7 @@ public class HintAnalyzerTest extends BaseDBTestCase {
      * Test of analyze method, of class HintAnalyzer.
      */
     @Test
-    public void testAnalyze() throws Exception {
+    void testAnalyze() throws Exception {
         //File guice = new File(this.getClass().getClassLoader().getResource("guice-3.0.jar").getPath());
         File guice = BaseTest.getResourceAsFile(this, "guice-3.0.jar");
         //Dependency guice = new EngineDependency(fileg);
@@ -110,7 +110,7 @@ public class HintAnalyzerTest extends BaseDBTestCase {
      * Test of analyze method, of class HintAnalyzer.
      */
     @Test
-    public void testAnalyze_1() throws Exception {
+    void testAnalyze_1() throws Exception {
         File path = BaseTest.getResourceAsFile(this, "hints_12.xml");
         getSettings().setString(Settings.KEYS.HINTS_FILE, path.getPath());
         HintAnalyzer instance = new HintAnalyzer();
@@ -125,13 +125,13 @@ public class HintAnalyzerTest extends BaseDBTestCase {
         d.addEvidence(EvidenceType.VENDOR, "hint analyzer", "other vendor name", "vendor", Confidence.HIGH);
         d.addEvidence(EvidenceType.PRODUCT, "hint analyzer", "other product name", "product", Confidence.HIGH);
 
-        assertEquals("vendor evidence mismatch", 2, d.getEvidence(EvidenceType.VENDOR).size());
-        assertEquals("product evidence mismatch", 2, d.getEvidence(EvidenceType.PRODUCT).size());
-        assertEquals("version evidence mismatch", 3, d.getEvidence(EvidenceType.VERSION).size());
+        assertEquals(2, d.getEvidence(EvidenceType.VENDOR).size(), "vendor evidence mismatch");
+        assertEquals(2, d.getEvidence(EvidenceType.PRODUCT).size(), "product evidence mismatch");
+        assertEquals(3, d.getEvidence(EvidenceType.VERSION).size(), "version evidence mismatch");
         instance.analyze(d, null);
-        assertEquals("vendor evidence mismatch", 1, d.getEvidence(EvidenceType.VENDOR).size());
-        assertEquals("product evidence mismatch", 1, d.getEvidence(EvidenceType.PRODUCT).size());
-        assertEquals("version evidence mismatch", 2, d.getEvidence(EvidenceType.VERSION).size());
+        assertEquals(1, d.getEvidence(EvidenceType.VENDOR).size(), "vendor evidence mismatch");
+        assertEquals(1, d.getEvidence(EvidenceType.PRODUCT).size(), "product evidence mismatch");
+        assertEquals(2, d.getEvidence(EvidenceType.VERSION).size(), "version evidence mismatch");
 
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/JarAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/JarAnalyzerTest.java
@@ -17,7 +17,7 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.dependency.Dependency;
@@ -32,14 +32,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Jeremy Long
  */
-public class JarAnalyzerTest extends BaseTest {
+class JarAnalyzerTest extends BaseTest {
 
     /**
      * Test of inspect method, of class JarAnalyzer.
@@ -47,7 +47,7 @@ public class JarAnalyzerTest extends BaseTest {
      * @throws Exception is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyze() throws Exception {
+    void testAnalyze() throws Exception {
         //File file = new File(this.getClass().getClassLoader().getResource("struts2-core-2.1.2.jar").getPath());
         File file = BaseTest.getResourceAsFile(this, "struts2-core-2.1.2.jar");
         Dependency result = new Dependency(file);
@@ -65,12 +65,12 @@ public class JarAnalyzerTest extends BaseTest {
         boolean found = false;
         for (Evidence e : result.getEvidence(EvidenceType.VENDOR)) {
             if (e.getName().equals("url")) {
-                assertEquals("Project url was not as expected in dwr.jar", "http://getahead.ltd.uk/dwr", e.getValue());
+                assertEquals("http://getahead.ltd.uk/dwr", e.getValue(), "Project url was not as expected in dwr.jar");
                 found = true;
                 break;
             }
         }
-        assertTrue("Project url was not found in dwr.jar", found);
+        assertTrue(found, "Project url was not found in dwr.jar");
 
         //file = new File(this.getClass().getClassLoader().getResource("org.mortbay.jetty.jar").getPath());
         file = BaseTest.getResourceAsFile(this, "org.mortbay.jetty.jar");
@@ -84,7 +84,7 @@ public class JarAnalyzerTest extends BaseTest {
                 break;
             }
         }
-        assertTrue("package-title of org.mortbay.http not found in org.mortbay.jetty.jar", found);
+        assertTrue(found, "package-title of org.mortbay.http not found in org.mortbay.jetty.jar");
 
         found = false;
         for (Evidence e : result.getEvidence(EvidenceType.VENDOR)) {
@@ -94,7 +94,7 @@ public class JarAnalyzerTest extends BaseTest {
                 break;
             }
         }
-        assertTrue("implementation-url of http://jetty.mortbay.org not found in org.mortbay.jetty.jar", found);
+        assertTrue(found, "implementation-url of http://jetty.mortbay.org not found in org.mortbay.jetty.jar");
 
         found = false;
         for (Evidence e : result.getEvidence(EvidenceType.VERSION)) {
@@ -104,17 +104,17 @@ public class JarAnalyzerTest extends BaseTest {
                 break;
             }
         }
-        assertTrue("implementation-version of 4.2.27 not found in org.mortbay.jetty.jar", found);
+        assertTrue(found, "implementation-version of 4.2.27 not found in org.mortbay.jetty.jar");
 
         //file = new File(this.getClass().getClassLoader().getResource("org.mortbay.jmx.jar").getPath());
         file = BaseTest.getResourceAsFile(this, "org.mortbay.jmx.jar");
         result = new Dependency(file);
         instance.analyze(result, null);
-        assertEquals("org.mortbar.jmx.jar has version evidence?", 0, result.getEvidence(EvidenceType.VERSION).size());
+        assertEquals(0, result.getEvidence(EvidenceType.VERSION).size(), "org.mortbar.jmx.jar has version evidence?");
     }
 
     @Test
-    public void testAddMatchingValues() throws Exception {
+    void testAddMatchingValues() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "struts2-core-2.1.2.jar");
         Dependency dependency = new Dependency(file);
         JarAnalyzer instance = new JarAnalyzer();
@@ -148,14 +148,14 @@ public class JarAnalyzerTest extends BaseTest {
      * Test of getSupportedExtensions method, of class JarAnalyzer.
      */
     @Test
-    public void testAcceptSupportedExtensions() throws Exception {
+    void testAcceptSupportedExtensions() throws Exception {
         JarAnalyzer instance = new JarAnalyzer();
         instance.initialize(getSettings());
         instance.prepare(null);
         instance.setEnabled(true);
         String[] files = {"test.jar", "test.war"};
         for (String name : files) {
-            assertTrue(name, instance.accept(new File(name)));
+            assertTrue(instance.accept(new File(name)), name);
         }
     }
 
@@ -163,7 +163,7 @@ public class JarAnalyzerTest extends BaseTest {
      * Test of getName method, of class JarAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         JarAnalyzer instance = new JarAnalyzer();
         String expResult = "Jar Analyzer";
         String result = instance.getName();
@@ -171,7 +171,7 @@ public class JarAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testParseManifest() throws Exception {
+    void testParseManifest() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "xalan-2.7.0.jar");
         Dependency result = new Dependency(file);
         JarAnalyzer instance = new JarAnalyzer();
@@ -185,7 +185,7 @@ public class JarAnalyzerTest extends BaseTest {
      * Test of getAnalysisPhase method, of class JarAnalyzer.
      */
     @Test
-    public void testGetAnalysisPhase() {
+    void testGetAnalysisPhase() {
         JarAnalyzer instance = new JarAnalyzer();
         AnalysisPhase expResult = AnalysisPhase.INFORMATION_COLLECTION;
         AnalysisPhase result = instance.getAnalysisPhase();
@@ -196,7 +196,7 @@ public class JarAnalyzerTest extends BaseTest {
      * Test of getAnalyzerEnabledSettingKey method, of class JarAnalyzer.
      */
     @Test
-    public void testGetAnalyzerEnabledSettingKey() {
+    void testGetAnalyzerEnabledSettingKey() {
         JarAnalyzer instance = new JarAnalyzer();
         String expResult = Settings.KEYS.ANALYZER_JAR_ENABLED;
         String result = instance.getAnalyzerEnabledSettingKey();
@@ -204,7 +204,7 @@ public class JarAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testClassInformation() {
+    void testClassInformation() {
         JarAnalyzer.ClassNameInformation instance = new JarAnalyzer.ClassNameInformation("org/owasp/dependencycheck/analyzer/JarAnalyzer");
         assertEquals("org/owasp/dependencycheck/analyzer/JarAnalyzer", instance.getName());
         List<String> expected = Arrays.asList("owasp", "dependencycheck", "analyzer", "jaranalyzer");
@@ -213,7 +213,7 @@ public class JarAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testAnalyzeDependency_SkipsMacOSMetaDataFile() throws Exception {
+    void testAnalyzeDependency_SkipsMacOSMetaDataFile() throws Exception {
         JarAnalyzer instance = new JarAnalyzer();
         Dependency macOSMetaDataFile = new Dependency();
 
@@ -232,7 +232,7 @@ public class JarAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testAnalyseDependency_SkipsNonZipFile() throws Exception {
+    void testAnalyseDependency_SkipsNonZipFile() throws Exception {
         JarAnalyzer instance = new JarAnalyzer();
         Dependency textFileWithJarExtension = new Dependency();
         textFileWithJarExtension

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/LibmanAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/LibmanAnalyzerTest.java
@@ -17,9 +17,8 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.dependency.Dependency;
@@ -28,18 +27,18 @@ import org.owasp.dependencycheck.utils.Settings;
 
 import java.io.File;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Arjen Korevaar
  */
-public class LibmanAnalyzerTest extends BaseTest {
+class LibmanAnalyzerTest extends BaseTest {
 
     private Engine engine;
     private LibmanAnalyzer analyzer;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -54,7 +53,7 @@ public class LibmanAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testGetAnalyzerName() {
+    void testGetAnalyzerName() {
         String expected = "Libman Analyzer";
         String actual = analyzer.getName();
 
@@ -62,14 +61,14 @@ public class LibmanAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testSupportedFileNames() {
+    void testSupportedFileNames() {
         boolean condition = analyzer.accept(new File("libman.json"));
 
         assertTrue(condition);
     }
 
     @Test
-    public void testGetAnalyzerEnabledSettingKey() {
+    void testGetAnalyzerEnabledSettingKey() {
         String expected = Settings.KEYS.ANALYZER_LIBMAN_ENABLED;
         String actual = analyzer.getAnalyzerEnabledSettingKey();
 
@@ -77,7 +76,7 @@ public class LibmanAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testLibmanAnalysis() throws Exception {
+    void testLibmanAnalysis() throws Exception {
         try (Engine engine = new Engine(getSettings())) {
             File file = BaseTest.getResourceAsFile(this, "libman/libman.json");
             Dependency dependency = new Dependency(file);
@@ -118,7 +117,7 @@ public class LibmanAnalyzerTest extends BaseTest {
                 }
             }
 
-            assertEquals("4 dependencies should be found", 4, count);
+            assertEquals(4, count, "4 dependencies should be found");
         }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/MSBuildProjectAnalyzerTest.java
@@ -17,26 +17,27 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.Evidence;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 
 import java.io.File;
 import java.util.stream.Collectors;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.owasp.dependencycheck.analyzer.NuspecAnalyzer.DEPENDENCY_ECOSYSTEM;
 
-public class MSBuildProjectAnalyzerTest extends BaseTest {
+class MSBuildProjectAnalyzerTest extends BaseTest {
 
     private MSBuildProjectAnalyzer instance;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -48,24 +49,24 @@ public class MSBuildProjectAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testGetAnalyzerName() {
+    void testGetAnalyzerName() {
         assertEquals("MSBuild Project Analyzer", instance.getName());
     }
 
     @Test
-    public void testSupportsFileExtensions() {
+    void testSupportsFileExtensions() {
         assertTrue(instance.accept(new File("test.csproj")));
         assertTrue(instance.accept(new File("test.vbproj")));
         assertFalse(instance.accept(new File("test.nuspec")));
     }
 
     @Test
-    public void testGetAnalysisPhaze() {
+    void testGetAnalysisPhaze() {
         assertEquals(AnalysisPhase.INFORMATION_COLLECTION, instance.getAnalysisPhase());
     }
 
     @Test
-    public void testMSBuildProjectAnalysis() throws Exception {
+    void testMSBuildProjectAnalysis() throws Exception {
 
         try (Engine engine = new Engine(getSettings())) {
             File file = BaseTest.getResourceAsFile(this, "msbuild/test.csproj");
@@ -77,7 +78,7 @@ public class MSBuildProjectAnalyzerTest extends BaseTest {
             analyzer.setEnabled(true);
             analyzer.analyze(toScan, engine);
 
-            assertEquals("5 dependencies should be found", 5, engine.getDependencies().length);
+            assertEquals(5, engine.getDependencies().length, "5 dependencies should be found");
 
             int foundCount = 0;
 
@@ -120,7 +121,7 @@ public class MSBuildProjectAnalyzerTest extends BaseTest {
                             foundCount++;
                             assertTrue(result.getEvidence(EvidenceType.VENDOR).toString().contains("NodaTime"));
                             assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("NodaTime"));
-                            assertTrue("Expected 3.0.0; contained: " + result.getEvidence(EvidenceType.VERSION).stream().map(e -> e.toString()).collect(Collectors.joining(",", "{", "}")), result.getEvidence(EvidenceType.VERSION).toString().contains("3.0.0"));
+                            assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains("3.0.0"), "Expected 3.0.0; contained: " + result.getEvidence(EvidenceType.VERSION).stream().map(Evidence::toString).collect(Collectors.joining(",", "{", "}")));
                             break;
                         default:
                             break;
@@ -128,12 +129,12 @@ public class MSBuildProjectAnalyzerTest extends BaseTest {
                 }
             }
 
-            assertEquals("5 expected dependencies should be found", 5, foundCount);
+            assertEquals(5, foundCount, "5 expected dependencies should be found");
         }
     }
 
     @Test
-    public void testMSBuildProjectAnalysis_WithImports() throws Exception {
+    void testMSBuildProjectAnalysis_WithImports() throws Exception {
         testMSBuildProjectAnalysisWithImport("msbuild/ProjectA/ProjectA.csproj", "3.0.0", "1.0.0");
         testMSBuildProjectAnalysisWithImport("msbuild/ProjectB/ProjectB.csproj", "3.0.0", "2.0.0");
         testMSBuildProjectAnalysisWithImport("msbuild/ProjectC/ProjectC.csproj", "3.0.0", "3.0.0");
@@ -154,7 +155,7 @@ public class MSBuildProjectAnalyzerTest extends BaseTest {
             analyzer.setEnabled(true);
             analyzer.analyze(toScan, engine);
 
-            assertEquals("2 dependencies should be found", 2, engine.getDependencies().length);
+            assertEquals(2, engine.getDependencies().length, "2 dependencies should be found");
 
             int foundCount = 0;
 
@@ -168,13 +169,13 @@ public class MSBuildProjectAnalyzerTest extends BaseTest {
                             foundCount++;
                             assertTrue(result.getEvidence(EvidenceType.VENDOR).toString().contains("Humanizer"));
                             assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("Humanizer"));
-                            assertTrue("Expected " + humanizerVersion + "; contained: " + result.getEvidence(EvidenceType.VERSION).stream().map(e -> e.toString()).collect(Collectors.joining(",", "{", "}")), result.getEvidence(EvidenceType.VERSION).toString().contains(humanizerVersion));
+                            assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains(humanizerVersion), "Expected " + humanizerVersion + "; contained: " + result.getEvidence(EvidenceType.VERSION).stream().map(Evidence::toString).collect(Collectors.joining(",", "{", "}")));
                             break;
                         case "NodaTime":
                             foundCount++;
                             assertTrue(result.getEvidence(EvidenceType.VENDOR).toString().contains("NodaTime"));
                             assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("NodaTime"));
-                            assertTrue("Expected " + nodaVersion + "; contained: " + result.getEvidence(EvidenceType.VERSION).stream().map(e -> e.toString()).collect(Collectors.joining(",", "{", "}")), result.getEvidence(EvidenceType.VERSION).toString().contains(nodaVersion));
+                            assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains(nodaVersion), "Expected " + nodaVersion + "; contained: " + result.getEvidence(EvidenceType.VERSION).stream().map(Evidence::toString).collect(Collectors.joining(",", "{", "}")));
                             break;
                         default:
                             break;
@@ -182,7 +183,7 @@ public class MSBuildProjectAnalyzerTest extends BaseTest {
                 }
             }
 
-            assertEquals("2 expected dependencies should be found", 2, foundCount);
+            assertEquals(2, foundCount, "2 expected dependencies should be found");
         }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/NodeAuditAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/NodeAuditAnalyzerIT.java
@@ -1,23 +1,24 @@
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import org.junit.Assume;
-import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
 
-public class NodeAuditAnalyzerIT extends BaseTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class NodeAuditAnalyzerIT extends BaseTest {
 
     @Test
-    public void testAnalyzePackage() throws AnalysisException, InitializationException, InvalidSettingException {
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED), is(true));
+    void testAnalyzePackage() throws AnalysisException, InitializationException, InvalidSettingException {
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED));
         try (Engine engine = new Engine(getSettings())) {
             NodeAuditAnalyzer analyzer = new NodeAuditAnalyzer();
             analyzer.setFilesMatched(true);
@@ -26,7 +27,7 @@ public class NodeAuditAnalyzerIT extends BaseTest {
             final Dependency toScan = new Dependency(BaseTest.getResourceAsFile(this, "nodeaudit/package-lock.json"));
             analyzer.analyze(toScan, engine);
             boolean found = false;
-            assertTrue("More then 1 dependency should be identified", 1 < engine.getDependencies().length);
+            assertTrue(1 < engine.getDependencies().length, "More then 1 dependency should be identified");
             for (Dependency result : engine.getDependencies()) {
                 if ("package-lock.json?uglify-js".equals(result.getFileName())) {
                     found = true;
@@ -36,13 +37,13 @@ public class NodeAuditAnalyzerIT extends BaseTest {
                     assertTrue(result.isVirtual());
                 }
             }
-            assertTrue("Uglify was not found", found);
+            assertTrue(found, "Uglify was not found");
         }
     }
 
     @Test
-    public void testAnalyzeEmpty() throws AnalysisException, InitializationException, InvalidSettingException {
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED), is(true));
+    void testAnalyzeEmpty() throws AnalysisException, InitializationException, InvalidSettingException {
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED));
         try (Engine engine = new Engine(getSettings())) {
             NodeAuditAnalyzer analyzer = new NodeAuditAnalyzer();
             analyzer.setFilesMatched(true);
@@ -58,8 +59,8 @@ public class NodeAuditAnalyzerIT extends BaseTest {
     }
 
     @Test
-    public void testAnalyzePackageJsonInNodeModulesDirectory() throws AnalysisException, InitializationException, InvalidSettingException {
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED), is(true));
+    void testAnalyzePackageJsonInNodeModulesDirectory() throws AnalysisException, InitializationException, InvalidSettingException {
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED));
         try (Engine engine = new Engine(getSettings())) {
             NodeAuditAnalyzer analyzer = new NodeAuditAnalyzer();
             analyzer.setFilesMatched(true);
@@ -68,7 +69,7 @@ public class NodeAuditAnalyzerIT extends BaseTest {
             final Dependency toScan = new Dependency(BaseTest.getResourceAsFile(this, "nodejs/node_modules/dns-sync/package.json"));
             engine.addDependency(toScan);
             analyzer.analyze(toScan, engine);
-            assertEquals("No dependencies should exist", 0, engine.getDependencies().length);
+            assertEquals(0, engine.getDependencies().length, "No dependencies should exist");
         }
     }
 

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/NodeAuditAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/NodeAuditAnalyzerTest.java
@@ -1,21 +1,23 @@
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
+
 import java.io.File;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class NodeAuditAnalyzerTest extends BaseTest {
+class NodeAuditAnalyzerTest extends BaseTest {
 
     @Test
-    public void testGetName() {
+    void testGetName() {
         NodeAuditAnalyzer analyzer = new NodeAuditAnalyzer();
         assertThat(analyzer.getName(), is("Node Audit Analyzer"));
     }
 
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         NodeAuditAnalyzer analyzer = new NodeAuditAnalyzer();
         assertThat(analyzer.accept(new File("package-lock.json")), is(true));
         assertThat(analyzer.accept(new File("npm-shrinkwrap.json")), is(true));

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzerTest.java
@@ -17,33 +17,34 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.EvidenceType;
+import org.owasp.dependencycheck.exception.InitializationException;
+import org.owasp.dependencycheck.utils.InvalidSettingException;
+import org.owasp.dependencycheck.utils.Settings;
 
 import java.io.File;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
-
-import org.junit.Assume;
-import org.owasp.dependencycheck.Engine;
-import org.owasp.dependencycheck.dependency.EvidenceType;
-import org.owasp.dependencycheck.exception.InitializationException;
-import org.owasp.dependencycheck.utils.InvalidSettingException;
-import org.owasp.dependencycheck.utils.Settings;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Unit tests for NodePackageAnalyzer.
  *
  * @author Dale Visser
  */
-public class NodePackageAnalyzerTest extends BaseTest {
+class NodePackageAnalyzerTest extends BaseTest {
 
     /**
      * The analyzer to test.
@@ -89,7 +90,7 @@ public class NodePackageAnalyzerTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -115,7 +116,7 @@ public class NodePackageAnalyzerTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         if (getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED)) {
@@ -130,9 +131,9 @@ public class NodePackageAnalyzerTest extends BaseTest {
      * Test of getName method, of class PythonDistributionAnalyzer.
      */
     @Test
-    public void testGetName() throws InvalidSettingException {
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED), is(true));
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED), is(true));
+    void testGetName() throws InvalidSettingException {
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED));
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED));
         assertThat(analyzer.getName(), is("Node.js Package Analyzer"));
     }
 
@@ -140,9 +141,9 @@ public class NodePackageAnalyzerTest extends BaseTest {
      * Test of supportsExtension method, of class PythonDistributionAnalyzer.
      */
     @Test
-    public void testSupportsFiles() throws InvalidSettingException {
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED), is(true));
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED), is(true));
+    void testSupportsFiles() throws InvalidSettingException {
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED));
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED));
         assertThat(analyzer.accept(new File("package-lock.json")), is(true));
         assertThat(analyzer.accept(new File("npm-shrinkwrap.json")), is(true));
     }
@@ -153,9 +154,9 @@ public class NodePackageAnalyzerTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzeShrinkwrapJson() throws AnalysisException, InvalidSettingException {
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED), is(true));
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED), is(true));
+    void testAnalyzeShrinkwrapJson() throws AnalysisException, InvalidSettingException {
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED));
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED));
         final Dependency toScan = new Dependency(BaseTest.getResourceAsFile(this,
                 "nodejs/npm-shrinkwrap.json"));
         final Dependency toCombine = new Dependency(BaseTest.getResourceAsFile(this,
@@ -206,9 +207,9 @@ public class NodePackageAnalyzerTest extends BaseTest {
             }
         }
 
-        assertTrue("need to contain braces", bracesFound);
+        assertTrue(bracesFound, "need to contain braces");
         //check if dependencies of dependencies are imported
-        assertTrue("need to contain expand-range (dependency of braces)", expandRangeFound);
+        assertTrue(expandRangeFound, "need to contain expand-range (dependency of braces)");
 
         final String vendorString = result.getEvidence(EvidenceType.VENDOR).toString();
         assertThat(vendorString, containsString("Sanjeev Koranga"));
@@ -232,9 +233,9 @@ public class NodePackageAnalyzerTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzePackageJsonWithShrinkwrap() throws AnalysisException, InvalidSettingException {
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED), is(true));
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED), is(true));
+    void testAnalyzePackageJsonWithShrinkwrap() throws AnalysisException, InvalidSettingException {
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED));
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED));
         final Dependency packageJson = new Dependency(BaseTest.getResourceAsFile(this,
                 "nodejs/package.json"));
         final Dependency shrinkwrap = new Dependency(BaseTest.getResourceAsFile(this,
@@ -256,16 +257,16 @@ public class NodePackageAnalyzerTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testWithoutLock() throws AnalysisException, InvalidSettingException {
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED), is(true));
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED), is(true));
+    void testWithoutLock() throws AnalysisException, InvalidSettingException {
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED));
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED));
         final Dependency packageJson = new Dependency(BaseTest.getResourceAsFile(this,
                 "nodejs/no_lock/package.json"));
         engine.addDependency(packageJson);
         analyzer.analyze(packageJson, engine);
 
         //final boolean isMac = !System.getProperty("os.name").toLowerCase().contains("mac");
-        assertEquals("Expected 1 dependencies", 1, engine.getDependencies().length);
+        assertEquals(1, engine.getDependencies().length, "Expected 1 dependencies");
     }
 
     /**
@@ -274,9 +275,9 @@ public class NodePackageAnalyzerTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testPackageLockV2() throws AnalysisException, InvalidSettingException {
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED), is(true));
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED), is(true));
+    void testPackageLockV2() throws AnalysisException, InvalidSettingException {
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED));
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED));
         final Dependency packageJson = new Dependency(BaseTest.getResourceAsFile(this,
                 "nodejs/test_lockv2/package.json"));
         final Dependency packageLockJson = new Dependency(BaseTest.getResourceAsFile(this,
@@ -284,9 +285,9 @@ public class NodePackageAnalyzerTest extends BaseTest {
         engine.addDependency(packageJson);
         engine.addDependency(packageLockJson);
         analyzer.analyze(packageJson, engine);
-        assertEquals("Expected 1 dependencies", 1, engine.getDependencies().length);
+        assertEquals(1, engine.getDependencies().length, "Expected 1 dependencies");
         analyzer.analyze(packageLockJson, engine);
-        assertEquals("Expected 1 dependencies", 6, engine.getDependencies().length);
+        assertEquals(6, engine.getDependencies().length, "Expected 1 dependencies");
     }
 
     /**
@@ -295,9 +296,9 @@ public class NodePackageAnalyzerTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testPackageLockV3() throws AnalysisException, InvalidSettingException {
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED), is(true));
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED), is(true));
+    void testPackageLockV3() throws AnalysisException, InvalidSettingException {
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED));
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_AUDIT_ENABLED));
         final Dependency packageJson = new Dependency(BaseTest.getResourceAsFile(this,
                 "nodejs/test_lockv3/package.json"));
         final Dependency packageLockJson = new Dependency(BaseTest.getResourceAsFile(this,
@@ -305,9 +306,9 @@ public class NodePackageAnalyzerTest extends BaseTest {
         engine.addDependency(packageJson);
         engine.addDependency(packageLockJson);
         analyzer.analyze(packageJson, engine);
-        assertEquals("Expected 1 dependencies", 1, engine.getDependencies().length);
+        assertEquals(1, engine.getDependencies().length, "Expected 1 dependencies");
         analyzer.analyze(packageLockJson, engine);
-        assertEquals("Expected 1 dependencies", 6, engine.getDependencies().length);
+        assertEquals(6, engine.getDependencies().length, "Expected 1 dependencies");
     }
 
     /**
@@ -318,8 +319,8 @@ public class NodePackageAnalyzerTest extends BaseTest {
      * @throws AnalysisException if there was a problem with the analysis
      */
     @Test
-    public void testLocalPackageDependency() throws AnalysisException, InvalidSettingException {
-        Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED), is(true));
+    void testLocalPackageDependency() throws AnalysisException, InvalidSettingException {
+        assumeTrue(getSettings().getBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED));
         final Dependency packageJson = new Dependency(BaseTest.getResourceAsFile(this,
                 "nodejs/local_package/package.json"));
         final Dependency packageLockJson = new Dependency(BaseTest.getResourceAsFile(this,
@@ -327,8 +328,8 @@ public class NodePackageAnalyzerTest extends BaseTest {
         engine.addDependency(packageJson);
         engine.addDependency(packageLockJson);
         analyzer.analyze(packageJson, engine);
-        assertEquals("Expected 1 dependencies", 1, engine.getDependencies().length);
+        assertEquals(1, engine.getDependencies().length, "Expected 1 dependencies");
         analyzer.analyze(packageLockJson, engine);
-        assertEquals("Expected 2 dependencies", 2, engine.getDependencies().length);
+        assertEquals(2, engine.getDependencies().length, "Expected 2 dependencies");
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/NpmCPEAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/NpmCPEAnalyzerIT.java
@@ -17,20 +17,21 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
-import static org.junit.Assert.assertTrue;
 import org.owasp.dependencycheck.dependency.EvidenceType;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class NpmCPEAnalyzerIT extends BaseDBTestCase {
+class NpmCPEAnalyzerIT extends BaseDBTestCase {
 
     /**
      * Test of analyzeDependency method, of class CPEAnalyzer.
@@ -38,7 +39,7 @@ public class NpmCPEAnalyzerIT extends BaseDBTestCase {
      * @throws Exception is thrown when an exception occurs
      */
     @Test
-    public void testAnalyzeDependency() throws Exception {
+    void testAnalyzeDependency() throws Exception {
 
         NpmCPEAnalyzer instance = new NpmCPEAnalyzer();
         try (Engine engine = new Engine(getSettings())) {
@@ -82,11 +83,11 @@ public class NpmCPEAnalyzerIT extends BaseDBTestCase {
             System.out.println(id.getValue());
             return expectedCpe.equals(id.getValue());
         });
-        assertTrue(String.format("%s:%s:%s identifier not found", vendor, product, version), found);
+        assertTrue(found, String.format("%s:%s:%s identifier not found", vendor, product, version));
     }
 
     @Test
-    public void testAnalyzeDependencyNoMatch() throws Exception {
+    void testAnalyzeDependencyNoMatch() throws Exception {
 
         NpmCPEAnalyzer instance = new NpmCPEAnalyzer();
         try (Engine engine = new Engine(getSettings())) {

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/NpmCPEAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/NpmCPEAnalyzerTest.java
@@ -17,22 +17,23 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.utils.Settings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author jeremy long
  */
-public class NpmCPEAnalyzerTest extends BaseDBTestCase {
+class NpmCPEAnalyzerTest extends BaseDBTestCase {
 
     /**
      * Test of getName method, of class CPEAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         NpmCPEAnalyzer instance = new NpmCPEAnalyzer();
         String expResult = "NPM CPE Analyzer";
         String result = instance.getName();
@@ -43,7 +44,7 @@ public class NpmCPEAnalyzerTest extends BaseDBTestCase {
      * Test of getAnalyzerEnabledSettingKey method, of class CPEAnalyzer.
      */
     @Test
-    public void testGetAnalyzerEnabledSettingKey() {
+    void testGetAnalyzerEnabledSettingKey() {
         NpmCPEAnalyzer instance = new NpmCPEAnalyzer();
         String expResult = Settings.KEYS.ANALYZER_NPM_CPE_ENABLED;
         String result = instance.getAnalyzerEnabledSettingKey();

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/NugetconfAnalyzerTest.java
@@ -17,8 +17,8 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.dependency.Dependency;
@@ -26,16 +26,16 @@ import org.owasp.dependencycheck.dependency.EvidenceType;
 
 import java.io.File;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.owasp.dependencycheck.analyzer.NuspecAnalyzer.DEPENDENCY_ECOSYSTEM;
 
-public class NugetconfAnalyzerTest extends BaseTest {
+class NugetconfAnalyzerTest extends BaseTest {
 
     private NugetconfAnalyzer instance;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -46,18 +46,18 @@ public class NugetconfAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testGetAnalyzerName() {
+    void testGetAnalyzerName() {
         assertEquals("Nugetconf Analyzer", instance.getName());
     }
 
     @Test
-    public void testSupportedFileNames() {
+    void testSupportedFileNames() {
         assertTrue(instance.accept(new File("packages.config")));
         assertFalse(instance.accept(new File("packages.json")));
     }
 
     @Test
-    public void testNugetconfAnalysis() throws Exception {
+    void testNugetconfAnalysis() throws Exception {
 
         try (Engine engine = new Engine(getSettings())) {
             File file = BaseTest.getResourceAsFile(this, "nugetconf/packages.config");
@@ -99,12 +99,12 @@ public class NugetconfAnalyzerTest extends BaseTest {
                         assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("Newtonsoft.Json"));
                         assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains("10.0.3"));
                         break;
-                    
+
                     default :
                         break;
                     }
                 }
-            assertEquals("4 dependencies should be found", 4, foundCount);
+            assertEquals(4, foundCount, "4 dependencies should be found");
         }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/NuspecAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/NuspecAnalyzerTest.java
@@ -17,24 +17,23 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
-import org.owasp.dependencycheck.dependency.Evidence;
-
-import java.io.File;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 
-public class NuspecAnalyzerTest extends BaseTest {
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NuspecAnalyzerTest extends BaseTest {
 
     private NuspecAnalyzer instance;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -45,23 +44,23 @@ public class NuspecAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testGetAnalyzerName() {
+    void testGetAnalyzerName() {
         assertEquals("Nuspec Analyzer", instance.getName());
     }
 
     @Test
-    public void testSupportsFileExtensions() {
+    void testSupportsFileExtensions() {
         assertTrue(instance.accept(new File("test.nuspec")));
         assertFalse(instance.accept(new File("test.nupkg")));
     }
 
     @Test
-    public void testGetAnalysisPhaze() {
+    void testGetAnalysisPhaze() {
         assertEquals(AnalysisPhase.INFORMATION_COLLECTION, instance.getAnalysisPhase());
     }
 
     @Test
-    public void testNuspecAnalysis() throws Exception {
+    void testNuspecAnalysis() throws Exception {
 
         File file = BaseTest.getResourceAsFile(this, "nuspec/test.nuspec");
         Dependency result = new Dependency(file);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/OpenSSLAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/OpenSSLAnalyzerTest.java
@@ -17,27 +17,27 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.EvidenceType;
 
 import java.io.File;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import org.owasp.dependencycheck.dependency.EvidenceType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for OpenSSLAnalyzerAnalyzer.
  *
  * @author Dale Visser
  */
-public class OpenSSLAnalyzerTest extends BaseTest {
+class OpenSSLAnalyzerTest extends BaseTest {
 
     /**
      * The package analyzer to test.
@@ -49,7 +49,7 @@ public class OpenSSLAnalyzerTest extends BaseTest {
      *
      * @throws Exception if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -64,7 +64,7 @@ public class OpenSSLAnalyzerTest extends BaseTest {
      *
      * @throws Exception if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         analyzer.close();
@@ -75,21 +75,21 @@ public class OpenSSLAnalyzerTest extends BaseTest {
      * Test of getName method, of class OpenSSLAnalyzer.
      */
     @Test
-    public void testGetName() {
-        assertEquals("Analyzer name wrong.", "OpenSSL Source Analyzer", analyzer.getName());
+    void testGetName() {
+        assertEquals("OpenSSL Source Analyzer", analyzer.getName(), "Analyzer name wrong.");
     }
 
     /**
      * Test of supportsExtension method, of class PythonPackageAnalyzer.
      */
     @Test
-    public void testAccept() {
-        assertTrue("Should support files named \"opensslv.h\".",
-                analyzer.accept(new File("opensslv.h")));
+    void testAccept() {
+        assertTrue(analyzer.accept(new File("opensslv.h")),
+                "Should support files named \"opensslv.h\".");
     }
 
     @Test
-    public void testVersionConstantExamples() {
+    void testVersionConstantExamples() {
         final long[] constants = {0x1000203fL, 0x00903000L, 0x00903001L, 0x00903002L, 0x0090300fL, 0x0090301fL, 0x0090400fL, 0x102031afL};
         final String[] versions = {"1.0.2c",
             "0.9.3-dev",
@@ -106,7 +106,7 @@ public class OpenSSLAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testOpenSSLVersionHeaderFile() throws AnalysisException {
+    void testOpenSSLVersionHeaderFile() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                 this,
                 "openssl/opensslv.h"));

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
@@ -1,20 +1,6 @@
 package org.owasp.dependencycheck.analyzer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-
-import java.net.SocketTimeoutException;
-
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
@@ -23,16 +9,28 @@ import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.naming.Identifier;
 import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
 import org.owasp.dependencycheck.utils.Settings;
-
 import org.sonatype.goodies.packageurl.PackageUrl;
 import org.sonatype.ossindex.service.api.componentreport.ComponentReport;
 import org.sonatype.ossindex.service.client.OssindexClient;
 import org.sonatype.ossindex.service.client.transport.Transport;
 
-public class OssIndexAnalyzerTest extends BaseTest {
+import java.net.SocketTimeoutException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class OssIndexAnalyzerTest extends BaseTest {
 
     @Test
-    public void should_enrich_be_included_in_mutex_to_prevent_NPE()
+    void should_enrich_be_included_in_mutex_to_prevent_NPE()
             throws Exception {
 
         // Given
@@ -96,7 +94,7 @@ public class OssIndexAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void should_analyzeDependency_return_a_dedicated_error_message_when_403_response_from_sonatype() throws Exception {
+    void should_analyzeDependency_return_a_dedicated_error_message_when_403_response_from_sonatype() throws Exception {
         // Given
         OssIndexAnalyzer analyzer = new OssIndexAnalyzerThrowing403();
         analyzer.initialize(getSettings());
@@ -123,12 +121,12 @@ public class OssIndexAnalyzerTest extends BaseTest {
         analyzer.close();
     }
 
-    
+
     @Test
-    public void should_analyzeDependency_only_warn_when_transport_error_from_sonatype() throws Exception {
+    void should_analyzeDependency_only_warn_when_transport_error_from_sonatype() throws Exception {
         // Given
         OssIndexAnalyzer analyzer = new OssIndexAnalyzerThrowing502();
-        
+
         getSettings().setBoolean(Settings.KEYS.ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS, true);
         analyzer.initialize(getSettings());
 
@@ -139,22 +137,21 @@ public class OssIndexAnalyzerTest extends BaseTest {
         dependency.addSoftwareIdentifier(identifier);
         Settings settings = getSettings();
         Engine engine = new Engine(settings);
-        engine.setDependencies(Collections.singletonList(dependency));
 
         // When
-        try {
+        try (engine) {
+            engine.setDependencies(Collections.singletonList(dependency));
             analyzer.analyzeDependency(dependency, engine);
         } catch (AnalysisException e) {
-            Assert.fail("Analysis exception thrown upon remote error although only a warning should have been logged");
+            fail("Analysis exception thrown upon remote error although only a warning should have been logged");
         } finally {
             analyzer.close();
-            engine.close();
         }
     }
 
 
     @Test
-    public void should_analyzeDependency_only_warn_when_socket_error_from_sonatype() throws Exception {
+    void should_analyzeDependency_only_warn_when_socket_error_from_sonatype() throws Exception {
         // Given
         OssIndexAnalyzer analyzer = new OssIndexAnalyzerThrowingSocketTimeout();
 
@@ -168,22 +165,21 @@ public class OssIndexAnalyzerTest extends BaseTest {
         dependency.addSoftwareIdentifier(identifier);
         Settings settings = getSettings();
         Engine engine = new Engine(settings);
-        engine.setDependencies(Collections.singletonList(dependency));
 
         // When
-        try {
+        try (engine) {
+            engine.setDependencies(Collections.singletonList(dependency));
             analyzer.analyzeDependency(dependency, engine);
         } catch (AnalysisException e) {
-            Assert.fail("Analysis exception thrown upon remote error although only a warning should have been logged");
+            fail("Analysis exception thrown upon remote error although only a warning should have been logged");
         } finally {
             analyzer.close();
-            engine.close();
         }
     }
 
 
     @Test
-    public void should_analyzeDependency_fail_when_socket_error_from_sonatype() throws Exception {
+    void should_analyzeDependency_fail_when_socket_error_from_sonatype() throws Exception {
         // Given
         OssIndexAnalyzer analyzer = new OssIndexAnalyzerThrowingSocketTimeout();
 
@@ -234,7 +230,7 @@ public class OssIndexAnalyzerTest extends BaseTest {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() {
 
         }
     }
@@ -259,7 +255,7 @@ public class OssIndexAnalyzerTest extends BaseTest {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() {
 
         }
     }
@@ -284,7 +280,7 @@ public class OssIndexAnalyzerTest extends BaseTest {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() {
 
         }
     }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
@@ -23,9 +23,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class OssIndexAnalyzerTest extends BaseTest {
 
@@ -141,9 +141,8 @@ class OssIndexAnalyzerTest extends BaseTest {
         // When
         try (engine) {
             engine.setDependencies(Collections.singletonList(dependency));
-            analyzer.analyzeDependency(dependency, engine);
-        } catch (AnalysisException e) {
-            fail("Analysis exception thrown upon remote error although only a warning should have been logged");
+            assertDoesNotThrow(() -> analyzer.analyzeDependency(dependency, engine),
+                    "Analysis exception thrown upon remote error although only a warning should have been logged");
         } finally {
             analyzer.close();
         }
@@ -169,9 +168,8 @@ class OssIndexAnalyzerTest extends BaseTest {
         // When
         try (engine) {
             engine.setDependencies(Collections.singletonList(dependency));
-            analyzer.analyzeDependency(dependency, engine);
-        } catch (AnalysisException e) {
-            fail("Analysis exception thrown upon remote error although only a warning should have been logged");
+            assertDoesNotThrow(() -> analyzer.analyzeDependency(dependency, engine),
+                    "Analysis exception thrown upon remote error although only a warning should have been logged");
         } finally {
             analyzer.close();
         }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PEAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PEAnalyzerTest.java
@@ -17,16 +17,10 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import org.junit.After;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
@@ -35,13 +29,18 @@ import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * Tests for the PEAnalyzer.
  *
  * @author Jeremy Long
  *
  */
-public class PEAnalyzerTest extends BaseTest {
+class PEAnalyzerTest extends BaseTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PEAnalyzerTest.class);
 
@@ -54,7 +53,7 @@ public class PEAnalyzerTest extends BaseTest {
      *
      * @throws Exception if anything goes sideways
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -68,12 +67,12 @@ public class PEAnalyzerTest extends BaseTest {
      * Tests to make sure the name is correct.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertEquals("PE Analyzer", analyzer.getName());
     }
 
     @Test
-    public void testAnalysis() throws Exception {
+    void testAnalysis() throws Exception {
         File f = BaseTest.getResourceAsFile(this, "log4net.dll");
 
         Dependency d = new Dependency(f);
@@ -85,7 +84,7 @@ public class PEAnalyzerTest extends BaseTest {
         assertEquals("log4net", d.getName());
     }
 
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         try {

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PerlCpanfileAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PerlCpanfileAnalyzerTest.java
@@ -17,29 +17,30 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.utils.Settings;
+
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
 
-import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
-import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.dependency.Dependency;
-import org.owasp.dependencycheck.Engine;
-import org.owasp.dependencycheck.utils.Settings;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author jeremy long
  */
 @SuppressWarnings("unchecked")
-public class PerlCpanfileAnalyzerTest extends BaseTest {
+class PerlCpanfileAnalyzerTest extends BaseTest {
 
     /**
      * Test of getName method, of class PerlCpanfileAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer();
         String expResult = "Perl cpanfile Analyzer";
         String result = instance.getName();
@@ -50,7 +51,7 @@ public class PerlCpanfileAnalyzerTest extends BaseTest {
      * Test of getAnalysisPhase method, of class PerlCpanfileAnalyzer.
      */
     @Test
-    public void testGetAnalysisPhase() {
+    void testGetAnalysisPhase() {
         PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer();
         AnalysisPhase expResult = AnalysisPhase.INFORMATION_COLLECTION;
         AnalysisPhase result = instance.getAnalysisPhase();
@@ -62,7 +63,7 @@ public class PerlCpanfileAnalyzerTest extends BaseTest {
      * PerlCpanfileAnalyzer.
      */
     @Test
-    public void testGetAnalyzerEnabledSettingKey() {
+    void testGetAnalyzerEnabledSettingKey() {
         PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer();
         String expResult = Settings.KEYS.ANALYZER_CPANFILE_ENABLED;
         String result = instance.getAnalyzerEnabledSettingKey();
@@ -70,16 +71,14 @@ public class PerlCpanfileAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testProcessFileContents() throws AnalysisException {
+    void testProcessFileContents() throws AnalysisException {
         Dependency d = new Dependency();
-        List<String> dependencyLines = Arrays.asList(new String[]{
-            "requires 'Plack', '1.0'",
-            "requires 'JSON', '>= 2.00, < 2.80'",
-            "requires 'Mojolicious::Plugin::ZAPI' => '>= 2.015",
-            "requires 'Hash::MoreUtils' => '>= 0.05",
-            "requires 'JSON::MaybeXS' => '>= 1.002004'",
-            "requires 'Test::MockModule'"
-        });
+        List<String> dependencyLines = Arrays.asList("requires 'Plack', '1.0'",
+                "requires 'JSON', '>= 2.00, < 2.80'",
+                "requires 'Mojolicious::Plugin::ZAPI' => '>= 2.015",
+                "requires 'Hash::MoreUtils' => '>= 0.05",
+                "requires 'JSON::MaybeXS' => '>= 1.002004'",
+                "requires 'Test::MockModule'");
         PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer();
         Engine engine = new Engine(getSettings());
         instance.processFileContents(dependencyLines, "./cpanfile", engine);
@@ -88,10 +87,9 @@ public class PerlCpanfileAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testProcessSingleFileContents() throws AnalysisException {
+    void testProcessSingleFileContents() throws AnalysisException {
         Dependency d = new Dependency();
-        List<String> dependencyLines = Arrays.asList(new String[]{
-            "requires 'JSON', '>= 2.00, < 2.80'",});
+        List<String> dependencyLines = Arrays.asList("requires 'JSON', '>= 2.00, < 2.80'");
         PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer();
         Engine engine = new Engine(getSettings());
         instance.processFileContents(dependencyLines, "./cpanfile", engine);
@@ -104,10 +102,9 @@ public class PerlCpanfileAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testProcessDefaultZero() throws AnalysisException {
+    void testProcessDefaultZero() throws AnalysisException {
         Dependency d = new Dependency();
-        List<String> dependencyLines = Arrays.asList(new String[]{
-            "requires 'JSON'",});
+        List<String> dependencyLines = Arrays.asList("requires 'JSON'");
         PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer();
         Engine engine = new Engine(getSettings());
         instance.processFileContents(dependencyLines, "./cpanfile", engine);
@@ -121,24 +118,24 @@ public class PerlCpanfileAnalyzerTest extends BaseTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testPrepareContent() {
+    void testPrepareContent() {
         PerlCpanfileAnalyzer instance = new PerlCpanfileAnalyzer();
         String content = "requires 'JSON'; #any version";
-        List<String> expResult = Arrays.asList(new String[]{"requires 'JSON'"});
+        List<String> expResult = Arrays.asList("requires 'JSON'");
         List<String> result = instance.prepareContents(content);
         assertEquals(expResult, result);
 
         content = "requires 'JSON'; requires 'XML';";
-        expResult = Arrays.asList(new String[]{"requires 'JSON'", "requires 'XML'"});
+        expResult = Arrays.asList("requires 'JSON'", "requires 'XML'");
         result = instance.prepareContents(content);
         assertEquals(expResult, result);
         content = "requires 'JSON';\n     requires 'XML';";
-        expResult = Arrays.asList(new String[]{"requires 'JSON'", "requires 'XML'"});
+        expResult = Arrays.asList("requires 'JSON'", "requires 'XML'");
         result = instance.prepareContents(content);
         assertEquals(expResult, result);
 
         content = "requires 'JSON';# requires 'XML';";
-        expResult = Arrays.asList(new String[]{"requires 'JSON'"});
+        expResult = Arrays.asList("requires 'JSON'");
         result = instance.prepareContents(content);
         assertEquals(expResult, result);
     }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PinnedMavenInstallAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PinnedMavenInstallAnalyzerTest.java
@@ -18,26 +18,25 @@
 package org.owasp.dependencycheck.analyzer;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
-import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.nvd.ecosystem.Ecosystem;
 import org.owasp.dependencycheck.dependency.Dependency;
 
 import java.io.File;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link PinnedMavenInstallAnalyzer}.
  */
-public class PinnedMavenInstallAnalyzerTest extends BaseDBTestCase {
+class PinnedMavenInstallAnalyzerTest extends BaseDBTestCase {
 
     /**
      * The analyzer to test.
@@ -49,7 +48,7 @@ public class PinnedMavenInstallAnalyzerTest extends BaseDBTestCase {
      *
      * @throws Exception thrown if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -64,7 +63,7 @@ public class PinnedMavenInstallAnalyzerTest extends BaseDBTestCase {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         analyzer.close();
@@ -72,19 +71,19 @@ public class PinnedMavenInstallAnalyzerTest extends BaseDBTestCase {
     }
 
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertEquals("Pinned Maven install Analyzer", analyzer.getName());
     }
 
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         assertTrue(analyzer.accept(new File("install_maven.json")));
         assertTrue(analyzer.accept(new File("maven_install.json")));
         assertTrue(analyzer.accept(new File("maven_install_v010.json")));
         assertTrue(analyzer.accept(new File("maven_install_v2.json")));
         assertTrue(analyzer.accept(new File("rules_jvm_external_install.json")));
         assertTrue(analyzer.accept(new File("pinned_install_gplonly.json")));
-        assertFalse("should not accept Cloudflare install.json", analyzer.accept(new File("install.json")));
+        assertFalse(analyzer.accept(new File("install.json")), "should not accept Cloudflare install.json");
         assertFalse(analyzer.accept(new File("maven_install.txt")));
         assertFalse(analyzer.accept(new File("pinned.json")));
         assertFalse(analyzer.accept(new File("install.json.zip")));
@@ -94,7 +93,7 @@ public class PinnedMavenInstallAnalyzerTest extends BaseDBTestCase {
      * Tests that the analyzer correctly pulls dependencies out of a pinned v0.1.0 {@code maven_install.json}.
      */
     @Test
-    public void testAnalyzePinnedInstallJsonV010() throws Exception {
+    void testAnalyzePinnedInstallJsonV010() throws Exception {
         try (Engine engine = new Engine(getSettings())) {
             final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "maven_install_v010.json"));
             engine.addDependency(result);
@@ -109,7 +108,7 @@ public class PinnedMavenInstallAnalyzerTest extends BaseDBTestCase {
                     assertEquals(Ecosystem.JAVA, d.getEcosystem());
                 }
             }
-            assertTrue("Expected to find com.google.errorprone:error_prone_annotations:2.3.4", found);
+            assertTrue(found, "Expected to find com.google.errorprone:error_prone_annotations:2.3.4");
         }
     }
 
@@ -117,7 +116,7 @@ public class PinnedMavenInstallAnalyzerTest extends BaseDBTestCase {
      * Tests that the analyzer correctly pulls dependencies out of a pinned v2 {@code maven_install.json}.
      */
     @Test
-    public void testAnalyzePinnedInstallJsonV2() throws Exception {
+    void testAnalyzePinnedInstallJsonV2() throws Exception {
         try (Engine engine = new Engine(getSettings())) {
             final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "maven_install_v2.json"));
             engine.addDependency(result);
@@ -132,7 +131,7 @@ public class PinnedMavenInstallAnalyzerTest extends BaseDBTestCase {
                     assertEquals(Ecosystem.JAVA, d.getEcosystem());
                 }
             }
-            assertTrue("Expected to find com.google.errorprone:error_prone_annotations:2.3.4", found);
+            assertTrue(found, "Expected to find com.google.errorprone:error_prone_annotations:2.3.4");
         }
     }
 
@@ -140,7 +139,7 @@ public class PinnedMavenInstallAnalyzerTest extends BaseDBTestCase {
      * Tests that the analyzer ignores a Cloudflare-style {@code install.json}.
      */
     @Test
-    public void testAnalyzeOtherInstallJson() throws Exception {
+    void testAnalyzeOtherInstallJson() throws Exception {
         try (Engine engine = new Engine(getSettings())) {
             final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "install.json"));
             engine.addDependency(result);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PipAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PipAnalyzerIT.java
@@ -1,27 +1,26 @@
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.exception.InitializationException;
-import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  *
  * @author anupamjuniwal
  */
-public class PipAnalyzerIT extends BaseTest {
+class PipAnalyzerIT extends BaseTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(PipAnalyzerIT.class);
 
     /**
@@ -34,7 +33,7 @@ public class PipAnalyzerIT extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -49,7 +48,7 @@ public class PipAnalyzerIT extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         if (analyzer != null) {
@@ -66,13 +65,13 @@ public class PipAnalyzerIT extends BaseTest {
      * @throws AnalysisException thrown if there is a problem
      */
     @Test
-    public void testAnalyzePipAnalyzer() throws AnalysisException{
+    void testAnalyzePipAnalyzer() throws AnalysisException{
         try (Engine engine = new Engine(getSettings())) {
             analyzer.prepare(engine);
             final Dependency toScan = new Dependency(BaseTest.getResourceAsFile(this, "requirements.txt"));
             analyzer.analyze(toScan, engine);
             boolean found = false;
-            assertTrue("More then 1 dependency should be identified", 1 < engine.getDependencies().length);
+            assertTrue(1 < engine.getDependencies().length, "More then 1 dependency should be identified");
             for (Dependency result : engine.getDependencies()) {
                 if ("PyYAML".equals(result.getName())) {
                     found = true;
@@ -82,10 +81,10 @@ public class PipAnalyzerIT extends BaseTest {
                     assertTrue(result.isVirtual());
                 }
             }
-            assertTrue("Expeced to find PyYAML", found);
+            assertTrue(found, "Expeced to find PyYAML");
         } catch (InitializationException ex) {
             //yarn is not installed - skip the test case.
-            Assume.assumeNoException(ex);
+            assumeTrue(false, ex.toString());
         }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PipAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PipAnalyzerTest.java
@@ -17,9 +17,10 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
@@ -27,18 +28,17 @@ import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 
 import java.io.File;
-import org.apache.commons.lang3.ArrayUtils;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for PipAnalyzerTest.
  */
-public class PipAnalyzerTest extends BaseDBTestCase {
+class PipAnalyzerTest extends BaseDBTestCase {
 
     /**
      * The analyzer to test.
@@ -50,7 +50,7 @@ public class PipAnalyzerTest extends BaseDBTestCase {
      *
      * @throws Exception thrown if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -65,7 +65,7 @@ public class PipAnalyzerTest extends BaseDBTestCase {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         analyzer.close();
@@ -76,7 +76,7 @@ public class PipAnalyzerTest extends BaseDBTestCase {
      * Test of getName method, of class PipAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertEquals("pip Analyzer", analyzer.getName());
     }
 
@@ -84,7 +84,7 @@ public class PipAnalyzerTest extends BaseDBTestCase {
      * Test of supportsExtension method, of class PipAnalyzer.
      */
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         assertTrue(analyzer.accept(new File("requirements.txt")));
         assertFalse(analyzer.accept(new File("requirements2.txt")));
         assertFalse(analyzer.accept(new File("requirements.py")));
@@ -97,7 +97,7 @@ public class PipAnalyzerTest extends BaseDBTestCase {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzePackageJson() throws Exception {
+    void testAnalyzePackageJson() throws Exception {
         try (Engine engine = new Engine(getSettings())) {
             final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "requirements.txt"));
             engine.addDependency(result);
@@ -120,8 +120,8 @@ public class PipAnalyzerTest extends BaseDBTestCase {
                     assertEquals(PythonDistributionAnalyzer.DEPENDENCY_ECOSYSTEM, d.getEcosystem());
                 }
             }
-            assertTrue("Expected to find PyYAML", foundPyYAML);
-            assertTrue("Expected to find cryptography", foundCryptography);
+            assertTrue(foundPyYAML, "Expected to find PyYAML");
+            assertTrue(foundCryptography, "Expected to find cryptography");
         }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PipfileAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PipfileAnalyzerTest.java
@@ -17,9 +17,10 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
@@ -27,18 +28,17 @@ import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 
 import java.io.File;
-import org.apache.commons.lang3.ArrayUtils;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for PipAnalyzerTest.
  */
-public class PipfileAnalyzerTest extends BaseDBTestCase {
+class PipfileAnalyzerTest extends BaseDBTestCase {
 
     /**
      * The analyzer to test.
@@ -50,7 +50,7 @@ public class PipfileAnalyzerTest extends BaseDBTestCase {
      *
      * @throws Exception thrown if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -65,7 +65,7 @@ public class PipfileAnalyzerTest extends BaseDBTestCase {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         analyzer.close();
@@ -76,7 +76,7 @@ public class PipfileAnalyzerTest extends BaseDBTestCase {
      * Test of getName method, of class PipAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertEquals("Pipfile Analyzer", analyzer.getName());
     }
 
@@ -84,7 +84,7 @@ public class PipfileAnalyzerTest extends BaseDBTestCase {
      * Test of supportsExtension method, of class PipAnalyzer.
      */
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         assertTrue(analyzer.accept(new File("Pipfile")));
         assertFalse(analyzer.accept(new File("Pipfile.lock")));
     }
@@ -95,7 +95,7 @@ public class PipfileAnalyzerTest extends BaseDBTestCase {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzePackageJson() throws Exception {
+    void testAnalyzePackageJson() throws Exception {
         try (Engine engine = new Engine(getSettings())) {
             final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "Pipfile"));
             engine.addDependency(result);
@@ -118,8 +118,8 @@ public class PipfileAnalyzerTest extends BaseDBTestCase {
                     assertEquals(PythonDistributionAnalyzer.DEPENDENCY_ECOSYSTEM, d.getEcosystem());
                 }
             }
-            assertTrue("Expeced to find urllib3", foundUrllib3);
-            assertTrue("Expeced to find cryptography", foundCryptography);
+            assertTrue(foundUrllib3, "Expeced to find urllib3");
+            assertTrue(foundCryptography, "Expeced to find cryptography");
         }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PipfilelockAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PipfilelockAnalyzerTest.java
@@ -17,28 +17,27 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
-import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 
 import java.io.File;
-import org.apache.commons.lang3.ArrayUtils;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for PipfilelockAnalyzerTest.
  */
-public class PipfilelockAnalyzerTest extends BaseDBTestCase {
+class PipfilelockAnalyzerTest extends BaseDBTestCase {
 
     /**
      * The analyzer to test.
@@ -50,7 +49,7 @@ public class PipfilelockAnalyzerTest extends BaseDBTestCase {
      *
      * @throws Exception thrown if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -65,7 +64,7 @@ public class PipfilelockAnalyzerTest extends BaseDBTestCase {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         analyzer.close();
@@ -76,7 +75,7 @@ public class PipfilelockAnalyzerTest extends BaseDBTestCase {
      * Test of getName method, of class PipAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertEquals("Pipfile.lock Analyzer", analyzer.getName());
     }
 
@@ -84,13 +83,13 @@ public class PipfilelockAnalyzerTest extends BaseDBTestCase {
      * Test of supportsExtension method, of class PipAnalyzer.
      */
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         assertFalse(analyzer.accept(new File("Pipfile")));
         assertTrue(analyzer.accept(new File("Pipfile.lock")));
     }
 
     @Test
-    public void testAnalyzePackageLock() throws Exception {
+    void testAnalyzePackageLock() throws Exception {
         try (Engine engine = new Engine(getSettings())) {
             final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "pip/Pipfile.lock"));
             engine.addDependency(result);
@@ -107,7 +106,7 @@ public class PipfilelockAnalyzerTest extends BaseDBTestCase {
                     break;
                 }
             }
-            assertTrue("Expeced to find urllib3", found);
+            assertTrue(found, "Expeced to find urllib3");
         }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PnpmAuditAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PnpmAuditAnalyzerIT.java
@@ -1,7 +1,7 @@
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
@@ -9,14 +9,14 @@ import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.exception.InitializationException;
 
-import static org.junit.Assert.assertTrue;
-import org.junit.Ignore;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class PnpmAuditAnalyzerIT extends BaseTest {
+class PnpmAuditAnalyzerIT extends BaseTest {
 
     @Test
-    @Ignore("unfortunately pnpm and brew are somewhat broken on my machine atm...")
-    public void testAnalyzePackagePnpm() throws AnalysisException {
+    @Disabled("unfortunately pnpm and brew are somewhat broken on my machine atm...")
+    void testAnalyzePackagePnpm() throws AnalysisException {
 
         try (Engine engine = new Engine(getSettings())) {
             PnpmAuditAnalyzer analyzer = new PnpmAuditAnalyzer();
@@ -27,7 +27,7 @@ public class PnpmAuditAnalyzerIT extends BaseTest {
             final Dependency toScan = new Dependency(BaseTest.getResourceAsFile(this, "pnpmaudit/pnpm-lock.yaml"));
             analyzer.analyze(toScan, engine);
             boolean found = false;
-            assertTrue("More than 1 dependency should be identified", 1 < engine.getDependencies().length);
+            assertTrue(1 < engine.getDependencies().length, "More than 1 dependency should be identified");
             for (Dependency result : engine.getDependencies()) {
                 if ("pnpm-lock.yaml?dns-sync".equals(result.getFileName())) {
                     found = true;
@@ -36,10 +36,10 @@ public class PnpmAuditAnalyzerIT extends BaseTest {
                     assertTrue(result.isVirtual());
                 }
             }
-            assertTrue("dns-sync was not found", found);
+            assertTrue(found, "dns-sync was not found");
         } catch (InitializationException ex) {
             //yarn is not installed - skip the test case.
-            Assume.assumeNoException(ex);
+            assumeTrue(false, ex.toString());
         }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PnpmAuditAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PnpmAuditAnalyzerTest.java
@@ -3,29 +3,24 @@ package org.owasp.dependencycheck.analyzer;
 import org.apache.commons.io.IOUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.Engine;
-import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.nodeaudit.Advisory;
 import org.owasp.dependencycheck.data.nodeaudit.NpmAuditParser;
-import org.owasp.dependencycheck.dependency.Dependency;
-import org.owasp.dependencycheck.utils.Settings;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class PnpmAuditAnalyzerTest extends BaseTest
+class PnpmAuditAnalyzerTest extends BaseTest
 {
 
     @Test
-    public void testNpmAuditParserCompatibility() throws IOException, JSONException
+    void testNpmAuditParserCompatibility() throws IOException, JSONException
     {
         NpmAuditParser npmAuditParser = new NpmAuditParser();
         JSONObject vulnsAuditJson = new JSONObject(IOUtils.toString(getResourceAsStream(this, "pnpmaudit/pnpm-audit.json"), StandardCharsets.UTF_8));
@@ -34,7 +29,7 @@ public class PnpmAuditAnalyzerTest extends BaseTest
     }
 
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         PnpmAuditAnalyzer analyzer = new PnpmAuditAnalyzer();
         assertThat(analyzer.accept(new File("package-lock.json")), is(false));
         assertThat(analyzer.accept(new File("npm-shrinkwrap.json")), is(false));

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PoetryAnalyzerTest.java
@@ -15,28 +15,29 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import java.io.File;
-
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 
-public class PoetryAnalyzerTest extends BaseTest {
+import java.io.File;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PoetryAnalyzerTest extends BaseTest {
 
     private PoetryAnalyzer analyzer;
     private Engine engine;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         analyzer = new PoetryAnalyzer();
@@ -44,18 +45,19 @@ public class PoetryAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testName() {
-        assertEquals("Analyzer name wrong.", "Poetry Analyzer",
-                analyzer.getName());
+    void testName() {
+        assertEquals("Poetry Analyzer",
+                analyzer.getName(),
+                "Analyzer name wrong.");
     }
 
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         assertThat(analyzer.accept(new File("poetry.lock")), is(true));
     }
 
     @Test
-    public void testPoetryLock() throws AnalysisException {
+    void testPoetryLock() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "poetry.lock"));
         analyzer.analyze(result, engine);
         assertEquals(88, engine.getDependencies().length);
@@ -68,27 +70,28 @@ public class PoetryAnalyzerTest extends BaseTest {
                 assertEquals(PythonDistributionAnalyzer.DEPENDENCY_ECOSYSTEM, d.getEcosystem());
             }
         }
-        assertTrue("Expeced to find PyYAML", found);
+        assertTrue(found, "Expeced to find PyYAML");
     }
 
     @Test
-    public void testPyprojectToml() throws AnalysisException {
+    void testPyprojectToml() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "python-myproject-toml/pyproject.toml"));
         //returns with no error.
         analyzer.analyze(result, engine);
     }
 
     @Test
-    public void testNodeGypToml() throws AnalysisException {
+    void testNodeGypToml() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "node-gyp-toml/pyproject.toml"));
         //returns with no error.
         analyzer.analyze(result, engine);
     }
 
-    @Test(expected = AnalysisException.class)
-    public void testPoetryToml() throws AnalysisException {
+    @Test
+    void testPoetryToml() {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this, "python-poetry-toml/pyproject.toml"));
-        //causes an exception.
-        analyzer.analyze(result, engine);
+        assertThrows(AnalysisException.class, () ->
+            //causes an exception.
+            analyzer.analyze(result, engine));
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PythonDistributionAnalyzerTest.java
@@ -17,27 +17,27 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
+import org.owasp.dependencycheck.dependency.EvidenceType;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import org.owasp.dependencycheck.dependency.EvidenceType;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for PythonDistributionAnalyzer.
  *
  * @author Dale Visser
  */
-public class PythonDistributionAnalyzerTest extends BaseTest {
+class PythonDistributionAnalyzerTest extends BaseTest {
 
     /**
      * The analyzer to test.
@@ -49,7 +49,7 @@ public class PythonDistributionAnalyzerTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -64,7 +64,7 @@ public class PythonDistributionAnalyzerTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         analyzer.close();
@@ -75,39 +75,36 @@ public class PythonDistributionAnalyzerTest extends BaseTest {
      * Test of getName method, of class PythonDistributionAnalyzer.
      */
     @Test
-    public void testGetName() {
-        assertEquals("Analyzer name wrong.", "Python Distribution Analyzer",
-                analyzer.getName());
+    void testGetName() {
+        assertEquals("Python Distribution Analyzer",
+                analyzer.getName(),
+                "Analyzer name wrong.");
     }
 
     /**
      * Test of supportsExtension method, of class PythonDistributionAnalyzer.
      */
     @Test
-    public void testSupportsFiles() {
-        assertTrue("Should support \"whl\" extension.",
-                analyzer.accept(new File("test.whl")));
-        assertTrue("Should support \"egg\" extension.",
-                analyzer.accept(new File("test.egg")));
-        assertTrue("Should support \"zip\" extension.",
-                analyzer.accept(new File("test.zip")));
-        assertTrue("Should support \"METADATA\" extension.",
-                analyzer.accept(new File("METADATA")));
-        assertTrue("Should support \"PKG-INFO\" extension.",
-                analyzer.accept(new File("PKG-INFO")));
+    void testSupportsFiles() {
+        assertTrue(analyzer.accept(new File("test.whl")),
+                "Should support \"whl\" extension.");
+        assertTrue(analyzer.accept(new File("test.egg")),
+                "Should support \"egg\" extension.");
+        assertTrue(analyzer.accept(new File("test.zip")),
+                "Should support \"zip\" extension.");
+        assertTrue(analyzer.accept(new File("METADATA")),
+                "Should support \"METADATA\" extension.");
+        assertTrue(analyzer.accept(new File("PKG-INFO")),
+                "Should support \"PKG-INFO\" extension.");
     }
 
     /**
      * Test of inspect method, of class PythonDistributionAnalyzer.
      */
     @Test
-    public void testAnalyzeWheel() {
-        try {
-            djangoAssertions(new Dependency(BaseTest.getResourceAsFile(this,
-                    "python/Django-1.7.2-py2.py3-none-any.whl")));
-        } catch (AnalysisException ex) {
-            fail(ex.getMessage());
-        }
+    void testAnalyzeWheel() {
+        assertDoesNotThrow(() -> djangoAssertions(new Dependency(BaseTest.getResourceAsFile(this,
+                "python/Django-1.7.2-py2.py3-none-any.whl"))));
     }
 
     /**
@@ -116,7 +113,7 @@ public class PythonDistributionAnalyzerTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzeSitePackage() throws AnalysisException {
+    void testAnalyzeSitePackage() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                 this, "python/site-packages/Django-1.7.2.dist-info/METADATA"));
         djangoAssertions(result);
@@ -126,15 +123,15 @@ public class PythonDistributionAnalyzerTest extends BaseTest {
             throws AnalysisException {
         boolean found = false;
         analyzer.analyze(result, null);
-        assertTrue("Expected vendor evidence to contain \"djangoproject\".",
-                result.getEvidence(EvidenceType.VENDOR).toString().contains("djangoproject"));
+        assertTrue(result.getEvidence(EvidenceType.VENDOR).toString().contains("djangoproject"),
+                "Expected vendor evidence to contain \"djangoproject\".");
         for (final Evidence e : result.getEvidence(EvidenceType.VERSION)) {
             if ("Version".equals(e.getName()) && "1.7.2".equals(e.getValue())) {
                 found = true;
                 break;
             }
         }
-        assertTrue("Version 1.7.2 not found in Django dependency.", found);
+        assertTrue(found, "Version 1.7.2 not found in Django dependency.");
         assertEquals("1.7.2",result.getVersion());
         assertEquals("Django",result.getName());
         assertEquals("Django:1.7.2",result.getDisplayFileName());
@@ -142,55 +139,39 @@ public class PythonDistributionAnalyzerTest extends BaseTest {
     }
 
     @Test
-    public void testAnalyzeEggInfoFolder() {
-        try {
-            eggtestAssertions(this, "python/site-packages/EggTest.egg-info/PKG-INFO");
-        } catch (AnalysisException ex) {
-            fail(ex.getMessage());
-        }
+    void testAnalyzeEggInfoFolder() {
+        assertDoesNotThrow(() -> eggtestAssertions(this, "python/site-packages/EggTest.egg-info/PKG-INFO"));
     }
 
     @Test
-    public void testAnalyzeEggArchive() {
-        try {
-            eggtestAssertions(this, "python/dist/EggTest-0.0.1-py2.7.egg");
-        } catch (AnalysisException ex) {
-            fail(ex.getMessage());
-        }
+    void testAnalyzeEggArchive() {
+        assertDoesNotThrow(() -> eggtestAssertions(this, "python/dist/EggTest-0.0.1-py2.7.egg"));
     }
 
     @Test
-    public void testAnalyzeEggArchiveNamedZip() {
-        try {
-            eggtestAssertions(this, "python/dist/EggTest-0.0.1-py2.7.zip");
-        } catch (AnalysisException ex) {
-            fail(ex.getMessage());
-        }
+    void testAnalyzeEggArchiveNamedZip() {
+        assertDoesNotThrow(() -> eggtestAssertions(this, "python/dist/EggTest-0.0.1-py2.7.zip"));
     }
 
     @Test
-    public void testAnalyzeEggFolder() {
-        try {
-            eggtestAssertions(this, "python/site-packages/EggTest-0.0.1-py2.7.egg/EGG-INFO/PKG-INFO");
-        } catch (AnalysisException ex) {
-            fail(ex.getMessage());
-        }
+    void testAnalyzeEggFolder() {
+        assertDoesNotThrow(() -> eggtestAssertions(this, "python/site-packages/EggTest-0.0.1-py2.7.egg/EGG-INFO/PKG-INFO"));
     }
 
-    public void eggtestAssertions(Object context, final String resource) throws AnalysisException {
+    private void eggtestAssertions(Object context, final String resource) throws AnalysisException {
         boolean found = false;
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                 context, resource));
         analyzer.analyze(result, null);
-        assertTrue("Expected vendor evidence to contain \"example\".", result
-                .getEvidence(EvidenceType.VENDOR).toString().contains("example"));
+        assertTrue(result
+                .getEvidence(EvidenceType.VENDOR).toString().contains("example"), "Expected vendor evidence to contain \"example\".");
         for (final Evidence e : result.getEvidence(EvidenceType.VERSION)) {
             if ("0.0.1".equals(e.getValue())) {
                 found = true;
                 break;
             }
         }
-        assertTrue("Version 0.0.1 not found in EggTest dependency.", found);
+        assertTrue(found, "Version 0.0.1 not found in EggTest dependency.");
         assertEquals("0.0.1",result.getVersion());
         assertEquals("EggTest",result.getName());
         assertEquals("EggTest:0.0.1",result.getDisplayFileName());

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/PythonPackageAnalyzerTest.java
@@ -17,26 +17,26 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
+import org.owasp.dependencycheck.dependency.EvidenceType;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import org.owasp.dependencycheck.dependency.EvidenceType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for PythonPackageAnalyzer.
  *
  * @author Dale Visser
  */
-public class PythonPackageAnalyzerTest extends BaseTest {
+class PythonPackageAnalyzerTest extends BaseTest {
 
     /**
      * The package analyzer to test.
@@ -48,7 +48,7 @@ public class PythonPackageAnalyzerTest extends BaseTest {
      *
      * @throws Exception if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -63,7 +63,7 @@ public class PythonPackageAnalyzerTest extends BaseTest {
      *
      * @throws Exception if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         analyzer.close();
@@ -74,35 +74,36 @@ public class PythonPackageAnalyzerTest extends BaseTest {
      * Test of getName method, of class PythonPackageAnalyzer.
      */
     @Test
-    public void testGetName() {
-        assertEquals("Analyzer name wrong.", "Python Package Analyzer",
-                analyzer.getName());
+    void testGetName() {
+        assertEquals("Python Package Analyzer",
+                analyzer.getName(),
+                "Analyzer name wrong.");
     }
 
     /**
      * Test of supportsExtension method, of class PythonPackageAnalyzer.
      */
     @Test
-    public void testSupportsFileExtension() {
-        assertTrue("Should support \"py\" extension.",
-                analyzer.accept(new File("test.py")));
+    void testSupportsFileExtension() {
+        assertTrue(analyzer.accept(new File("test.py")),
+                "Should support \"py\" extension.");
     }
 
     @Test
-    public void testAnalyzeSourceMetadata() throws AnalysisException {
+    void testAnalyzeSourceMetadata() throws AnalysisException {
         boolean found = false;
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(
                 this, "python/eggtest/__init__.py"));
         analyzer.analyze(result, null);
-        assertTrue("Expected vendor evidence to contain \"example\".", 
-                result.getEvidence(EvidenceType.VENDOR).toString().contains("example"));
+        assertTrue(result.getEvidence(EvidenceType.VENDOR).toString().contains("example"),
+                "Expected vendor evidence to contain \"example\".");
         for (final Evidence e : result.getEvidence(EvidenceType.VERSION)) {
             if ("0.0.1".equals(e.getValue())) {
                 found = true;
                 break;
             }
         }
-        assertTrue("Version 0.0.1 not found in EggTest dependency.", found);
+        assertTrue(found, "Version 0.0.1 not found in EggTest dependency.");
         assertEquals("0.0.1",result.getVersion());
         assertEquals("eggtest",result.getName());
         assertEquals("eggtest:0.0.1",result.getDisplayFileName());

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzerFiltersTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzerFiltersTest.java
@@ -17,20 +17,21 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.data.update.RetireJSDataSource;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.utils.Settings;
+
 import java.io.File;
 import java.util.List;
-import static org.junit.Assert.*;
-import org.owasp.dependencycheck.BaseDBTestCase;
-import org.owasp.dependencycheck.data.update.RetireJSDataSource;
 
-public class RetireJsAnalyzerFiltersTest extends BaseDBTestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RetireJsAnalyzerFiltersTest extends BaseDBTestCase {
 
     /**
      * Test of filters method.
@@ -38,7 +39,7 @@ public class RetireJsAnalyzerFiltersTest extends BaseDBTestCase {
      * @throws Exception is thrown when an exception occurs.
      */
     @Test
-    public void testFilters() throws Exception {
+    void testFilters() throws Exception {
 
         String[] filter = {"jQuery JavaScript Library"};
         getSettings().setArrayIfNotEmpty(Settings.KEYS.ANALYZER_RETIREJS_FILTERS, filter);
@@ -63,7 +64,7 @@ public class RetireJsAnalyzerFiltersTest extends BaseDBTestCase {
             //remove non-vulnerable
             file = BaseTest.getResourceAsFile(this, "javascript/custom.js");
             scanned = engine.scan(file);
-            assertTrue(scanned.size() == 1);
+            assertEquals(1, scanned.size());
             assertEquals(1, engine.getDependencies().length);
             analyzer.analyze(scanned.get(0), engine);
             assertEquals(0, engine.getDependencies().length);
@@ -71,7 +72,7 @@ public class RetireJsAnalyzerFiltersTest extends BaseDBTestCase {
             //kept because it is does not match the filter and is vulnerable
             file = BaseTest.getResourceAsFile(this, "javascript/ember.js");
             scanned = engine.scan(file);
-            assertTrue(scanned.size() == 1);
+            assertEquals(1, scanned.size());
             assertEquals(1, engine.getDependencies().length);
             analyzer.analyze(scanned.get(0), engine);
             assertEquals(1, engine.getDependencies().length);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzerIT.java
@@ -17,11 +17,13 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.data.update.RetireJSDataSource;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
 import org.owasp.dependencycheck.dependency.EvidenceType;
@@ -32,18 +34,15 @@ import java.io.File;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.owasp.dependencycheck.BaseDBTestCase;
-import org.owasp.dependencycheck.data.update.RetireJSDataSource;
-
-public class RetireJsAnalyzerIT extends BaseDBTestCase {
+class RetireJsAnalyzerIT extends BaseDBTestCase {
 
     private RetireJsAnalyzer analyzer;
     private Engine engine;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -57,7 +56,7 @@ public class RetireJsAnalyzerIT extends BaseDBTestCase {
         analyzer.prepare(engine);
     }
 
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         analyzer.close();
@@ -66,7 +65,7 @@ public class RetireJsAnalyzerIT extends BaseDBTestCase {
     }
 
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertThat(analyzer.getName(), is("RetireJS Analyzer"));
     }
 
@@ -74,11 +73,11 @@ public class RetireJsAnalyzerIT extends BaseDBTestCase {
      * Test of getSupportedExtensions method.
      */
     @Test
-    public void testAcceptSupportedExtensions() throws Exception {
+    void testAcceptSupportedExtensions() {
         analyzer.setEnabled(true);
         String[] files = {"test.js", "test.min.js"};
         for (String name : files) {
-            assertTrue(name, analyzer.accept(new File(name)));
+            assertTrue(analyzer.accept(new File(name)), name);
         }
     }
 
@@ -86,7 +85,7 @@ public class RetireJsAnalyzerIT extends BaseDBTestCase {
      * Test of getAnalysisPhase method.
      */
     @Test
-    public void testGetAnalysisPhase() {
+    void testGetAnalysisPhase() {
         AnalysisPhase expResult = AnalysisPhase.FINDING_ANALYSIS;
         AnalysisPhase result = analyzer.getAnalysisPhase();
         assertEquals(expResult, result);
@@ -96,7 +95,7 @@ public class RetireJsAnalyzerIT extends BaseDBTestCase {
      * Test of getAnalyzerEnabledSettingKey method.
      */
     @Test
-    public void testGetAnalyzerEnabledSettingKey() {
+    void testGetAnalyzerEnabledSettingKey() {
         String expResult = Settings.KEYS.ANALYZER_RETIREJS_ENABLED;
         String result = analyzer.getAnalyzerEnabledSettingKey();
         assertEquals(expResult, result);
@@ -108,7 +107,7 @@ public class RetireJsAnalyzerIT extends BaseDBTestCase {
      * @throws Exception is thrown when an exception occurs.
      */
     @Test
-    public void testJquery() throws Exception {
+    void testJquery() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "javascript/jquery-1.6.2.js");
         Dependency dependency = new Dependency(file);
         analyzer.analyze(dependency, engine);
@@ -138,7 +137,7 @@ public class RetireJsAnalyzerIT extends BaseDBTestCase {
      * @throws Exception is thrown when an exception occurs.
      */
     @Test
-    public void testAngular() throws Exception {
+    void testAngular() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "javascript/angular.safe.js");
         Dependency dependency = new Dependency(file);
         analyzer.analyze(dependency, engine);
@@ -156,8 +155,8 @@ public class RetireJsAnalyzerIT extends BaseDBTestCase {
         assertEquals("version", version.getName());
         assertEquals("1.2.27", version.getValue());
 
-        assertTrue("At leats 6 vulnerabilities should be detected",
-                dependency.getVulnerabilities().size() >= 6);
+        assertTrue(dependency.getVulnerabilities().size() >= 6,
+                "At leats 6 vulnerabilities should be detected");
         assertTrue(dependency.getVulnerabilities().contains(new Vulnerability("Universal CSP bypass via add-on in Firefox")));
         assertTrue(dependency.getVulnerabilities().contains(new Vulnerability("XSS in $sanitize in Safari/Firefox")));
         assertTrue(dependency.getVulnerabilities().contains(new Vulnerability("DOS in $sanitize")));
@@ -170,7 +169,7 @@ public class RetireJsAnalyzerIT extends BaseDBTestCase {
      * @throws Exception is thrown when an exception occurs.
      */
     @Test
-    public void testEmber() throws Exception {
+    void testEmber() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "javascript/ember.js");
         Dependency dependency = new Dependency(file);
         analyzer.analyze(dependency, engine);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzerIT.java
@@ -17,39 +17,40 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
+import org.owasp.dependencycheck.data.update.exception.UpdateException;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.dependency.Vulnerability;
 import org.owasp.dependencycheck.exception.ExceptionCollection;
+import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.owasp.dependencycheck.data.update.exception.UpdateException;
-import org.owasp.dependencycheck.exception.InitializationException;
+
+import java.io.File;
+
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import org.owasp.dependencycheck.dependency.EvidenceType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Unit tests for {@link RubyBundleAuditAnalyzer}.
  *
  * @author Dale Visser
  */
-public class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
+class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RubyBundleAuditAnalyzerIT.class);
 
@@ -63,7 +64,7 @@ public class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
      *
      * @throws Exception thrown if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -80,7 +81,7 @@ public class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         if (analyzer != null) {
@@ -94,7 +95,7 @@ public class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
      * Test Ruby Gemspec name.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertThat(analyzer.getName(), is("Ruby Bundle Audit Analyzer"));
     }
 
@@ -102,17 +103,16 @@ public class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
      * Test Ruby Bundler Audit file support.
      */
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         assertThat(analyzer.accept(new File("Gemfile.lock")), is(true));
     }
 
     /**
      * Test Ruby BundlerAudit analysis.
      *
-     * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalysis() throws AnalysisException, DatabaseException {
+    void testAnalysis() throws DatabaseException {
         try (Engine engine = new Engine(getSettings())) {
             engine.openDatabase();
             analyzer.prepare(engine);
@@ -132,11 +132,11 @@ public class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
                     break;
                 }
             }
-            assertTrue("redcarpet was not identified", found);
+            assertTrue(found, "redcarpet was not identified");
 
         } catch (InitializationException | DatabaseException | AnalysisException e) {
             LOGGER.warn("Exception setting up RubyBundleAuditAnalyzer. Make sure Ruby gem bundle-audit is installed. You may also need to set property \"analyzer.bundle.audit.path\".");
-            Assume.assumeNoException("Exception setting up RubyBundleAuditAnalyzer; bundle audit may not be installed, or property \"analyzer.bundle.audit.path\" may not be set.", e);
+            assumeTrue(false, "Exception setting up RubyBundleAuditAnalyzer; bundle audit may not be installed, or property \"analyzer.bundle.audit.path\" may not be set: " + e);
         }
     }
 
@@ -144,7 +144,7 @@ public class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
      * Test Ruby addCriticalityToVulnerability
      */
     @Test
-    public void testAddCriticalityToVulnerability() throws AnalysisException, DatabaseException {
+    void testAddCriticalityToVulnerability() throws DatabaseException {
         try (Engine engine = new Engine(getSettings())) {
             engine.doUpdates(true);
             analyzer.prepare(engine);
@@ -162,20 +162,19 @@ public class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
                     break;
                 }
             }
-            assertTrue("CVE-2015-3225 was not found among the vulnerabilities",found);
+            assertTrue(found,"CVE-2015-3225 was not found among the vulnerabilities");
         } catch (InitializationException | DatabaseException | AnalysisException | UpdateException e) {
             LOGGER.warn("Exception setting up RubyBundleAuditAnalyzer. Make sure Ruby gem bundle-audit is installed. You may also need to set property \"analyzer.bundle.audit.path\".");
-            Assume.assumeNoException("Exception setting up RubyBundleAuditAnalyzer; bundle audit may not be installed, or property \"analyzer.bundle.audit.path\" may not be set.", e);
+            assumeTrue(false, "Exception setting up RubyBundleAuditAnalyzer; bundle audit may not be installed, or property \"analyzer.bundle.audit.path\" may not be set: " + e);
         }
     }
 
     /**
      * Test when Ruby bundle-audit is not available on the system.
      *
-     * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testInvalidBundleAudit() throws AnalysisException, DatabaseException {
+    void testInvalidBundleAudit() throws DatabaseException {
 
         String path = BaseTest.getResourceAsFile(this, "ruby/invalid-bundle-audit").getAbsolutePath();
         getSettings().setString(Settings.KEYS.ANALYZER_BUNDLE_AUDIT_PATH, path);
@@ -195,11 +194,10 @@ public class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
     /**
      * Test Ruby dependencies and their paths.
      *
-     * @throws AnalysisException is thrown when an exception occurs.
      * @throws DatabaseException thrown when an exception occurs
      */
     @Test
-    public void testDependenciesPath() throws AnalysisException, DatabaseException {
+    void testDependenciesPath() throws DatabaseException {
         try (Engine engine = new Engine(getSettings())) {
             try {
                 engine.scan(BaseTest.getResourceAsFile(this, "ruby/vulnerable/gems/rails-4.1.15/"));
@@ -208,7 +206,7 @@ public class RubyBundleAuditAnalyzerIT extends BaseDBTestCase {
                 LOGGER.error("NPE", ex);
                 fail(ex.getMessage());
             } catch (ExceptionCollection ex) {
-                Assume.assumeNoException("Exception setting up RubyBundleAuditAnalyzer; bundle audit may not be installed, or property \"analyzer.bundle.audit.path\" may not be set.", ex);
+                assumeTrue(false, "Exception setting up RubyBundleAuditAnalyzer; bundle audit may not be installed, or property \"analyzer.bundle.audit.path\" may not be set: " + ex);
                 return;
             }
             Dependency[] dependencies = engine.getDependencies();

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundlerAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/RubyBundlerAnalyzerTest.java
@@ -17,27 +17,27 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.EvidenceType;
 
 import java.io.File;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import org.owasp.dependencycheck.dependency.EvidenceType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for {@link RubyBundlerAnalyzer}.
  *
  * @author Bianca Jiang
  */
-public class RubyBundlerAnalyzerTest extends BaseTest {
+class RubyBundlerAnalyzerTest extends BaseTest {
 
     /**
      * The analyzer to test.
@@ -49,7 +49,7 @@ public class RubyBundlerAnalyzerTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -64,7 +64,7 @@ public class RubyBundlerAnalyzerTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         analyzer.close();
@@ -75,7 +75,7 @@ public class RubyBundlerAnalyzerTest extends BaseTest {
      * Test Analyzer name.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertThat(analyzer.getName(), is("Ruby Bundler Analyzer"));
     }
 
@@ -83,7 +83,7 @@ public class RubyBundlerAnalyzerTest extends BaseTest {
      * Test Ruby Gemspec file support.
      */
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         assertThat(analyzer.accept(new File("test.gemspec")), is(false));
         assertThat(analyzer.accept(new File("specifications" + File.separator + "test.gemspec")), is(true));
         assertThat(analyzer.accept(new File("gemspec.lock")), is(false));
@@ -95,7 +95,7 @@ public class RubyBundlerAnalyzerTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzeGemspec() throws AnalysisException {
+    void testAnalyzeGemspec() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "ruby/vulnerable/gems/rails-4.1.15/vendor/bundle/ruby/2.2.0/specifications/dalli-2.7.5.gemspec"));
         analyzer.analyze(result, null);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/RubyGemspecAnalyzerTest.java
@@ -17,27 +17,27 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.EvidenceType;
 
 import java.io.File;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import org.owasp.dependencycheck.dependency.EvidenceType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for {@link RubyGemspecAnalyzer}.
  *
  * @author Dale Visser
  */
-public class RubyGemspecAnalyzerTest extends BaseTest {
+class RubyGemspecAnalyzerTest extends BaseTest {
 
     /**
      * The analyzer to test.
@@ -49,7 +49,7 @@ public class RubyGemspecAnalyzerTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -64,7 +64,7 @@ public class RubyGemspecAnalyzerTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         analyzer.close();
@@ -75,7 +75,7 @@ public class RubyGemspecAnalyzerTest extends BaseTest {
      * Test Ruby Gemspec name.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertThat(analyzer.getName(), is("Ruby Gemspec Analyzer"));
     }
 
@@ -83,7 +83,7 @@ public class RubyGemspecAnalyzerTest extends BaseTest {
      * Test Ruby Gemspec file support.
      */
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         assertThat(analyzer.accept(new File("test.gemspec")), is(true));
         assertThat(analyzer.accept(new File("gemspec.lock")), is(false));
 //        assertThat(analyzer.accept(new File("Rakefile")), is(true));
@@ -95,7 +95,7 @@ public class RubyGemspecAnalyzerTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testAnalyzePackageJson() throws AnalysisException {
+    void testAnalyzePackageJson() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "ruby/vulnerable/gems/specifications/rest-client-1.7.2.gemspec"));
         analyzer.analyze(result, null);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/SwiftAnalyzersTest.java
@@ -1,21 +1,21 @@
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertTrue;
+import org.owasp.dependencycheck.dependency.EvidenceType;
 
 import java.io.File;
-import org.owasp.dependencycheck.dependency.EvidenceType;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for CocoaPodsAnalyzer, CarthageAnalyzer and SwiftPackageManagerAnalyzer.
@@ -24,7 +24,7 @@ import org.owasp.dependencycheck.dependency.EvidenceType;
  * @author Jorge Mendes
  * @author Alin Radut
  */
-public class SwiftAnalyzersTest extends BaseTest {
+class SwiftAnalyzersTest extends BaseTest {
 
     /**
      * The analyzer to test.
@@ -39,7 +39,7 @@ public class SwiftAnalyzersTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -69,7 +69,7 @@ public class SwiftAnalyzersTest extends BaseTest {
      *
      * @throws Exception thrown if there is a problem
      */
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         podsAnalyzer.close();
@@ -85,7 +85,7 @@ public class SwiftAnalyzersTest extends BaseTest {
      * Test of getName method, of class CocoaPodsAnalyzer.
      */
     @Test
-    public void testPodsGetName() {
+    void testPodsGetName() {
         assertThat(podsAnalyzer.getName(), is("CocoaPods Package Analyzer"));
     }
 
@@ -93,7 +93,7 @@ public class SwiftAnalyzersTest extends BaseTest {
      * Test of getName method, of class CarthageAnalyzer.
      */
     @Test
-    public void testCarthageGetName() {
+    void testCarthageGetName() {
         assertThat(carthageAnalyzer.getName(), is("Carthage Package Analyzer"));
     }
 
@@ -101,7 +101,7 @@ public class SwiftAnalyzersTest extends BaseTest {
      * Test of getName method, of class SwiftPackageManagerAnalyzer.
      */
     @Test
-    public void testSPMGetName() {
+    void testSPMGetName() {
         assertThat(spmAnalyzer.getName(), is("SWIFT Package Manager Analyzer"));
     }
 
@@ -109,7 +109,7 @@ public class SwiftAnalyzersTest extends BaseTest {
      * Test of supportsFiles method, of class CocoaPodsAnalyzer.
      */
     @Test
-    public void testPodsSupportsFiles() {
+    void testPodsSupportsFiles() {
         assertThat(podsAnalyzer.accept(new File("test.podspec")), is(true));
         assertThat(podsAnalyzer.accept(new File("Podfile.lock")), is(true));
     }
@@ -118,7 +118,7 @@ public class SwiftAnalyzersTest extends BaseTest {
      * Test of supportsFiles method, of class CocoaPodsAnalyzer.
      */
     @Test
-    public void testCarthageSupportsFiles() {
+    void testCarthageSupportsFiles() {
         assertThat(carthageAnalyzer.accept(new File("Cartfile.resolved")), is(true));
     }
 
@@ -126,7 +126,7 @@ public class SwiftAnalyzersTest extends BaseTest {
      * Test of supportsFiles method, of class SwiftPackageManagerAnalyzer.
      */
     @Test
-    public void testSPMSupportsFiles() {
+    void testSPMSupportsFiles() {
         assertThat(spmAnalyzer.accept(new File("Package.swift")), is(true));
         assertThat(sprAnalyzer.accept(new File("Package.resolved")), is(true));
     }
@@ -137,7 +137,7 @@ public class SwiftAnalyzersTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testCocoaPodsPodfileAnalyzer() throws AnalysisException {
+    void testCocoaPodsPodfileAnalyzer() throws AnalysisException {
         final Engine engine = new Engine(getSettings());
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "swift/cocoapods/Podfile.lock"));
@@ -165,7 +165,7 @@ public class SwiftAnalyzersTest extends BaseTest {
     }
 
     @Test
-    public void testCocoaPodsPodspecAnalyzer() throws AnalysisException {
+    void testCocoaPodsPodspecAnalyzer() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "swift/cocoapods/EasyPeasy.podspec"));
         podsAnalyzer.analyze(result, null);
@@ -188,7 +188,7 @@ public class SwiftAnalyzersTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testCarthageCartfileResolvedAnalyzer() throws AnalysisException {
+    void testCarthageCartfileResolvedAnalyzer() throws AnalysisException {
         final Engine engine = new Engine(getSettings());
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "swift/carthage/Cartfile.resolved"));
@@ -221,7 +221,7 @@ public class SwiftAnalyzersTest extends BaseTest {
      * @throws AnalysisException is thrown when an exception occurs.
      */
     @Test
-    public void testSPMAnalyzer() throws AnalysisException {
+    void testSPMAnalyzer() throws AnalysisException {
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "swift/Gloss/Package.swift"));
         spmAnalyzer.analyze(result, null);
@@ -234,7 +234,7 @@ public class SwiftAnalyzersTest extends BaseTest {
     }
 
     @Test
-    public void testSPMResolvedAnalyzerV1() throws AnalysisException {
+    void testSPMResolvedAnalyzerV1() throws AnalysisException {
         final Engine engine = new Engine(getSettings());
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "swift/spm/Package.resolved"));
@@ -250,7 +250,7 @@ public class SwiftAnalyzersTest extends BaseTest {
     }
 
     @Test
-    public void testSPMResolvedAnalyzerV2() throws AnalysisException {
+    void testSPMResolvedAnalyzerV2() throws AnalysisException {
         final Engine engine = new Engine(getSettings());
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "swift/spmV2/Package.resolved"));
@@ -266,7 +266,7 @@ public class SwiftAnalyzersTest extends BaseTest {
     }
 
     @Test
-    public void testSPMResolvedAnalyzerV3() throws AnalysisException {
+    void testSPMResolvedAnalyzerV3() throws AnalysisException {
         final Engine engine = new Engine(getSettings());
         final Dependency result = new Dependency(BaseTest.getResourceAsFile(this,
                 "swift/spmV3/Package.resolved"));
@@ -282,7 +282,7 @@ public class SwiftAnalyzersTest extends BaseTest {
     }
 
     @Test
-    public void testIsEnabledIsTrueByDefault() {
+    void testIsEnabledIsTrueByDefault() {
         assertTrue(spmAnalyzer.isEnabled());
         assertTrue(sprAnalyzer.isEnabled());
     }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/UnusedSuppressionRuleAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/UnusedSuppressionRuleAnalyzerTest.java
@@ -1,42 +1,42 @@
 package org.owasp.dependencycheck.analyzer;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
-import static org.owasp.dependencycheck.analyzer.AbstractSuppressionAnalyzer.SUPPRESSION_OBJECT_KEY;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
-import static org.owasp.dependencycheck.analyzer.UnusedSuppressionRuleAnalyzer.EXCEPTION_MSG;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.naming.Identifier;
 import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
 import org.owasp.dependencycheck.utils.Settings;
-import org.owasp.dependencycheck.xml.suppression.SuppressionRule;
 import org.owasp.dependencycheck.xml.suppression.PropertyType;
+import org.owasp.dependencycheck.xml.suppression.SuppressionRule;
 
-public class UnusedSuppressionRuleAnalyzerTest extends BaseTest {
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.owasp.dependencycheck.analyzer.AbstractSuppressionAnalyzer.SUPPRESSION_OBJECT_KEY;
+import static org.owasp.dependencycheck.analyzer.UnusedSuppressionRuleAnalyzer.EXCEPTION_MSG;
+
+class UnusedSuppressionRuleAnalyzerTest extends BaseTest {
 	private static final String NAME = "Unused Suppression Rule Analyzer";
 	private static final String PACKAGE_NAME = "CoolAsACucumber";
 	private static final String EXPECTED_EX = "should have thrown an AnalysisException";
 
     @Test
-    public void testGetName() {
+    void testGetName() {
         UnusedSuppressionRuleAnalyzer analyzer = new UnusedSuppressionRuleAnalyzer();
         assertEquals(NAME, analyzer.getName());
     }
 
     @Test
-    public void testException() throws Exception {
+    void testException() throws Exception {
 		boolean shouldFail = true;
 		Dependency dependency10 = getDependency("1.0");
 		Dependency dependency11 = getDependency("1.1");
-		
+
 		UnusedSuppressionRuleAnalyzer analyzer = getAnalyzer(shouldFail);
 		Engine engine = getEngine(true, false, dependency10, dependency11);
 		try {
@@ -45,7 +45,7 @@ public class UnusedSuppressionRuleAnalyzerTest extends BaseTest {
 		} catch(AnalysisException ok){
 			assertEquals(String.format(EXCEPTION_MSG, 1), ok.getMessage());
 		}
-		
+
 		// no exception
 		shouldFail = false;
 		analyzer = getAnalyzer(shouldFail);
@@ -53,14 +53,14 @@ public class UnusedSuppressionRuleAnalyzerTest extends BaseTest {
 		analyzer.analyzeDependency(dependency10, engine);
     	assertEquals(1, analyzer.getUnusedSuppressionRuleCount());
 	}
-	
+
     @Test
-    public void testCheckUnusedRules() throws Exception {
+    void testCheckUnusedRules() throws Exception {
 		// flag unset
 		boolean shouldFail = false;
 		Dependency dependency10 = getDependency("1.0");
 		Dependency dependency11 = getDependency("1.1");
-		
+
 		// a run without any suppression rule ➫ no unused suppression
 		checkUnusedRules(shouldFail, 0, false, false, dependency10);
 
@@ -70,7 +70,7 @@ public class UnusedSuppressionRuleAnalyzerTest extends BaseTest {
 		// a run with the vulnerable package ➫ no unused suppression
 		checkUnusedRules(shouldFail, 0, true, true, dependency10, dependency11);
 
-			
+
 		// set flag
 		shouldFail = true;
 
@@ -83,31 +83,31 @@ public class UnusedSuppressionRuleAnalyzerTest extends BaseTest {
 		// a run with the vulnerable package ➫ no unused suppression
 		checkUnusedRules(shouldFail, 0, true, true, dependency10, dependency11);
     }
-	
-	private void checkUnusedRules(boolean shouldFail, int expectedCount, 
+
+	private void checkUnusedRules(boolean shouldFail, int expectedCount,
 		boolean withSuppressionRules, boolean matching,
-		Dependency ... dependencies) throws Exception {
+		Dependency ... dependencies) {
         UnusedSuppressionRuleAnalyzer analyzer = getAnalyzer(shouldFail);
 		assertNotNull(analyzer);
 		Engine engine = getEngine(withSuppressionRules, matching, dependencies);
 		analyzer.checkUnusedRules(engine);
 		assertEquals(expectedCount, analyzer.getUnusedSuppressionRuleCount());
 	}
-	
-		
+
+
 	private Dependency getDependency(String type, String namespace, String name, String version) throws Exception {
         Dependency dependency = new Dependency();
 		Identifier id = new PurlIdentifier(type,namespace,name,version,Confidence.HIGHEST);
         dependency.addSoftwareIdentifier(id);
 		return dependency;
 	}
-	
+
 	private Dependency getDependency(String version) throws Exception {
 		return getDependency("maven", "test", PACKAGE_NAME, version);
-	}	
+	}
 
-	
-	private Engine getEngine(boolean hasSuppressionRules, boolean matching, Dependency ... dependencies) throws Exception {
+
+	private Engine getEngine(boolean hasSuppressionRules, boolean matching, Dependency ... dependencies) {
         Engine engine = new Engine(getSettings());
 		List<Dependency> dependencyList = new ArrayList<>();
 		if (dependencies!=null) {
@@ -121,20 +121,20 @@ public class UnusedSuppressionRuleAnalyzerTest extends BaseTest {
 		engine.putObject(SUPPRESSION_OBJECT_KEY,rules);
 		return engine;
 	}
-	
-	private UnusedSuppressionRuleAnalyzer getAnalyzer(boolean flag) throws AnalysisException {
+
+	private UnusedSuppressionRuleAnalyzer getAnalyzer(boolean flag) {
         UnusedSuppressionRuleAnalyzer analyzer = new UnusedSuppressionRuleAnalyzer();
 		assertNotNull(analyzer);
-		
+
 		Settings settings = getSettings();
         settings.setBoolean(Settings.KEYS.FAIL_ON_UNUSED_SUPPRESSION_RULE, flag);
         analyzer.initialize(settings);
         assertEquals(flag, analyzer.failsForUnusedSuppressionRule());
         assertEquals(0, analyzer.getUnusedSuppressionRuleCount());
-		
-		return analyzer;		
+
+		return analyzer;
 	}
-	
+
 	private SuppressionRule getSuppressionRule(boolean matching) {
         SuppressionRule instance = new SuppressionRule();
 		instance.addVulnerabilityName(getPropertyType("CVE-2023-5072", false, false));
@@ -144,7 +144,7 @@ public class UnusedSuppressionRuleAnalyzerTest extends BaseTest {
 		instance.setMatched(matching);
 		return instance;
     }
-	
+
 	private PropertyType getPropertyType(String value, boolean regex, boolean caseSensitive) {
 		PropertyType property = new PropertyType();
 		property.setValue(value);
@@ -152,6 +152,6 @@ public class UnusedSuppressionRuleAnalyzerTest extends BaseTest {
 		property.setCaseSensitive(caseSensitive);
 		return property;
 	}
-	
+
 
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/VersionFilterAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/VersionFilterAnalyzerTest.java
@@ -17,25 +17,27 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.utils.Settings;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 /**
  *
  * @author Jeremy Long
  */
-public class VersionFilterAnalyzerTest extends BaseTest {
+class VersionFilterAnalyzerTest extends BaseTest {
 
     /**
      * Test of getName method, of class VersionFilterAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         VersionFilterAnalyzer instance = new VersionFilterAnalyzer();
         String expResult = "Version Filter Analyzer";
         String result = instance.getName();
@@ -46,7 +48,7 @@ public class VersionFilterAnalyzerTest extends BaseTest {
      * Test of getAnalysisPhase method, of class VersionFilterAnalyzer.
      */
     @Test
-    public void testGetAnalysisPhase() {
+    void testGetAnalysisPhase() {
         VersionFilterAnalyzer instance = new VersionFilterAnalyzer();
         instance.initialize(getSettings());
         AnalysisPhase expResult = AnalysisPhase.POST_INFORMATION_COLLECTION3;
@@ -59,7 +61,7 @@ public class VersionFilterAnalyzerTest extends BaseTest {
      * VersionFilterAnalyzer.
      */
     @Test
-    public void testGetAnalyzerEnabledSettingKey() {
+    void testGetAnalyzerEnabledSettingKey() {
         VersionFilterAnalyzer instance = new VersionFilterAnalyzer();
         instance.initialize(getSettings());
         String expResult = Settings.KEYS.ANALYZER_VERSION_FILTER_ENABLED;
@@ -71,7 +73,7 @@ public class VersionFilterAnalyzerTest extends BaseTest {
      * Test of analyzeDependency method, of class VersionFilterAnalyzer.
      */
     @Test
-    public void testAnalyzeDependency() throws Exception {
+    void testAnalyzeDependency() throws Exception {
         Dependency dependency = new Dependency();
 
         dependency.addEvidence(EvidenceType.VERSION, "util", "version", "33.3", Confidence.HIGHEST);
@@ -112,7 +114,7 @@ public class VersionFilterAnalyzerTest extends BaseTest {
      * Test of analyzeDependency method, of class VersionFilterAnalyzer.
      */
     @Test
-    public void testAnalyzeDependencyFilePom() throws Exception {
+    void testAnalyzeDependencyFilePom() throws Exception {
         Dependency dependency = new Dependency();
 
         dependency.addEvidence(EvidenceType.VERSION, "util", "version", "33.3", Confidence.HIGHEST);
@@ -149,7 +151,7 @@ public class VersionFilterAnalyzerTest extends BaseTest {
      * Test of analyzeDependency method, of class VersionFilterAnalyzer.
      */
     @Test
-    public void testAnalyzeDependencyFileManifest() throws Exception {
+    void testAnalyzeDependencyFileManifest() throws Exception {
         Dependency dependency = new Dependency();
 
         dependency.addEvidence(EvidenceType.VERSION, "util", "version", "33.3", Confidence.HIGHEST);
@@ -176,7 +178,7 @@ public class VersionFilterAnalyzerTest extends BaseTest {
      * Test of analyzeDependency method, of class VersionFilterAnalyzer.
      */
     @Test
-    public void testAnalyzeDependencyPomManifest() throws Exception {
+    void testAnalyzeDependencyPomManifest() throws Exception {
         Dependency dependency = new Dependency();
 
         dependency.addEvidence(EvidenceType.VERSION, "util", "version", "33.3", Confidence.HIGHEST);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/VulnerabilitySuppressionAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/VulnerabilitySuppressionAnalyzerIT.java
@@ -17,28 +17,30 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.utils.Settings;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Testing the vulnerability suppression analyzer.
  *
  * @author Jeremy Long
  */
-public class VulnerabilitySuppressionAnalyzerIT extends BaseDBTestCase {
+class VulnerabilitySuppressionAnalyzerIT extends BaseDBTestCase {
 
     /**
      * Test of getName method, of class VulnerabilitySuppressionAnalyzer.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         VulnerabilitySuppressionAnalyzer instance = new VulnerabilitySuppressionAnalyzer();
         instance.initialize(getSettings());
         String expResult = "Vulnerability Suppression Analyzer";
@@ -51,7 +53,7 @@ public class VulnerabilitySuppressionAnalyzerIT extends BaseDBTestCase {
      * VulnerabilitySuppressionAnalyzer.
      */
     @Test
-    public void testGetAnalysisPhase() {
+    void testGetAnalysisPhase() {
         VulnerabilitySuppressionAnalyzer instance = new VulnerabilitySuppressionAnalyzer();
         instance.initialize(getSettings());
         AnalysisPhase expResult = AnalysisPhase.POST_FINDING_ANALYSIS;
@@ -63,7 +65,7 @@ public class VulnerabilitySuppressionAnalyzerIT extends BaseDBTestCase {
      * Test of analyze method, of class VulnerabilitySuppressionAnalyzer.
      */
     @Test
-    public void testAnalyze() throws Exception {
+    void testAnalyze() throws Exception {
 
         File file = BaseTest.getResourceAsFile(this, "commons-fileupload-1.2.1.jar");
         File suppression = BaseTest.getResourceAsFile(this, "commons-fileupload-1.2.1.suppression.xml");
@@ -81,7 +83,7 @@ public class VulnerabilitySuppressionAnalyzerIT extends BaseDBTestCase {
             cpeSize = dependency.getVulnerableSoftwareIdentifiers().size();
             assertTrue(cveSize > 0);
             assertTrue(cpeSize > 0);
-            
+
         }
         getSettings().setString(Settings.KEYS.SUPPRESSION_FILE, suppression.getAbsolutePath());
         try (Engine engine = new Engine(getSettings())) {

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzerIT.java
@@ -17,32 +17,32 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.EvidenceType;
 import org.owasp.dependencycheck.exception.InitializationException;
-import org.owasp.dependencycheck.utils.InvalidSettingException;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class YarnAuditAnalyzerIT extends BaseTest {
+class YarnAuditAnalyzerIT extends BaseTest {
 
     @Test
-    public void testAnalyzePackageYarnClassic() throws AnalysisException, InitializationException, InvalidSettingException {
+    void testAnalyzePackageYarnClassic() throws AnalysisException {
         testAnalyzePackageYarn("yarn/yarn-classic-audit/yarn.lock");
     }
 
     @Test
-    public void testAnalyzePackageYarnBerry() throws AnalysisException, InitializationException, InvalidSettingException {
+    void testAnalyzePackageYarnBerry() throws AnalysisException {
         testAnalyzePackageYarn("yarn/yarn-berry-audit/yarn.lock");
     }
 
     @Test
-    public void testAnalyzePackageYarnBerryNoVulnerability() throws AnalysisException, InitializationException, InvalidSettingException {
+    void testAnalyzePackageYarnBerryNoVulnerability() throws AnalysisException {
         //Assume.assumeThat(getSettings().getBoolean(Settings.KEYS.ANALYZER_YARN_AUDIT_ENABLED), is(true));
         try (Engine engine = new Engine(getSettings())) {
             var analyzer = new YarnAuditAnalyzer();
@@ -51,10 +51,10 @@ public class YarnAuditAnalyzerIT extends BaseTest {
             analyzer.prepare(engine);
             final Dependency toScan = new Dependency(BaseTest.getResourceAsFile(this, "yarn/yarn-berry-audit-no-vulnerability/yarn.lock"));
             analyzer.analyze(toScan, engine);
-            assertTrue("No dependency should be identified", engine.getDependencies().length == 0);
+            assertEquals(0, engine.getDependencies().length, "No dependency should be identified");
         } catch (InitializationException ex) {
             //yarn is not installed - skip the test case.
-            Assume.assumeNoException(ex);
+            assumeTrue(false, ex.toString());
         }
     }
 
@@ -68,20 +68,20 @@ public class YarnAuditAnalyzerIT extends BaseTest {
             final Dependency toScan = new Dependency(BaseTest.getResourceAsFile(this, yarnLockFile));
             analyzer.analyze(toScan, engine);
             boolean found = false;
-            assertTrue("More then 1 dependency should be identified", 1 < engine.getDependencies().length);
+            assertTrue(1 < engine.getDependencies().length, "More then 1 dependency should be identified");
             for (Dependency result : engine.getDependencies()) {
                 if ("yarn.lock?uglify-js".equals(result.getFileName())) {
                     found = true;
                     assertTrue(result.getEvidence(EvidenceType.VENDOR).toString().contains("uglify-js"));
                     assertTrue(result.getEvidence(EvidenceType.PRODUCT).toString().contains("uglify-js"));
-                    assertTrue("Unable to find version 2.4.24: " + result.getEvidence(EvidenceType.VERSION).toString(), result.getEvidence(EvidenceType.VERSION).toString().contains("2.4.24"));
+                    assertTrue(result.getEvidence(EvidenceType.VERSION).toString().contains("2.4.24"), "Unable to find version 2.4.24: " + result.getEvidence(EvidenceType.VERSION).toString());
                     assertTrue(result.isVirtual());
                 }
             }
-            assertTrue("Uglify was not found", found);
+            assertTrue(found, "Uglify was not found");
         } catch (InitializationException ex) {
             //yarn is not installed - skip the test case.
-            Assume.assumeNoException(ex);
+            assumeTrue(false, ex.toString());
         }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzerTest.java
@@ -1,23 +1,23 @@
 package org.owasp.dependencycheck.analyzer;
 
-import java.io.File;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
+
+import java.io.File;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class YarnAuditAnalyzerTest extends BaseTest {
+class YarnAuditAnalyzerTest extends BaseTest {
 
     @Test
-    public void testGetName() {
+    void testGetName() {
         YarnAuditAnalyzer analyzer = new YarnAuditAnalyzer();
         assertThat(analyzer.getName(), is("Yarn Audit Analyzer"));
     }
 
     @Test
-    public void testSupportsFiles() {
+    void testSupportsFiles() {
         YarnAuditAnalyzer analyzer = new YarnAuditAnalyzer();
         assertThat(analyzer.accept(new File("package-lock.json")), is(false));
         assertThat(analyzer.accept(new File("npm-shrinkwrap.json")), is(false));

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchIT.java
@@ -17,8 +17,8 @@
  */
 package org.owasp.dependencycheck.data.artifactory;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.utils.Settings;
@@ -27,15 +27,15 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@Ignore
-public class ArtifactorySearchIT {
+@Disabled
+class ArtifactorySearchIT {
 
 
     @Test
-    public void testWithRealInstanceUsingBearerToken() throws IOException {
+    void testWithRealInstanceUsingBearerToken() throws IOException {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
@@ -63,7 +63,7 @@ public class ArtifactorySearchIT {
     }
 
     @Test
-    public void testWithRealInstanceAnonymous() throws IOException {
+    void testWithRealInstanceAnonymous() throws IOException {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
@@ -82,7 +82,7 @@ public class ArtifactorySearchIT {
     }
 
     @Test
-    public void testWithRealInstanceWithUserToken() throws IOException {
+    void testWithRealInstanceWithUserToken() throws IOException {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("0695b63d702f505b9b916e02272e3b6381bade7f");

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchIT.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Disabled
 class ArtifactorySearchIT {
@@ -63,7 +63,7 @@ class ArtifactorySearchIT {
     }
 
     @Test
-    void testWithRealInstanceAnonymous() throws IOException {
+    void testWithRealInstanceAnonymous() {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
@@ -72,13 +72,10 @@ class ArtifactorySearchIT {
         settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_URL, "https://artifactory.techno.ingenico.com/artifactory");
         final ArtifactorySearch artifactorySearch = new ArtifactorySearch(settings);
         // When
-        try {
-            artifactorySearch.search(dependency);
-            fail("No Match found, should throw an exception!");
-        } catch (FileNotFoundException e) {
-            // Then
-            assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory", e.getMessage());
-        }
+        FileNotFoundException e = assertThrows(FileNotFoundException.class, () -> artifactorySearch.search(dependency),
+                "No Match found, should throw an exception!");
+        // Then
+        assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory", e.getMessage());
     }
 
     @Test

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchResponseHandlerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchResponseHandlerTest.java
@@ -23,8 +23,8 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpEntity;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.dependency.Dependency;
@@ -36,21 +36,21 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ArtifactorySearchResponseHandlerTest extends BaseTest {
+class ArtifactorySearchResponseHandlerTest extends BaseTest {
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
     }
 
     @Test
-    public void shouldProcessCorrectlyArtifactoryAnswerWithoutSha256() throws IOException {
+    void shouldProcessCorrectlyArtifactoryAnswerWithoutSha256() throws IOException {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("2e66da15851f9f5b5079228f856c2f090ba98c38");
@@ -105,7 +105,7 @@ public class ArtifactorySearchResponseHandlerTest extends BaseTest {
     }
 
     @Test
-    public void shouldProcessCorrectlyArtifactoryAnswerWithMultipleMatches() throws IOException {
+    void shouldProcessCorrectlyArtifactoryAnswerWithMultipleMatches() throws IOException {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("94a9ce681a42d0352b3ad22659f67835e560d107");
@@ -146,7 +146,7 @@ public class ArtifactorySearchResponseHandlerTest extends BaseTest {
      * @throws IOException
      */
     @Test
-    public void shouldProcessCorrectlyForMissingXResultDetailHeader() throws IOException {
+    void shouldProcessCorrectlyForMissingXResultDetailHeader() throws IOException {
         // Inject logback ListAppender to capture test-logs from ArtifactorySearchResponseHandler
         final Logger sutLogger = (Logger) LoggerFactory.getLogger(ArtifactorySearchResponseHandler.class);
         final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
@@ -178,7 +178,7 @@ public class ArtifactorySearchResponseHandlerTest extends BaseTest {
 
             // There should be a WARN-log for for each of the results regarding the absence of X-Result-Detail header driven attributes
             final List<ILoggingEvent> logsList = listAppender.list;
-            assertEquals("Number of log entries for the ArtifactorySearchResponseHandler", 2, logsList.size());
+            assertEquals(2, logsList.size(), "Number of log entries for the ArtifactorySearchResponseHandler");
 
             ILoggingEvent logEvent = logsList.get(0);
             assertEquals(Level.WARN, logEvent.getLevel());
@@ -201,7 +201,7 @@ public class ArtifactorySearchResponseHandlerTest extends BaseTest {
     }
 
     @Test
-    public void shouldHandleNoMatches() throws IOException {
+    void shouldHandleNoMatches() throws IOException {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("94a9ce681a42d0352b3ad22659f67835e560d108");
@@ -289,7 +289,7 @@ public class ArtifactorySearchResponseHandlerTest extends BaseTest {
     }
 
     @Test
-    public void shouldProcessCorrectlyArtifactoryAnswer() throws IOException {
+    void shouldProcessCorrectlyArtifactoryAnswer() throws IOException {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
@@ -410,7 +410,7 @@ public class ArtifactorySearchResponseHandlerTest extends BaseTest {
     }
 
     @Test
-    public void shouldProcessCorrectlyArtifactoryAnswerMisMatchMd5() throws IOException {
+    void shouldProcessCorrectlyArtifactoryAnswerMisMatchMd5() throws IOException {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
@@ -429,14 +429,14 @@ public class ArtifactorySearchResponseHandlerTest extends BaseTest {
             fail("MD5 mismatching should throw an exception!");
         } catch (FileNotFoundException e) {
             // Then
-            assertEquals("Artifact " + dependency.toString()
+            assertEquals("Artifact " + dependency
                     + " not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts", e.getMessage());
 
         }
     }
 
     @Test
-    public void shouldProcessCorrectlyArtifactoryAnswerMisMatchSha1() throws IOException {
+    void shouldProcessCorrectlyArtifactoryAnswerMisMatchSha1() throws IOException {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0e");
@@ -460,7 +460,7 @@ public class ArtifactorySearchResponseHandlerTest extends BaseTest {
     }
 
     @Test
-    public void shouldProcessCorrectlyArtifactoryAnswerMisMatchSha256() throws IOException {
+    void shouldProcessCorrectlyArtifactoryAnswerMisMatchSha256() throws IOException {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
@@ -484,7 +484,7 @@ public class ArtifactorySearchResponseHandlerTest extends BaseTest {
     }
 
     @Test
-    public void shouldThrowNotFoundWhenPatternCannotBeParsed() throws IOException {
+    void shouldThrowNotFoundWhenPatternCannotBeParsed() throws IOException {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
@@ -509,7 +509,7 @@ public class ArtifactorySearchResponseHandlerTest extends BaseTest {
     }
 
     @Test
-    public void shouldSkipResultsWherePatternCannotBeParsed() throws IOException {
+    void shouldSkipResultsWherePatternCannotBeParsed() throws IOException {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchResponseHandlerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchResponseHandlerTest.java
@@ -37,7 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -168,36 +168,35 @@ class ArtifactorySearchResponseHandlerTest extends BaseTest {
 
         // When
         final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
-        try {
-            handler.handleResponse(response);
-            fail("Result with no details due to missing X-Result-Detail header, should throw an exception!");
-        } catch (FileNotFoundException e) {
-            // Then
-            assertEquals("Artifact Dependency{ fileName='freemarker-2.3.33.jar', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts",
-                    e.getMessage());
 
-            // There should be a WARN-log for for each of the results regarding the absence of X-Result-Detail header driven attributes
-            final List<ILoggingEvent> logsList = listAppender.list;
-            assertEquals(2, logsList.size(), "Number of log entries for the ArtifactorySearchResponseHandler");
+        FileNotFoundException e = assertThrows(FileNotFoundException.class, () -> handler.handleResponse(response),
+                "Result with no details due to missing X-Result-Detail header, should throw an exception!");
 
-            ILoggingEvent logEvent = logsList.get(0);
-            assertEquals(Level.WARN, logEvent.getLevel());
-            assertEquals("No checksums found in artifactory search result of uri {}. Please make sure that header X-Result-Detail is retained on any (reverse)-proxy, loadbalancer or WebApplicationFirewall in the network path to your Artifactory Server", logEvent.getMessage());
-            Object[] args = logEvent.getArgumentArray();
-            assertEquals(1, args.length);
-            assertEquals("https://artifactory.example.com:443/artifactory/api/storage/maven-central-cache/org/freemarker/freemarker/2.3.33/freemarker-2.3.33.jar", args[0]);
+        // Then
+        assertEquals("Artifact Dependency{ fileName='freemarker-2.3.33.jar', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts",
+                e.getMessage());
 
-            logEvent = logsList.get(1);
-            assertEquals(Level.WARN, logEvent.getLevel());
-            assertEquals("No checksums found in artifactory search result of uri {}. Please make sure that header X-Result-Detail is retained on any (reverse)-proxy, loadbalancer or WebApplicationFirewall in the network path to your Artifactory Server", logEvent.getMessage());
-            args = logEvent.getArgumentArray();
-            assertEquals(1, args.length);
-            assertEquals("https://artifactory.example.com:443/artifactory/api/storage/gradle-plugins-extended-cache/org/freemarker/freemarker/2.3.33/freemarker-2.3.33.jar", args[0]);
+        // There should be a WARN-log for for each of the results regarding the absence of X-Result-Detail header driven attributes
+        final List<ILoggingEvent> logsList = listAppender.list;
+        assertEquals(2, logsList.size(), "Number of log entries for the ArtifactorySearchResponseHandler");
 
-            // Remove our manually injected additional appender
-            sutLogger.detachAppender(listAppender);
-            listAppender.stop();
-        }
+        ILoggingEvent logEvent = logsList.get(0);
+        assertEquals(Level.WARN, logEvent.getLevel());
+        assertEquals("No checksums found in artifactory search result of uri {}. Please make sure that header X-Result-Detail is retained on any (reverse)-proxy, loadbalancer or WebApplicationFirewall in the network path to your Artifactory Server", logEvent.getMessage());
+        Object[] args = logEvent.getArgumentArray();
+        assertEquals(1, args.length);
+        assertEquals("https://artifactory.example.com:443/artifactory/api/storage/maven-central-cache/org/freemarker/freemarker/2.3.33/freemarker-2.3.33.jar", args[0]);
+
+        logEvent = logsList.get(1);
+        assertEquals(Level.WARN, logEvent.getLevel());
+        assertEquals("No checksums found in artifactory search result of uri {}. Please make sure that header X-Result-Detail is retained on any (reverse)-proxy, loadbalancer or WebApplicationFirewall in the network path to your Artifactory Server", logEvent.getMessage());
+        args = logEvent.getArgumentArray();
+        assertEquals(1, args.length);
+        assertEquals("https://artifactory.example.com:443/artifactory/api/storage/gradle-plugins-extended-cache/org/freemarker/freemarker/2.3.33/freemarker-2.3.33.jar", args[0]);
+
+        // Remove our manually injected additional appender
+        sutLogger.detachAppender(listAppender);
+        listAppender.stop();
     }
 
     @Test
@@ -214,14 +213,11 @@ class ArtifactorySearchResponseHandlerTest extends BaseTest {
 
         // When
         final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
-        try {
-            handler.handleResponse(response);
-            fail("No Match found, should throw an exception!");
-        } catch (FileNotFoundException e) {
-            // Then
-            assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory",
-                    e.getMessage());
-        }
+        FileNotFoundException e = assertThrows(FileNotFoundException.class, () -> handler.handleResponse(response),
+                "No Match found, should throw an exception!");
+        // Then
+        assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory",
+                e.getMessage());
     }
 
     private byte[] multipleMatchesPayload() {
@@ -424,15 +420,12 @@ class ArtifactorySearchResponseHandlerTest extends BaseTest {
 
         // When
         final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
-        try {
-            handler.handleResponse(response);
-            fail("MD5 mismatching should throw an exception!");
-        } catch (FileNotFoundException e) {
-            // Then
-            assertEquals("Artifact " + dependency
-                    + " not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts", e.getMessage());
+        FileNotFoundException e = assertThrows(FileNotFoundException.class, () -> handler.handleResponse(response),
+                "MD5 mismatching should throw an exception!");
 
-        }
+        // Then
+        assertEquals("Artifact " + dependency
+                + " not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts", e.getMessage());
     }
 
     @Test
@@ -450,13 +443,11 @@ class ArtifactorySearchResponseHandlerTest extends BaseTest {
 
         // When
         final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
-        try {
-            handler.handleResponse(response);
-            fail("SHA1 mismatching should throw an exception!");
-        } catch (FileNotFoundException e) {
-            // Then
-            assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts", e.getMessage());
-        }
+        FileNotFoundException e = assertThrows(FileNotFoundException.class, () -> handler.handleResponse(response),
+                "SHA1 mismatching should throw an exception!");
+
+        // Then
+        assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts", e.getMessage());
     }
 
     @Test
@@ -474,13 +465,11 @@ class ArtifactorySearchResponseHandlerTest extends BaseTest {
 
         // When
         final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
-        try {
-            handler.handleResponse(response);
-            fail("SHA256 mismatching should throw an exception!");
-        } catch (FileNotFoundException e) {
-            // Then
-            assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts", e.getMessage());
-        }
+        FileNotFoundException e = assertThrows(FileNotFoundException.class, () -> handler.handleResponse(response),
+                "SHA256 mismatching should throw an exception!");
+
+        // Then
+        assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts", e.getMessage());
     }
 
     @Test
@@ -499,13 +488,11 @@ class ArtifactorySearchResponseHandlerTest extends BaseTest {
 
         // When
         final ArtifactorySearchResponseHandler handler = new ArtifactorySearchResponseHandler(dependency);
-        try {
-            handler.handleResponse(response);
-            fail("Maven GAV pattern mismatch for filepath should throw a not found exception!");
-        } catch (FileNotFoundException e) {
+        FileNotFoundException e = assertThrows(FileNotFoundException.class, () -> handler.handleResponse(response),
+                "Maven GAV pattern mismatch for filepath should throw a not found exception!");
+
             // Then
             assertEquals("Artifact Dependency{ fileName='null', actualFilePath='null', filePath='null', packagePath='null'} not found in Artifactory; discovered sha1 hits not recognized as matching maven artifacts", e.getMessage());
-        }
     }
 
     @Test

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
@@ -17,10 +17,10 @@
  */
 package org.owasp.dependencycheck.data.artifactory;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.utils.Settings;
@@ -28,17 +28,16 @@ import org.owasp.dependencycheck.utils.Settings;
 import java.io.IOException;
 import java.net.UnknownHostException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class ArtifactorySearchTest extends BaseTest {
+class ArtifactorySearchTest extends BaseTest {
     private static String httpsProxyHostOrig;
     private static String httpsPortOrig;
 
-    @BeforeClass
-    public static void tinkerProxies() {
+    @BeforeAll
+    static void tinkerProxies() {
         httpsProxyHostOrig = System.getProperty("https.proxyHost");
         if (httpsProxyHostOrig == null) {
             httpsProxyHostOrig = System.getenv("https.proxyHost");
@@ -51,8 +50,8 @@ public class ArtifactorySearchTest extends BaseTest {
         System.setProperty("https.proxyPort", "");
     }
 
-    @AfterClass
-    public static void restoreProxies() {
+    @AfterAll
+    static void restoreProxies() {
         if (httpsProxyHostOrig != null) {
             System.setProperty("https.proxyHost", httpsProxyHostOrig);
         }
@@ -61,7 +60,7 @@ public class ArtifactorySearchTest extends BaseTest {
         }
     }
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -69,7 +68,7 @@ public class ArtifactorySearchTest extends BaseTest {
 
 
     @Test
-    public void shouldFailWhenHostUnknown() throws IOException {
+    void shouldFailWhenHostUnknown() throws IOException {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");

--- a/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/artifactory/ArtifactorySearchTest.java
@@ -25,12 +25,11 @@ import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.utils.Settings;
 
-import java.io.IOException;
 import java.net.UnknownHostException;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class ArtifactorySearchTest extends BaseTest {
     private static String httpsProxyHostOrig;
@@ -68,7 +67,7 @@ class ArtifactorySearchTest extends BaseTest {
 
 
     @Test
-    void shouldFailWhenHostUnknown() throws IOException {
+    void shouldFailWhenHostUnknown() {
         // Given
         Dependency dependency = new Dependency();
         dependency.setSha1sum("c5b4c491aecb72e7c32a78da0b5c6b9cda8dee0f");
@@ -79,14 +78,12 @@ class ArtifactorySearchTest extends BaseTest {
         settings.setString(Settings.KEYS.ANALYZER_ARTIFACTORY_URL, "https://artifactory.techno.ingenico.com.invalid/artifactory");
         final ArtifactorySearch artifactorySearch = new ArtifactorySearch(settings);
         // When
-        try {
-            artifactorySearch.search(dependency);
-            fail("Should have thrown an UnknownHostException");
-        } catch (UnknownHostException exception) {
-            // Then
-            assertNotNull(exception.getMessage());
-            assertTrue(exception.getMessage().contains("artifactory.techno.ingenico.com.invalid"));
-        }
+        UnknownHostException exception = assertThrows(UnknownHostException.class, () -> artifactorySearch.search(dependency),
+                "Should have thrown an UnknownHostException");
+
+        // Then
+        assertNotNull(exception.getMessage());
+        assertTrue(exception.getMessage().contains("artifactory.techno.ingenico.com.invalid"));
     }
 
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/cache/DataCacheFactoryTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/cache/DataCacheFactoryTest.java
@@ -17,26 +17,29 @@
  */
 package org.owasp.dependencycheck.data.cache;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.data.nexus.MavenArtifact;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.data.nexus.MavenArtifact;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class DataCacheFactoryTest extends BaseTest {
+class DataCacheFactoryTest extends BaseTest {
 
     /**
      * Test of getCache method, of class DataCacheFactory.
      */
     @Test
-    public void testGetCache() throws IOException {
+    void testGetCache() throws IOException {
         DataCacheFactory instance = new DataCacheFactory(getSettings());
         DataCache<List<MavenArtifact>> result = instance.getCentralCache();
         assertNotNull(result);

--- a/core/src/test/java/org/owasp/dependencycheck/data/central/CentralSearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/central/CentralSearchTest.java
@@ -69,7 +69,7 @@ class CentralSearchTest extends BaseTest {
     void testMissingSha1() {
         IOException ex = assertThrows(IOException.class, () -> searcher.searchSha1("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
 
-        //abort if we hit a failure state on the CI
+        // abort if we hit a failure state on the CI
         assumeFalse(StringUtils.contains(ex.getMessage(), "Could not connect to MavenCentral"));
         assumeFalse(ex.getMessage().matches("^https://.+ - Server status: \\d{3} - Server reason: .+$"));
 

--- a/core/src/test/java/org/owasp/dependencycheck/data/central/CentralSearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/central/CentralSearchTest.java
@@ -6,10 +6,12 @@ import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -46,13 +48,16 @@ class CentralSearchTest extends BaseTest {
     @Test
     void testValidSha1() throws Exception {
         try {
-        List<MavenArtifact> ma = searcher.searchSha1("9977a8d04e75609cf01badc4eb6a9c7198c4c5ea");
-        assertEquals("org.apache.maven.plugins", ma.get(0).getGroupId(), "Incorrect group");
-        assertEquals("maven-compiler-plugin", ma.get(0).getArtifactId(), "Incorrect artifact");
-        assertEquals("3.1", ma.get(0).getVersion(), "Incorrect version");
-                } catch (IOException ex) {
-            //we hit a failure state on the CI
+            List<MavenArtifact> ma = searcher.searchSha1("9977a8d04e75609cf01badc4eb6a9c7198c4c5ea");
+            assertEquals("org.apache.maven.plugins", ma.get(0).getGroupId(), "Incorrect group");
+            assertEquals("maven-compiler-plugin", ma.get(0).getArtifactId(), "Incorrect artifact");
+            assertEquals("3.1", ma.get(0).getVersion(), "Incorrect version");
+        } catch (IOException ex) {
+            // abort if we hit a failure state on the CI
             assumeFalse(StringUtils.contains(ex.getMessage(), "Could not connect to MavenCentral"));
+            assumeFalse(ex.getMessage().matches("^https://.+ - Server status: \\d{3} - Server reason: .+$"));
+
+            // otherwise fail the test
             throw ex;
         }
     }
@@ -62,15 +67,15 @@ class CentralSearchTest extends BaseTest {
     // test it anyway
     @Test
     void testMissingSha1() {
-        assertThrows(IOException.class, () -> {
-            try {
-                searcher.searchSha1("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-            } catch (IOException ex) {
-                //we hit a failure state on the CI
-                assumeFalse(StringUtils.contains(ex.getMessage(), "Could not connect to MavenCentral"));
-                throw ex;
-            }
-        });
+        IOException ex = assertThrows(IOException.class, () -> searcher.searchSha1("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+
+        //abort if we hit a failure state on the CI
+        assumeFalse(StringUtils.contains(ex.getMessage(), "Could not connect to MavenCentral"));
+        assumeFalse(ex.getMessage().matches("^https://.+ - Server status: \\d{3} - Server reason: .+$"));
+
+        // otherwise assert that the exception is a FileNotFoundException
+        assertInstanceOf(FileNotFoundException.class, ex);
+        assertEquals("Artifact not found in Central", ex.getMessage());
     }
 
     // This test should give us multiple results back from Central
@@ -80,8 +85,11 @@ class CentralSearchTest extends BaseTest {
             List<MavenArtifact> ma = searcher.searchSha1("94A9CE681A42D0352B3AD22659F67835E560D107");
             assertTrue(ma.size() > 1);
         } catch (IOException ex) {
-            //we hit a failure state on the CI
+            // abort if we hit a failure state on the CI
             assumeFalse(StringUtils.contains(ex.getMessage(), "Could not connect to MavenCentral"));
+            assumeFalse(ex.getMessage().matches("^https://.+ - Server status: \\d{3} - Server reason: .+$"));
+
+            // otherwise fail the test
             throw ex;
         }
     }

--- a/core/src/test/java/org/owasp/dependencycheck/data/central/CentralSearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/central/CentralSearchTest.java
@@ -1,56 +1,58 @@
 package org.owasp.dependencycheck.data.central;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 
 import java.io.IOException;
 import java.util.List;
-import org.apache.commons.lang3.StringUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import org.junit.Assume;
-import org.owasp.dependencycheck.utils.Settings;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * Created by colezlaw on 10/13/14.
  */
-public class CentralSearchTest extends BaseTest {
+class CentralSearchTest extends BaseTest {
 
     private CentralSearch searcher;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
         searcher = new CentralSearch(getSettings());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testNullSha1() throws Exception {
-        searcher.searchSha1(null);
+    @Test
+    void testNullSha1() {
+        assertThrows(IllegalArgumentException.class, () ->
+            searcher.searchSha1(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testMalformedSha1() throws Exception {
-        searcher.searchSha1("invalid");
+    @Test
+    void testMalformedSha1() {
+        assertThrows(IllegalArgumentException.class, () ->
+            searcher.searchSha1("invalid"));
     }
 
     // This test does generate network traffic and communicates with a host
     // you may not be able to reach. Remove the @Ignore annotation if you want to
     // test it anyway
     @Test
-    public void testValidSha1() throws Exception {
+    void testValidSha1() throws Exception {
         try {
         List<MavenArtifact> ma = searcher.searchSha1("9977a8d04e75609cf01badc4eb6a9c7198c4c5ea");
-        assertEquals("Incorrect group", "org.apache.maven.plugins", ma.get(0).getGroupId());
-        assertEquals("Incorrect artifact", "maven-compiler-plugin", ma.get(0).getArtifactId());
-        assertEquals("Incorrect version", "3.1", ma.get(0).getVersion());
+        assertEquals("org.apache.maven.plugins", ma.get(0).getGroupId(), "Incorrect group");
+        assertEquals("maven-compiler-plugin", ma.get(0).getArtifactId(), "Incorrect artifact");
+        assertEquals("3.1", ma.get(0).getVersion(), "Incorrect version");
                 } catch (IOException ex) {
             //we hit a failure state on the CI
-            Assume.assumeFalse(StringUtils.contains(ex.getMessage(), "Could not connect to MavenCentral"));
+            assumeFalse(StringUtils.contains(ex.getMessage(), "Could not connect to MavenCentral"));
             throw ex;
         }
     }
@@ -58,26 +60,28 @@ public class CentralSearchTest extends BaseTest {
     // This test does generate network traffic and communicates with a host
     // you may not be able to reach. Remove the @Ignore annotation if you want to
     // test it anyway
-    @Test(expected = IOException.class)
-    public void testMissingSha1() throws Exception {
-        try {
-        searcher.searchSha1("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-                } catch (IOException ex) {
-            //we hit a failure state on the CI
-            Assume.assumeFalse(StringUtils.contains(ex.getMessage(), "Could not connect to MavenCentral"));
-            throw ex;
-        }
+    @Test
+    void testMissingSha1() {
+        assertThrows(IOException.class, () -> {
+            try {
+                searcher.searchSha1("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+            } catch (IOException ex) {
+                //we hit a failure state on the CI
+                assumeFalse(StringUtils.contains(ex.getMessage(), "Could not connect to MavenCentral"));
+                throw ex;
+            }
+        });
     }
 
     // This test should give us multiple results back from Central
     @Test
-    public void testMultipleReturns() throws Exception {
+    void testMultipleReturns() throws Exception {
         try {
             List<MavenArtifact> ma = searcher.searchSha1("94A9CE681A42D0352B3AD22659F67835E560D107");
             assertTrue(ma.size() > 1);
         } catch (IOException ex) {
             //we hit a failure state on the CI
-            Assume.assumeFalse(StringUtils.contains(ex.getMessage(), "Could not connect to MavenCentral"));
+            assumeFalse(StringUtils.contains(ex.getMessage(), "Could not connect to MavenCentral"));
             throw ex;
         }
     }

--- a/core/src/test/java/org/owasp/dependencycheck/data/composer/ComposerLockParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/composer/ComposerLockParserTest.java
@@ -17,24 +17,27 @@
  */
 package org.owasp.dependencycheck.data.composer;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 
-import static org.junit.Assert.*;
-import org.owasp.dependencycheck.BaseTest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Created by colezlaw on 9/5/15.
  */
-public class ComposerLockParserTest extends BaseTest  {
+class ComposerLockParserTest extends BaseTest {
 
     private InputStream inputStream;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -42,17 +45,17 @@ public class ComposerLockParserTest extends BaseTest  {
     }
 
     @Test
-    public void testValidComposerLock() {
+    void testValidComposerLock() {
         ComposerLockParser clp = new ComposerLockParser(inputStream, false);
         clp.process();
         assertEquals(30, clp.getDependencies().size());
         assertTrue(clp.getDependencies().contains(new ComposerDependency("symfony", "translation", "2.7.3")));
         assertTrue(clp.getDependencies().contains(new ComposerDependency("vlucas", "phpdotenv", "1.1.1")));
     }
-    
-    
+
+
     @Test
-    public void testComposerLockSkipDev() {
+    void testComposerLockSkipDev() {
         ComposerLockParser clp = new ComposerLockParser(inputStream, true);
         clp.process();
         assertEquals(29, clp.getDependencies().size());
@@ -61,24 +64,24 @@ public class ComposerLockParserTest extends BaseTest  {
         assertFalse(clp.getDependencies().contains(new ComposerDependency("vlucas", "phpdotenv", "1.1.1")));
     }
 
-    @Test(expected = ComposerException.class)
-    public void testNotJSON() throws Exception {
+    @Test
+    void testNotJSON() {
         String input = "NOT VALID JSON";
         ComposerLockParser clp = new ComposerLockParser(new ByteArrayInputStream(input.getBytes(Charset.defaultCharset())), false);
-        clp.process();
+        assertThrows(ComposerException.class, clp::process);
     }
 
-    @Test(expected = ComposerException.class)
-    public void testNotComposer() throws Exception {
+    @Test
+    void testNotComposer() {
         String input = "[\"ham\",\"eggs\"]";
         ComposerLockParser clp = new ComposerLockParser(new ByteArrayInputStream(input.getBytes(Charset.defaultCharset())), false);
-        clp.process();
+        assertThrows(ComposerException.class, clp::process);
     }
 
-    @Test(expected = ComposerException.class)
-    public void testNotPackagesArray() throws Exception {
+    @Test
+    void testNotPackagesArray() {
         String input = "{\"packages\":\"eleventy\"}";
         ComposerLockParser clp = new ComposerLockParser(new ByteArrayInputStream(input.getBytes(Charset.defaultCharset())), false);
-        clp.process();
+        assertThrows(ComposerException.class, clp::process);
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/cpe/CpeMemoryIndexTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/cpe/CpeMemoryIndexTest.java
@@ -20,23 +20,26 @@ package org.owasp.dependencycheck.data.cpe;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
 import org.owasp.dependencycheck.Engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author jeremy long
  */
-public class CpeMemoryIndexTest extends BaseDBTestCase {
+class CpeMemoryIndexTest extends BaseDBTestCase {
 
     private static final CpeMemoryIndex instance = CpeMemoryIndex.getInstance();
     private static Engine engine = null;
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() {
         if (instance.isOpen()) {
             instance.close();
@@ -46,7 +49,7 @@ public class CpeMemoryIndexTest extends BaseDBTestCase {
         }
     }
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -61,7 +64,7 @@ public class CpeMemoryIndexTest extends BaseDBTestCase {
      * Test of getInstance method, of class CpeMemoryIndex.
      */
     @Test
-    public void testGetInstance() {
+    void testGetInstance() {
         CpeMemoryIndex result = CpeMemoryIndex.getInstance();
         assertNotNull(result);
     }
@@ -70,7 +73,7 @@ public class CpeMemoryIndexTest extends BaseDBTestCase {
      * Test of isOpen method, of class CpeMemoryIndex.
      */
     @Test
-    public void testIsOpen() {
+    void testIsOpen() {
         boolean expResult = true;
         boolean result = instance.isOpen();
         assertEquals(expResult, result);
@@ -80,7 +83,7 @@ public class CpeMemoryIndexTest extends BaseDBTestCase {
      * Test of search method, of class CpeMemoryIndex.
      */
     @Test
-    public void testSearch_String_int() throws Exception {
+    void testSearch_String_int() throws Exception {
         String searchString = "product:(commons) AND vendor:(apache)";
         int maxQueryResults = 3;
         TopDocs result = instance.search(searchString, maxQueryResults);
@@ -92,7 +95,7 @@ public class CpeMemoryIndexTest extends BaseDBTestCase {
      * Test of parseQuery method, of class CpeMemoryIndex.
      */
     @Test
-    public void testParseQuery() throws Exception {
+    void testParseQuery() throws Exception {
         String searchString = "product:(resteasy) AND vendor:(red hat)";
 
         String expResult = "+product:resteasy +(vendor:red vendor:redhat vendor:hat)";
@@ -111,7 +114,7 @@ public class CpeMemoryIndexTest extends BaseDBTestCase {
      * Test of search method, of class CpeMemoryIndex.
      */
     @Test
-    public void testSearch_Query_int() throws Exception {
+    void testSearch_Query_int() throws Exception {
         String searchString = "product:(commons) AND vendor:(apache)";
         Query query = instance.parseQuery(searchString);
         int maxQueryResults = 3;
@@ -123,7 +126,7 @@ public class CpeMemoryIndexTest extends BaseDBTestCase {
      * Test of getDocument method, of class CpeMemoryIndex.
      */
     @Test
-    public void testGetDocument() throws Exception {
+    void testGetDocument() throws Exception {
         String searchString = "product:(commons) AND vendor:(apache)";
         int maxQueryResults = 1;
         TopDocs docs = instance.search(searchString, maxQueryResults);
@@ -136,7 +139,7 @@ public class CpeMemoryIndexTest extends BaseDBTestCase {
      * Test of numDocs method, of class CpeMemoryIndex.
      */
     @Test
-    public void testNumDocs() {
+    void testNumDocs() {
         int result = instance.numDocs();
         assertTrue(result > 100);
     }

--- a/core/src/test/java/org/owasp/dependencycheck/data/cpe/IndexEntryTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/cpe/IndexEntryTest.java
@@ -17,15 +17,16 @@
  */
 package org.owasp.dependencycheck.data.cpe;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author Jeremy Long
  */
-public class IndexEntryTest extends BaseTest  {
+class IndexEntryTest extends BaseTest {
 
     /**
      * Test of setName method, of class IndexEntry.
@@ -33,13 +34,13 @@ public class IndexEntryTest extends BaseTest  {
      * @throws Exception is thrown when an exception occurs.
      */
     @Test
-    public void testSetName() throws Exception {
+    void testSetName() throws Exception {
         String name = "cpe:/a:apache:struts:1.1:rc2";
 
         IndexEntry instance = new IndexEntry();
         instance.parseName(name);
 
-        Assert.assertEquals("apache", instance.getVendor());
-        Assert.assertEquals("struts", instance.getProduct());
+        assertEquals("apache", instance.getVendor());
+        assertEquals("struts", instance.getProduct());
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/cwe/CweDBTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/cwe/CweDBTest.java
@@ -17,23 +17,23 @@
  */
 package org.owasp.dependencycheck.data.cwe;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  *
  * @author Jeremy Long
  */
-public class CweDBTest extends BaseTest {
+class CweDBTest extends BaseTest {
 
     /**
      * Test of getName method, of class CweDB.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         String cweId = "CWE-16";
         String expResult = "Configuration";
         String result = CweDB.getName(cweId);
@@ -48,7 +48,7 @@ public class CweDBTest extends BaseTest {
      * Test of getFullName method, of class CweDB.
      */
     @Test
-    public void testGetFullName() {
+    void testGetFullName() {
         String cweId = "CWE-16";
         String expResult = "CWE-16 Configuration";
         String result = CweDB.getFullName(cweId);

--- a/core/src/test/java/org/owasp/dependencycheck/data/elixir/MixAuditJsonParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/elixir/MixAuditJsonParserTest.java
@@ -1,17 +1,19 @@
 package org.owasp.dependencycheck.data.elixir;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class MixAuditJsonParserTest {
+class MixAuditJsonParserTest {
 
     @Test
-    public void testEmptyResult() throws AnalysisException, FileNotFoundException {
+    void testEmptyResult() throws AnalysisException, FileNotFoundException {
         MixAuditJsonParser parser;
 
         File jsonFixtureFile = BaseTest.getResourceAsFile(this, "elixir/mix_audit/empty.json");
@@ -20,11 +22,11 @@ public class MixAuditJsonParserTest {
         parser = new MixAuditJsonParser(fir);
         parser.process();
 
-        assertEquals("results must be empty", 0, parser.getResults().size());
+        assertEquals(0, parser.getResults().size(), "results must be empty");
     }
 
     @Test
-    public void testSingleResult() throws AnalysisException, FileNotFoundException {
+    void testSingleResult() throws AnalysisException, FileNotFoundException {
         MixAuditJsonParser parser;
 
         File jsonFixtureFile = BaseTest.getResourceAsFile(this, "elixir/mix_audit/plug.json");
@@ -33,7 +35,7 @@ public class MixAuditJsonParserTest {
         parser = new MixAuditJsonParser(fir);
         parser.process();
 
-        assertEquals("must have 1 result", 1, parser.getResults().size());
+        assertEquals(1, parser.getResults().size(), "must have 1 result");
 
         MixAuditResult r = parser.getResults().get(0);
         assertEquals("dc96aba4-4462-4d3b-b73f-28b9349133d8", r.getId());

--- a/core/src/test/java/org/owasp/dependencycheck/data/golang/GoModJsonParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/golang/GoModJsonParserTest.java
@@ -17,17 +17,19 @@
  */
 package org.owasp.dependencycheck.data.golang;
 
+import org.junit.jupiter.api.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author jeremy
  */
-public class GoModJsonParserTest {
+class GoModJsonParserTest {
 
     final String issue2891 = "{\n"
             + "	\"Path\": \"cloud.google.com/go\",\n"
@@ -783,7 +785,7 @@ public class GoModJsonParserTest {
      * Test of process method, of class GoModJsonParser.
      */
     @Test
-    public void testProcess() throws Exception {
+    void testProcess() throws Exception {
         InputStream inputStream = new ByteArrayInputStream(issue2891.getBytes());
         List<GoModDependency> expResult = null;
         List<GoModDependency> result = GoModJsonParser.process(inputStream);

--- a/core/src/test/java/org/owasp/dependencycheck/data/lucene/AlphaNumericFilterTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/lucene/AlphaNumericFilterTest.java
@@ -17,27 +17,29 @@
  */
 package org.owasp.dependencycheck.data.lucene;
 
+import java.io.IOException;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
+import static org.apache.lucene.tests.analysis.BaseTokenStreamTestCase.checkOneTerm;
+import static org.apache.lucene.tests.analysis.BaseTokenStreamTestCase.checkRandomData;
+import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
-import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
-import org.apache.lucene.tests.analysis.MockTokenizer;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.apache.lucene.tests.util.LuceneTestCase.RANDOM_MULTIPLIER;
+import static org.apache.lucene.tests.util.LuceneTestCase.random;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
 
 /**
  *
  * @author Jeremy Long
  */
-class AlphaNumericFilterTest extends BaseTokenStreamTestCase {
+public class AlphaNumericFilterTest extends BaseTokenStreamTestCase {
 
     private Analyzer analyzer;
 
-    @BeforeEach
+    @Before
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -56,7 +58,7 @@ class AlphaNumericFilterTest extends BaseTokenStreamTestCase {
      * @throws Exception thrown if there is a problem
      */
     @Test
-    void testIncrementToken() throws Exception {
+    public void testIncrementToken() throws Exception {
         String[] expected = new String[6];
         expected[0] = "http";
         expected[1] = "www";
@@ -73,7 +75,7 @@ class AlphaNumericFilterTest extends BaseTokenStreamTestCase {
      * @throws Exception thrown if there is a problem
      */
     @Test
-    void testGarbage() throws Exception {
+    public void testGarbage() throws Exception {
         String[] expected = new String[2];
         expected[0] = "test";
         expected[1] = "two";
@@ -86,8 +88,12 @@ class AlphaNumericFilterTest extends BaseTokenStreamTestCase {
      * blast some random strings through the analyzer
      */
     @Test
-    void testRandomStrings() {
-        assertDoesNotThrow(() -> checkRandomData(random(), analyzer, 1000 * RANDOM_MULTIPLIER), "Failed test random strings: ");
+    public void testRandomStrings() {
+        try {
+            checkRandomData(random(), analyzer, 1000 * RANDOM_MULTIPLIER);
+        } catch (IOException ex) {
+            fail("Failed test random strings: " + ex.getMessage());
+        }
     }
 
     /**
@@ -97,7 +103,7 @@ class AlphaNumericFilterTest extends BaseTokenStreamTestCase {
      * @throws IOException
      */
     @Test
-    void testEmptyTerm() throws IOException {
+    public void testEmptyTerm() throws IOException {
         Analyzer a = new Analyzer() {
             @Override
             protected Analyzer.TokenStreamComponents createComponents(String fieldName) {

--- a/core/src/test/java/org/owasp/dependencycheck/data/lucene/AlphaNumericFilterTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/lucene/AlphaNumericFilterTest.java
@@ -17,29 +17,27 @@
  */
 package org.owasp.dependencycheck.data.lucene;
 
-import java.io.IOException;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
-import static org.apache.lucene.tests.analysis.BaseTokenStreamTestCase.checkOneTerm;
-import static org.apache.lucene.tests.analysis.BaseTokenStreamTestCase.checkRandomData;
-import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
-import static org.apache.lucene.tests.util.LuceneTestCase.RANDOM_MULTIPLIER;
-import static org.apache.lucene.tests.util.LuceneTestCase.random;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.junit.Before;
+import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
+import org.apache.lucene.tests.analysis.MockTokenizer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  *
  * @author Jeremy Long
  */
-public class AlphaNumericFilterTest extends BaseTokenStreamTestCase {
+class AlphaNumericFilterTest extends BaseTokenStreamTestCase {
 
     private Analyzer analyzer;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -54,11 +52,11 @@ public class AlphaNumericFilterTest extends BaseTokenStreamTestCase {
 
     /**
      * Test of incrementToken method, of class AlphaNumericFilter.
-     * 
+     *
      * @throws Exception thrown if there is a problem
      */
     @Test
-    public void testIncrementToken() throws Exception {
+    void testIncrementToken() throws Exception {
         String[] expected = new String[6];
         expected[0] = "http";
         expected[1] = "www";
@@ -75,7 +73,7 @@ public class AlphaNumericFilterTest extends BaseTokenStreamTestCase {
      * @throws Exception thrown if there is a problem
      */
     @Test
-    public void testGarbage() throws Exception {
+    void testGarbage() throws Exception {
         String[] expected = new String[2];
         expected[0] = "test";
         expected[1] = "two";
@@ -88,12 +86,8 @@ public class AlphaNumericFilterTest extends BaseTokenStreamTestCase {
      * blast some random strings through the analyzer
      */
     @Test
-    public void testRandomStrings() {
-        try {
-            checkRandomData(random(), analyzer, 1000 * RANDOM_MULTIPLIER);
-        } catch (IOException ex) {
-            fail("Failed test random strings: " + ex.getMessage());
-        }
+    void testRandomStrings() {
+        assertDoesNotThrow(() -> checkRandomData(random(), analyzer, 1000 * RANDOM_MULTIPLIER), "Failed test random strings: ");
     }
 
     /**
@@ -103,7 +97,7 @@ public class AlphaNumericFilterTest extends BaseTokenStreamTestCase {
      * @throws IOException
      */
     @Test
-    public void testEmptyTerm() throws IOException {
+    void testEmptyTerm() throws IOException {
         Analyzer a = new Analyzer() {
             @Override
             protected Analyzer.TokenStreamComponents createComponents(String fieldName) {

--- a/core/src/test/java/org/owasp/dependencycheck/data/lucene/FieldAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/lucene/FieldAnalyzerTest.java
@@ -17,9 +17,6 @@
  */
 package org.owasp.dependencycheck.data.lucene;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
@@ -37,21 +34,24 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopScoreDocCollector;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MMapDirectory;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  *
  * @author Jeremy Long
  */
-public class FieldAnalyzerTest extends BaseTest {
+class FieldAnalyzerTest extends BaseTest {
 
     @Test
-    public void testAnalyzers() throws Exception {
+    void testAnalyzers() throws Exception {
 
         Analyzer analyzer = new SearchFieldAnalyzer();
         File temp = getSettings().getTempDirectory();
@@ -92,7 +92,7 @@ public class FieldAnalyzerTest extends BaseTest {
         searcher.search(q, collector);
         ScoreDoc[] hits = collector.topDocs().scoreDocs;
 
-        assertEquals("Did not find 1 document?", 1, hits.length);
+        assertEquals(1, hits.length, "Did not find 1 document?");
         assertEquals("springframework", searcher.doc(hits[0].doc).get(field1));
         assertEquals("springsource", searcher.doc(hits[0].doc).get(field2));
 
@@ -100,7 +100,7 @@ public class FieldAnalyzerTest extends BaseTest {
 
         reset(searchAnalyzerProduct, searchAnalyzerVendor);
         Query q2 = parser.parse(querystr);
-        assertFalse("second parsing contains previousWord from the TokenPairConcatenatingFilter", q2.toString().contains("core"));
+        assertFalse(q2.toString().contains("core"), "second parsing contains previousWord from the TokenPairConcatenatingFilter");
 
         querystr = "product:(  x-stream^5 )  AND  vendor:(  thoughtworks.xstream )";
         reset(searchAnalyzerProduct, searchAnalyzerVendor);

--- a/core/src/test/java/org/owasp/dependencycheck/data/lucene/LuceneUtilsTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/lucene/LuceneUtilsTest.java
@@ -17,24 +17,24 @@
  */
 package org.owasp.dependencycheck.data.lucene;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class LuceneUtilsTest extends BaseTest {
+class LuceneUtilsTest extends BaseTest {
 
     /**
      * Test of appendEscapedLuceneQuery method, of class LuceneUtils.
      */
     @Test
-    public void testAppendEscapedLuceneQuery() {
+    void testAppendEscapedLuceneQuery() {
         StringBuilder buf = new StringBuilder();
         CharSequence text = "test encoding + - & | ! ( ) { } [ ] ^ \" ~ * ? : \\";
         String expResult = "test encoding \\+ \\- \\& \\| \\! \\( \\) \\{ \\} \\[ \\] \\^ \\\" \\~ \\* \\? \\: \\\\";
@@ -46,7 +46,7 @@ public class LuceneUtilsTest extends BaseTest {
      * Test of appendEscapedLuceneQuery method, of class LuceneUtils.
      */
     @Test
-    public void testAppendEscapedLuceneQuery_null() {
+    void testAppendEscapedLuceneQuery_null() {
         StringBuilder buf = new StringBuilder();
         CharSequence text = null;
         LuceneUtils.appendEscapedLuceneQuery(buf, text);
@@ -57,7 +57,7 @@ public class LuceneUtilsTest extends BaseTest {
      * Test of escapeLuceneQuery method, of class LuceneUtils.
      */
     @Test
-    public void testEscapeLuceneQuery() {
+    void testEscapeLuceneQuery() {
         CharSequence text = "test encoding + - & | ! ( ) { } [ ] ^ \" ~ * ? : \\";
         String expResult = "test encoding \\+ \\- \\& \\| \\! \\( \\) \\{ \\} \\[ \\] \\^ \\\" \\~ \\* \\? \\: \\\\";
         String result = LuceneUtils.escapeLuceneQuery(text);
@@ -68,7 +68,7 @@ public class LuceneUtilsTest extends BaseTest {
      * Test of escapeLuceneQuery method, of class LuceneUtils.
      */
     @Test
-    public void testEscapeLuceneQuery_null() {
+    void testEscapeLuceneQuery_null() {
         CharSequence text = null;
         String expResult = null;
         String result = LuceneUtils.escapeLuceneQuery(text);
@@ -76,13 +76,13 @@ public class LuceneUtilsTest extends BaseTest {
     }
 
     @Test
-    public void testIsKeyword() {
-        assertTrue("'AND' is a keyword and should return true", LuceneUtils.isKeyword("And"));
-        assertTrue("'OR' is a keyword and should return true", LuceneUtils.isKeyword("OR"));
-        assertTrue("'NOT' is a keyword and should return true", LuceneUtils.isKeyword("nOT"));
-        assertTrue("'TO' is being considered a keyword and should return true", LuceneUtils.isKeyword("TO"));
-        assertTrue("'+' is being considered a keyword and should return true", LuceneUtils.isKeyword("+"));
-        assertTrue("'-' is being considered a keyword and should return true", LuceneUtils.isKeyword("-"));
-        assertFalse("'the' is not a keyword and should return false", LuceneUtils.isKeyword("test"));
+    void testIsKeyword() {
+        assertTrue(LuceneUtils.isKeyword("And"), "'AND' is a keyword and should return true");
+        assertTrue(LuceneUtils.isKeyword("OR"), "'OR' is a keyword and should return true");
+        assertTrue(LuceneUtils.isKeyword("nOT"), "'NOT' is a keyword and should return true");
+        assertTrue(LuceneUtils.isKeyword("TO"), "'TO' is being considered a keyword and should return true");
+        assertTrue(LuceneUtils.isKeyword("+"), "'+' is being considered a keyword and should return true");
+        assertTrue(LuceneUtils.isKeyword("-"), "'-' is being considered a keyword and should return true");
+        assertFalse(LuceneUtils.isKeyword("test"), "'the' is not a keyword and should return false");
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/lucene/SearchFieldAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/lucene/SearchFieldAnalyzerTest.java
@@ -18,20 +18,21 @@
 package org.owasp.dependencycheck.data.lucene;
 
 import org.apache.lucene.analysis.CharArraySet;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author jeremy long
  */
-public class SearchFieldAnalyzerTest {
+class SearchFieldAnalyzerTest {
 
     /**
      * Test of getStopWords method, of class SearchFieldAnalyzer.
      */
     @Test
-    public void testGetStopWords() {
+    void testGetStopWords() {
         CharArraySet result = SearchFieldAnalyzer.getStopWords();
         assertTrue(result.size() > 20);
         assertTrue(result.contains("software"));

--- a/core/src/test/java/org/owasp/dependencycheck/data/lucene/TokenPairConcatenatingFilterTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/lucene/TokenPairConcatenatingFilterTest.java
@@ -17,22 +17,21 @@
  */
 package org.owasp.dependencycheck.data.lucene;
 
-import java.io.IOException;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
-import static org.apache.lucene.tests.analysis.BaseTokenStreamTestCase.checkOneTerm;
-import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
-import static org.junit.Assert.fail;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  *
  * @author Jeremy Long
  */
-public class TokenPairConcatenatingFilterTest extends BaseTokenStreamTestCase {
+class TokenPairConcatenatingFilterTest extends BaseTokenStreamTestCase {
 
 //    private Analyzer analyzer;
 //
@@ -81,7 +80,7 @@ public class TokenPairConcatenatingFilterTest extends BaseTokenStreamTestCase {
      * @throws IOException
      */
     @Test
-    public void testEmptyTerm() {
+    void testEmptyTerm() {
         Analyzer a = new Analyzer() {
             @Override
             protected Analyzer.TokenStreamComponents createComponents(String fieldName) {
@@ -89,10 +88,6 @@ public class TokenPairConcatenatingFilterTest extends BaseTokenStreamTestCase {
                 return new Analyzer.TokenStreamComponents(tokenizer, new TokenPairConcatenatingFilter(tokenizer));
             }
         };
-        try {
-            checkOneTerm(a, "", "");
-        } catch (IOException ex) {
-            fail("Failed test random strings: " + ex.getMessage());
-        }
+        assertDoesNotThrow(() -> checkOneTerm(a, "", ""), "Failed test random strings: ");
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/lucene/TokenPairConcatenatingFilterTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/lucene/TokenPairConcatenatingFilterTest.java
@@ -17,21 +17,22 @@
  */
 package org.owasp.dependencycheck.data.lucene;
 
+import java.io.IOException;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
+import static org.apache.lucene.tests.analysis.BaseTokenStreamTestCase.checkOneTerm;
+import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
-import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  *
  * @author Jeremy Long
  */
-class TokenPairConcatenatingFilterTest extends BaseTokenStreamTestCase {
+public class TokenPairConcatenatingFilterTest extends BaseTokenStreamTestCase {
 
 //    private Analyzer analyzer;
 //
@@ -80,7 +81,7 @@ class TokenPairConcatenatingFilterTest extends BaseTokenStreamTestCase {
      * @throws IOException
      */
     @Test
-    void testEmptyTerm() {
+    public void testEmptyTerm() {
         Analyzer a = new Analyzer() {
             @Override
             protected Analyzer.TokenStreamComponents createComponents(String fieldName) {
@@ -88,6 +89,10 @@ class TokenPairConcatenatingFilterTest extends BaseTokenStreamTestCase {
                 return new Analyzer.TokenStreamComponents(tokenizer, new TokenPairConcatenatingFilter(tokenizer));
             }
         };
-        assertDoesNotThrow(() -> checkOneTerm(a, "", ""), "Failed test random strings: ");
+        try {
+            checkOneTerm(a, "", "");
+        } catch (IOException ex) {
+            fail("Failed test random strings: " + ex.getMessage());
+        }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/lucene/UrlTokenizingFilterTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/lucene/UrlTokenizingFilterTest.java
@@ -17,36 +17,37 @@
  */
 package org.owasp.dependencycheck.data.lucene;
 
+import java.io.IOException;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.Tokenizer;
-import org.apache.lucene.analysis.core.KeywordTokenizer;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.tests.analysis.MockTokenizer;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.core.KeywordTokenizer;
+import org.junit.Test;
 
 /**
  *
  * @author Jeremy Long
  */
-class UrlTokenizingFilterTest extends BaseTokenStreamTestCase {
+public class UrlTokenizingFilterTest extends BaseTokenStreamTestCase {
 
-    private final Analyzer analyzer = new Analyzer() {
+    private final Analyzer analyzer;
+
+    public UrlTokenizingFilterTest() {
+        analyzer = new Analyzer() {
             @Override
             protected TokenStreamComponents createComponents(String fieldName) {
                 Tokenizer source = new MockTokenizer(MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(source, new UrlTokenizingFilter(source));
             }
         };
+    }
 
     /**
      * test some example domains
      */
     @Test
-    void testExamples() throws IOException {
+    public void testExamples() throws IOException {
         String[] expected = new String[2];
         expected[0] = "domain";
         expected[1] = "test";
@@ -60,8 +61,12 @@ class UrlTokenizingFilterTest extends BaseTokenStreamTestCase {
      * blast some random strings through the analyzer
      */
     @Test
-    void testRandomStrings() {
-        assertDoesNotThrow(() -> checkRandomData(random(), analyzer, 1000 * RANDOM_MULTIPLIER), "Failed test random strings: ");
+    public void testRandomStrings() {
+        try {
+            checkRandomData(random(), analyzer, 1000 * RANDOM_MULTIPLIER);
+        } catch (IOException ex) {
+            fail("Failed test random strings: " + ex.getMessage());
+        }
     }
 
     /**
@@ -71,7 +76,7 @@ class UrlTokenizingFilterTest extends BaseTokenStreamTestCase {
      * @throws IOException
      */
     @Test
-    void testEmptyTerm() throws IOException {
+    public void testEmptyTerm() throws IOException {
         Analyzer a = new Analyzer() {
             @Override
             protected TokenStreamComponents createComponents(String fieldName) {

--- a/core/src/test/java/org/owasp/dependencycheck/data/lucene/UrlTokenizingFilterTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/lucene/UrlTokenizingFilterTest.java
@@ -17,37 +17,36 @@
  */
 package org.owasp.dependencycheck.data.lucene;
 
-import java.io.IOException;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
-import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
-import org.junit.Test;
+import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
+import org.apache.lucene.tests.analysis.MockTokenizer;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  *
  * @author Jeremy Long
  */
-public class UrlTokenizingFilterTest extends BaseTokenStreamTestCase {
+class UrlTokenizingFilterTest extends BaseTokenStreamTestCase {
 
-    private final Analyzer analyzer;
-
-    public UrlTokenizingFilterTest() {
-        analyzer = new Analyzer() {
+    private final Analyzer analyzer = new Analyzer() {
             @Override
             protected TokenStreamComponents createComponents(String fieldName) {
                 Tokenizer source = new MockTokenizer(MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(source, new UrlTokenizingFilter(source));
             }
         };
-    }
 
     /**
      * test some example domains
      */
     @Test
-    public void testExamples() throws IOException {
+    void testExamples() throws IOException {
         String[] expected = new String[2];
         expected[0] = "domain";
         expected[1] = "test";
@@ -61,12 +60,8 @@ public class UrlTokenizingFilterTest extends BaseTokenStreamTestCase {
      * blast some random strings through the analyzer
      */
     @Test
-    public void testRandomStrings() {
-        try {
-            checkRandomData(random(), analyzer, 1000 * RANDOM_MULTIPLIER);
-        } catch (IOException ex) {
-            fail("Failed test random strings: " + ex.getMessage());
-        }
+    void testRandomStrings() {
+        assertDoesNotThrow(() -> checkRandomData(random(), analyzer, 1000 * RANDOM_MULTIPLIER), "Failed test random strings: ");
     }
 
     /**
@@ -76,7 +71,7 @@ public class UrlTokenizingFilterTest extends BaseTokenStreamTestCase {
      * @throws IOException
      */
     @Test
-    public void testEmptyTerm() throws IOException {
+    void testEmptyTerm() throws IOException {
         Analyzer a = new Analyzer() {
             @Override
             protected TokenStreamComponents createComponents(String fieldName) {

--- a/core/src/test/java/org/owasp/dependencycheck/data/nexus/MavenArtifactTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nexus/MavenArtifactTest.java
@@ -1,14 +1,14 @@
 package org.owasp.dependencycheck.data.nexus;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 
-public class MavenArtifactTest extends BaseTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MavenArtifactTest extends BaseTest {
 
     @Test
-    public void getPomUrl() {
+    void getPomUrl() {
         // Given
         final MavenArtifact mavenArtifact = new MavenArtifact("com.google.code.gson", "gson", "2.1",
                 "https://artifactory.techno.ingenico.com/artifactory/jcenter-cache/com/google/code/gson/gson/2.1/gson-2.1.jar", MavenArtifact.derivePomUrl("gson", "2.1",
@@ -21,7 +21,7 @@ public class MavenArtifactTest extends BaseTest {
     }
 
     @Test
-    public void getPomUrlWithQualifier() {
+    void getPomUrlWithQualifier() {
         // Given
         final MavenArtifact mavenArtifact = new MavenArtifact("com.google.code.gson", "gson", "2.8.5",
                 "https://artifactory.techno.ingenico.com/artifactory/repo1-cache/com/google/code/gson/gson/2.8.5/gson-2.8.5-sources.jar", MavenArtifact.derivePomUrl("gson", "2.8.5",

--- a/core/src/test/java/org/owasp/dependencycheck/data/nexus/NexusV2SearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nexus/NexusV2SearchTest.java
@@ -17,24 +17,27 @@
  */
 package org.owasp.dependencycheck.data.nexus;
 
-import java.io.FileNotFoundException;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class NexusV2SearchTest extends BaseTest {
+import java.io.FileNotFoundException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class NexusV2SearchTest extends BaseTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NexusV2SearchTest.class);
     private NexusV2Search searcher;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -45,40 +48,43 @@ public class NexusV2SearchTest extends BaseTest {
         String nexusUrl = sett.getString(Settings.KEYS.ANALYZER_NEXUS_URL);
         LOGGER.debug(nexusUrl);
         searcher = new NexusV2Search(sett, false);
-        Assume.assumeTrue(searcher.preflightRequest());
+        assumeTrue(searcher.preflightRequest());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    @Ignore
-    public void testNullSha1() throws Exception {
-        searcher.searchSha1(null);
+    @Test
+    @Disabled
+    void testNullSha1() {
+        assertThrows(IllegalArgumentException.class, () ->
+            searcher.searchSha1(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    @Ignore
-    public void testMalformedSha1() throws Exception {
-        searcher.searchSha1("invalid");
+    @Test
+    @Disabled
+    void testMalformedSha1() {
+        assertThrows(IllegalArgumentException.class, () ->
+            searcher.searchSha1("invalid"));
     }
 
     // This test does generate network traffic and communicates with a host
     // you may not be able to reach. Remove the @Ignore annotation if you want to
     // test it anyway
     @Test
-    @Ignore
-    public void testValidSha1() throws Exception {
+    @Disabled
+    void testValidSha1() throws Exception {
         MavenArtifact ma = searcher.searchSha1("9977a8d04e75609cf01badc4eb6a9c7198c4c5ea");
-        assertEquals("Incorrect group", "org.apache.maven.plugins", ma.getGroupId());
-        assertEquals("Incorrect artifact", "maven-compiler-plugin", ma.getArtifactId());
-        assertEquals("Incorrect version", "3.1", ma.getVersion());
-        assertNotNull("URL Should not be null", ma.getArtifactUrl());
+        assertEquals("org.apache.maven.plugins", ma.getGroupId(), "Incorrect group");
+        assertEquals("maven-compiler-plugin", ma.getArtifactId(), "Incorrect artifact");
+        assertEquals("3.1", ma.getVersion(), "Incorrect version");
+        assertNotNull(ma.getArtifactUrl(), "URL Should not be null");
     }
 
     // This test does generate network traffic and communicates with a host
     // you may not be able to reach. Remove the @Ignore annotation if you want to
     // test it anyway
-    @Test(expected = FileNotFoundException.class)
-    @Ignore
-    public void testMissingSha1() throws Exception {
-        searcher.searchSha1("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    @Test
+    @Disabled
+    void testMissingSha1() {
+        assertThrows(FileNotFoundException.class, () ->
+            searcher.searchSha1("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/nexus/NexusV3SearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nexus/NexusV3SearchTest.java
@@ -17,10 +17,9 @@
  */
 package org.owasp.dependencycheck.data.nexus;
 
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
@@ -28,15 +27,17 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class NexusV3SearchTest extends BaseTest {
+class NexusV3SearchTest extends BaseTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NexusV3SearchTest.class);
     private NexusV3Search searcher;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -48,40 +49,43 @@ public class NexusV3SearchTest extends BaseTest {
 
         LOGGER.debug(nexusUrl);
         searcher = new NexusV3Search(sett, false);
-        Assume.assumeTrue(searcher.preflightRequest());
+        assumeTrue(searcher.preflightRequest());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    @Ignore
-    public void testNullSha1() throws Exception {
-        searcher.searchSha1(null);
+    @Test
+    @Disabled
+    void testNullSha1() {
+        assertThrows(IllegalArgumentException.class, () ->
+            searcher.searchSha1(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    @Ignore
-    public void testMalformedSha1() throws Exception {
-        searcher.searchSha1("invalid");
+    @Test
+    @Disabled
+    void testMalformedSha1() {
+        assertThrows(IllegalArgumentException.class, () ->
+            searcher.searchSha1("invalid"));
     }
 
     // This test does generate network traffic and communicates with a host
     // you may not be able to reach. Remove the @Ignore annotation if you want to
     // test it anyway
     @Test
-    @Ignore
-    public void testValidSha1() throws Exception {
+    @Disabled
+    void testValidSha1() throws Exception {
         MavenArtifact ma = searcher.searchSha1("9977a8d04e75609cf01badc4eb6a9c7198c4c5ea");
-        assertEquals("Incorrect group", "org.apache.maven.plugins", ma.getGroupId());
-        assertEquals("Incorrect artifact", "maven-compiler-plugin", ma.getArtifactId());
-        assertEquals("Incorrect version", "3.1", ma.getVersion());
-        assertNotNull("URL Should not be null", ma.getArtifactUrl());
+        assertEquals("org.apache.maven.plugins", ma.getGroupId(), "Incorrect group");
+        assertEquals("maven-compiler-plugin", ma.getArtifactId(), "Incorrect artifact");
+        assertEquals("3.1", ma.getVersion(), "Incorrect version");
+        assertNotNull(ma.getArtifactUrl(), "URL Should not be null");
     }
 
     // This test does generate network traffic and communicates with a host
     // you may not be able to reach. Remove the @Ignore annotation if you want to
     // test it anyway
-    @Test(expected = FileNotFoundException.class)
-    @Ignore
-    public void testMissingSha1() throws Exception {
-        searcher.searchSha1("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    @Test
+    @Disabled
+    void testMissingSha1() {
+        assertThrows(FileNotFoundException.class, () ->
+            searcher.searchSha1("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/nodeaudit/NodeAuditSearchTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nodeaudit/NodeAuditSearchTest.java
@@ -18,45 +18,30 @@
 package org.owasp.dependencycheck.data.nodeaudit;
 
 import org.owasp.dependencycheck.BaseTest;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonReader;
-import java.io.InputStream;
-import java.util.List;
-import static org.junit.Assume.assumeFalse;
-import org.owasp.dependencycheck.utils.URLConnectionFailureException;
 
-public class NodeAuditSearchTest extends BaseTest {
+class NodeAuditSearchTest extends BaseTest {
 
 // Tested as part of the NodeAuditAnalyzerIT.  Adding this test can cause build failures due to an external service.
 //    private static final Logger LOGGER = LoggerFactory.getLogger(NodeAuditSearchTest.class);
 //    private NodeAuditSearch searcher;
 //
-//    @Before
+//    @BeforeEach
 //    @Override
-//    public void setUp() throws Exception {
+//    void setUp() throws Exception {
 //        super.setUp();
 //        searcher = new NodeAuditSearch(getSettings());
 //    }
 //
 //    @Test
-//    public void testNodeAuditSearchPositive() throws Exception {
+//    void testNodeAuditSearchPositive() throws Exception {
 //        InputStream in = BaseTest.getResourceAsStream(this, "nodeaudit/package-lock.json");
 //        try (JsonReader jsonReader = Json.createReader(in)) {
 //            final JsonObject packageJson = jsonReader.readObject();
 //            final JsonObject payload = SanitizePackage.sanitize(packageJson);
 //            final List<Advisory> advisories = searcher.submitPackage(payload);
-//            Assert.assertTrue(advisories.size() > 0);
-//        } catch (Exception ex) {
-//            assumeFalse(ex instanceof URLConnectionFailureException
-//                    && ex.getMessage().contains("Unable to connect to "));
-//            throw ex;
+//            URLConnectionFailureException ex = assertThrows(URLConnectionFailureException.class,
+//                    () -> searcher.submitPackage(payload));
+//            assumeFalse(ex.getMessage().contains("Unable to connect to "));
 //        }
 //
 //        //this should result in a cache hit
@@ -64,25 +49,20 @@ public class NodeAuditSearchTest extends BaseTest {
 //        try (JsonReader jsonReader = Json.createReader(in)) {
 //            final JsonObject packageJson = jsonReader.readObject();
 //            final JsonObject payload = SanitizePackage.sanitize(packageJson);
-//            final List<Advisory> advisories = searcher.submitPackage(payload);
-//            Assert.assertTrue(advisories.size() > 0);
-//        } catch (Exception ex) {
-//            assumeFalse(ex instanceof URLConnectionFailureException
-//                    && ex.getMessage().contains("Unable to connect to "));
-//            throw ex;
+//            URLConnectionFailureException ex = assertThrows(URLConnectionFailureException.class,
+//                    () -> searcher.submitPackage(payload));
+//            assumeFalse(ex.getMessage().contains("Unable to connect to "));
 //        }
 //    }
-//    @Test(expected = AnalysisException.class)
-//    public void testNodeAuditSearchNegative() throws Exception {
+//
+//    void testNodeAuditSearchNegative() throws Exception {
 //        InputStream in = BaseTest.getResourceAsStream(this, "nodeaudit/package.json");
 //        try (JsonReader jsonReader = Json.createReader(in)) {
 //            final JsonObject packageJson = jsonReader.readObject();
 //            final JsonObject sanitizedJson = SanitizePackage.sanitize(packageJson);
-//            searcher.submitPackage(sanitizedJson);
-//        } catch (Exception ex) {
-//            assumeFalse(ex instanceof URLConnectionFailureException
-//                    && ex.getMessage().contains("Unable to connect to "));
-//            throw ex;
+//            URLConnectionFailureException ex = assertThrows(URLConnectionFailureException.class,
+//                    () -> searcher.submitPackage(sanitizedJson));
+//            assumeFalse(ex.getMessage().contains("Unable to connect to "));
 //        }
 //    }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilderTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nodeaudit/NpmPayloadBuilderTest.java
@@ -17,24 +17,25 @@
  */
 package org.owasp.dependencycheck.data.nodeaudit;
 
-import java.io.InputStream;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonReader;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
-
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 
-public class NpmPayloadBuilderTest {
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NpmPayloadBuilderTest {
 
     @Test
-    public void testSanitizer() {
+    void testSanitizer() {
         JsonObjectBuilder builder = Json.createObjectBuilder()
                 .add("name", "my app")
                 .add("version", "1.0.0")
@@ -61,26 +62,26 @@ public class NpmPayloadBuilderTest {
         final MultiValuedMap<String, String> dependencyMap = new HashSetValuedHashMap<>();
         JsonObject sanitized = NpmPayloadBuilder.build(packageJson, dependencyMap, false);
 
-        Assert.assertTrue(sanitized.containsKey("name"));
-        Assert.assertTrue(sanitized.containsKey("version"));
-        Assert.assertTrue(sanitized.containsKey("dependencies"));
-        Assert.assertTrue(sanitized.containsKey("requires"));
+        assertTrue(sanitized.containsKey("name"));
+        assertTrue(sanitized.containsKey("version"));
+        assertTrue(sanitized.containsKey("dependencies"));
+        assertTrue(sanitized.containsKey("requires"));
 
         JsonObject dependencies = sanitized.getJsonObject("dependencies");
-        Assert.assertTrue(dependencies.containsKey("node_modules/jest-resolve"));
+        assertTrue(dependencies.containsKey("node_modules/jest-resolve"));
 
         JsonObject requires = sanitized.getJsonObject("requires");
-        Assert.assertTrue(requires.containsKey("abbrev"));
-        Assert.assertEquals("^1.1.1", requires.getString("abbrev"));
-        Assert.assertEquals("*", requires.getString("node_modules/jest-resolve"));
+        assertTrue(requires.containsKey("abbrev"));
+        assertEquals("^1.1.1", requires.getString("abbrev"));
+        assertEquals("*", requires.getString("node_modules/jest-resolve"));
 
-        Assert.assertFalse(sanitized.containsKey("lockfileVersion"));
-        Assert.assertFalse(sanitized.containsKey("random"));
+        assertFalse(sanitized.containsKey("lockfileVersion"));
+        assertFalse(sanitized.containsKey("random"));
     }
 
 
     @Test
-    public void testSkippedDependencies() {
+    void testSkippedDependencies() {
         JsonObjectBuilder builder = Json.createObjectBuilder()
                 .add("name", "my app")
                 .add("version", "1.0.0")
@@ -110,47 +111,47 @@ public class NpmPayloadBuilderTest {
         final MultiValuedMap<String, String> dependencyMap = new HashSetValuedHashMap<>();
         JsonObject sanitized = NpmPayloadBuilder.build(packageJson, dependencyMap, false);
 
-        Assert.assertTrue(sanitized.containsKey("name"));
-        Assert.assertTrue(sanitized.containsKey("version"));
-        Assert.assertTrue(sanitized.containsKey("dependencies"));
-        Assert.assertTrue(sanitized.containsKey("requires"));
+        assertTrue(sanitized.containsKey("name"));
+        assertTrue(sanitized.containsKey("version"));
+        assertTrue(sanitized.containsKey("dependencies"));
+        assertTrue(sanitized.containsKey("requires"));
 
         JsonObject requires = sanitized.getJsonObject("requires");
-        Assert.assertTrue(requires.containsKey("abbrev"));
-        Assert.assertEquals("^1.1.1", requires.getString("abbrev"));
+        assertTrue(requires.containsKey("abbrev"));
+        assertEquals("^1.1.1", requires.getString("abbrev"));
 
         //local and alias need to be skipped
-        Assert.assertFalse(requires.containsKey("react-dom"));
-        Assert.assertFalse(requires.containsKey("fake_submodule"));
+        assertFalse(requires.containsKey("react-dom"));
+        assertFalse(requires.containsKey("fake_submodule"));
 
-        Assert.assertFalse(sanitized.containsKey("lockfileVersion"));
-        Assert.assertFalse(sanitized.containsKey("random"));
+        assertFalse(sanitized.containsKey("lockfileVersion"));
+        assertFalse(sanitized.containsKey("random"));
     }
 
     @Test
-    public void testSanitizePackage() {
+    void testSanitizePackage() {
         InputStream in = BaseTest.getResourceAsStream(this, "nodeaudit/package-lock.json");
         final MultiValuedMap<String, String> dependencyMap = new HashSetValuedHashMap<>();
         try (JsonReader jsonReader = Json.createReader(in)) {
             JsonObject packageJson = jsonReader.readObject();
             JsonObject sanitized = NpmPayloadBuilder.build(packageJson, dependencyMap, false);
 
-            Assert.assertTrue(sanitized.containsKey("name"));
-            Assert.assertTrue(sanitized.containsKey("version"));
-            Assert.assertTrue(sanitized.containsKey("dependencies"));
-            Assert.assertTrue(sanitized.containsKey("requires"));
+            assertTrue(sanitized.containsKey("name"));
+            assertTrue(sanitized.containsKey("version"));
+            assertTrue(sanitized.containsKey("dependencies"));
+            assertTrue(sanitized.containsKey("requires"));
 
             JsonObject requires = sanitized.getJsonObject("requires");
-            Assert.assertTrue(requires.containsKey("bcrypt-nodejs"));
-            Assert.assertEquals("^0.0.3", requires.getString("bcrypt-nodejs"));
+            assertTrue(requires.containsKey("bcrypt-nodejs"));
+            assertEquals("^0.0.3", requires.getString("bcrypt-nodejs"));
 
-            Assert.assertFalse(sanitized.containsKey("lockfileVersion"));
-            Assert.assertFalse(sanitized.containsKey("random"));
+            assertFalse(sanitized.containsKey("lockfileVersion"));
+            assertFalse(sanitized.containsKey("random"));
         }
     }
 
     @Test
-    public void testPayloadWithLockAndPackage() {
+    void testPayloadWithLockAndPackage() {
         InputStream lock = BaseTest.getResourceAsStream(this, "nodeaudit/package-lock.json");
         InputStream json = BaseTest.getResourceAsStream(this, "nodeaudit/package.json");
         final MultiValuedMap<String, String> dependencyMap = new HashSetValuedHashMap<>();
@@ -159,26 +160,26 @@ public class NpmPayloadBuilderTest {
             JsonObject lockJson =    lockReader.readObject();
             JsonObject sanitized = NpmPayloadBuilder.build(lockJson, packageJson, dependencyMap, false);
 
-            Assert.assertTrue(sanitized.containsKey("name"));
-            Assert.assertTrue(sanitized.containsKey("version"));
-            Assert.assertTrue(sanitized.containsKey("dependencies"));
-            Assert.assertTrue(sanitized.containsKey("requires"));
+            assertTrue(sanitized.containsKey("name"));
+            assertTrue(sanitized.containsKey("version"));
+            assertTrue(sanitized.containsKey("dependencies"));
+            assertTrue(sanitized.containsKey("requires"));
 
             JsonObject requires = sanitized.getJsonObject("requires");
-            Assert.assertTrue(requires.containsKey("bcrypt-nodejs"));
-            Assert.assertEquals("0.0.3", requires.getString("bcrypt-nodejs"));
+            assertTrue(requires.containsKey("bcrypt-nodejs"));
+            assertEquals("0.0.3", requires.getString("bcrypt-nodejs"));
 
-            Assert.assertFalse(sanitized.containsKey("lockfileVersion"));
-            Assert.assertFalse(sanitized.containsKey("random"));
+            assertFalse(sanitized.containsKey("lockfileVersion"));
+            assertFalse(sanitized.containsKey("random"));
 
-            Assert.assertTrue(sanitized.containsKey("name"));
-            Assert.assertTrue(sanitized.containsKey("version"));
-            Assert.assertTrue(sanitized.containsKey("dependencies"));
-            Assert.assertTrue(sanitized.containsKey("requires"));
+            assertTrue(sanitized.containsKey("name"));
+            assertTrue(sanitized.containsKey("version"));
+            assertTrue(sanitized.containsKey("dependencies"));
+            assertTrue(sanitized.containsKey("requires"));
 
             //local and alias need to be skipped
-            Assert.assertFalse(requires.containsKey("react-dom"));
-            Assert.assertFalse(requires.containsKey("fake_submodule"));
+            assertFalse(requires.containsKey("react-dom"));
+            assertFalse(requires.containsKey("fake_submodule"));
         }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/nuget/XPathNuspecParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nuget/XPathNuspecParserTest.java
@@ -17,19 +17,22 @@
  */
 package org.owasp.dependencycheck.data.nuget;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-import org.owasp.dependencycheck.BaseTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  *
  * @author colezlaw
  *
  */
-public class XPathNuspecParserTest extends BaseTest {
+class XPathNuspecParserTest extends BaseTest {
 
     /**
      * Test all the valid components.
@@ -37,7 +40,7 @@ public class XPathNuspecParserTest extends BaseTest {
      * @throws Exception if anything goes sideways.
      */
     @Test
-    public void testGoodDocument() throws Exception {
+    void testGoodDocument() throws Exception {
         XPathNuspecParser parser = new XPathNuspecParser();
         //InputStream is = XPathNuspecParserTest.class.getClassLoader().getResourceAsStream("log4net.2.0.3.nuspec");
         InputStream is = BaseTest.getResourceAsStream(this, "log4net.2.0.3.nuspec");
@@ -55,17 +58,15 @@ public class XPathNuspecParserTest extends BaseTest {
      *
      * @throws Exception we expect this.
      */
-    @Test(expected = NuspecParseException.class)
-    public void testMissingDocument() throws Exception {
+    @Test
+    void testMissingDocument() {
         XPathNuspecParser parser = new XPathNuspecParser();
-        //InputStream is = XPathNuspecParserTest.class.getClassLoader().getResourceAsStream("dependencycheck.properties");
         InputStream is = BaseTest.getResourceAsStream(this, "dependencycheck.properties");
-
-        //hide the fatal message from the core parser
         final ByteArrayOutputStream myOut = new ByteArrayOutputStream();
         System.setErr(new PrintStream(myOut));
+        assertThrows(NuspecParseException.class, () ->
 
-        parser.parse(is);
+            parser.parse(is));
     }
 
     /**
@@ -73,11 +74,11 @@ public class XPathNuspecParserTest extends BaseTest {
      *
      * @throws Exception we expect this.
      */
-    @Test(expected = NuspecParseException.class)
-    public void testNotNuspec() throws Exception {
+    @Test
+    void testNotNuspec() {
         XPathNuspecParser parser = new XPathNuspecParser();
-        //InputStream is = XPathNuspecParserTest.class.getClassLoader().getResourceAsStream("suppressions.xml");
         InputStream is = BaseTest.getResourceAsStream(this, "suppressions.xml");
-        parser.parse(is);
+        assertThrows(NuspecParseException.class, () ->
+            parser.parse(is));
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/nvd/ecosystem/CveEcosystemMapperTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nvd/ecosystem/CveEcosystemMapperTest.java
@@ -19,28 +19,30 @@ package org.owasp.dependencycheck.data.nvd.ecosystem;
 
 import io.github.jeremylong.openvulnerability.client.nvd.Config;
 import io.github.jeremylong.openvulnerability.client.nvd.CpeMatch;
-import java.util.ArrayList;
-import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.owasp.dependencycheck.analyzer.JarAnalyzer;
-
-import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
 import io.github.jeremylong.openvulnerability.client.nvd.CveItem;
+import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
 import io.github.jeremylong.openvulnerability.client.nvd.LangString;
 import io.github.jeremylong.openvulnerability.client.nvd.Node;
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.analyzer.JarAnalyzer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  *
  * @author Jeremy Long
  */
-public class CveEcosystemMapperTest {
+class CveEcosystemMapperTest {
 
     /**
      * Test of getEcosystem method, of class CveEcosystemMapper.
      */
     @Test
-    public void testGetEcosystem() {
+    void testGetEcosystem() {
         CveEcosystemMapper mapper = new CveEcosystemMapper();
         String value = "There is a vulnerability in some.java file";
         assertEquals(JarAnalyzer.DEPENDENCY_ECOSYSTEM, mapper.getEcosystem(asCve(value)));

--- a/core/src/test/java/org/owasp/dependencycheck/data/nvd/ecosystem/DescriptionEcosystemMapperTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nvd/ecosystem/DescriptionEcosystemMapperTest.java
@@ -1,8 +1,10 @@
 package org.owasp.dependencycheck.data.nvd.ecosystem;
 
 import io.github.jeremylong.openvulnerability.client.nvd.CveItem;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
+import io.github.jeremylong.openvulnerability.client.nvd.LangString;
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.analyzer.JarAnalyzer;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -10,19 +12,16 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.junit.Test;
-import org.owasp.dependencycheck.analyzer.JarAnalyzer;
-import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
-import io.github.jeremylong.openvulnerability.client.nvd.LangString;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class DescriptionEcosystemMapperTest {
+class DescriptionEcosystemMapperTest {
 
     private static final String POSTFIX = ".ecosystem.txt";
 
@@ -44,19 +43,19 @@ public class DescriptionEcosystemMapperTest {
     }
 
     @Test
-    public void testDescriptionEcosystemMapper() throws IOException {
+    void testDescriptionEcosystemMapper() throws IOException {
         DescriptionEcosystemMapper mapper = new DescriptionEcosystemMapper();
         Map<String, File> ecosystemFiles = getEcosystemFiles();
         for (Entry<String, File> entry : ecosystemFiles.entrySet()) {
             try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(new FileInputStream(entry.getValue()), StandardCharsets.UTF_8))) {
                 String description;
                 while ((description = bufferedReader.readLine()) != null) {
-                    if (description.length() > 0 && !description.startsWith("#")) {
+                    if (!description.isEmpty() && !description.startsWith("#")) {
                         String ecosystem = mapper.getEcosystem(asCve(description));
                         if (entry.getKey().equals("null")) {
-                            assertNull(description, ecosystem);
+                            assertNull(ecosystem, description);
                         } else {
-                            assertEquals(description, entry.getKey(), ecosystem);
+                            assertEquals(entry.getKey(), ecosystem, description);
                         }
                     }
                 }
@@ -65,42 +64,42 @@ public class DescriptionEcosystemMapperTest {
     }
 
     @Test
-    public void testScoring() throws IOException {
+    void testScoring() {
         DescriptionEcosystemMapper mapper = new DescriptionEcosystemMapper();
         String value = "a.cpp b.java c.java";
         assertEquals(JarAnalyzer.DEPENDENCY_ECOSYSTEM, mapper.getEcosystem(asCve(value)));
     }
 
     @Test
-    public void testJspLinksDoNotCountScoring() throws IOException {
+    void testJspLinksDoNotCountScoring() {
         DescriptionEcosystemMapper mapper = new DescriptionEcosystemMapper();
         String value = "Read more at https://domain/help.jsp.";
         assertNull(mapper.getEcosystem(asCve(value)));
     }
 
     @Test
-    public void testSubsetFileExtensionsDoNotMatch() throws IOException {
+    void testSubsetFileExtensionsDoNotMatch() {
         DescriptionEcosystemMapper mapper = new DescriptionEcosystemMapper();
         String value = "Read more at index.html."; // i.e. does not match .h
         assertNull(mapper.getEcosystem(asCve(value)));
     }
 
     @Test
-    public void testSubsetKeywordsDoNotMatch() throws IOException {
+    void testSubsetKeywordsDoNotMatch() {
         DescriptionEcosystemMapper mapper = new DescriptionEcosystemMapper();
         String value = "Wonder if java senses the gc."; // i.e. does not match 'java se'
         assertNull(mapper.getEcosystem(asCve(value)));
     }
 
     @Test
-    public void testPhpLinksDoNotCountScoring() throws IOException {
+    void testPhpLinksDoNotCountScoring() {
         DescriptionEcosystemMapper mapper = new DescriptionEcosystemMapper();
         String value = "Read more at https://domain/help.php.";
         assertNull(mapper.getEcosystem(asCve(value)));
     }
 
     private DefCveItem asCve(String description) {
-        
+
         List<LangString> descriptions = new ArrayList<>();
         LangString desc = new LangString("en",description);
         descriptions.add(desc);

--- a/core/src/test/java/org/owasp/dependencycheck/data/nvd/ecosystem/UrlEcosystemMapperTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nvd/ecosystem/UrlEcosystemMapperTest.java
@@ -3,38 +3,39 @@ package org.owasp.dependencycheck.data.nvd.ecosystem;
 import io.github.jeremylong.openvulnerability.client.nvd.CveItem;
 import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
 import io.github.jeremylong.openvulnerability.client.nvd.Reference;
-import java.util.ArrayList;
-import java.util.List;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.analyzer.PythonPackageAnalyzer;
 
+import java.util.ArrayList;
+import java.util.List;
 
-public class UrlEcosystemMapperTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+
+class UrlEcosystemMapperTest {
 
     @Test
-    public void testUrlHostEcosystemMapper() {
-        
+    void testUrlHostEcosystemMapper() {
+
         UrlEcosystemMapper mapper = new UrlEcosystemMapper();
-        
+
         assertEquals(PythonPackageAnalyzer.DEPENDENCY_ECOSYSTEM, mapper.getEcosystem(asCve("https://python.org/path")));
     }
 
     private DefCveItem asCve(String url) {
-        
+
         List<Reference> references  = new ArrayList<>();
         Reference ref = new Reference(url, null, null);
         references.add(ref);
         CveItem cveItem = new CveItem(null, null, null, null, null, null, null, null, null, null, null, null, null, null, references, null, null, null, null);
         DefCveItem defCveItem = new DefCveItem(cveItem);
-        
+
         return defCveItem;
     }
 
     @Test
-    public void testGetEcosystemMustHandleNullCveReferences() {
+    void testGetEcosystemMustHandleNullCveReferences() {
         // Given
         UrlEcosystemMapper mapper = new UrlEcosystemMapper();
 
@@ -49,7 +50,7 @@ public class UrlEcosystemMapperTest {
     }
 
     @Test
-    public void testGetEcosystemMustHandleNullCve() {
+    void testGetEcosystemMustHandleNullCve() {
         // Given
         UrlEcosystemMapper mapper = new UrlEcosystemMapper();
 
@@ -63,7 +64,7 @@ public class UrlEcosystemMapperTest {
     }
 
     @Test
-    public void testGetEcosystemMustHandleNullCveItem() {
+    void testGetEcosystemMustHandleNullCveItem() {
         // Given
         UrlEcosystemMapper mapper = new UrlEcosystemMapper();
 

--- a/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/CveDBIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/CveDBIT.java
@@ -17,37 +17,38 @@
  */
 package org.owasp.dependencycheck.data.nvdcve;
 
-import java.sql.SQLException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
+import org.owasp.dependencycheck.data.update.cpe.CpePlus;
 import org.owasp.dependencycheck.dependency.Vulnerability;
 import org.owasp.dependencycheck.dependency.VulnerableSoftware;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import org.junit.After;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import org.junit.Before;
-import org.owasp.dependencycheck.data.update.cpe.CpePlus;
 import org.owasp.dependencycheck.dependency.VulnerableSoftwareBuilder;
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.CpeBuilder;
 import us.springett.parsers.cpe.values.LogicalValue;
 import us.springett.parsers.cpe.values.Part;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  *
  * @author Jeremy Long
  */
-public class CveDBIT extends BaseDBTestCase {
+class CveDBIT extends BaseDBTestCase {
 
     private CveDB instance = null;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -55,7 +56,7 @@ public class CveDBIT extends BaseDBTestCase {
         instance.open();
     }
 
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         instance.close();
@@ -67,7 +68,7 @@ public class CveDBIT extends BaseDBTestCase {
      * Test of getCPEs method, of class CveDB.
      */
     @Test
-    public void testGetCPEs() throws Exception {
+    void testGetCPEs() {
         String vendor = "apache";
         String product = "struts";
         Set<CpePlus> result = instance.getCPEs(vendor, product);
@@ -78,7 +79,7 @@ public class CveDBIT extends BaseDBTestCase {
      * Test of getVulnerability method, of class CveDB.
      */
     @Test
-    public void testgetVulnerability() throws Exception {
+    void testgetVulnerability() {
         Vulnerability result = instance.getVulnerability("CVE-2014-0094");
         assertTrue(result.getDescription().startsWith("The ParametersInterceptor in Apache Struts"));
     }
@@ -87,7 +88,7 @@ public class CveDBIT extends BaseDBTestCase {
      * Test of getVulnerabilities method, of class CveDB.
      */
     @Test
-    public void testGetVulnerabilities() throws Exception {
+    void testGetVulnerabilities() throws Exception {
 
         CpeBuilder builder = new CpeBuilder();
         Cpe cpe = builder.part(Part.APPLICATION).vendor("apache").product("struts").version("2.1.2").build();
@@ -107,7 +108,7 @@ public class CveDBIT extends BaseDBTestCase {
                 break;
             }
         }
-        assertTrue("Expected " + expected + ", but was not identified", found);
+        assertTrue(found, "Expected " + expected + ", but was not identified");
 
         found = false;
         expected = "CVE-2014-0096";
@@ -117,11 +118,11 @@ public class CveDBIT extends BaseDBTestCase {
                 break;
             }
         }
-        assertTrue("Expected " + expected + ", but was not identified", found);
+        assertTrue(found, "Expected " + expected + ", but was not identified");
 
         cpe = builder.part(Part.APPLICATION).vendor("jenkins").product("mailer").version("1.13").build();
         results = instance.getVulnerabilities(cpe);
-        assertTrue(results.size() >= 1);
+        assertFalse(results.isEmpty());
 
         found = false;
         expected = "CVE-2017-2651";
@@ -131,11 +132,11 @@ public class CveDBIT extends BaseDBTestCase {
                 break;
             }
         }
-        assertTrue("Expected " + expected + ", but was not identified", found);
+        assertTrue(found, "Expected " + expected + ", but was not identified");
 
         cpe = builder.part(Part.APPLICATION).vendor("fasterxml").product("jackson-databind").version("2.8.1").build();
         results = instance.getVulnerabilities(cpe);
-        assertTrue(results.size() >= 1);
+        assertFalse(results.isEmpty());
 
         found = false;
         expected = "CVE-2017-15095";
@@ -145,14 +146,14 @@ public class CveDBIT extends BaseDBTestCase {
                 break;
             }
         }
-        assertTrue("Expected " + expected + ", but was not identified", found);
+        assertTrue(found, "Expected " + expected + ", but was not identified");
     }
 
     /**
      * Test of getMatchingSoftware method, of class CveDB.
      */
     @Test
-    public void testGetMatchingSoftware() throws Exception {
+    void testGetMatchingSoftware() throws Exception {
 
         VulnerableSoftwareBuilder vsBuilder = new VulnerableSoftwareBuilder();
         Set<VulnerableSoftware> software = new HashSet<>();

--- a/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/CveDBMySqlIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/CveDBMySqlIT.java
@@ -17,31 +17,30 @@
  */
 package org.owasp.dependencycheck.data.nvdcve;
 
-import java.sql.SQLException;
-import java.util.List;
-import java.util.Set;
-import org.junit.After;
-
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.dependency.Vulnerability;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import org.junit.Before;
 import org.owasp.dependencycheck.data.update.cpe.CpePlus;
+import org.owasp.dependencycheck.dependency.Vulnerability;
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.CpeBuilder;
 import us.springett.parsers.cpe.values.Part;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class CveDBMySqlIT extends BaseTest {
+class CveDBMySqlIT extends BaseTest {
 
     private CveDB instance = null;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -49,23 +48,23 @@ public class CveDBMySqlIT extends BaseTest {
         instance.open();
     }
 
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         instance.close();
         super.tearDown();
-    }   
+    }
 
     /**
      * Test of getCPEs method, of class CveDB.
      */
     @Test
-    public void testGetCPEs() throws Exception {
+    void testGetCPEs() {
         try {
             String vendor = "apache";
             String product = "struts";
             Set<CpePlus> result = instance.getCPEs(vendor, product);
-            assertTrue("Has data been loaded into the MySQL DB? if not consider using the CLI to populate it", result.size() > 5);
+            assertTrue(result.size() > 5, "Has data been loaded into the MySQL DB? if not consider using the CLI to populate it");
         } catch (Exception ex) {
             System.out.println("Unable to access the My SQL database; verify that the db server is running and that the schema has been generated");
             throw ex;
@@ -76,7 +75,7 @@ public class CveDBMySqlIT extends BaseTest {
      * Test of getVulnerabilities method, of class CveDB.
      */
     @Test
-    public void testGetVulnerabilities() throws Exception {
+    void testGetVulnerabilities() throws Exception {
         CpeBuilder builder = new CpeBuilder();
         Cpe cpe = builder.part(Part.APPLICATION).vendor("apache").product("struts").version("2.1.2").build();
         try {

--- a/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/CveItemOperatorTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/CveItemOperatorTest.java
@@ -28,25 +28,26 @@ import io.github.jeremylong.openvulnerability.client.nvd.Node;
 import io.github.jeremylong.openvulnerability.client.nvd.Reference;
 import io.github.jeremylong.openvulnerability.client.nvd.VendorComment;
 import io.github.jeremylong.openvulnerability.client.nvd.Weakness;
+import org.junit.jupiter.api.Test;
+
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author jeremy
  */
-public class CveItemOperatorTest {
+class CveItemOperatorTest {
 
     /**
      * Test of testCveCpeStartWithFilter method, of class CveItemOperator.
      */
     @Test
-    public void testTestCveCpeStartWithFilter() {
+    void testTestCveCpeStartWithFilter() {
 
         ZonedDateTime published = ZonedDateTime.now();
         ZonedDateTime lastModified = ZonedDateTime.now();
@@ -73,7 +74,7 @@ public class CveItemOperatorTest {
         nodes.add(first);
         nodes.add(second);
         nodes.add(third);
-        
+
         Config c = new Config(Config.Operator.AND, null, nodes);
         configurations.add(c);
         List<VendorComment> vendorComments = null;
@@ -91,7 +92,7 @@ public class CveItemOperatorTest {
     }
 
     @Test
-    public void testTestCveCpeStartWithFilterForConfigurationWithoutCpeMatches() {
+    void testTestCveCpeStartWithFilterForConfigurationWithoutCpeMatches() {
         ZonedDateTime published = ZonedDateTime.now();
         ZonedDateTime lastModified = ZonedDateTime.now();
         LocalDate cisaExploitAdd = null;

--- a/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/DatabaseManagerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/DatabaseManagerTest.java
@@ -15,18 +15,19 @@
  */
 package org.owasp.dependencycheck.data.nvdcve;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseDBTestCase;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.owasp.dependencycheck.BaseDBTestCase;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  *
  * @author jeremy long
  */
-public class DatabaseManagerTest extends BaseDBTestCase {
+class DatabaseManagerTest extends BaseDBTestCase {
 
     /**
      * Test of initialize method, of class DatabaseManager.
@@ -34,7 +35,7 @@ public class DatabaseManagerTest extends BaseDBTestCase {
      * @throws org.owasp.dependencycheck.data.nvdcve.DatabaseException
      */
     @Test
-    public void testInitialize() throws DatabaseException, SQLException {
+    void testInitialize() throws DatabaseException, SQLException {
         DatabaseManager factory = new DatabaseManager(getSettings());
         factory.open();
         try (Connection result = factory.getConnection()) {

--- a/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/DatabasePropertiesIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/DatabasePropertiesIT.java
@@ -17,24 +17,27 @@
  */
 package org.owasp.dependencycheck.data.nvdcve;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseDBTestCase;
+
 import java.util.Properties;
-import org.junit.After;
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import org.junit.Before;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class DatabasePropertiesIT extends BaseDBTestCase {
+class DatabasePropertiesIT extends BaseDBTestCase {
 
     private CveDB cveDb = null;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -42,7 +45,7 @@ public class DatabasePropertiesIT extends BaseDBTestCase {
         cveDb.open();
     }
 
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws Exception {
         cveDb.close();
@@ -53,7 +56,7 @@ public class DatabasePropertiesIT extends BaseDBTestCase {
      * Test of isEmpty method, of class DatabaseProperties.
      */
     @Test
-    public void testIsEmpty() throws Exception {
+    void testIsEmpty() {
         DatabaseProperties prop = cveDb.getDatabaseProperties();
         assertNotNull(prop);
         //no exception means the call worked... whether or not it is empty depends on if the db is new
@@ -64,7 +67,7 @@ public class DatabasePropertiesIT extends BaseDBTestCase {
      * Test of save method, of class DatabaseProperties.
      */
     @Test
-    public void testSave() throws Exception {
+    void testSave() {
         String key = "test";
         String value = "something";
         String expected = "something";
@@ -74,12 +77,12 @@ public class DatabasePropertiesIT extends BaseDBTestCase {
         String results = instance.getProperty(key);
         assertEquals(expected, results);
     }
-    
+
     /**
      * Test of getProperty method, of class DatabaseProperties.
      */
     @Test
-    public void testGetProperty_String_String() throws Exception {
+    void testGetProperty_String_String() {
         String key = "doesn't exist";
         String defaultValue = "default";
         DatabaseProperties instance = cveDb.getDatabaseProperties();
@@ -92,13 +95,13 @@ public class DatabasePropertiesIT extends BaseDBTestCase {
      * Test of getProperty method, of class DatabaseProperties.
      */
     @Test
-    public void testGetProperty_String() throws DatabaseException {
+    void testGetProperty_String() throws DatabaseException {
         String key = "version";
         DatabaseProperties instance = cveDb.getDatabaseProperties();
         String result = instance.getProperty(key);
-        
+
         int major = Integer.parseInt(result.substring(0, result.indexOf('.')));
-       
+
         assertTrue(major >= 5);
     }
 
@@ -106,10 +109,10 @@ public class DatabasePropertiesIT extends BaseDBTestCase {
      * Test of getProperties method, of class DatabaseProperties.
      */
     @Test
-    public void testGetProperties() throws DatabaseException {
+    void testGetProperties() throws DatabaseException {
         DatabaseProperties instance = cveDb.getDatabaseProperties();
         Properties result = instance.getProperties();
-        assertTrue(result.size() > 0);
+        assertFalse(result.isEmpty());
         cveDb.close();
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/DriverLoaderTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/DriverLoaderTest.java
@@ -25,6 +25,7 @@ import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,9 +48,7 @@ class DriverLoaderTest extends BaseTest {
         String className = "org.h2.Driver";
         Driver d = null;
         try {
-            d = DriverLoader.load(className);
-        } catch (DriverLoadException ex) {
-            fail(ex.getMessage());
+            d = assertDoesNotThrow(() ->  DriverLoader.load(className));
         } finally {
             if (d != null) {
                 DriverManager.deregisterDriver(d);
@@ -107,9 +106,7 @@ class DriverLoaderTest extends BaseTest {
 
         Driver d = null;
         try {
-            d = DriverLoader.load(className, paths);
-        } catch (DriverLoadException ex) {
-            fail(ex.getMessage());
+            d = assertDoesNotThrow(() -> DriverLoader.load(className, paths));
         } finally {
             if (d != null) {
                 try {

--- a/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/DriverLoaderTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nvdcve/DriverLoaderTest.java
@@ -17,23 +17,24 @@
  */
 package org.owasp.dependencycheck.data.nvdcve;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+
 import java.io.File;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import org.junit.Test;
-import org.owasp.dependencycheck.BaseTest;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
  * @author Jeremy Long
  */
-public class DriverLoaderTest extends BaseTest {
+class DriverLoaderTest extends BaseTest {
 
     /**
      * Test of load method, of class DriverLoader.
@@ -42,7 +43,7 @@ public class DriverLoaderTest extends BaseTest {
      * the driver
      */
     @Test
-    public void testLoad_String() throws SQLException {
+    void testLoad_String() throws SQLException {
         String className = "org.h2.Driver";
         Driver d = null;
         try {
@@ -60,23 +61,24 @@ public class DriverLoaderTest extends BaseTest {
      * Test of load method, of class DriverLoader; expecting an exception due to
      * a bad driver class name.
      */
-    @Test(expected = DriverLoadException.class)
-    public void testLoad_String_ex() throws Exception {
+    @Test
+    void testLoad_String_ex() {
         final String className = "bad.Driver";
-        DriverLoader.load(className);
+        assertThrows(DriverLoadException.class, () ->
+            DriverLoader.load(className));
     }
 
     /**
      * Test of load method, of class DriverLoader.
      */
     @Test
-    public void testLoad_String_String() throws Exception {
+    void testLoad_String_String() throws Exception {
         String className = "com.mysql.jdbc.Driver";
         //we know this is in target/test-classes
         //File testClassPath = (new File(this.getClass().getClassLoader().getResource("org.mortbay.jetty.jar").getPath())).getParentFile();
         File testClassPath = BaseTest.getResourceAsFile(this, "org.mortbay.jetty.jar").getParentFile();
         File driver = new File(testClassPath, "../../src/test/resources/mysql-connector-java-5.1.27-bin.jar");
-        assertTrue("MySQL Driver JAR file not found in src/test/resources?", driver.isFile());
+        assertTrue(driver.isFile(), "MySQL Driver JAR file not found in src/test/resources?");
 
         Driver d = null;
         try {
@@ -94,7 +96,7 @@ public class DriverLoaderTest extends BaseTest {
      * Test of load method, of class DriverLoader.
      */
     @Test
-    public void testLoad_String_String_multiple_paths()  {
+    void testLoad_String_String_multiple_paths() {
         final String className = "com.mysql.jdbc.Driver";
         //we know this is in target/test-classes
         //final File testClassPath = (new File(this.getClass().getClassLoader().getResource("org.mortbay.jetty.jar").getPath())).getParentFile();
@@ -122,28 +124,25 @@ public class DriverLoaderTest extends BaseTest {
     /**
      * Test of load method, of class DriverLoader with an incorrect class name.
      */
-    @Test(expected = DriverLoadException.class)
-    public void testLoad_String_String_badClassName() throws Exception {
+    @Test
+    void testLoad_String_String_badClassName() {
         String className = "com.mybad.jdbc.Driver";
-        //we know this is in target/test-classes
-        //File testClassPath = (new File(this.getClass().getClassLoader().getResource("org.mortbay.jetty.jar").getPath())).getParentFile();
         File testClassPath = BaseTest.getResourceAsFile(this, "org.mortbay.jetty.jar").getParentFile();
         File driver = new File(testClassPath, "../../src/test/resources/mysql-connector-java-5.1.27-bin.jar");
-        assertTrue("MySQL Driver JAR file not found in src/test/resources?", driver.isFile());
-
-        DriverLoader.load(className, driver.getAbsolutePath());
+        assertTrue(driver.isFile(), "MySQL Driver JAR file not found in src/test/resources?");
+        assertThrows(DriverLoadException.class, () ->
+            DriverLoader.load(className, driver.getAbsolutePath()));
     }
 
     /**
      * Test of load method, of class DriverLoader with an incorrect class path.
      */
-    @Test(expected = DriverLoadException.class)
-    public void testLoad_String_String_badPath() throws Exception {
+    @Test
+    void testLoad_String_String_badPath() {
         String className = "com.mysql.jdbc.Driver";
-        //we know this is in target/test-classes
-        //File testClassPath = (new File(this.getClass().getClassLoader().getResource("org.mortbay.jetty.jar").getPath())).getParentFile();
         File testClassPath = BaseTest.getResourceAsFile(this, "org.mortbay.jetty.jar").getParentFile();
         File driver = new File(testClassPath, "../../src/test/bad/mysql-connector-java-5.1.27-bin.jar");
-        DriverLoader.load(className, driver.getAbsolutePath());
+        assertThrows(DriverLoadException.class, () ->
+            DriverLoader.load(className, driver.getAbsolutePath()));
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/update/EngineVersionCheckTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/update/EngineVersionCheckTest.java
@@ -15,32 +15,32 @@
  */
 package org.owasp.dependencycheck.data.update;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAccessor;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.data.nvdcve.CveDB;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseProperties;
 import org.owasp.dependencycheck.utils.DependencyVersion;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+
 /**
  * @author Jeremy Long
  */
-@RunWith(MockitoJUnitRunner.class)
-public class EngineVersionCheckTest extends BaseTest {
+@ExtendWith(MockitoExtension.class)
+class EngineVersionCheckTest extends BaseTest {
 
     @Mock
     private CveDB cveDb;
@@ -53,7 +53,7 @@ public class EngineVersionCheckTest extends BaseTest {
      * Test of shouldUpdate method, of class EngineVersionCheck.
      */
     @Test
-    public void testShouldUpdate() throws Exception {
+    void testShouldUpdate() throws Exception {
 
         doAnswer(invocation -> null).when(dbProperties).save(anyString(), anyString());
 
@@ -128,7 +128,7 @@ public class EngineVersionCheckTest extends BaseTest {
      * Test of getCurrentReleaseVersion method, of class EngineVersionCheck.
      */
     @Test
-    public void testGetCurrentReleaseVersion() {
+    void testGetCurrentReleaseVersion() {
         EngineVersionCheck instance = new EngineVersionCheck(getSettings());
         DependencyVersion minExpResult = new DependencyVersion("1.2.6");
         String release = instance.getCurrentReleaseVersion();

--- a/core/src/test/java/org/owasp/dependencycheck/data/update/NvdApiDataSourceTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/update/NvdApiDataSourceTest.java
@@ -17,28 +17,22 @@
  */
 package org.owasp.dependencycheck.data.update;
 
-import java.time.ZonedDateTime;
-import java.util.Map;
-import java.util.Properties;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.owasp.dependencycheck.Engine;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  *
  * @author Jeremy Long
  */
-public class NvdApiDataSourceTest {
+class NvdApiDataSourceTest {
 
     /**
      * Test of extractUrlData method, of class NvdApiDataSource.
      */
     @Test
-    public void testExtractUrlData() {
+    void testExtractUrlData() {
         String nvdDataFeedUrl = "https://internal.server/nist/nvdcve-{0}.json.gz";
         NvdApiDataSource instance = new NvdApiDataSource();
         String expectedUrl = "https://internal.server/nist/";
@@ -51,7 +45,7 @@ public class NvdApiDataSourceTest {
 
         assertEquals(expectedUrl, result.getUrl());
         assertNull(result.getPattern());
-        
+
         nvdDataFeedUrl = "https://internal.server/nist";
         expectedUrl = "https://internal.server/nist/";
         result = instance.extractUrlData(nvdDataFeedUrl);

--- a/core/src/test/java/org/owasp/dependencycheck/data/update/cisa/KnownExploitedVulnerabilityParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/update/cisa/KnownExploitedVulnerabilityParserTest.java
@@ -17,24 +17,26 @@
  */
 package org.owasp.dependencycheck.data.update.cisa;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.data.knownexploited.json.KnownExploitedVulnerabilitiesSchema;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.owasp.dependencycheck.data.knownexploited.json.KnownExploitedVulnerabilitiesSchema;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author jeremy
  */
-public class KnownExploitedVulnerabilityParserTest {
+class KnownExploitedVulnerabilityParserTest {
 
     /**
      * Test of parse method, of class KnownExploitedVulnerabilityParser.
      */
     @Test
-    public void testParse() throws Exception {
+    void testParse() throws Exception {
         File file = new File("./src/test/resources/update/cisa/known_exploited_vulnerabilities.json");
         try (InputStream in = new FileInputStream(file)) {
             KnownExploitedVulnerabilityParser instance = new KnownExploitedVulnerabilityParser();

--- a/core/src/test/java/org/owasp/dependencycheck/data/update/cpe/CpeEcosystemCacheTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/update/cpe/CpeEcosystemCacheTest.java
@@ -17,27 +17,28 @@
  */
 package org.owasp.dependencycheck.data.update.cpe;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.utils.Pair;
+
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.owasp.dependencycheck.utils.Pair;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class CpeEcosystemCacheTest {
+class CpeEcosystemCacheTest {
 
     /**
      * Test of getEcosystem method, of class CpeEcosystemCache.
      */
     @Test
-    public void testGetEcosystem() {
+    void testGetEcosystem() {
         Pair<String, String> key = new Pair<>("apache", "zookeeper");
         Map<Pair<String, String>, String> map = new HashMap<>();
         map.put(key, "java");
@@ -46,28 +47,28 @@ public class CpeEcosystemCacheTest {
         String expected = "java";
         String result = CpeEcosystemCache.getEcosystem("apache", "zookeeper", null);
         assertEquals(expected, result);
-        
+
         //changes to MULTIPLE = which is returned as null
         result = CpeEcosystemCache.getEcosystem("apache", "zookeeper", "c++");
         assertNull(result);
-        
+
         result = CpeEcosystemCache.getEcosystem("pivotal", "spring-framework", null);
         assertNull(result);
-        
+
         expected = "java";
         result = CpeEcosystemCache.getEcosystem("pivotal", "spring-framework", "java");
         assertEquals(expected, result);
-        
+
         expected = "java";
         result = CpeEcosystemCache.getEcosystem("pivotal", "spring-framework", "java");
         assertEquals(expected, result);
-        
+
         result = CpeEcosystemCache.getEcosystem("microsoft", "word", null );
         assertNull(result);
-        
+
         result = CpeEcosystemCache.getEcosystem("microsoft", "word", null );
         assertNull(result);
-        
+
         result = CpeEcosystemCache.getEcosystem("microsoft", "word", "" );
         assertNull(result);
     }
@@ -76,7 +77,7 @@ public class CpeEcosystemCacheTest {
      * Test of setCache method, of class CpeEcosystemCache.
      */
     @Test
-    public void testSetCache() {
+    void testSetCache() {
         Map<Pair<String, String>, String> map = new HashMap<>();
         CpeEcosystemCache.setCache(map);
         assertTrue(CpeEcosystemCache.isEmpty());
@@ -93,7 +94,7 @@ public class CpeEcosystemCacheTest {
      * Test of getChanged method, of class CpeEcosystemCache.
      */
     @Test
-    public void testGetChanged() {
+    void testGetChanged() {
         Pair<String, String> key = new Pair<>("apache", "zookeeper");
         Map<Pair<String, String>, String> map = new HashMap<>();
         map.put(key, "java");
@@ -120,7 +121,7 @@ public class CpeEcosystemCacheTest {
      * Test of isEmpty method, of class CpeEcosystemCache.
      */
     @Test
-    public void testIsEmpty() {
+    void testIsEmpty() {
         Map<Pair<String, String>, String> map = new HashMap<>();
         CpeEcosystemCache.setCache(map);
         boolean expResult = true;

--- a/core/src/test/java/org/owasp/dependencycheck/data/update/nvd/api/NvdApiProcessorTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/update/nvd/api/NvdApiProcessorTest.java
@@ -16,26 +16,25 @@
 package org.owasp.dependencycheck.data.update.nvd.api;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.data.nvdcve.CveDB;
-import org.owasp.dependencycheck.utils.Settings;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  *
  * @author Jeremy Long
  */
-public class NvdApiProcessorTest extends BaseTest {
+class NvdApiProcessorTest extends BaseTest {
 
     @Test
-    public void doesNotExistFile() throws Exception {
+    void doesNotExistFile() {
         try (CveDB cve = new CveDB(getSettings())) {
             File file = new File("does_not_exist");
             NvdApiProcessor processor = new NvdApiProcessor(null, file);
@@ -44,7 +43,7 @@ public class NvdApiProcessorTest extends BaseTest {
     }
 
     @Test
-    public void unspecifiedFileName() throws Exception {
+    void unspecifiedFileName() throws Exception {
         try (CveDB cve = new CveDB(getSettings())) {
             File file = File.createTempFile("test", "test");
             writeFileString(file, "");
@@ -54,7 +53,7 @@ public class NvdApiProcessorTest extends BaseTest {
     }
 
     @Test
-    public void invalidFileContent() throws Exception {
+    void invalidFileContent() throws Exception {
         try (CveDB cve = new CveDB(getSettings())) {
             File file = File.createTempFile("test", "test.json");
             // invalid content (broken array)
@@ -65,7 +64,7 @@ public class NvdApiProcessorTest extends BaseTest {
     }
 
     @Test
-    public void processValidStructure() throws Exception {
+    void processValidStructure() throws Exception {
         try (CveDB cve = new CveDB(getSettings())) {
             File file = File.createTempFile("test", "test.json");
             writeFileString(file, "[]");

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/CweSetTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/CweSetTest.java
@@ -17,24 +17,28 @@
  */
 package org.owasp.dependencycheck.dependency;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author jeremy
  */
-public class CweSetTest {
+class CweSetTest {
 
     /**
      * Test of getEntries method, of class CweSet.
      */
     @Test
-    public void testGetEntries() {
+    void testGetEntries() {
         CweSet instance = new CweSet();
         Set<String> result = instance.getEntries();
         assertTrue(result.isEmpty());
@@ -44,7 +48,7 @@ public class CweSetTest {
      * Test of addCwe method, of class CweSet.
      */
     @Test
-    public void testAddCwe() {
+    void testAddCwe() {
         System.out.println("addCwe");
         String cwe = "CWE-89";
         CweSet instance = new CweSet();
@@ -56,7 +60,7 @@ public class CweSetTest {
      * Test of toString method, of class CweSet.
      */
     @Test
-    public void testToString() {
+    void testToString() {
         CweSet instance = new CweSet();
         instance.addCwe("CWE-79");
         String expResult = "CWE-79 Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')";
@@ -68,7 +72,7 @@ public class CweSetTest {
      * Test of stream method, of class CweSet.
      */
     @Test
-    public void testStream() {
+    void testStream() {
         CweSet instance = new CweSet();
         instance.addCwe("79");
         String expResult = "79";
@@ -80,7 +84,7 @@ public class CweSetTest {
      * Test of getFullCwes method, of class CweSet.
      */
     @Test
-    public void testGetFullCwes() {
+    void testGetFullCwes() {
         CweSet instance = new CweSet();
         instance.addCwe("CWE-89");
         instance.addCwe("CWE-79");
@@ -89,8 +93,8 @@ public class CweSetTest {
         expResult.put("CWE-89", "Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')");
         Map<String, String> result = instance.getFullCwes();
         for (Map.Entry<String,String> entry : expResult.entrySet()) {
-            assertTrue(result.get(entry.getKey()).equals(entry.getValue()));
+            assertEquals(result.get(entry.getKey()), entry.getValue());
         }
     }
-    
+
 }

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
@@ -17,35 +17,35 @@
  */
 package org.owasp.dependencycheck.dependency;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
-
-import java.io.File;
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import org.owasp.dependencycheck.dependency.naming.CpeIdentifier;
 import org.owasp.dependencycheck.dependency.naming.Identifier;
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.CpeBuilder;
 import us.springett.parsers.cpe.values.Part;
 
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * @author Jeremy Long
  */
-public class DependencyTest extends BaseTest {
+class DependencyTest extends BaseTest {
 
     /**
      * Test of getFileName method, of class Dependency.
      */
     @Test
-    public void testGetFileName() {
+    void testGetFileName() {
         Dependency instance = new Dependency();
         String expResult = "filename";
         instance.setFileName(expResult);
@@ -57,7 +57,7 @@ public class DependencyTest extends BaseTest {
      * Test of setFileName method, of class Dependency.
      */
     @Test
-    public void testSetFileName() {
+    void testSetFileName() {
         String fileName = "file.tar";
         Dependency instance = new Dependency();
         instance.setFileName(fileName);
@@ -68,7 +68,7 @@ public class DependencyTest extends BaseTest {
      * Test of setActualFilePath method, of class Dependency.
      */
     @Test
-    public void testSetActualFilePath() {
+    void testSetActualFilePath() {
         String expectedPath = "file.tar";
         String actualPath = "file.tar";
         Dependency instance = new Dependency();
@@ -81,7 +81,7 @@ public class DependencyTest extends BaseTest {
      * Test of getActualFilePath method, of class Dependency.
      */
     @Test
-    public void testGetActualFilePath() {
+    void testGetActualFilePath() {
         Dependency instance = new Dependency();
         String expResult = "file.tar";
         instance.setSha1sum("non-null value");
@@ -94,7 +94,7 @@ public class DependencyTest extends BaseTest {
      * Test of setFilePath method, of class Dependency.
      */
     @Test
-    public void testSetFilePath() {
+    void testSetFilePath() {
         String filePath = "file.tar";
         Dependency instance = new Dependency();
         instance.setFilePath(filePath);
@@ -105,7 +105,7 @@ public class DependencyTest extends BaseTest {
      * Test of getFilePath method, of class Dependency.
      */
     @Test
-    public void testGetFilePath() {
+    void testGetFilePath() {
         Dependency instance = new Dependency();
         String expResult = "file.tar";
         instance.setFilePath(expResult);
@@ -117,7 +117,7 @@ public class DependencyTest extends BaseTest {
      * Test of getMd5sum method, of class Dependency.
      */
     @Test
-    public void testGetMd5sum() {
+    void testGetMd5sum() {
         //File file = new File(this.getClass().getClassLoader().getResource("struts2-core-2.1.2.jar").getPath());
         File file = BaseTest.getResourceAsFile(this, "struts2-core-2.1.2.jar");
 
@@ -133,7 +133,7 @@ public class DependencyTest extends BaseTest {
      * Test of setMd5sum method, of class Dependency.
      */
     @Test
-    public void testSetMd5sum() {
+    void testSetMd5sum() {
         String md5sum = "test";
         Dependency instance = new Dependency();
         instance.setMd5sum(md5sum);
@@ -144,7 +144,7 @@ public class DependencyTest extends BaseTest {
      * Test of getSha1sum method, of class Dependency.
      */
     @Test
-    public void testGetSha1sum() {
+    void testGetSha1sum() {
         //File file = new File(this.getClass().getClassLoader().getResource("struts2-core-2.1.2.jar").getPath());
         File file = BaseTest.getResourceAsFile(this, "struts2-core-2.1.2.jar");
         Dependency instance = new Dependency(file);
@@ -158,7 +158,7 @@ public class DependencyTest extends BaseTest {
      * Test of getSha256sum method, of class Dependency.
      */
     @Test
-    public void testGetSha256sum() {
+    void testGetSha256sum() {
         File file = BaseTest.getResourceAsFile(this, "struts2-core-2.1.2.jar");
         Dependency instance = new Dependency(file);
         String expResult = "5c1847a10800027254fcd0073385cceb46b1dacee061f3cd465e314bec592e81";
@@ -170,7 +170,7 @@ public class DependencyTest extends BaseTest {
      * Test of setSha1sum method, of class Dependency.
      */
     @Test
-    public void testSetSha1sum() {
+    void testSetSha1sum() {
         String sha1sum = "test";
         Dependency instance = new Dependency();
         instance.setSha1sum(sha1sum);
@@ -181,7 +181,7 @@ public class DependencyTest extends BaseTest {
      * Test of setSha256sum method, of class Dependency.
      */
     @Test
-    public void testSetSha256sum() {
+    void testSetSha256sum() {
         String sha256sum = "test";
         Dependency instance = new Dependency();
         instance.setSha256sum(sha256sum);
@@ -192,7 +192,7 @@ public class DependencyTest extends BaseTest {
      * Test of getSoftwareIdentifiers method, of class Dependency.
      */
     @Test
-    public void testGetSoftwareIdentifiers() {
+    void testGetSoftwareIdentifiers() {
         Dependency instance = new Dependency();
         Set<Identifier> result = instance.getSoftwareIdentifiers();
 
@@ -203,7 +203,7 @@ public class DependencyTest extends BaseTest {
      * Test of addSoftwareIdentifiers method, of class Dependency.
      */
     @Test
-    public void testAddSoftwareIdentifiers() {
+    void testAddSoftwareIdentifiers() {
         Set<Identifier> identifiers = new HashSet<>();
         Dependency instance = new Dependency();
         instance.addSoftwareIdentifiers(identifiers);
@@ -214,7 +214,7 @@ public class DependencyTest extends BaseTest {
      * Test of addVulnerableSoftwareIdentifier method, of class Dependency.
      */
     @Test
-    public void testAddVulnerableSoftwareIdentifier() throws Exception {
+    void testAddVulnerableSoftwareIdentifier() throws Exception {
         CpeBuilder builder = new CpeBuilder();
         Cpe cpe = builder.part(Part.APPLICATION).vendor("apache").product("struts").version("2.1.2").build();
         CpeIdentifier id = new CpeIdentifier(cpe, Confidence.HIGHEST);
@@ -225,14 +225,14 @@ public class DependencyTest extends BaseTest {
         Dependency instance = new Dependency();
         instance.addVulnerableSoftwareIdentifier(id);
         assertEquals(1, instance.getVulnerableSoftwareIdentifiers().size());
-        assertTrue("Identifier doesn't contain expected result.", instance.getVulnerableSoftwareIdentifiers().contains(expResult));
+        assertTrue(instance.getVulnerableSoftwareIdentifiers().contains(expResult), "Identifier doesn't contain expected result.");
     }
 
     /**
      * Test of getEvidence method, of class Dependency.
      */
     @Test
-    public void testGetEvidence() {
+    void testGetEvidence() {
         Dependency instance = new Dependency();
         Set<Evidence> result = instance.getEvidence(EvidenceType.VENDOR);
         assertNotNull(result);
@@ -246,7 +246,7 @@ public class DependencyTest extends BaseTest {
      * Test of addAsEvidence method, of class Dependency.
      */
     @Test
-    public void testAddAsEvidence() {
+    void testAddAsEvidence() {
         Dependency instance = new Dependency();
         MavenArtifact mavenArtifact = new MavenArtifact("group", "artifact", "version", "url");
         instance.addAsEvidence("pom", mavenArtifact, Confidence.HIGH);
@@ -259,12 +259,12 @@ public class DependencyTest extends BaseTest {
      * Test of addAsEvidence method, of class Dependency.
      */
     @Test
-    public void testAddAsEvidenceWithEmptyArtifact() {
+    void testAddAsEvidenceWithEmptyArtifact() {
         Dependency instance = new Dependency();
         MavenArtifact mavenArtifact = new MavenArtifact(null, null, null, null);
         instance.addAsEvidence("pom", mavenArtifact, Confidence.HIGH);
         assertFalse(instance.getEvidence(EvidenceType.VENDOR).stream().anyMatch(e -> e.getConfidence() == Confidence.HIGH));
-        assertTrue(instance.size() == 0);
+        assertEquals(0, instance.size());
         assertTrue(instance.getSoftwareIdentifiers().isEmpty());
     }
 
@@ -272,12 +272,12 @@ public class DependencyTest extends BaseTest {
      * Test of addAsEvidence method, of class Dependency.
      */
     @Test
-    public void testAddAsEvidenceWithExisting() {
+    void testAddAsEvidenceWithExisting() {
         Dependency instance = new Dependency();
         MavenArtifact mavenArtifact = new MavenArtifact("group", "artifact", "version", null);
         instance.addAsEvidence("pom", mavenArtifact, Confidence.HIGH);
         assertTrue(instance.getEvidence(EvidenceType.VENDOR).stream().anyMatch(e -> e.getConfidence() == Confidence.HIGH));
-        assertTrue(instance.size() == 4);
+        assertEquals(4, instance.size());
         assertFalse(instance.getSoftwareIdentifiers().isEmpty());
 
         instance.getSoftwareIdentifiers().forEach((i) -> assertNull(i.getUrl()));
@@ -285,7 +285,7 @@ public class DependencyTest extends BaseTest {
         mavenArtifact = new MavenArtifact("group", "artifact", "version", "url");
         instance.addAsEvidence("pom", mavenArtifact, Confidence.HIGH);
         assertTrue(instance.getEvidence(EvidenceType.VENDOR).stream().anyMatch(e -> e.getConfidence() == Confidence.HIGH));
-        assertTrue(instance.size() == 4);
+        assertEquals(4, instance.size());
         assertFalse(instance.getSoftwareIdentifiers().isEmpty());
 
         instance.getSoftwareIdentifiers().forEach((i) -> assertNotNull(i.getUrl()));

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/EvidenceTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/EvidenceTest.java
@@ -17,25 +17,27 @@
  */
 package org.owasp.dependencycheck.dependency;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import org.owasp.dependencycheck.BaseTest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class EvidenceTest extends BaseTest {
+class EvidenceTest extends BaseTest {
 
     /**
      * Test of equals method, of class Evidence.
      */
     @Test
-    public void testEquals() {
+    void testEquals() {
         Evidence that0 = new Evidence("file", "name", "guice-3.0", Confidence.HIGHEST);
         Evidence that1 = new Evidence("jar", "package name", "dependency", Confidence.HIGHEST);
         Evidence that2 = new Evidence("jar", "package name", "google", Confidence.HIGHEST);
@@ -47,19 +49,19 @@ public class EvidenceTest extends BaseTest {
         Evidence that8 = new Evidence("Manifest", "Implementation-Title", "Spring Framework", Confidence.HIGH);
 
         Evidence instance = new Evidence("Manifest", "Implementation-Title", "Spring Framework", Confidence.HIGH);
-        assertFalse(instance.equals(that0));
-        assertFalse(instance.equals(that1));
-        assertFalse(instance.equals(that2));
-        assertFalse(instance.equals(that3));
-        assertFalse(instance.equals(that4));
-        assertFalse(instance.equals(that5));
-        assertFalse(instance.equals(that6));
-        assertFalse(instance.equals(that7));
-        assertTrue(instance.equals(that8));
+        assertNotEquals(instance, that0);
+        assertNotEquals(instance, that1);
+        assertNotEquals(instance, that2);
+        assertNotEquals(instance, that3);
+        assertNotEquals(instance, that4);
+        assertNotEquals(instance, that5);
+        assertNotEquals(instance, that6);
+        assertNotEquals(instance, that7);
+        assertEquals(instance, that8);
     }
 
     @Test
-    public void testHashcodeContract() throws Exception {
+    void testHashcodeContract() {
         final Evidence titleCase = new Evidence("Manifest", "Implementation-Title", "Spring Framework", Confidence.HIGH);
         final Evidence lowerCase = new Evidence("manifest", "implementation-title", "spring framework", Confidence.HIGH);
         assertThat(titleCase, is(equalTo(lowerCase)));
@@ -70,7 +72,7 @@ public class EvidenceTest extends BaseTest {
      * Test of compareTo method, of class Evidence.
      */
     @Test
-    public void testCompareTo() {
+    void testCompareTo() {
         Evidence that0 = new Evidence("file", "name", "guice-3.0", Confidence.HIGHEST);
         Evidence that1 = new Evidence("jar", "package name", "dependency", Confidence.HIGHEST);
         Evidence that2 = new Evidence("jar", "package name", "google", Confidence.HIGHEST);
@@ -110,7 +112,7 @@ public class EvidenceTest extends BaseTest {
         assertTrue(result > 0);
 
         result = instance.compareTo(that8);
-        assertTrue(result == 0);
+        assertEquals(0, result);
 
         result = instance.compareTo(that9);
         assertTrue(result < 0);

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/VulnerabilityTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/VulnerabilityTest.java
@@ -22,11 +22,7 @@ import io.github.jeremylong.openvulnerability.client.nvd.CvssV2;
 import io.github.jeremylong.openvulnerability.client.nvd.CvssV2Data;
 import io.github.jeremylong.openvulnerability.client.nvd.CvssV3;
 import io.github.jeremylong.openvulnerability.client.nvd.CvssV3Data;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import us.springett.parsers.cpe.exceptions.CpeValidationException;
 
@@ -35,17 +31,21 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.TreeSet;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * @author Jens Hausherr, Hans Aikema
  */
-public class VulnerabilityTest extends BaseTest {
+class VulnerabilityTest extends BaseTest {
 
     /**
      * Test of addVulnerableSoftware method, of class VulnerableSoftware.
      * @throws CpeValidationException
      */
     @Test
-    public void testDuplicateVersions() throws CpeValidationException {
+    void testDuplicateVersions() throws CpeValidationException {
         Vulnerability obj = new Vulnerability();
         VulnerableSoftwareBuilder builder = new VulnerableSoftwareBuilder();
         obj.addVulnerableSoftware(builder.vendor("owasp").product("dependency-check").version("3.0.0").build());
@@ -59,7 +59,7 @@ public class VulnerabilityTest extends BaseTest {
      * Test of compareTo
      */
     @Test
-    public void compareTo_proper_sorting() {
+    void compareTo_proper_sorting() {
         // vulnerabilities take a name in reverse alphabetical order of expected sorting sequence
         // this way we ensure that the validated sorting was indeed due to the decreasing order of
         // severity and not by coincidence due to equal severity + alphabetical order on name.
@@ -112,28 +112,28 @@ public class VulnerabilityTest extends BaseTest {
         unscoredMedium.setUnscoredSeverity("meDiUm");
 
 
-        assertTrue("V2 HIGH 9.9 to V2 HIGH 9.0, 9.9 should be most severe", cvssV2Only99.compareTo(cvssV2Only90) < 0);
-        assertTrue("V2 HIGH 9.9 to V3 CRIT 9.0 should make V3 9.0 should be most severe to retain the CRITICAL rating",
-                   cvssV3Only90.compareTo(cvssV2Only99) < 0);
-        assertTrue("V3 CRIT 9.9 to V3 CRIT 9.0, 9.9 should be most severe", cvssV3OnlyCritHigh.compareTo(cvssV3Only90) < 0);
-        assertTrue("V3 CRIT 9.0 to V3 HIGH 8.0 V2 HIGH 9.9, V3 9.0 should be most severe",
-                   cvssV3Only90.compareTo(cvssV3_80v2_99) < 0);
-        assertTrue("CVSS v3 CRITICAL should be smaller (more severe) than unscored critical",
-                   cvssV3Only90.compareTo(unscoredCritical) < 0);
-        assertTrue("unscored critical should be smaller (more severe) than CVSS v2 HIGH 10.0 should be larger (less severe)",
-                   unscoredCritical.compareTo(cvssV2Only10_0) < 0);
-        assertTrue("CVSS v3 CRITICAL should be smaller (more severe) than unscored assumed critical",
-                   cvssV3Only90.compareTo(unscoredAssumedCritical) < 0);
-        assertTrue("Unscored CRITICAL should be smaller (more severe) than unscored assumed critical",
-                   unscoredCritical.compareTo(unscoredAssumedCritical) < 0);
-        assertTrue("unscored assumed critical should be smaller (more severe) than CVSS v2 HIGH 10.0",
-                   unscoredAssumedCritical.compareTo(cvssV2Only10_0) < 0);
-        assertTrue("unscored assumed critical should be smaller (more severe) CVSS v2 9.9 v3 8.0 (HIGH)",
-                   unscoredAssumedCritical.compareTo(cvssV3_80v2_99) < 0);
-        assertTrue("CVSS v3 score should be considered over V2 score; alphabetical sort determines final sequence",
-                   cvssV3_89v2_90.compareTo(cvssV3_89v2_99) < 0);
-        assertTrue("CVSS v3 medium top-range score should be smaller (more severe) than unscored medium",
-                   v3Medium69.compareTo(unscoredMedium) < 0);
+        assertTrue(cvssV2Only99.compareTo(cvssV2Only90) < 0, "V2 HIGH 9.9 to V2 HIGH 9.0, 9.9 should be most severe");
+        assertTrue(cvssV3Only90.compareTo(cvssV2Only99) < 0,
+                   "V2 HIGH 9.9 to V3 CRIT 9.0 should make V3 9.0 should be most severe to retain the CRITICAL rating");
+        assertTrue(cvssV3OnlyCritHigh.compareTo(cvssV3Only90) < 0, "V3 CRIT 9.9 to V3 CRIT 9.0, 9.9 should be most severe");
+        assertTrue(cvssV3Only90.compareTo(cvssV3_80v2_99) < 0,
+                   "V3 CRIT 9.0 to V3 HIGH 8.0 V2 HIGH 9.9, V3 9.0 should be most severe");
+        assertTrue(cvssV3Only90.compareTo(unscoredCritical) < 0,
+                   "CVSS v3 CRITICAL should be smaller (more severe) than unscored critical");
+        assertTrue(unscoredCritical.compareTo(cvssV2Only10_0) < 0,
+                   "unscored critical should be smaller (more severe) than CVSS v2 HIGH 10.0 should be larger (less severe)");
+        assertTrue(cvssV3Only90.compareTo(unscoredAssumedCritical) < 0,
+                   "CVSS v3 CRITICAL should be smaller (more severe) than unscored assumed critical");
+        assertTrue(unscoredCritical.compareTo(unscoredAssumedCritical) < 0,
+                   "Unscored CRITICAL should be smaller (more severe) than unscored assumed critical");
+        assertTrue(unscoredAssumedCritical.compareTo(cvssV2Only10_0) < 0,
+                   "unscored assumed critical should be smaller (more severe) than CVSS v2 HIGH 10.0");
+        assertTrue(unscoredAssumedCritical.compareTo(cvssV3_80v2_99) < 0,
+                   "unscored assumed critical should be smaller (more severe) CVSS v2 9.9 v3 8.0 (HIGH)");
+        assertTrue(cvssV3_89v2_90.compareTo(cvssV3_89v2_99) < 0,
+                   "CVSS v3 score should be considered over V2 score; alphabetical sort determines final sequence");
+        assertTrue(v3Medium69.compareTo(unscoredMedium) < 0,
+                   "CVSS v3 medium top-range score should be smaller (more severe) than unscored medium");
 
         List<Vulnerability> vulns = Arrays.asList(cvssV2Only99, cvssV2Only90, cvssV3Only90, cvssV3OnlyCritHigh, cvssV3_80v2_99,
                                                   cvssV2Only10_0, cvssV3_89v2_90,
@@ -142,9 +142,9 @@ public class VulnerabilityTest extends BaseTest {
         List<String> expectedStartLetters = Arrays.asList("Z", "Y", "X", "W", "V", "U", "T", "SA", "SB", "R", "Q", "P", "O");
 
         for (int i = 0; i < vulns.size(); i++) {
-            assertTrue("Expected start:" + expectedStartLetters.get(i) + " encountered start: " + vulns.get(i).getName()
-                                                                                                       .substring(0, 2),
-                       vulns.get(i).getName().startsWith(expectedStartLetters.get(i)));
+            assertTrue(vulns.get(i).getName().startsWith(expectedStartLetters.get(i)),
+                       "Expected start:" + expectedStartLetters.get(i) + " encountered start: " + vulns.get(i).getName()
+                                                                                                       .substring(0, 2));
         }
         testSortStabilityForPermutations(vulns);
     }
@@ -154,10 +154,10 @@ public class VulnerabilityTest extends BaseTest {
                 CvssV3Data.AttackComplexityType.HIGH, CvssV3Data.PrivilegesRequiredType.HIGH,
                 CvssV3Data.UserInteractionType.NONE, CvssV3Data.ScopeType.CHANGED,
                 CvssV3Data.CiaType.NONE, CvssV3Data.CiaType.NONE, CvssV3Data.CiaType.LOW,
-                
-                score, CvssV3Data.SeverityType.valueOf(severity), 
-                
-                CvssV3Data.ExploitCodeMaturityType.PROOF_OF_CONCEPT, CvssV3Data.RemediationLevelType.NOT_DEFINED, 
+
+                score, CvssV3Data.SeverityType.valueOf(severity),
+
+                CvssV3Data.ExploitCodeMaturityType.PROOF_OF_CONCEPT, CvssV3Data.RemediationLevelType.NOT_DEFINED,
                 CvssV3Data.ConfidenceType.REASONABLE, Double.MAX_VALUE, CvssV3Data.SeverityType.MEDIUM,
                 CvssV3Data.CiaRequirementType.NOT_DEFINED, CvssV3Data.CiaRequirementType.NOT_DEFINED,
                 CvssV3Data.CiaRequirementType.NOT_DEFINED, CvssV3Data.ModifiedAttackVectorType.ADJACENT_NETWORK,
@@ -169,22 +169,22 @@ public class VulnerabilityTest extends BaseTest {
         return cvssV3;
     }
 
-    
+
     private CvssV2 createCvssV2(double score, String severity) {
         CvssV2Data v2Data = new CvssV2Data(CvssV2Data.Version._2_0, severity, CvssV2Data.AccessVectorType.NETWORK,
-                CvssV2Data.AccessComplexityType.MEDIUM, CvssV2Data.AuthenticationType.MULTIPLE, 
-                CvssV2Data.CiaType.PARTIAL, CvssV2Data.CiaType.PARTIAL, CvssV2Data.CiaType.PARTIAL, 
-                
-                score, severity, 
-                
-                CvssV2Data.ExploitabilityType.UNPROVEN, CvssV2Data.RemediationLevelType.NOT_DEFINED, 
-                CvssV2Data.ReportConfidenceType.UNCONFIRMED, 0.0, CvssV2Data.CollateralDamagePotentialType.NOT_DEFINED, 
-                CvssV2Data.TargetDistributionType.MEDIUM, CvssV2Data.CiaRequirementType.NOT_DEFINED, 
+                CvssV2Data.AccessComplexityType.MEDIUM, CvssV2Data.AuthenticationType.MULTIPLE,
+                CvssV2Data.CiaType.PARTIAL, CvssV2Data.CiaType.PARTIAL, CvssV2Data.CiaType.PARTIAL,
+
+                score, severity,
+
+                CvssV2Data.ExploitabilityType.UNPROVEN, CvssV2Data.RemediationLevelType.NOT_DEFINED,
+                CvssV2Data.ReportConfidenceType.UNCONFIRMED, 0.0, CvssV2Data.CollateralDamagePotentialType.NOT_DEFINED,
+                CvssV2Data.TargetDistributionType.MEDIUM, CvssV2Data.CiaRequirementType.NOT_DEFINED,
                 CvssV2Data.CiaRequirementType.NOT_DEFINED, CvssV2Data.CiaRequirementType.NOT_DEFINED, 0.0);
         CvssV2 cvssV2 = new CvssV2("testing", CvssV2.Type.PRIMARY, v2Data, severity, 0.0, 0.0, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE);
         return cvssV2;
     }
-    
+
     /**
      * Sorts the offered list of vulnerabilities four times starting with the vulnerabilities arranged in different sequences
      * before sorting to check that sorting is stable for permutations of input sequence.<br> The input array is added to a
@@ -244,8 +244,8 @@ public class VulnerabilityTest extends BaseTest {
 
     private void assertPermutationSortedEqual(final Vulnerability[] prev, final Vulnerability[] current, final int[] permutation,
                                               final int[] prevPermutation) {
-        assertArrayEquals(String.format("Differently sorted for permutation '%s' versus '%s'", Arrays.toString(prevPermutation),
-                                        Arrays.toString(permutation)), prev, current);
+        assertArrayEquals(prev, current, String.format("Differently sorted for permutation '%s' versus '%s'", Arrays.toString(prevPermutation),
+                                        Arrays.toString(permutation)));
     }
 
 }

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/VulnerableSoftwareTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/VulnerableSoftwareTest.java
@@ -17,20 +17,22 @@
  */
 package org.owasp.dependencycheck.dependency;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import us.springett.parsers.cpe.exceptions.CpeValidationException;
 import us.springett.parsers.cpe.values.LogicalValue;
 import us.springett.parsers.cpe.values.Part;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  *
  * @author Jeremy Long
  */
-public class VulnerableSoftwareTest extends BaseTest {
+class VulnerableSoftwareTest extends BaseTest {
 
     /**
      * Test of equals method, of class VulnerableSoftware.
@@ -38,19 +40,19 @@ public class VulnerableSoftwareTest extends BaseTest {
      * @throws CpeValidationException
      */
     @Test
-    public void testEquals() throws CpeValidationException {
+    void testEquals() throws CpeValidationException {
         VulnerableSoftwareBuilder builder = new VulnerableSoftwareBuilder();
         VulnerableSoftware obj = null;
         VulnerableSoftware instance = builder.part(Part.APPLICATION).vendor("mortbay").product("jetty").version("6.1").build();
-        assertFalse(instance.equals(obj));
+        assertNotEquals(obj, instance);
 
         obj = builder.part(Part.APPLICATION).vendor("mortbay").product("jetty").version("6.1.0").build();
         instance = builder.part(Part.APPLICATION).vendor("mortbay").product("jetty").version("6.1").build();
-        assertFalse(instance.equals(obj));
+        assertNotEquals(instance, obj);
 
         obj = builder.part(Part.APPLICATION).vendor("mortbay").product("jetty").version("6.1.0").build();
         instance = builder.part(Part.APPLICATION).vendor("mortbay").product("jetty").version("6.1.0").build();
-        assertTrue(instance.equals(obj));
+        assertEquals(instance, obj);
     }
 
     /**
@@ -59,7 +61,7 @@ public class VulnerableSoftwareTest extends BaseTest {
      * @throws CpeValidationException
      */
     @Test
-    public void testCompareTo() throws CpeValidationException {
+    void testCompareTo() throws CpeValidationException {
         VulnerableSoftwareBuilder builder = new VulnerableSoftwareBuilder();
         VulnerableSoftware obj = builder.part(Part.APPLICATION).vendor("mortbay").product("jetty").version("6.1.0").build();
         VulnerableSoftware instance = builder.part(Part.APPLICATION).vendor("mortbay").product("jetty").version("6.1").build();
@@ -73,7 +75,7 @@ public class VulnerableSoftwareTest extends BaseTest {
     }
 
     @Test
-    public void testCompareVersionRange() throws CpeValidationException {
+    void testCompareVersionRange() throws CpeValidationException {
         VulnerableSoftwareBuilder builder = new VulnerableSoftwareBuilder();
         VulnerableSoftware instance = builder.version("2.0.0").build();
         assertTrue(instance.compareVersionRange("2.0.0"));
@@ -103,7 +105,7 @@ public class VulnerableSoftwareTest extends BaseTest {
     }
 
     @Test
-    public void testcompareUpdateAttributes() throws CpeValidationException {
+    void testcompareUpdateAttributes() {
 
         assertTrue(VulnerableSoftware.compareUpdateAttributes("update1", "u1"));
         assertTrue(VulnerableSoftware.compareUpdateAttributes("u1", "update1"));

--- a/core/src/test/java/org/owasp/dependencycheck/reporting/EscapeToolTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/reporting/EscapeToolTest.java
@@ -17,26 +17,28 @@
  */
 package org.owasp.dependencycheck.reporting;
 
-import java.util.HashSet;
-import java.util.Set;
-import org.junit.Test;
-import static org.junit.Assert.*;
-
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.naming.GenericIdentifier;
 import org.owasp.dependencycheck.dependency.naming.Identifier;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  *
-* @author Jeremy Long
+ * @author Jeremy Long
  */
-public class EscapeToolTest {
+class EscapeToolTest {
 
     /**
      * Test of url method, of class EscapeTool.
      */
     @Test
-    public void testUrl() {
+    void testUrl() {
         String text = null;
         EscapeTool instance = new EscapeTool();
         String expResult = null;
@@ -58,7 +60,7 @@ public class EscapeToolTest {
      * Test of html method, of class EscapeTool.
      */
     @Test
-    public void testHtml() {
+    void testHtml() {
         EscapeTool instance = new EscapeTool();
         String text = null;
         String expResult = null;
@@ -80,7 +82,7 @@ public class EscapeToolTest {
      * Test of xml method, of class EscapeTool.
      */
     @Test
-    public void testXml() {
+    void testXml() {
         EscapeTool instance = new EscapeTool();
         String text = null;
         String expResult = null;
@@ -102,7 +104,7 @@ public class EscapeToolTest {
      * Test of json method, of class EscapeTool.
      */
     @Test
-    public void testJson() {
+    void testJson() {
         String text = null;
         EscapeTool instance = new EscapeTool();
         String expResult = null;
@@ -124,7 +126,7 @@ public class EscapeToolTest {
      * Test of csv method, of class EscapeTool.
      */
     @Test
-    public void testCsv() {
+    void testCsv() {
         String text = null;
         EscapeTool instance = new EscapeTool();
         String expResult = "\"\"";
@@ -146,7 +148,7 @@ public class EscapeToolTest {
      * Test of csvIdentifiers method, of class EscapeTool.
      */
     @Test
-    public void testCsvIdentifiers() {
+    void testCsvIdentifiers() {
         EscapeTool instance = new EscapeTool();
         Set<Identifier> ids = null;
         String expResult = "\"\"";
@@ -177,7 +179,7 @@ public class EscapeToolTest {
      * Test of csvCpeConfidence method, of class EscapeTool.
      */
     @Test
-    public void testCsvCpeConfidence() {
+    void testCsvCpeConfidence() {
         EscapeTool instance = new EscapeTool();
         Set<Identifier> ids = null;
         String expResult = "\"\"";

--- a/core/src/test/java/org/owasp/dependencycheck/reporting/ReportGeneratorIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/reporting/ReportGeneratorIT.java
@@ -17,46 +17,43 @@
  */
 package org.owasp.dependencycheck.reporting;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseDBTestCase;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.data.update.exception.UpdateException;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.exception.ExceptionCollection;
+import org.owasp.dependencycheck.utils.DownloadFailedException;
+import org.owasp.dependencycheck.utils.Settings;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
-import javax.xml.XMLConstants;
-import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
-import javax.xml.validation.Validator;
-import org.junit.Assert;
 
-import org.junit.Test;
-import org.owasp.dependencycheck.BaseDBTestCase;
-import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.Engine;
-import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
-import org.owasp.dependencycheck.exception.ExceptionCollection;
-import org.owasp.dependencycheck.exception.ReportException;
-import org.owasp.dependencycheck.utils.InvalidSettingException;
-import org.owasp.dependencycheck.utils.Settings;
-import org.xml.sax.SAXException;
-import static org.junit.Assert.fail;
-import org.owasp.dependencycheck.data.update.exception.UpdateException;
-import org.owasp.dependencycheck.dependency.Dependency;
-import org.owasp.dependencycheck.utils.DownloadFailedException;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author Jeremy Long
  */
-public class ReportGeneratorIT extends BaseDBTestCase {
+class ReportGeneratorIT extends BaseDBTestCase {
 
     /**
      * Generates an XML report containing known vulnerabilities and realistic
      * data and validates the generated XML document against the XSD.
      */
     @Test
-    public void testGenerateReport() {
+    void testGenerateReport() {
         File writeTo = new File("target/test-reports/Report.xml");
         File writeJsonTo = new File("target/test-reports/Report.json");
         File writeHtmlTo = new File("target/test-reports/Report.html");
@@ -74,7 +71,7 @@ public class ReportGeneratorIT extends BaseDBTestCase {
         settings.setBoolean(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, false);
         settings.setBoolean(Settings.KEYS.PRETTY_PRINT, true);
 
-        generateReport(settings, writeTo, writeJsonTo, writeHtmlTo, writeJunitTo, writeCsvTo, writeSarifTo, suppressionFile);        
+        generateReport(settings, writeTo, writeJsonTo, writeHtmlTo, writeJunitTo, writeCsvTo, writeSarifTo, suppressionFile);
     }
 
     /**
@@ -82,7 +79,7 @@ public class ReportGeneratorIT extends BaseDBTestCase {
      * data and validates the generated XML document against the XSD.
      */
     @Test
-    public void testGenerateNodeAuditReport() {
+    void testGenerateNodeAuditReport() {
         File writeTo = new File("target/test-reports/nodeAudit/Report.xml");
         File writeJsonTo = new File("target/test-reports/nodeAudit/Report.json");
         File writeHtmlTo = new File("target/test-reports/nodeAudit/Report.html");
@@ -108,7 +105,7 @@ public class ReportGeneratorIT extends BaseDBTestCase {
      * data and validates the generated XML document against the XSD.
      */
     @Test
-    public void testGenerateRetireJsReport() {
+    void testGenerateRetireJsReport() {
         File writeTo = new File("target/test-reports/retireJS/Report.xml");
         File writeJsonTo = new File("target/test-reports/retireJS/Report.json");
         File writeHtmlTo = new File("target/test-reports/retireJS/Report.html");
@@ -127,12 +124,13 @@ public class ReportGeneratorIT extends BaseDBTestCase {
 
         generateReport(settings, writeTo, writeJsonTo, writeHtmlTo, writeJunitTo, writeCsvTo, writeSarifTo, suppressionFile);
     }
+
     /**
      * Generates an XML report containing known vulnerabilities and realistic
      * data and validates the generated XML document against the XSD.
      */
     @Test
-    public void testGenerateNodePackageReport() {
+    void testGenerateNodePackageReport() {
         File writeTo = new File("target/test-reports/NodePackage/Report.xml");
         File writeJsonTo = new File("target/test-reports/NodePackage/Report.json");
         File writeHtmlTo = new File("target/test-reports/NodePackage/Report.html");
@@ -153,8 +151,8 @@ public class ReportGeneratorIT extends BaseDBTestCase {
     }
 
 
-    public void generateReport(Settings settings, File writeTo, File writeJsonTo, File writeHtmlTo, File writeJunitTo, File writeCsvTo, File writeSarifTo, File suppressionFile){
-        try {
+    private void generateReport(Settings settings, File writeTo, File writeJsonTo, File writeHtmlTo, File writeJunitTo, File writeCsvTo, File writeSarifTo, File suppressionFile){
+        assertDoesNotThrow(() -> {
             //first check parent folder
             createParentFolder(writeTo);
             createParentFolder(writeJsonTo);
@@ -166,7 +164,7 @@ public class ReportGeneratorIT extends BaseDBTestCase {
             File struts = new File(this.getClass().getClassLoader().getResource("struts2-core-2.1.2.jar").getPath());
             File war = BaseTest.getResourceAsFile(this, "war-4.0.war");
             File cfu = BaseTest.getResourceAsFile(this, "commons-fileupload-1.2.1.jar");
-            
+
             //File axis = new File(this.getClass().getClassLoader().getResource("axis2-adb-1.4.1.jar").getPath());
             File axis = BaseTest.getResourceAsFile(this, "axis2-adb-1.4.1.jar");
             //File jetty = new File(this.getClass().getClassLoader().getResource("org.mortbay.jetty.jar").getPath());
@@ -208,10 +206,8 @@ public class ReportGeneratorIT extends BaseDBTestCase {
 
             //Test CSV
             int linesWritten = countLines(writeCsvTo);
-            Assert.assertEquals(vulnCount + 1, linesWritten);
-        } catch (DatabaseException | ExceptionCollection | ReportException | SAXException | IOException ex) {
-            fail(ex.getMessage());
-        }
+            assertEquals(vulnCount + 1, linesWritten);
+        });
     }
 
     /**

--- a/core/src/test/java/org/owasp/dependencycheck/resources/DependencyCheckBaseSuppressionTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/resources/DependencyCheckBaseSuppressionTest.java
@@ -1,26 +1,26 @@
 package org.owasp.dependencycheck.resources;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-public class DependencyCheckBaseSuppressionTest {
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DependencyCheckBaseSuppressionTest {
 
     @Test
-    public void testAllSuppressionsHaveBaseAttribute() throws ParserConfigurationException, SAXException, IOException {
+    void testAllSuppressionsHaveBaseAttribute() throws ParserConfigurationException, SAXException, IOException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 
@@ -45,6 +45,6 @@ public class DependencyCheckBaseSuppressionTest {
             }
         }
 
-        Assert.assertEquals(0, numberOfSuppressTagsWithoutBaseTrueAttribute);
+        assertEquals(0, numberOfSuppressTagsWithoutBaseTrueAttribute);
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/utils/CvssUtilTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/CvssUtilTest.java
@@ -21,20 +21,22 @@ import io.github.jeremylong.openvulnerability.client.nvd.CvssV2;
 import io.github.jeremylong.openvulnerability.client.nvd.CvssV2Data;
 import io.github.jeremylong.openvulnerability.client.nvd.CvssV3;
 import io.github.jeremylong.openvulnerability.client.nvd.CvssV3Data;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  *
  * @author Jeremy Long
  */
-public class CvssUtilTest {
+class CvssUtilTest {
 
     /**
      * Test of vectorToCvssV2 method, of class CvssUtil.
      */
     @Test
-    public void testVectorToCvssV2() {
+    void testVectorToCvssV2() {
         String vectorString = "/AV:L/AC:L/Au:N/C:N/I:N/A:C";
         Double baseScore = 1.0;
         CvssV2 result = CvssUtil.vectorToCvssV2(vectorString, baseScore);
@@ -53,7 +55,7 @@ public class CvssUtilTest {
      * Test of cvssV2ScoreToSeverity method, of class CvssUtil.
      */
     @Test
-    public void testCvssV2ScoreToSeverity() {
+    void testCvssV2ScoreToSeverity() {
         Double score = -1.0;
         String expResult = "UNKNOWN";
         String result = CvssUtil.cvssV2ScoreToSeverity(score);
@@ -104,7 +106,7 @@ public class CvssUtilTest {
      * Test of cvssV3ScoreToSeverity method, of class CvssUtil.
      */
     @Test
-    public void testCvssV3ScoreToSeverity() {
+    void testCvssV3ScoreToSeverity() {
         Double score = 0.0;
         CvssV3Data.SeverityType expResult = CvssV3Data.SeverityType.NONE;
         CvssV3Data.SeverityType result = CvssUtil.cvssV3ScoreToSeverity(score);
@@ -163,7 +165,7 @@ public class CvssUtilTest {
      * Test of vectorToCvssV3 method, of class CvssUtil.
      */
     @Test
-    public void testVectorToCvssV3() {
+    void testVectorToCvssV3() {
         String vectorString = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H";
         Double baseScore = 10.0;
         CvssV3 result = CvssUtil.vectorToCvssV3(vectorString, baseScore);

--- a/core/src/test/java/org/owasp/dependencycheck/utils/DateUtilTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/DateUtilTest.java
@@ -15,26 +15,26 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.exception.ParseException;
+
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.exception.ParseException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author Jeremy Long
  */
-public class DateUtilTest extends BaseTest {
+class DateUtilTest extends BaseTest {
 
     /**
      * Test of withinDateRange method, of class DateUtil.
      */
     @Test
-    public void testWithinDateRange() {
+    void testWithinDateRange() {
         Calendar c = Calendar.getInstance();
 
         long current = c.getTimeInMillis() / 1000;
@@ -49,12 +49,12 @@ public class DateUtilTest extends BaseTest {
         result = DateUtil.withinDateRange(lastRun, current, range);
         assertEquals(expResult, result);
     }
-    
-       /**
+
+    /**
      * Test of withinDateRange method, of class DateUtil.
      */
     @Test
-    public void testWithinZonedDateRange() {
+    void testWithinZonedDateRange() {
         ZonedDateTime lastRun = ZonedDateTime.parse("2023-11-15T11:15:03Z");
         ZonedDateTime current = ZonedDateTime.parse("2023-11-17T11:15:03Z");
         int range = 5;
@@ -74,7 +74,7 @@ public class DateUtilTest extends BaseTest {
      * @throws ParseException thrown when there is a parse error
      */
     @Test
-    public void testParseXmlDate() throws ParseException {
+    void testParseXmlDate() throws ParseException {
         String xsDate = "2019-01-02Z";
         Calendar result = DateUtil.parseXmlDate(xsDate);
         assertEquals(2019, result.get(Calendar.YEAR));
@@ -84,7 +84,7 @@ public class DateUtilTest extends BaseTest {
     }
 
     @Test
-    public void testGetEpochValueInSeconds() throws ParseException {
+    void testGetEpochValueInSeconds() {
         String milliseconds = "1550538553466";
         long expected = 1550538553;
         long result = DateUtil.getEpochValueInSeconds(milliseconds);

--- a/core/src/test/java/org/owasp/dependencycheck/utils/DependencyVersionTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/DependencyVersionTest.java
@@ -17,26 +17,29 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
-import org.owasp.dependencycheck.BaseTest;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class DependencyVersionTest extends BaseTest {
+class DependencyVersionTest extends BaseTest {
 
     /**
      * Test of parseVersion method, of class DependencyVersion.
      */
     @Test
-    public void testParseVersion() {
+    void testParseVersion() {
         String version = "1.2r1";
         DependencyVersion instance = new DependencyVersion();
         instance.parseVersion(version);
@@ -70,14 +73,14 @@ public class DependencyVersionTest extends BaseTest {
      * Test of iterator method, of class DependencyVersion.
      */
     @Test
-    public void testIterator() {
+    void testIterator() {
         DependencyVersion instance = new DependencyVersion("1.2.3");
         Iterator<String> result = instance.iterator();
         assertTrue(result.hasNext());
         int count = 1;
         while (result.hasNext()) {
             String v = result.next();
-            assertTrue(String.valueOf(count++).equals(v));
+            assertEquals(String.valueOf(count++), v);
         }
     }
 
@@ -85,7 +88,7 @@ public class DependencyVersionTest extends BaseTest {
      * Test of toString method, of class DependencyVersion.
      */
     @Test
-    public void testToString() {
+    void testToString() {
         DependencyVersion instance = new DependencyVersion("1.2.3r1");
         String expResult = "1.2.3.r1";
         String result = instance.toString();
@@ -96,7 +99,7 @@ public class DependencyVersionTest extends BaseTest {
      * Test of equals method, of class DependencyVersion.
      */
     @Test
-    public void testEquals() {
+    void testEquals() {
         DependencyVersion obj = new DependencyVersion("1.2.3.r1");
         DependencyVersion instance = new DependencyVersion("1.2.3");
         boolean expResult = false;
@@ -106,26 +109,26 @@ public class DependencyVersionTest extends BaseTest {
         expResult = true;
         result = instance.equals(obj);
         assertEquals(expResult, result);
-        
+
         instance = new DependencyVersion("2.0.0");
         obj = new DependencyVersion("2");
         expResult = false;
         result = instance.equals(obj);
         assertEquals(expResult, result);
-        
+
         obj = new DependencyVersion("2.0");
         expResult = true;
         result = instance.equals(obj);
         assertEquals(expResult, result);
-        
-        
+
+
     }
 
     /**
      * Test of hashCode method, of class DependencyVersion.
      */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         DependencyVersion instance = new DependencyVersion("3.2.1");
         int expResult = 80756;
         int result = instance.hashCode();
@@ -136,26 +139,26 @@ public class DependencyVersionTest extends BaseTest {
      * Test of matchesAtLeastThreeLevels method, of class DependencyVersion.
      */
     @Test
-    public void testMatchesAtLeastThreeLevels() {
+    void testMatchesAtLeastThreeLevels() {
 
         DependencyVersion instance = new DependencyVersion("2.3.16.3");
         DependencyVersion version = new DependencyVersion("2.3.16.4");
         //true tests
-        assertEquals(true, instance.matchesAtLeastThreeLevels(version));
+        assertTrue(instance.matchesAtLeastThreeLevels(version));
         version = new DependencyVersion("2.3");
-        assertEquals(true, instance.matchesAtLeastThreeLevels(version));
+        assertTrue(instance.matchesAtLeastThreeLevels(version));
         //false tests
         version = new DependencyVersion("2.3.16.1");
-        assertEquals(false, instance.matchesAtLeastThreeLevels(version));
+        assertFalse(instance.matchesAtLeastThreeLevels(version));
         version = new DependencyVersion("2");
-        assertEquals(false, instance.matchesAtLeastThreeLevels(version));
+        assertFalse(instance.matchesAtLeastThreeLevels(version));
     }
 
     /**
      * Test of compareTo method, of class DependencyVersion.
      */
     @Test
-    public void testCompareTo() {
+    void testCompareTo() {
         DependencyVersion instance = new DependencyVersion("1.2.3");
         DependencyVersion version = new DependencyVersion("1.2.3");
         assertEquals(0, instance.compareTo(version));
@@ -202,7 +205,7 @@ public class DependencyVersionTest extends BaseTest {
      * Test of getVersionParts method, of class DependencyVersion.
      */
     @Test
-    public void testGetVersionParts() {
+    void testGetVersionParts() {
         DependencyVersion instance = new DependencyVersion();
         List<String> versionParts = Arrays.asList("1", "1", "1");
         instance.setVersionParts(versionParts);
@@ -215,7 +218,7 @@ public class DependencyVersionTest extends BaseTest {
      * Test of setVersionParts method, of class DependencyVersion.
      */
     @Test
-    public void testSetVersionParts() {
+    void testSetVersionParts() {
         List<String> versionParts = Arrays.asList("1", "1", "1");
         DependencyVersion instance = new DependencyVersion();
         instance.setVersionParts(versionParts);

--- a/core/src/test/java/org/owasp/dependencycheck/utils/DependencyVersionUtilTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/DependencyVersionUtilTest.java
@@ -17,23 +17,23 @@
  */
 package org.owasp.dependencycheck.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  *
  * @author Jeremy Long
  */
-public class DependencyVersionUtilTest extends BaseTest {
+class DependencyVersionUtilTest extends BaseTest {
 
     /**
      * Test of parseVersion method, of class DependencyVersionUtil.
      */
     @Test
-    public void testParseVersion_String() {
+    void testParseVersion_String() {
         final String[] fileName = {"openssl1.0.1c", "something-0.9.5.jar", "lib2-1.1.jar", "lib1.5r4-someflag-R26.jar",
             "lib-1.2.5-dev-20050313.jar", "testlib_V4.4.0.jar", "lib-core-2.0.0-RC1-SNAPSHOT.jar",
             "lib-jsp-2.0.1_R114940.jar", "dev-api-2.3.11_R121413.jar", "lib-api-3.7-SNAPSHOT.jar",
@@ -49,14 +49,14 @@ public class DependencyVersionUtilTest extends BaseTest {
             if (version != null) {
                 result = version.toString();
             }
-            assertEquals("Failed extraction on \"" + fileName[i] + "\".", expResult[i], result);
+            assertEquals(expResult[i], result, "Failed extraction on \"" + fileName[i] + "\".");
         }
 
         String[] failingNames = {"no-version-identified.jar", "somelib-04aug2000r7-dev.jar", /*"no.version15.jar",*/
             "lib_1.0_spec-1.1.jar", "lib-api_1.0_spec-1.0.1.jar"};
         for (String failingName : failingNames) {
             final DependencyVersion version = DependencyVersionUtil.parseVersion(failingName);
-            assertNull("Found version in name that should have failed \"" + failingName + "\".", version);
+            assertNull(version, "Found version in name that should have failed \"" + failingName + "\".");
         }
     }
 
@@ -64,7 +64,7 @@ public class DependencyVersionUtilTest extends BaseTest {
      * Test of parseVersion method, of class DependencyVersionUtil.
      */
     @Test
-    public void testParseVersion_String_boolean() {
+    void testParseVersion_String_boolean() {
         //cpe:/a:playframework:play_framework:2.1.1:rc1-2.9.x-backport
         String text = "2.1.1.rc1.2.9.x-backport";
         boolean firstMatchOnly = false;
@@ -89,7 +89,7 @@ public class DependencyVersionUtilTest extends BaseTest {
      * Test of parsePreVersion method, of class DependencyVersionUtil.
      */
     @Test
-    public void testParsePreVersion() {
+    void testParsePreVersion() {
         String text = "library-name-1.4.1r2-release.jar";
         String expResult = "library-name";
         String result = DependencyVersionUtil.parsePreVersion(text);

--- a/core/src/test/java/org/owasp/dependencycheck/utils/ExtractionUtilTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/ExtractionUtilTest.java
@@ -63,7 +63,8 @@ class ExtractionUtilTest extends BaseTest {
     void testExtractFilesUsingFilter() throws Exception {
         File destination = getSettings().getTempDirectory();
         File archive = BaseTest.getResourceAsFile(this, "evil.zip");
-        ExtractionUtil.extractFiles(archive, destination);
+        assertThrows(org.owasp.dependencycheck.utils.ExtractionException.class, () ->
+            ExtractionUtil.extractFiles(archive, destination));
         FilenameFilter filter = new NameFileFilter("evil.txt");
         assertThrows(org.owasp.dependencycheck.utils.ExtractionException.class, () ->
             ExtractionUtil.extractFilesUsingFilter(archive, destination, filter));

--- a/core/src/test/java/org/owasp/dependencycheck/utils/ExtractionUtilTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/ExtractionUtilTest.java
@@ -17,49 +17,55 @@
  */
 package org.owasp.dependencycheck.utils;
 
-import java.io.File;
-import java.io.FilenameFilter;
 import org.apache.commons.io.filefilter.NameFileFilter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.Engine;
+
+import java.io.File;
+import java.io.FilenameFilter;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  *
  * @author Jeremy Long
  */
-public class ExtractionUtilTest extends BaseTest {
+class ExtractionUtilTest extends BaseTest {
 
     /**
      * Test of extractFiles method, of class ExtractionUtil.
      */
-    @Test(expected = org.owasp.dependencycheck.utils.ExtractionException.class)
-    public void testExtractFiles_File_File() throws Exception {
+    @Test
+    void testExtractFiles_File_File() throws Exception {
         File destination = getSettings().getTempDirectory();
         File archive = BaseTest.getResourceAsFile(this, "evil.zip");
-        ExtractionUtil.extractFiles(archive, destination);
+        assertThrows(org.owasp.dependencycheck.utils.ExtractionException.class, () ->
+            ExtractionUtil.extractFiles(archive, destination));
     }
 
     /**
      * Test of extractFiles method, of class ExtractionUtil.
      */
-    @Test(expected = org.owasp.dependencycheck.utils.ExtractionException.class)
-    public void testExtractFiles_3args() throws Exception {
+    @Test
+    void testExtractFiles_3args() throws Exception {
         File destination = getSettings().getTempDirectory();
         File archive = BaseTest.getResourceAsFile(this, "evil.zip");
         Engine engine = null;
-        ExtractionUtil.extractFiles(archive, destination, engine);
+        assertThrows(org.owasp.dependencycheck.utils.ExtractionException.class, () ->
+            ExtractionUtil.extractFiles(archive, destination, engine));
     }
 
     /**
      * Test of extractFilesUsingFilter method, of class ExtractionUtil.
      */
-    @Test(expected = org.owasp.dependencycheck.utils.ExtractionException.class)
-    public void testExtractFilesUsingFilter() throws Exception {
+    @Test
+    void testExtractFilesUsingFilter() throws Exception {
         File destination = getSettings().getTempDirectory();
         File archive = BaseTest.getResourceAsFile(this, "evil.zip");
         ExtractionUtil.extractFiles(archive, destination);
         FilenameFilter filter = new NameFileFilter("evil.txt");
-        ExtractionUtil.extractFilesUsingFilter(archive, destination, filter);
+        assertThrows(org.owasp.dependencycheck.utils.ExtractionException.class, () ->
+            ExtractionUtil.extractFilesUsingFilter(archive, destination, filter));
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/utils/FilterTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/FilterTest.java
@@ -17,37 +17,39 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+
 import java.util.ArrayList;
 import java.util.List;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
-import org.owasp.dependencycheck.BaseTest;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class FilterTest extends BaseTest {
+class FilterTest extends BaseTest {
 
     /**
      * Test of passes method, of class Filter.
      */
     @Test
-    public void testPasses() {
+    void testPasses() {
         String keep = "keep";
         String fail = "fail";
 
-        assertTrue("String contained keep - but passes returned false.", TEST_FILTER.passes(keep));
-        assertFalse("String contained fail - but passes returned true.", TEST_FILTER.passes(fail));
+        assertTrue(TEST_FILTER.passes(keep), "String contained keep - but passes returned false.");
+        assertFalse(TEST_FILTER.passes(fail), "String contained fail - but passes returned true.");
     }
 
     /**
      * Test of filter method, of class Filter.
      */
     @Test
-    public void testFilter_Iterable() {
+    void testFilter_Iterable() {
         List<String> testData = new ArrayList<>();
         testData.add("keep");
         testData.add("remove");
@@ -64,10 +66,10 @@ public class FilterTest extends BaseTest {
         assertArrayEquals(expResults.toArray(), actResults.toArray());
     }
     private static final Filter<String> TEST_FILTER
-            = new Filter<String>() {
-                @Override
-                public boolean passes(String str) {
-                    return str.contains("keep");
-                }
-            };
+            = new Filter<>() {
+        @Override
+        public boolean passes(String str) {
+            return str.contains("keep");
+        }
+    };
 }

--- a/core/src/test/java/org/owasp/dependencycheck/utils/InterpolationUtilTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/InterpolationUtilTest.java
@@ -17,21 +17,23 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Properties;
-import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author Jeremy Long
  */
-public class InterpolationUtilTest {
+class InterpolationUtilTest {
 
     /**
      * Test of interpolate method, of class InterpolationUtil.
      */
     @Test
-    public void testInterpolate() {
+    void testInterpolate() {
         Properties prop = new Properties();
         prop.setProperty("key", "value");
         prop.setProperty("nested", "nested ${key}");
@@ -42,7 +44,7 @@ public class InterpolationUtilTest {
     }
 
     @Test
-    public void testInterpolateNonexistentErased() {
+    void testInterpolateNonexistentErased() {
         Properties prop = new Properties();
         prop.setProperty("key", "value");
         String text = "This is a test of '${key}' and '${nothing}'";
@@ -52,7 +54,7 @@ public class InterpolationUtilTest {
     }
 
     @Test
-    public void testInterpolateMSBuild() {
+    void testInterpolateMSBuild() {
         Properties prop = new Properties();
         prop.setProperty("key", "value");
         prop.setProperty("nested", "nested $(key)");
@@ -63,7 +65,7 @@ public class InterpolationUtilTest {
     }
 
     @Test
-    public void testInterpolateNonexistentErasedMSBuild() {
+    void testInterpolateNonexistentErasedMSBuild() {
         Properties prop = new Properties();
         prop.setProperty("key", "value");
         String text = "This is a test of '$(key)' and '$(nothing)'";

--- a/core/src/test/java/org/owasp/dependencycheck/utils/PyPACoreMetadataParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/PyPACoreMetadataParserTest.java
@@ -1,29 +1,31 @@
 package org.owasp.dependencycheck.utils;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Properties;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class PyPACoreMetadataParserTest {
+class PyPACoreMetadataParserTest {
 
     @Test
-    public void getProperties_should_throw_exception_for_too_large_major() throws IOException {
+    void getProperties_should_throw_exception_for_too_large_major() throws IOException {
         try {
             PyPACoreMetadataParser.getProperties(new BufferedReader(new StringReader("Metadata-Version: 3.0")));
-            Assert.fail("Expected IllegalArgumentException for too large major in Metadata-Version");
+            fail("Expected IllegalArgumentException for too large major in Metadata-Version");
         } catch (IllegalArgumentException e) {
-            Assert.assertTrue(e.getMessage().contains("Unsupported PyPA Wheel metadata"));
+            assertTrue(e.getMessage().contains("Unsupported PyPA Wheel metadata"));
         }
     }
 
     @Test
-    public void getProperties_should_properly_parse_multiline_description() throws IOException {
+    void getProperties_should_properly_parse_multiline_description() throws IOException {
         String payload = "Metadata-Version: 1.0\r\n"
                          + "Description: This is the first line\r\n"
                          + "       | and this the second\r\n"
@@ -32,38 +34,40 @@ public class PyPACoreMetadataParserTest {
                          + "\r\n"
                          + "This: is the body and it is ignored. It may contain an extensive description in various formats";
         Properties props = PyPACoreMetadataParser.getProperties(new BufferedReader(new StringReader(payload)));
-        Assert.assertEquals("1.0", props.get("Metadata-Version"));
-        Assert.assertEquals("This is the first line\n"
+        assertEquals("1.0", props.get("Metadata-Version"));
+        assertEquals("This is the first line\n"
                             + " and this the second\n"
                             + "\n"
                             + " and the fourth after an empty third", props.get("Description"));
-        Assert.assertFalse("Body was parsed as a header", props.containsKey("This"));
+        assertFalse(props.containsKey("This"), "Body was parsed as a header");
     }
 
     @Test
-    public void getProperties_should_support_colon_in_headerValue() throws IOException {
+    void getProperties_should_support_colon_in_headerValue() throws IOException {
         String payload = "Metadata-Version: 2.2\r\n"
                          + "Description: My value contains a : colon\r\n";
         Properties props = PyPACoreMetadataParser.getProperties(new BufferedReader(new StringReader(payload)));
-        Assert.assertEquals("2.2", props.getProperty("Metadata-Version"));
-        Assert.assertEquals("My value contains a : colon", props.getProperty("Description"));
+        assertEquals("2.2", props.getProperty("Metadata-Version"));
+        assertEquals("My value contains a : colon", props.getProperty("Description"));
     }
+
     @Test
-    public void getProperties_should_support_folding_in_headerValue() throws IOException {
+    void getProperties_should_support_folding_in_headerValue() throws IOException {
         String payload = "Metadata-Version: 2\r\n"
                          + " .2\r\n"
                          + "Description: My value\r\n"
                          + "  contains a \r\n"
                          + " : colon\r\n";
         Properties props = PyPACoreMetadataParser.getProperties(new BufferedReader(new StringReader(payload)));
-        Assert.assertEquals("2.2", props.getProperty("Metadata-Version"));
-        Assert.assertEquals("My value contains a : colon", props.getProperty("Description"));
+        assertEquals("2.2", props.getProperty("Metadata-Version"));
+        assertEquals("My value contains a : colon", props.getProperty("Description"));
     }
+
     @Test
-    public void getProperties_should_support_newer_minors() throws IOException {
+    void getProperties_should_support_newer_minors() throws IOException {
         String payload = "Metadata-Version: 2\r\n"
                          + " .5\r\n";
         Properties props = PyPACoreMetadataParser.getProperties(new BufferedReader(new StringReader(payload)));
-        Assert.assertEquals("2.5", props.getProperty("Metadata-Version"));
+        assertEquals("2.5", props.getProperty("Metadata-Version"));
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/utils/PyPACoreMetadataParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/PyPACoreMetadataParserTest.java
@@ -9,19 +9,17 @@ import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class PyPACoreMetadataParserTest {
 
     @Test
-    void getProperties_should_throw_exception_for_too_large_major() throws IOException {
-        try {
-            PyPACoreMetadataParser.getProperties(new BufferedReader(new StringReader("Metadata-Version: 3.0")));
-            fail("Expected IllegalArgumentException for too large major in Metadata-Version");
-        } catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("Unsupported PyPA Wheel metadata"));
-        }
+    void getProperties_should_throw_exception_for_too_large_major() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> PyPACoreMetadataParser.getProperties(new BufferedReader(new StringReader("Metadata-Version: 3.0"))),
+                "Expected IllegalArgumentException for too large major in Metadata-Version");
+        assertTrue(e.getMessage().contains("Unsupported PyPA Wheel metadata"));
     }
 
     @Test

--- a/core/src/test/java/org/owasp/dependencycheck/utils/SemverTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/SemverTest.java
@@ -13,34 +13,35 @@
  */
 package org.owasp.dependencycheck.utils;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.semver4j.Semver;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class SemverTest {
+class SemverTest {
 
     /**
      * Test of semver4j. See https://github.com/dependency-check/DependencyCheck/issues/5128#issuecomment-1343080426
      */
     @Test
-    public void testSemver() {
+    void testSemver() {
         Semver semver = new Semver("3.1.4");
         assertTrue(semver.satisfies("^3.0.0-0"));
     }
+
     /**
      * Test of semver4j. See https://github.com/dependency-check/DependencyCheck/issues/5158
      */
     @Test
-    public void testSemverComplex() {
+    void testSemverComplex() {
         Semver semver = new Semver("18.11.5");
         assertFalse(semver.satisfies("^14.14.20 || ^16.0.0"));
-        
+
         semver = new Semver("14.15.0");
         assertTrue(semver.satisfies("^14.14.20 || ^16.0.0"));
     }

--- a/core/src/test/java/org/owasp/dependencycheck/utils/SeverityUtilTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/SeverityUtilTest.java
@@ -18,20 +18,21 @@
 package org.owasp.dependencycheck.utils;
 
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  *
  * @author Jeremy Long
  */
-public class SeverityUtilTest {
+class SeverityUtilTest {
 
     /**
      * Test of estimateCvssV2 method, of class SeverityUtil.
      */
     @Test
-    public void testEstimateCvssV2() {
+    void testEstimateCvssV2() {
         String severity = null;
         double expResult = 0.0;
         Double result = SeverityUtil.estimateCvssV2(severity);

--- a/core/src/test/java/org/owasp/dependencycheck/utils/UrlStringUtilsTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/UrlStringUtilsTest.java
@@ -17,22 +17,26 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author jeremy long
  */
-public class UrlStringUtilsTest {
+class UrlStringUtilsTest {
 
     /**
      * Test of containsUrl method, of class UrlStringUtils.
      */
     @Test
-    public void testContainsUrl() {
+    void testContainsUrl() {
         String text = "Test of https://github.com";
         assertTrue(UrlStringUtils.containsUrl(text));
         text = "Test of github.com";
@@ -43,7 +47,7 @@ public class UrlStringUtilsTest {
      * Test of isUrl method, of class UrlStringUtils.
      */
     @Test
-    public void testIsUrl() {
+    void testIsUrl() {
         String text = "https://github.com";
         assertTrue(UrlStringUtils.isUrl(text));
         text = "simple text";
@@ -54,17 +58,17 @@ public class UrlStringUtilsTest {
      * Test of extractImportantUrlData method, of class UrlStringUtils.
      */
     @Test
-    public void testExtractImportantUrlData() throws Exception {
+    void testExtractImportantUrlData() throws Exception {
         String text = "http://github.com/dependency-check/DependencyCheck/.gitignore";
         List<String> expResult = Arrays.asList("dependency-check", "DependencyCheck", "gitignore");
         List<String> result = UrlStringUtils.extractImportantUrlData(text);
         assertEquals(expResult, result);
-        
+
         text = "https://dependency-check.github.io/DependencyCheck/index.html";
         expResult = Arrays.asList("dependency-check", "DependencyCheck", "index");
         result = UrlStringUtils.extractImportantUrlData(text);
         assertEquals(expResult, result);
-        
+
         text = "http://example.com/dependency-check/DependencyCheck/something";
         expResult = Arrays.asList("example", "dependency-check", "DependencyCheck", "something");
         result = UrlStringUtils.extractImportantUrlData(text);

--- a/core/src/test/java/org/owasp/dependencycheck/xml/XmlEntityTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/XmlEntityTest.java
@@ -17,20 +17,21 @@
  */
 package org.owasp.dependencycheck.xml;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author Jeremy Long
  */
-public class XmlEntityTest {
+class XmlEntityTest {
 
     /**
      * Test of fromNamedReference method, of class XmlEntity.
      */
     @Test
-    public void testFromNamedReference() {
+    void testFromNamedReference() {
         CharSequence s = null;
         String expResult = null;
         String result = XmlEntity.fromNamedReference(s);

--- a/core/src/test/java/org/owasp/dependencycheck/xml/XmlInputStreamTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/XmlInputStreamTest.java
@@ -17,24 +17,28 @@
  */
 package org.owasp.dependencycheck.xml;
 
+import org.junit.jupiter.api.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class XmlInputStreamTest {
+class XmlInputStreamTest {
 
     /**
      * Test of length method, of class XmlInputStream.
      */
     @Test
-    public void testLength() {
+    void testLength() {
         String data = "";
         InputStream stream = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
         XmlInputStream instance = new XmlInputStream(stream);
@@ -53,7 +57,7 @@ public class XmlInputStreamTest {
      * Test of read method, of class XmlInputStream.
      */
     @Test
-    public void testRead_0args() throws Exception {
+    void testRead_0args() throws Exception {
         String data = "";
         InputStream stream = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
         XmlInputStream instance = new XmlInputStream(stream);
@@ -73,7 +77,7 @@ public class XmlInputStreamTest {
      * Test of read method, of class XmlInputStream.
      */
     @Test
-    public void testRead_3args() throws Exception {
+    void testRead_3args() throws Exception {
         byte[] data = new byte[10];
         int offset = 0;
         int length = 10;
@@ -85,8 +89,8 @@ public class XmlInputStreamTest {
         int result = instance.read(data, offset, length);
         assertEquals(expResult, result);
         assertArrayEquals(expected, data);
-        
-        
+
+
         data = new byte[5];
         offset = 0;
         length = 5;
@@ -98,7 +102,7 @@ public class XmlInputStreamTest {
         result = instance.read(data, offset, length);
         assertEquals(expResult, result);
         assertArrayEquals(expected, data);
-        
+
         data = new byte[10];
         offset = 0;
         length = 10;
@@ -116,7 +120,7 @@ public class XmlInputStreamTest {
      * Test of toString method, of class XmlInputStream.
      */
     @Test
-    public void testToString() throws IOException {
+    void testToString() throws IOException {
         String data = "test";
         InputStream stream = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
         XmlInputStream instance = new XmlInputStream(stream);

--- a/core/src/test/java/org/owasp/dependencycheck/xml/assembly/GrokHandlerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/assembly/GrokHandlerTest.java
@@ -17,25 +17,27 @@
  */
 package org.owasp.dependencycheck.xml.assembly;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.utils.XmlUtils;
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+
+import javax.xml.parsers.SAXParser;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import javax.xml.parsers.SAXParser;
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.utils.XmlUtils;
-import org.xml.sax.InputSource;
-import org.xml.sax.XMLReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author Jeremy Long
  */
-public class GrokHandlerTest extends BaseTest {
+class GrokHandlerTest extends BaseTest {
 
     /**
      * Test of getSuppressionRules method, of class SuppressionHandler.
@@ -43,7 +45,7 @@ public class GrokHandlerTest extends BaseTest {
      * @throws Exception thrown if there is an exception....
      */
     @Test
-    public void testHandler() throws Exception {
+    void testHandler() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "assembly/sample-grok.xml");
         InputStream schemaStream = BaseTest.getResourceAsStream(this, "schema/grok-assembly.1.0.xsd");
 

--- a/core/src/test/java/org/owasp/dependencycheck/xml/assembly/GrokParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/assembly/GrokParserTest.java
@@ -17,24 +17,25 @@
  */
 package org.owasp.dependencycheck.xml.assembly;
 
-import java.io.File;
-import org.junit.Assert;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test of the Grok Assembly parser.
  *
  * @author Jeremy Long
  */
-public class GrokParserTest extends BaseTest {
+class GrokParserTest extends BaseTest {
 
     @Test
-    public void testParseSuppressionRulesV1dot0() throws Exception {
+    void testParseSuppressionRulesV1dot0() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "assembly/sample-grok-error.xml");
         GrokParser instance = new GrokParser();
         AssemblyData result = instance.parse(file);
-        Assert.assertEquals("Unable to process file", result.getError());
+        assertEquals("Unable to process file", result.getError());
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/xml/hints/EvidenceMatcherTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/hints/EvidenceMatcherTest.java
@@ -17,18 +17,19 @@
  */
 package org.owasp.dependencycheck.xml.hints;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Evidence;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * Unit tests for {@link EvidenceMatcher}.
- * 
+ *
  * @author Hans Aikema
  */
-public class EvidenceMatcherTest {
+class EvidenceMatcherTest {
 
     private static final Evidence EVIDENCE_HIGHEST = new Evidence("source", "name", "value", Confidence.HIGHEST);
     private static final Evidence EVIDENCE_HIGH = new Evidence("source", "name", "value", Confidence.HIGH);
@@ -44,76 +45,76 @@ public class EvidenceMatcherTest {
     private static final Evidence REGEX_EVIDENCE_LOW = new Evidence("source", "name", "val that should not match", Confidence.LOW);
 
     @Test
-    public void testExactMatching() throws Exception {
+    void testExactMatching() {
         final EvidenceMatcher exactMatcherHighest = new EvidenceMatcher("source", "name", "value", false, Confidence.HIGHEST);
-        assertTrue("exact matcher should match EVIDENCE_HIGHEST", exactMatcherHighest.matches(EVIDENCE_HIGHEST));
-        assertFalse("exact matcher should not match EVIDENCE_HIGH", exactMatcherHighest.matches(EVIDENCE_HIGH));
-        assertFalse("exact matcher should not match EVIDENCE_MEDIUM", exactMatcherHighest.matches(EVIDENCE_MEDIUM));
-        assertFalse("exact matcher should not match EVIDENCE_MEDIUM_SECOND_SOURCE", exactMatcherHighest.matches(EVIDENCE_MEDIUM_SECOND_SOURCE));
-        assertFalse("exact matcher should not match EVIDENCE_LOW", exactMatcherHighest.matches(EVIDENCE_LOW));
+        assertTrue(exactMatcherHighest.matches(EVIDENCE_HIGHEST), "exact matcher should match EVIDENCE_HIGHEST");
+        assertFalse(exactMatcherHighest.matches(EVIDENCE_HIGH), "exact matcher should not match EVIDENCE_HIGH");
+        assertFalse(exactMatcherHighest.matches(EVIDENCE_MEDIUM), "exact matcher should not match EVIDENCE_MEDIUM");
+        assertFalse(exactMatcherHighest.matches(EVIDENCE_MEDIUM_SECOND_SOURCE), "exact matcher should not match EVIDENCE_MEDIUM_SECOND_SOURCE");
+        assertFalse(exactMatcherHighest.matches(EVIDENCE_LOW), "exact matcher should not match EVIDENCE_LOW");
     }
 
     @Test
-    public void testWildcardConfidenceMatching() throws Exception {
+    void testWildcardConfidenceMatching() {
         final EvidenceMatcher wildcardCofidenceMatcher = new EvidenceMatcher("source", "name", "value", false, null);
-        assertTrue("wildcard confidence matcher should match EVIDENCE_HIGHEST", wildcardCofidenceMatcher.matches(EVIDENCE_HIGHEST));
-        assertTrue("wildcard confidence matcher should match EVIDENCE_HIGH", wildcardCofidenceMatcher.matches(EVIDENCE_HIGH));
-        assertTrue("wildcard confidence matcher should match EVIDENCE_MEDIUM", wildcardCofidenceMatcher.matches(EVIDENCE_MEDIUM));
-        assertFalse("wildcard confidence matcher should not match EVIDENCE_MEDIUM_SECOND_SOURCE", wildcardCofidenceMatcher.matches(EVIDENCE_MEDIUM_SECOND_SOURCE));
-        assertTrue("wildcard confidence matcher should match EVIDENCE_LOW", wildcardCofidenceMatcher.matches(EVIDENCE_LOW));
+        assertTrue(wildcardCofidenceMatcher.matches(EVIDENCE_HIGHEST), "wildcard confidence matcher should match EVIDENCE_HIGHEST");
+        assertTrue(wildcardCofidenceMatcher.matches(EVIDENCE_HIGH), "wildcard confidence matcher should match EVIDENCE_HIGH");
+        assertTrue(wildcardCofidenceMatcher.matches(EVIDENCE_MEDIUM), "wildcard confidence matcher should match EVIDENCE_MEDIUM");
+        assertFalse(wildcardCofidenceMatcher.matches(EVIDENCE_MEDIUM_SECOND_SOURCE), "wildcard confidence matcher should not match EVIDENCE_MEDIUM_SECOND_SOURCE");
+        assertTrue(wildcardCofidenceMatcher.matches(EVIDENCE_LOW), "wildcard confidence matcher should match EVIDENCE_LOW");
     }
 
     @Test
-    public void testWildcardSourceMatching() throws Exception {
+    void testWildcardSourceMatching() {
         final EvidenceMatcher wildcardSourceMatcher = new EvidenceMatcher(null, "name", "value", false, Confidence.MEDIUM);
-        assertFalse("wildcard source matcher should not match EVIDENCE_HIGHEST", wildcardSourceMatcher.matches(EVIDENCE_HIGHEST));
-        assertFalse("wildcard source matcher should not match EVIDENCE_HIGH", wildcardSourceMatcher.matches(EVIDENCE_HIGH));
-        assertTrue("wildcard source matcher should match EVIDENCE_MEDIUM", wildcardSourceMatcher.matches(EVIDENCE_MEDIUM));
-        assertTrue("wildcard source matcher should match EVIDENCE_MEDIUM_SECOND_SOURCE", wildcardSourceMatcher.matches(EVIDENCE_MEDIUM_SECOND_SOURCE));
-        assertFalse("wildcard source matcher should not match EVIDENCE_LOW", wildcardSourceMatcher.matches(EVIDENCE_LOW));
+        assertFalse(wildcardSourceMatcher.matches(EVIDENCE_HIGHEST), "wildcard source matcher should not match EVIDENCE_HIGHEST");
+        assertFalse(wildcardSourceMatcher.matches(EVIDENCE_HIGH), "wildcard source matcher should not match EVIDENCE_HIGH");
+        assertTrue(wildcardSourceMatcher.matches(EVIDENCE_MEDIUM), "wildcard source matcher should match EVIDENCE_MEDIUM");
+        assertTrue(wildcardSourceMatcher.matches(EVIDENCE_MEDIUM_SECOND_SOURCE), "wildcard source matcher should match EVIDENCE_MEDIUM_SECOND_SOURCE");
+        assertFalse(wildcardSourceMatcher.matches(EVIDENCE_LOW), "wildcard source matcher should not match EVIDENCE_LOW");
     }
 
     @Test
-    public void testRegExMatching() throws Exception {
+    void testRegExMatching() {
         final EvidenceMatcher regexMediumMatcher = new EvidenceMatcher("source 2", "name", ".*value.*", true, Confidence.MEDIUM);
-        assertFalse("regex medium matcher should not match REGEX_EVIDENCE_HIGHEST", regexMediumMatcher.matches(REGEX_EVIDENCE_HIGHEST));
-        assertFalse("regex medium matcher should not match REGEX_EVIDENCE_HIGH", regexMediumMatcher.matches(REGEX_EVIDENCE_HIGH));
-        assertFalse("regex medium matcher should not match REGEX_EVIDENCE_MEDIUM", regexMediumMatcher.matches(REGEX_EVIDENCE_MEDIUM));
-        assertTrue("regex medium matcher should match REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE", regexMediumMatcher.matches(REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE));
-        assertFalse("regex medium matcher should not match REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE", regexMediumMatcher.matches(REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE));
-        assertFalse("regex medium matcher should not match REGEX_EVIDENCE_LOW", regexMediumMatcher.matches(REGEX_EVIDENCE_LOW));
+        assertFalse(regexMediumMatcher.matches(REGEX_EVIDENCE_HIGHEST), "regex medium matcher should not match REGEX_EVIDENCE_HIGHEST");
+        assertFalse(regexMediumMatcher.matches(REGEX_EVIDENCE_HIGH), "regex medium matcher should not match REGEX_EVIDENCE_HIGH");
+        assertFalse(regexMediumMatcher.matches(REGEX_EVIDENCE_MEDIUM), "regex medium matcher should not match REGEX_EVIDENCE_MEDIUM");
+        assertTrue(regexMediumMatcher.matches(REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE), "regex medium matcher should match REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE");
+        assertFalse(regexMediumMatcher.matches(REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE), "regex medium matcher should not match REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE");
+        assertFalse(regexMediumMatcher.matches(REGEX_EVIDENCE_LOW), "regex medium matcher should not match REGEX_EVIDENCE_LOW");
     }
 
     @Test
-    public void testRegExWildcardSourceMatching() throws Exception {
+    void testRegExWildcardSourceMatching() {
         final EvidenceMatcher regexMediumWildcardSourceMatcher = new EvidenceMatcher(null, "name", "^.*v[al]{2,2}ue[a-z ]+$", true, Confidence.MEDIUM);
-        assertFalse("regex medium wildcard source matcher should not match REGEX_EVIDENCE_HIGHEST", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_HIGHEST));
-        assertFalse("regex medium wildcard source matcher should not match REGEX_EVIDENCE_HIGH", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_HIGH));
-        assertFalse("regex medium wildcard source matcher should not match REGEX_EVIDENCE_MEDIUM", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM));
-        assertTrue("regex medium wildcard source matcher should match REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE));
-        assertTrue("regex medium wildcard source matcher should match REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE));
-        assertFalse("regex medium wildcard source matcher should not match REGEX_EVIDENCE_LOW", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_LOW));
+        assertFalse(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_HIGHEST), "regex medium wildcard source matcher should not match REGEX_EVIDENCE_HIGHEST");
+        assertFalse(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_HIGH), "regex medium wildcard source matcher should not match REGEX_EVIDENCE_HIGH");
+        assertFalse(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM), "regex medium wildcard source matcher should not match REGEX_EVIDENCE_MEDIUM");
+        assertTrue(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE), "regex medium wildcard source matcher should match REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE");
+        assertTrue(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE), "regex medium wildcard source matcher should match REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE");
+        assertFalse(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_LOW), "regex medium wildcard source matcher should not match REGEX_EVIDENCE_LOW");
     }
 
     @Test
-    public void testRegExWildcardSourceWildcardConfidenceMatching() throws Exception {
+    void testRegExWildcardSourceWildcardConfidenceMatching() {
         final EvidenceMatcher regexMediumWildcardSourceMatcher = new EvidenceMatcher(null, "name", ".*value.*", true, null);
-        assertTrue("regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_HIGHEST", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_HIGHEST));
-        assertTrue("regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_HIGH", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_HIGH));
-        assertFalse("regex wildcard source wildcard confidence matcher should not match REGEX_EVIDENCE_MEDIUM", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM));
-        assertTrue("regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE));
-        assertTrue("regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE));
-        assertFalse("regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_LOW", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_LOW));
+        assertTrue(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_HIGHEST), "regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_HIGHEST");
+        assertTrue(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_HIGH), "regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_HIGH");
+        assertFalse(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM), "regex wildcard source wildcard confidence matcher should not match REGEX_EVIDENCE_MEDIUM");
+        assertTrue(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE), "regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE");
+        assertTrue(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE), "regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE");
+        assertFalse(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_LOW), "regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_LOW");
     }
 
     @Test
-    public void testRegExWildcardSourceWildcardConfidenceFourMatching() throws Exception {
+    void testRegExWildcardSourceWildcardConfidenceFourMatching() {
         final EvidenceMatcher regexMediumWildcardSourceMatcher = new EvidenceMatcher(null, "name", "^.*[Vv][al]{2,2}[a-z ]+$", true, null);
-        assertFalse("regex wildcard source wildcard confidence matcher should not match REGEX_EVIDENCE_HIGHEST", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_HIGHEST));
-        assertFalse("regex wildcard source wildcard confidence matcher should not match REGEX_EVIDENCE_HIGH", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_HIGH));
-        assertTrue("regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_MEDIUM", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM));
-        assertTrue("regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE));
-        assertTrue("regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE));
-        assertTrue("regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_LOW", regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_LOW));
+        assertFalse(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_HIGHEST), "regex wildcard source wildcard confidence matcher should not match REGEX_EVIDENCE_HIGHEST");
+        assertFalse(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_HIGH), "regex wildcard source wildcard confidence matcher should not match REGEX_EVIDENCE_HIGH");
+        assertTrue(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM), "regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_MEDIUM");
+        assertTrue(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE), "regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_MEDIUM_SECOND_SOURCE");
+        assertTrue(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE), "regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_MEDIUM_THIRD_SOURCE");
+        assertTrue(regexMediumWildcardSourceMatcher.matches(REGEX_EVIDENCE_LOW), "regex wildcard source wildcard confidence matcher should match REGEX_EVIDENCE_LOW");
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/xml/hints/HintHandlerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/hints/HintHandlerTest.java
@@ -17,36 +17,34 @@
  */
 package org.owasp.dependencycheck.xml.hints;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.owasp.dependencycheck.BaseTest;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXNotRecognizedException;
-import org.xml.sax.SAXNotSupportedException;
-import org.xml.sax.XMLReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author Jeremy Long
  */
-public class HintHandlerTest extends BaseTest {
-    
+class HintHandlerTest extends BaseTest {
+
     @Test
-    public void testHandler() throws ParserConfigurationException, SAXException, IOException {
+    void testHandler() throws ParserConfigurationException, SAXException, IOException {
         File file = BaseTest.getResourceAsFile(this, "hints.xml");
         File schema = BaseTest.getResourceAsFile(this, "schema/dependency-hint.1.1.xsd");
         HintHandler handler = new HintHandler();
@@ -67,7 +65,7 @@ public class HintHandlerTest extends BaseTest {
         xmlReader.parse(in);
 
         List<HintRule> result = handler.getHintRules();
-        assertEquals("two hint rules should have been loaded",2,result.size());
+        assertEquals(2,result.size(),"two hint rules should have been loaded");
     }
 
 }

--- a/core/src/test/java/org/owasp/dependencycheck/xml/hints/HintParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/hints/HintParserTest.java
@@ -17,50 +17,54 @@
  */
 package org.owasp.dependencycheck.xml.hints;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+
 import java.io.File;
 import java.io.InputStream;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import org.owasp.dependencycheck.BaseTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class HintParserTest extends BaseTest {
+class HintParserTest extends BaseTest {
 
     /**
      * Test of parseHints method, of class HintParser.
      */
     @Test
-    public void testParseHints_File() throws Exception {
+    void testParseHints_File() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "hints.xml");
         HintParser instance = new HintParser();
         instance.parseHints(file);
         List<HintRule> hintRules = instance.getHintRules();
         List<VendorDuplicatingHintRule> vendorRules = instance.getVendorDuplicatingHintRules();
-        assertEquals("Two duplicating hints should have been read", 2, vendorRules.size());
-        assertEquals("Two hint rules should have been read", 2, hintRules.size());
+        assertEquals(2, vendorRules.size(), "Two duplicating hints should have been read");
+        assertEquals(2, hintRules.size(), "Two hint rules should have been read");
 
-        assertEquals("One add product should have been read", 1, hintRules.get(0).getAddProduct().size());
-        assertEquals("One add vendor should have been read", 1, hintRules.get(0).getAddVendor().size());
-        assertEquals("Two file name should have been read", 2, hintRules.get(1).getFileNames().size());
+        assertEquals(1, hintRules.get(0).getAddProduct().size(), "One add product should have been read");
+        assertEquals(1, hintRules.get(0).getAddVendor().size(), "One add vendor should have been read");
+        assertEquals(2, hintRules.get(1).getFileNames().size(), "Two file name should have been read");
 
-        assertEquals("add product name not found", "add product name", hintRules.get(0).getAddProduct().get(0).getName());
-        assertEquals("add vendor name not found", "add vendor name", hintRules.get(0).getAddVendor().get(0).getName());
-        assertEquals("given product name not found", "given product name", hintRules.get(0).getGivenProduct().get(0).getName());
-        assertEquals("given vendor name not found", "given vendor name", hintRules.get(0).getGivenVendor().get(0).getName());
+        assertEquals("add product name", hintRules.get(0).getAddProduct().get(0).getName(), "add product name not found");
+        assertEquals("add vendor name", hintRules.get(0).getAddVendor().get(0).getName(), "add vendor name not found");
+        assertEquals("given product name", hintRules.get(0).getGivenProduct().get(0).getName(), "given product name not found");
+        assertEquals("given vendor name", hintRules.get(0).getGivenVendor().get(0).getName(), "given vendor name not found");
 
-        assertEquals("spring file name not found", "spring", hintRules.get(1).getFileNames().get(0).getValue());
-        assertEquals("file name 1 should not be case sensitive", false, hintRules.get(1).getFileNames().get(0).isCaseSensitive());
-        assertEquals("file name 1 should not be a regex", false, hintRules.get(1).getFileNames().get(0).isRegex());
-        assertEquals("file name 2 should be case sensitive", true, hintRules.get(1).getFileNames().get(1).isCaseSensitive());
-        assertEquals("file name 2 should be a regex", true, hintRules.get(1).getFileNames().get(1).isRegex());
+        assertEquals("spring", hintRules.get(1).getFileNames().get(0).getValue(), "spring file name not found");
+        assertFalse(hintRules.get(1).getFileNames().get(0).isCaseSensitive(), "file name 1 should not be case sensitive");
+        assertFalse(hintRules.get(1).getFileNames().get(0).isRegex(), "file name 1 should not be a regex");
+        assertTrue(hintRules.get(1).getFileNames().get(1).isCaseSensitive(), "file name 2 should be case sensitive");
+        assertTrue(hintRules.get(1).getFileNames().get(1).isRegex(), "file name 2 should be a regex");
 
-        assertEquals("sun duplicating vendor", "sun", vendorRules.get(0).getValue());
-        assertEquals("sun duplicates vendor oracle", "oracle", vendorRules.get(0).getDuplicate());
+        assertEquals("sun", vendorRules.get(0).getValue(), "sun duplicating vendor");
+        assertEquals("oracle", vendorRules.get(0).getDuplicate(), "sun duplicates vendor oracle");
     }
 
     /**
@@ -75,11 +79,11 @@ public class HintParserTest extends BaseTest {
      * error-message of the SAXParser in the exception's message.
      */
     @Test
-    public void testParseHintsXSDSelection() throws Exception {
+    void testParseHintsXSDSelection() {
         File file = BaseTest.getResourceAsFile(this, "hints_invalid.xml");
         HintParser instance = new HintParser();
-        Exception exception = Assert.assertThrows(org.owasp.dependencycheck.xml.hints.HintParseException.class, () -> instance.parseHints(file));
-        Assert.assertTrue(exception.getMessage().contains("Line=7, Column=133: cvc-enumeration-valid: Value 'version' is not facet-valid with respect to enumeration '[vendor, product]'. It must be a value from the enumeration."));
+        Exception exception = assertThrows(org.owasp.dependencycheck.xml.hints.HintParseException.class, () -> instance.parseHints(file));
+        assertTrue(exception.getMessage().contains("Line=7, Column=133: cvc-enumeration-valid: Value 'version' is not facet-valid with respect to enumeration '[vendor, product]'. It must be a value from the enumeration."));
 
     }
 
@@ -87,50 +91,50 @@ public class HintParserTest extends BaseTest {
      * Test of parseHints method, of class HintParser.
      */
     @Test
-    public void testParseHints_InputStream() throws Exception {
+    void testParseHints_InputStream() throws Exception {
         InputStream ins = BaseTest.getResourceAsStream(this, "hints_12.xml");
         HintParser instance = new HintParser();
         instance.parseHints(ins);
         List<HintRule> hintRules = instance.getHintRules();
         List<VendorDuplicatingHintRule> vendorRules = instance.getVendorDuplicatingHintRules();
-        assertEquals("Zero duplicating hints should have been read", 0, vendorRules.size());
-        assertEquals("Two hint rules should have been read", 2, hintRules.size());
+        assertEquals(0, vendorRules.size(), "Zero duplicating hints should have been read");
+        assertEquals(2, hintRules.size(), "Two hint rules should have been read");
 
-        assertEquals("One given product should have been read in hint 0", 1, hintRules.get(0).getGivenProduct().size());
-        assertEquals("One given vendor should have been read in hint 0", 1, hintRules.get(0).getGivenVendor().size());
-        assertEquals("One given version should have been read in hint 0", 1, hintRules.get(0).getGivenVersion().size());
+        assertEquals(1, hintRules.get(0).getGivenProduct().size(), "One given product should have been read in hint 0");
+        assertEquals(1, hintRules.get(0).getGivenVendor().size(), "One given vendor should have been read in hint 0");
+        assertEquals(1, hintRules.get(0).getGivenVersion().size(), "One given version should have been read in hint 0");
 
-        assertEquals("One add product should have been read in hint 0", 1, hintRules.get(0).getAddProduct().size());
-        assertEquals("One add vendor should have been read in hint 0", 1, hintRules.get(0).getAddVendor().size());
-        assertEquals("One add version should have been read in hint 0", 1, hintRules.get(0).getAddVersion().size());
-        assertEquals("Zero remove product should have been read in hint 0", 0, hintRules.get(0).getRemoveProduct().size());
-        assertEquals("Zero remove vendor should have been read in hint 0", 0, hintRules.get(0).getRemoveVendor().size());
-        assertEquals("Zero remove version should have been read in hint 0", 0, hintRules.get(0).getRemoveVersion().size());
+        assertEquals(1, hintRules.get(0).getAddProduct().size(), "One add product should have been read in hint 0");
+        assertEquals(1, hintRules.get(0).getAddVendor().size(), "One add vendor should have been read in hint 0");
+        assertEquals(1, hintRules.get(0).getAddVersion().size(), "One add version should have been read in hint 0");
+        assertEquals(0, hintRules.get(0).getRemoveProduct().size(), "Zero remove product should have been read in hint 0");
+        assertEquals(0, hintRules.get(0).getRemoveVendor().size(), "Zero remove vendor should have been read in hint 0");
+        assertEquals(0, hintRules.get(0).getRemoveVersion().size(), "Zero remove version should have been read in hint 0");
 
-        assertEquals("Zero given product should have been read in hint 1", 0, hintRules.get(1).getGivenProduct().size());
-        assertEquals("Zero given vendor should have been read in hint 1", 0, hintRules.get(1).getGivenVendor().size());
-        assertEquals("One given version should have been read in hint 1", 1, hintRules.get(1).getGivenVersion().size());
+        assertEquals(0, hintRules.get(1).getGivenProduct().size(), "Zero given product should have been read in hint 1");
+        assertEquals(0, hintRules.get(1).getGivenVendor().size(), "Zero given vendor should have been read in hint 1");
+        assertEquals(1, hintRules.get(1).getGivenVersion().size(), "One given version should have been read in hint 1");
 
-        assertEquals("One remove product should have been read in hint 1", 1, hintRules.get(1).getRemoveProduct().size());
-        assertEquals("One remove vendor should have been read in hint 1", 1, hintRules.get(1).getRemoveVendor().size());
-        assertEquals("One remove version should have been read in hint 1", 1, hintRules.get(1).getRemoveVersion().size());
-        assertEquals("Zero add product should have been read in hint 1", 0, hintRules.get(1).getAddProduct().size());
-        assertEquals("Zero add vendor should have been read in hint 1", 0, hintRules.get(1).getAddVendor().size());
-        assertEquals("Zero add version should have been read in hint 1", 0, hintRules.get(1).getAddVersion().size());
+        assertEquals(1, hintRules.get(1).getRemoveProduct().size(), "One remove product should have been read in hint 1");
+        assertEquals(1, hintRules.get(1).getRemoveVendor().size(), "One remove vendor should have been read in hint 1");
+        assertEquals(1, hintRules.get(1).getRemoveVersion().size(), "One remove version should have been read in hint 1");
+        assertEquals(0, hintRules.get(1).getAddProduct().size(), "Zero add product should have been read in hint 1");
+        assertEquals(0, hintRules.get(1).getAddVendor().size(), "Zero add vendor should have been read in hint 1");
+        assertEquals(0, hintRules.get(1).getAddVersion().size(), "Zero add version should have been read in hint 1");
 
-        assertEquals("add product name not found in hint 0", "add product name", hintRules.get(0).getAddProduct().get(0).getName());
-        assertEquals("add vendor name not found in hint 0", "add vendor name", hintRules.get(0).getAddVendor().get(0).getName());
-        assertEquals("add version name not found in hint 0", "add version name", hintRules.get(0).getAddVersion().get(0).getName());
+        assertEquals("add product name", hintRules.get(0).getAddProduct().get(0).getName(), "add product name not found in hint 0");
+        assertEquals("add vendor name", hintRules.get(0).getAddVendor().get(0).getName(), "add vendor name not found in hint 0");
+        assertEquals("add version name", hintRules.get(0).getAddVersion().get(0).getName(), "add version name not found in hint 0");
 
-        assertEquals("given product name not found in hint 0", "given product name", hintRules.get(0).getGivenProduct().get(0).getName());
-        assertEquals("given vendor name not found in hint 0", "given vendor name", hintRules.get(0).getGivenVendor().get(0).getName());
-        assertEquals("given version name not found in hint 0", "given version name", hintRules.get(0).getGivenVersion().get(0).getName());
+        assertEquals("given product name", hintRules.get(0).getGivenProduct().get(0).getName(), "given product name not found in hint 0");
+        assertEquals("given vendor name", hintRules.get(0).getGivenVendor().get(0).getName(), "given vendor name not found in hint 0");
+        assertEquals("given version name", hintRules.get(0).getGivenVersion().get(0).getName(), "given version name not found in hint 0");
 
-        assertEquals("given version name not found in hint 1", "given version name", hintRules.get(1).getGivenVersion().get(0).getName());
+        assertEquals("given version name", hintRules.get(1).getGivenVersion().get(0).getName(), "given version name not found in hint 1");
 
-        assertEquals("add product name not found in hint 1", "remove product name", hintRules.get(1).getRemoveProduct().get(0).getName());
-        assertEquals("add vendor name not found in hint 1", "remove vendor name", hintRules.get(1).getRemoveVendor().get(0).getName());
-        assertEquals("add version name not found in hint 1", "remove version name", hintRules.get(1).getRemoveVersion().get(0).getName());
+        assertEquals("remove product name", hintRules.get(1).getRemoveProduct().get(0).getName(), "add product name not found in hint 1");
+        assertEquals("remove vendor name", hintRules.get(1).getRemoveVendor().get(0).getName(), "add vendor name not found in hint 1");
+        assertEquals("remove version name", hintRules.get(1).getRemoveVersion().get(0).getName(), "add version name not found in hint 1");
 
     }
 
@@ -138,58 +142,58 @@ public class HintParserTest extends BaseTest {
      * Test of parseHints method, of class HintParser.
      */
     @Test
-    public void testParseHintsWithRegex() throws Exception {
+    void testParseHintsWithRegex() throws Exception {
         InputStream ins = BaseTest.getResourceAsStream(this, "hints_13.xml");
         HintParser instance = new HintParser();
         instance.parseHints(ins);
         List<VendorDuplicatingHintRule> vendor = instance.getVendorDuplicatingHintRules();
         List<HintRule> rules = instance.getHintRules();
 
-        assertEquals("Zero duplicating hints should have been read", 0, vendor.size());
-        assertEquals("Two hint rules should have been read", 2, rules.size());
+        assertEquals(0, vendor.size(), "Zero duplicating hints should have been read");
+        assertEquals(2, rules.size(), "Two hint rules should have been read");
 
-        assertEquals("One given product should have been read in hint 0", 1, rules.get(0).getGivenProduct().size());
-        assertEquals("One given vendor should have been read in hint 0", 1, rules.get(0).getGivenVendor().size());
-        assertEquals("One given version should have been read in hint 0", 1, rules.get(0).getGivenVersion().size());
+        assertEquals(1, rules.get(0).getGivenProduct().size(), "One given product should have been read in hint 0");
+        assertEquals(1, rules.get(0).getGivenVendor().size(), "One given vendor should have been read in hint 0");
+        assertEquals(1, rules.get(0).getGivenVersion().size(), "One given version should have been read in hint 0");
 
-        assertEquals("One add product should have been read in hint 0", 1, rules.get(0).getAddProduct().size());
-        assertEquals("One add vendor should have been read in hint 0", 1, rules.get(0).getAddVendor().size());
-        assertEquals("One add version should have been read in hint 0", 1, rules.get(0).getAddVersion().size());
-        assertEquals("Zero remove product should have been read in hint 0", 0, rules.get(0).getRemoveProduct().size());
-        assertEquals("Zero remove vendor should have been read in hint 0", 0, rules.get(0).getRemoveVendor().size());
-        assertEquals("Zero remove version should have been read in hint 0", 0, rules.get(0).getRemoveVersion().size());
+        assertEquals(1, rules.get(0).getAddProduct().size(), "One add product should have been read in hint 0");
+        assertEquals(1, rules.get(0).getAddVendor().size(), "One add vendor should have been read in hint 0");
+        assertEquals(1, rules.get(0).getAddVersion().size(), "One add version should have been read in hint 0");
+        assertEquals(0, rules.get(0).getRemoveProduct().size(), "Zero remove product should have been read in hint 0");
+        assertEquals(0, rules.get(0).getRemoveVendor().size(), "Zero remove vendor should have been read in hint 0");
+        assertEquals(0, rules.get(0).getRemoveVersion().size(), "Zero remove version should have been read in hint 0");
 
-        assertEquals("Zero given product should have been read in hint 1", 0, rules.get(1).getGivenProduct().size());
-        assertEquals("Zero given vendor should have been read in hint 1", 0, rules.get(1).getGivenVendor().size());
-        assertEquals("One given version should have been read in hint 1", 1, rules.get(1).getGivenVersion().size());
+        assertEquals(0, rules.get(1).getGivenProduct().size(), "Zero given product should have been read in hint 1");
+        assertEquals(0, rules.get(1).getGivenVendor().size(), "Zero given vendor should have been read in hint 1");
+        assertEquals(1, rules.get(1).getGivenVersion().size(), "One given version should have been read in hint 1");
 
-        assertEquals("One remove product should have been read in hint 1", 1, rules.get(1).getRemoveProduct().size());
-        assertEquals("One remove vendor should have been read in hint 1", 1, rules.get(1).getRemoveVendor().size());
-        assertEquals("One remove version should have been read in hint 1", 1, rules.get(1).getRemoveVersion().size());
-        assertEquals("Zero add product should have been read in hint 1", 0, rules.get(1).getAddProduct().size());
-        assertEquals("Zero add vendor should have been read in hint 1", 0, rules.get(1).getAddVendor().size());
-        assertEquals("Zero add version should have been read in hint 1", 0, rules.get(1).getAddVersion().size());
+        assertEquals(1, rules.get(1).getRemoveProduct().size(), "One remove product should have been read in hint 1");
+        assertEquals(1, rules.get(1).getRemoveVendor().size(), "One remove vendor should have been read in hint 1");
+        assertEquals(1, rules.get(1).getRemoveVersion().size(), "One remove version should have been read in hint 1");
+        assertEquals(0, rules.get(1).getAddProduct().size(), "Zero add product should have been read in hint 1");
+        assertEquals(0, rules.get(1).getAddVendor().size(), "Zero add vendor should have been read in hint 1");
+        assertEquals(0, rules.get(1).getAddVersion().size(), "Zero add version should have been read in hint 1");
 
-        assertEquals("add product name not found in hint 0", "add product name", rules.get(0).getAddProduct().get(0).getName());
-        assertEquals("add vendor name not found in hint 0", "add vendor name", rules.get(0).getAddVendor().get(0).getName());
-        assertEquals("add version name not found in hint 0", "add version name", rules.get(0).getAddVersion().get(0).getName());
+        assertEquals("add product name", rules.get(0).getAddProduct().get(0).getName(), "add product name not found in hint 0");
+        assertEquals("add vendor name", rules.get(0).getAddVendor().get(0).getName(), "add vendor name not found in hint 0");
+        assertEquals("add version name", rules.get(0).getAddVersion().get(0).getName(), "add version name not found in hint 0");
 
-        assertEquals("given product name not found in hint 0", "given product name", rules.get(0).getGivenProduct().get(0).getName());
-        assertEquals("value not registered to be a regex for given product in hint 0", true, rules.get(0).getGivenProduct().get(0).isRegex());
-        assertEquals("given vendor name not found in hint 0", "given vendor name", rules.get(0).getGivenVendor().get(0).getName());
-        assertEquals("value not registered to be a regex for given vendor in hint 0", true, rules.get(0).getGivenVendor().get(0).isRegex());
-        assertEquals("given version name not found in hint 0", "given version name", rules.get(0).getGivenVersion().get(0).getName());
-        assertEquals("value not registered to not be a regex for given version in hint 0", false, rules.get(0).getGivenVersion().get(0).isRegex());
+        assertEquals("given product name", rules.get(0).getGivenProduct().get(0).getName(), "given product name not found in hint 0");
+        assertTrue(rules.get(0).getGivenProduct().get(0).isRegex(), "value not registered to be a regex for given product in hint 0");
+        assertEquals("given vendor name", rules.get(0).getGivenVendor().get(0).getName(), "given vendor name not found in hint 0");
+        assertTrue(rules.get(0).getGivenVendor().get(0).isRegex(), "value not registered to be a regex for given vendor in hint 0");
+        assertEquals("given version name", rules.get(0).getGivenVersion().get(0).getName(), "given version name not found in hint 0");
+        assertFalse(rules.get(0).getGivenVersion().get(0).isRegex(), "value not registered to not be a regex for given version in hint 0");
 
-        assertEquals("given version name not found in hint 1", "given version name", rules.get(1).getGivenVersion().get(0).getName());
-        assertEquals("value not registered to not be a regex by default for given version in hint 1", false, rules.get(1).getRemoveProduct().get(0).isRegex());
+        assertEquals("given version name", rules.get(1).getGivenVersion().get(0).getName(), "given version name not found in hint 1");
+        assertFalse(rules.get(1).getRemoveProduct().get(0).isRegex(), "value not registered to not be a regex by default for given version in hint 1");
 
-        assertEquals("remove product name not found in hint 1", "remove product name", rules.get(1).getRemoveProduct().get(0).getName());
-        assertEquals("value not registered to not be a regex for product removal in hint 1", false, rules.get(1).getRemoveProduct().get(0).isRegex());
-        assertEquals("remove vendor name not found in hint 1", "remove vendor name", rules.get(1).getRemoveVendor().get(0).getName());
-        assertEquals("value not registered to not be a regex for vendor removal in hint 1", false, rules.get(1).getRemoveVendor().get(0).isRegex());
-        assertEquals("remove version name not found in hint 1", "remove version name", rules.get(1).getRemoveVersion().get(0).getName());
-        assertEquals("value not defaulted to not be a regex for vendor removal in hint 1", false, rules.get(1).getRemoveVersion().get(0).isRegex());
+        assertEquals("remove product name", rules.get(1).getRemoveProduct().get(0).getName(), "remove product name not found in hint 1");
+        assertFalse(rules.get(1).getRemoveProduct().get(0).isRegex(), "value not registered to not be a regex for product removal in hint 1");
+        assertEquals("remove vendor name", rules.get(1).getRemoveVendor().get(0).getName(), "remove vendor name not found in hint 1");
+        assertFalse(rules.get(1).getRemoveVendor().get(0).isRegex(), "value not registered to not be a regex for vendor removal in hint 1");
+        assertEquals("remove version name", rules.get(1).getRemoveVersion().get(0).getName(), "remove version name not found in hint 1");
+        assertFalse(rules.get(1).getRemoveVersion().get(0).isRegex(), "value not defaulted to not be a regex for vendor removal in hint 1");
 
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/xml/pom/ModelTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/pom/ModelTest.java
@@ -17,26 +17,27 @@
  */
 package org.owasp.dependencycheck.xml.pom;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.utils.InterpolationUtil;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  *
  * @author jeremy long
  */
-public class ModelTest extends BaseTest {
+class ModelTest extends BaseTest {
 
     /**
      * Test of getName method, of class Model.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         Model instance = new Model();
         instance.setName("");
         String expResult = "";
@@ -48,7 +49,7 @@ public class ModelTest extends BaseTest {
      * Test of setName method, of class Model.
      */
     @Test
-    public void testSetName() {
+    void testSetName() {
         String name = "name";
         Model instance = new Model();
         instance.setName(name);
@@ -59,7 +60,7 @@ public class ModelTest extends BaseTest {
      * Test of getOrganization method, of class Model.
      */
     @Test
-    public void testGetOrganization() {
+    void testGetOrganization() {
         Model instance = new Model();
         instance.setOrganization("");
         String expResult = "";
@@ -71,7 +72,7 @@ public class ModelTest extends BaseTest {
      * Test of setOrganization method, of class Model.
      */
     @Test
-    public void testSetOrganization() {
+    void testSetOrganization() {
         String organization = "apache";
         Model instance = new Model();
         instance.setOrganization(organization);
@@ -82,7 +83,7 @@ public class ModelTest extends BaseTest {
      * Test of getDescription method, of class Model.
      */
     @Test
-    public void testGetDescription() {
+    void testGetDescription() {
         Model instance = new Model();
         instance.setDescription("");
         String expResult = "";
@@ -94,7 +95,7 @@ public class ModelTest extends BaseTest {
      * Test of setDescription method, of class Model.
      */
     @Test
-    public void testSetDescription() {
+    void testSetDescription() {
         String description = "description";
         String expected = "description";
         Model instance = new Model();
@@ -106,7 +107,7 @@ public class ModelTest extends BaseTest {
      * Test of getGroupId method, of class Model.
      */
     @Test
-    public void testGetGroupId() {
+    void testGetGroupId() {
         Model instance = new Model();
         instance.setGroupId("");
         String expResult = "";
@@ -118,7 +119,7 @@ public class ModelTest extends BaseTest {
      * Test of setGroupId method, of class Model.
      */
     @Test
-    public void testSetGroupId() {
+    void testSetGroupId() {
         String groupId = "aaa";
         String expected = "aaa";
         Model instance = new Model();
@@ -130,7 +131,7 @@ public class ModelTest extends BaseTest {
      * Test of getArtifactId method, of class Model.
      */
     @Test
-    public void testGetArtifactId() {
+    void testGetArtifactId() {
         Model instance = new Model();
         instance.setArtifactId("");
         String expResult = "";
@@ -142,7 +143,7 @@ public class ModelTest extends BaseTest {
      * Test of setArtifactId method, of class Model.
      */
     @Test
-    public void testSetArtifactId() {
+    void testSetArtifactId() {
         String artifactId = "aaa";
         String expected = "aaa";
         Model instance = new Model();
@@ -154,7 +155,7 @@ public class ModelTest extends BaseTest {
      * Test of getVersion method, of class Model.
      */
     @Test
-    public void testGetVersion() {
+    void testGetVersion() {
         Model instance = new Model();
         instance.setVersion("");
         String expResult = "";
@@ -166,7 +167,7 @@ public class ModelTest extends BaseTest {
      * Test of setVersion method, of class Model.
      */
     @Test
-    public void testSetVersion() {
+    void testSetVersion() {
         String version = "";
         Model instance = new Model();
         instance.setVersion(version);
@@ -177,7 +178,7 @@ public class ModelTest extends BaseTest {
      * Test of getParentGroupId method, of class Model.
      */
     @Test
-    public void testGetParentGroupId() {
+    void testGetParentGroupId() {
         Model instance = new Model();
         instance.setParentGroupId("");
         String expResult = "";
@@ -189,7 +190,7 @@ public class ModelTest extends BaseTest {
      * Test of setParentGroupId method, of class Model.
      */
     @Test
-    public void testSetParentGroupId() {
+    void testSetParentGroupId() {
         String parentGroupId = "org.owasp";
         Model instance = new Model();
         instance.setParentGroupId(parentGroupId);
@@ -200,7 +201,7 @@ public class ModelTest extends BaseTest {
      * Test of getParentArtifactId method, of class Model.
      */
     @Test
-    public void testGetParentArtifactId() {
+    void testGetParentArtifactId() {
         Model instance = new Model();
         instance.setParentArtifactId("");
         String expResult = "";
@@ -212,7 +213,7 @@ public class ModelTest extends BaseTest {
      * Test of setParentArtifactId method, of class Model.
      */
     @Test
-    public void testSetParentArtifactId() {
+    void testSetParentArtifactId() {
         String parentArtifactId = "something";
         Model instance = new Model();
         instance.setParentArtifactId(parentArtifactId);
@@ -223,7 +224,7 @@ public class ModelTest extends BaseTest {
      * Test of getParentVersion method, of class Model.
      */
     @Test
-    public void testGetParentVersion() {
+    void testGetParentVersion() {
         Model instance = new Model();
         instance.setParentVersion("");
         String expResult = "";
@@ -235,7 +236,7 @@ public class ModelTest extends BaseTest {
      * Test of setParentVersion method, of class Model.
      */
     @Test
-    public void testSetParentVersion() {
+    void testSetParentVersion() {
         String parentVersion = "1.0";
         Model instance = new Model();
         instance.setParentVersion(parentVersion);
@@ -246,7 +247,7 @@ public class ModelTest extends BaseTest {
      * Test of getLicenses method, of class Model.
      */
     @Test
-    public void testGetLicenses() {
+    void testGetLicenses() {
         Model instance = new Model();
         instance.addLicense(new License("name", "url"));
         List<License> expResult = new ArrayList<>();
@@ -259,7 +260,7 @@ public class ModelTest extends BaseTest {
      * Test of addLicense method, of class Model.
      */
     @Test
-    public void testAddLicense() {
+    void testAddLicense() {
         License license = new License("name", "url");
         Model instance = new Model();
         instance.addLicense(license);
@@ -270,7 +271,7 @@ public class ModelTest extends BaseTest {
      * Test of processProperties method, of class Model.
      */
     @Test
-    public void testProcessProperties() {
+    void testProcessProperties() {
 
         String text = "This is a test of '${key}' '${nested}'";
         Model instance = new Model();

--- a/core/src/test/java/org/owasp/dependencycheck/xml/pom/PomParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/pom/PomParserTest.java
@@ -17,89 +17,94 @@
  */
 package org.owasp.dependencycheck.xml.pom;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+
 import java.io.File;
 import java.io.InputStream;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.owasp.dependencycheck.BaseTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  *
  * @author jeremy long
  */
-public class PomParserTest {
+class PomParserTest {
 
     /**
      * Test of parse method, of class PomParser.
      */
     @Test
-    public void testParse_File() throws Exception {
+    void testParse_File() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "pom/mailapi-1.4.3.pom");
         PomParser instance = new PomParser();
         String expVersion = "1.4.3";
         Model result = instance.parse(file);
-        assertEquals("Invalid version extracted", expVersion, result.getParentVersion());
+        assertEquals(expVersion, result.getParentVersion(), "Invalid version extracted");
     }
 
     /**
      * Test of parse method, of class PomParser.
      */
     @Test
-    public void testParse_InputStream() throws Exception {
+    void testParse_InputStream() throws Exception {
         InputStream inputStream = BaseTest.getResourceAsStream(this, "pom/plexus-utils-3.0.24.pom");
         PomParser instance = new PomParser();
         String expectedArtifactId = "plexus-utils";
         Model result = instance.parse(inputStream);
-        assertEquals("Invalid artifactId extracted", expectedArtifactId, result.getArtifactId());
+        assertEquals(expectedArtifactId, result.getArtifactId(), "Invalid artifactId extracted");
     }
 
     /**
      * Test of parse method, of class PomParser.
      */
     @Test
-    public void testParse_InputStreamWithDocType() throws Exception {
+    void testParse_InputStreamWithDocType() throws Exception {
         InputStream inputStream = BaseTest.getResourceAsStream(this, "pom/mailapi-1.4.3_doctype.pom");
         PomParser instance = new PomParser();
         String expVersion = "1.4.3";
         Model result = instance.parse(inputStream);
-        assertEquals("Invalid version extracted", expVersion, result.getParentVersion());
+        assertEquals(expVersion, result.getParentVersion(), "Invalid version extracted");
     }
 
     @Test
-    public void testParseWithoutDocTypeCleanup_InputStream() throws Exception {
+    void testParseWithoutDocTypeCleanup_InputStream() throws Exception {
         InputStream inputStream = BaseTest.getResourceAsStream(this, "pom/mailapi-1.4.3.pom");
         PomParser instance = new PomParser();
         String expVersion = "1.4.3";
         Model result = instance.parseWithoutDocTypeCleanup(inputStream);
-        assertEquals("Invalid version extracted", expVersion, result.getParentVersion());
+        assertEquals(expVersion, result.getParentVersion(), "Invalid version extracted");
     }
 
     @Test
-    public void testParseWithoutDocTypeCleanup() throws Exception {
+    void testParseWithoutDocTypeCleanup() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "pom/mailapi-1.4.3.pom");
         PomParser instance = new PomParser();
         String expVersion = "1.4.3";
         Model result = instance.parseWithoutDocTypeCleanup(file);
-        assertEquals("Invalid version extracted", expVersion, result.getParentVersion());
+        assertEquals(expVersion, result.getParentVersion(), "Invalid version extracted");
     }
 
-    
-    @Test(expected = PomParseException.class)
-    public void testParseWithoutDocTypeCleanup_InputStreamWithDocType() throws Exception {
+
+    @Test
+    void testParseWithoutDocTypeCleanup_InputStreamWithDocType() throws Exception {
         InputStream inputStream = BaseTest.getResourceAsStream(this, "pom/mailapi-1.4.3_doctype.pom");
         PomParser instance = new PomParser();
         String expVersion = "1.4.3";
         Model result = instance.parseWithoutDocTypeCleanup(inputStream);
-        assertEquals("Invalid version extracted", expVersion, result.getParentVersion());
+        assertThrows(PomParseException.class, () ->
+            assertEquals(expVersion, result.getParentVersion(), "Invalid version extracted"));
     }
 
-    @Test(expected = PomParseException.class)
-    public void testParseWithoutDocTypeCleanup_WithDocType() throws Exception {
+    @Test
+    void testParseWithoutDocTypeCleanup_WithDocType() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "pom/mailapi-1.4.3_doctype.pom");
         PomParser instance = new PomParser();
         String expVersion = "1.4.3";
         Model result = instance.parseWithoutDocTypeCleanup(file);
-        assertEquals("Invalid version extracted", expVersion, result.getParentVersion());
+        assertThrows(PomParseException.class, () ->
+            assertEquals(expVersion, result.getParentVersion(), "Invalid version extracted"));
     }
 
 }

--- a/core/src/test/java/org/owasp/dependencycheck/xml/pom/PomParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/pom/PomParserTest.java
@@ -88,23 +88,21 @@ class PomParserTest {
 
 
     @Test
-    void testParseWithoutDocTypeCleanup_InputStreamWithDocType() throws Exception {
+    void testParseWithoutDocTypeCleanup_InputStreamWithDocType() {
         InputStream inputStream = BaseTest.getResourceAsStream(this, "pom/mailapi-1.4.3_doctype.pom");
         PomParser instance = new PomParser();
-        String expVersion = "1.4.3";
-        Model result = instance.parseWithoutDocTypeCleanup(inputStream);
+
         assertThrows(PomParseException.class, () ->
-            assertEquals(expVersion, result.getParentVersion(), "Invalid version extracted"));
+            instance.parseWithoutDocTypeCleanup(inputStream));
     }
 
     @Test
-    void testParseWithoutDocTypeCleanup_WithDocType() throws Exception {
+    void testParseWithoutDocTypeCleanup_WithDocType() {
         File file = BaseTest.getResourceAsFile(this, "pom/mailapi-1.4.3_doctype.pom");
         PomParser instance = new PomParser();
-        String expVersion = "1.4.3";
-        Model result = instance.parseWithoutDocTypeCleanup(file);
+
         assertThrows(PomParseException.class, () ->
-            assertEquals(expVersion, result.getParentVersion(), "Invalid version extracted"));
+            instance.parseWithoutDocTypeCleanup(file));
     }
 
 }

--- a/core/src/test/java/org/owasp/dependencycheck/xml/pom/PomProjectInputStreamTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/pom/PomProjectInputStreamTest.java
@@ -17,19 +17,21 @@
  */
 package org.owasp.dependencycheck.xml.pom;
 
+import org.junit.jupiter.api.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author Jeremy Long
  */
-public class PomProjectInputStreamTest {
+class PomProjectInputStreamTest {
 
     private final String POM = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n"
             + "<!DOCTYPE xml [<!ENTITY quot \"&#34;\">\n"
@@ -62,7 +64,7 @@ public class PomProjectInputStreamTest {
             + "<blue></blue>";
 
     @Test
-    public void testFilter() throws IOException {
+    void testFilter() throws IOException {
         InputStream in = new ByteArrayInputStream(POM.getBytes(StandardCharsets.UTF_8));
         PomProjectInputStream instance = new PomProjectInputStream(in);
         byte[] expected = "<project></project>".getBytes(StandardCharsets.UTF_8);
@@ -85,7 +87,7 @@ public class PomProjectInputStreamTest {
      * Test of findSequence method, of class PomProjectInputStream.
      */
     @Test
-    public void testFindSequence() throws IOException {
+    void testFindSequence() {
 
         byte[] sequence = "project".getBytes(StandardCharsets.UTF_8);
         byte[] buffer = "my big project".getBytes(StandardCharsets.UTF_8);

--- a/core/src/test/java/org/owasp/dependencycheck/xml/pom/PomUtilsTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/pom/PomUtilsTest.java
@@ -17,20 +17,21 @@
  */
 package org.owasp.dependencycheck.xml.pom;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+
 import java.io.File;
 import java.util.jar.JarFile;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test the PomUtils object.
  *
  * @author Jeremy Long
  */
-public class PomUtilsTest extends BaseTest {
+class PomUtilsTest extends BaseTest {
 
     /**
      * Test of readPom method, of class PomUtils.
@@ -39,7 +40,7 @@ public class PomUtilsTest extends BaseTest {
      * exception
      */
     @Test
-    public void testReadPom_File() throws Exception {
+    void testReadPom_File() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "dwr-pom.xml");
         String expResult = "Direct Web Remoting";
         Model result = PomUtils.readPom(file);
@@ -62,7 +63,7 @@ public class PomUtilsTest extends BaseTest {
     }
 
     @Test
-    public void testReadPom_String_File() throws Exception {
+    void testReadPom_String_File() throws Exception {
         File fileCommonValidator = BaseTest.getResourceAsFile(this, "commons-validator-1.4.0.jar");
         JarFile jar = new JarFile(fileCommonValidator, false);
         String expResult = "Commons Validator";
@@ -71,7 +72,7 @@ public class PomUtilsTest extends BaseTest {
     }
 
     @Test
-    public void testReadPom_should_trim_version() throws AnalysisException {
+    void testReadPom_should_trim_version() throws AnalysisException {
         File input = BaseTest.getResourceAsFile(this, "pom/pom-with-new-line.xml");
         String expectedOutputVersion = "2.2.0";
 

--- a/core/src/test/java/org/owasp/dependencycheck/xml/suppression/PropertyTypeTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/suppression/PropertyTypeTest.java
@@ -17,24 +17,24 @@
  */
 package org.owasp.dependencycheck.xml.suppression;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class PropertyTypeTest extends BaseTest {
+class PropertyTypeTest extends BaseTest {
 
     /**
      * Test of set and getValue method, of class PropertyType.
      */
     @Test
-    public void testSetGetValue() {
+    void testSetGetValue() {
 
         PropertyType instance = new PropertyType();
         String expResult = "test";
@@ -47,7 +47,7 @@ public class PropertyTypeTest extends BaseTest {
      * Test of isRegex method, of class PropertyType.
      */
     @Test
-    public void testIsRegex() {
+    void testIsRegex() {
         PropertyType instance = new PropertyType();
         assertFalse(instance.isRegex());
         instance.setRegex(true);
@@ -58,7 +58,7 @@ public class PropertyTypeTest extends BaseTest {
      * Test of isCaseSensitive method, of class PropertyType.
      */
     @Test
-    public void testIsCaseSensitive() {
+    void testIsCaseSensitive() {
         PropertyType instance = new PropertyType();
         assertFalse(instance.isCaseSensitive());
         instance.setCaseSensitive(true);
@@ -69,7 +69,7 @@ public class PropertyTypeTest extends BaseTest {
      * Test of matches method, of class PropertyType.
      */
     @Test
-    public void testMatches() {
+    void testMatches() {
         String text = "Simple";
 
         PropertyType instance = new PropertyType();

--- a/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionHandlerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionHandlerTest.java
@@ -17,6 +17,13 @@
  */
 package org.owasp.dependencycheck.xml.suppression;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.utils.XmlUtils;
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+
+import javax.xml.parsers.SAXParser;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -24,19 +31,14 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import javax.xml.parsers.SAXParser;
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
-import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.utils.XmlUtils;
-import org.xml.sax.InputSource;
-import org.xml.sax.XMLReader;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class SuppressionHandlerTest extends BaseTest {
+class SuppressionHandlerTest extends BaseTest {
 
     /**
      * Test of getSuppressionRules method, of class SuppressionHandler.
@@ -44,7 +46,7 @@ public class SuppressionHandlerTest extends BaseTest {
      * @throws Exception thrown if there is an exception....
      */
     @Test
-    public void testHandler() throws Exception {
+    void testHandler() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "suppressions.xml");
         InputStream schemaStream = BaseTest.getResourceAsStream(this, "schema/suppression.xsd");
 

--- a/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionParserTest.java
@@ -17,31 +17,32 @@
  */
 package org.owasp.dependencycheck.xml.suppression;
 
+import org.junit.jupiter.api.Test;
+import org.owasp.dependencycheck.BaseTest;
+
 import java.io.File;
 import java.util.List;
-import org.junit.Assert;
 
-import org.junit.Test;
-import org.owasp.dependencycheck.BaseTest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test of the suppression parser.
  *
  * @author Jeremy Long
  */
-public class SuppressionParserTest extends BaseTest {
+class SuppressionParserTest extends BaseTest {
 
     /**
      * Test of parseSuppressionRules method, of class SuppressionParser for the
      * v1.0 suppression XML Schema.
      */
     @Test
-    public void testParseSuppressionRulesV1dot0() throws Exception {
+    void testParseSuppressionRulesV1dot0() throws Exception {
         //File file = new File(this.getClass().getClassLoader().getResource("suppressions.xml").getPath());
         File file = BaseTest.getResourceAsFile(this, "suppressions.xml");
         SuppressionParser instance = new SuppressionParser();
         List<SuppressionRule> result = instance.parseSuppressionRules(file);
-        Assert.assertEquals(5, result.size());
+        assertEquals(5, result.size());
     }
 
     /**
@@ -49,12 +50,12 @@ public class SuppressionParserTest extends BaseTest {
      * v1.1 suppression XML Schema.
      */
     @Test
-    public void testParseSuppressionRulesV1dot1() throws Exception {
+    void testParseSuppressionRulesV1dot1() throws Exception {
         //File file = new File(this.getClass().getClassLoader().getResource("suppressions.xml").getPath());
         File file = BaseTest.getResourceAsFile(this, "suppressions_1_1.xml");
         SuppressionParser instance = new SuppressionParser();
         List<SuppressionRule> result = instance.parseSuppressionRules(file);
-        Assert.assertEquals(5, result.size());
+        assertEquals(5, result.size());
     }
 
     /**
@@ -62,12 +63,12 @@ public class SuppressionParserTest extends BaseTest {
      * v1.2 suppression XML Schema.
      */
     @Test
-    public void testParseSuppressionRulesV1dot2() throws Exception {
+    void testParseSuppressionRulesV1dot2() throws Exception {
         //File file = new File(this.getClass().getClassLoader().getResource("suppressions.xml").getPath());
         File file = BaseTest.getResourceAsFile(this, "suppressions_1_2.xml");
         SuppressionParser instance = new SuppressionParser();
         List<SuppressionRule> result = instance.parseSuppressionRules(file);
-        Assert.assertEquals(4, result.size());
+        assertEquals(4, result.size());
     }
 
     /**
@@ -75,11 +76,11 @@ public class SuppressionParserTest extends BaseTest {
      * v1.2 suppression XML Schema.
      */
     @Test
-    public void testParseSuppressionRulesV1dot3() throws Exception {
+    void testParseSuppressionRulesV1dot3() throws Exception {
         //File file = new File(this.getClass().getClassLoader().getResource("suppressions.xml").getPath());
         File file = BaseTest.getResourceAsFile(this, "suppressions_1_3.xml");
         SuppressionParser instance = new SuppressionParser();
         List<SuppressionRule> result = instance.parseSuppressionRules(file);
-        Assert.assertEquals(4, result.size());
+        assertEquals(4, result.size());
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionRuleTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionRuleTest.java
@@ -19,16 +19,9 @@ package org.owasp.dependencycheck.xml.suppression;
 
 import com.github.packageurl.MalformedPackageURLException;
 import io.github.jeremylong.openvulnerability.client.nvd.CvssV2;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.dependency.Confidence;
-
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Vulnerability;
 import org.owasp.dependencycheck.dependency.naming.CpeIdentifier;
@@ -36,19 +29,27 @@ import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
 import org.owasp.dependencycheck.utils.CvssUtil;
 import us.springett.parsers.cpe.exceptions.CpeValidationException;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * Test of the suppression rule.
  *
  * @author Jeremy Long
  */
-public class SuppressionRuleTest extends BaseTest {
+class SuppressionRuleTest extends BaseTest {
 
     //<editor-fold defaultstate="collapsed" desc="Stupid tests of properties">
     /**
      * Test of FilePath property, of class SuppressionRule.
      */
     @Test
-    public void testFilePath() {
+    void testFilePath() {
         SuppressionRule instance = new SuppressionRule();
         PropertyType expResult = new PropertyType();
         expResult.setValue("test");
@@ -61,7 +62,7 @@ public class SuppressionRuleTest extends BaseTest {
      * Test of Sha1 property, of class SuppressionRule.
      */
     @Test
-    public void testSha1() {
+    void testSha1() {
         SuppressionRule instance = new SuppressionRule();
         String expResult = "384FAA82E193D4E4B0546059CA09572654BC3970";
         instance.setSha1(expResult);
@@ -73,7 +74,7 @@ public class SuppressionRuleTest extends BaseTest {
      * Test of Cpe property, of class SuppressionRule.
      */
     @Test
-    public void testCpe() {
+    void testCpe() {
         SuppressionRule instance = new SuppressionRule();
         List<PropertyType> cpe = new ArrayList<>();
         instance.setCpe(cpe);
@@ -91,7 +92,7 @@ public class SuppressionRuleTest extends BaseTest {
      * Test of CvssBelow property, of class SuppressionRule.
      */
     @Test
-    public void testGetCvssBelow() {
+    void testGetCvssBelow() {
         SuppressionRule instance = new SuppressionRule();
         List<Double> cvss = new ArrayList<>();
         instance.setCvssBelow(cvss);
@@ -106,7 +107,7 @@ public class SuppressionRuleTest extends BaseTest {
      * Test of Cwe property, of class SuppressionRule.
      */
     @Test
-    public void testCwe() {
+    void testCwe() {
         SuppressionRule instance = new SuppressionRule();
         List<String> cwe = new ArrayList<>();
         instance.setCwe(cwe);
@@ -121,7 +122,7 @@ public class SuppressionRuleTest extends BaseTest {
      * Test of Cve property, of class SuppressionRule.
      */
     @Test
-    public void testCve() {
+    void testCve() {
         SuppressionRule instance = new SuppressionRule();
         List<String> cve = new ArrayList<>();
         instance.setCve(cve);
@@ -136,12 +137,13 @@ public class SuppressionRuleTest extends BaseTest {
      * Test of base property, of class SuppressionRule.
      */
     @Test
-    public void testBase() {
+    void testBase() {
         SuppressionRule instance = new SuppressionRule();
         assertFalse(instance.isBase());
         instance.setBase(true);
         assertTrue(instance.isBase());
     }
+
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Ignored duplicate tests, left in, as empty tests, so IDE doesn't re-generate them">
@@ -150,7 +152,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testGetFilePath() {
+    void testGetFilePath() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -159,7 +161,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testSetFilePath() {
+    void testSetFilePath() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -168,7 +170,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testGetSha1() {
+    void testGetSha1() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -177,7 +179,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testSetSha1() {
+    void testSetSha1() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -186,7 +188,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testGetCpe() {
+    void testGetCpe() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -195,7 +197,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testSetCpe() {
+    void testSetCpe() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -204,7 +206,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testAddCpe() {
+    void testAddCpe() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -213,7 +215,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testHasCpe() {
+    void testHasCpe() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -222,7 +224,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testSetCvssBelow() {
+    void testSetCvssBelow() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -231,7 +233,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testAddCvssBelow() {
+    void testAddCvssBelow() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -240,7 +242,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testHasCvssBelow() {
+    void testHasCvssBelow() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -249,7 +251,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testGetCwe() {
+    void testGetCwe() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -258,7 +260,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testSetCwe() {
+    void testSetCwe() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -267,7 +269,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testAddCwe() {
+    void testAddCwe() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -276,7 +278,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testHasCwe() {
+    void testHasCwe() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -285,7 +287,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testGetCve() {
+    void testGetCve() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -294,7 +296,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testSetCve() {
+    void testSetCve() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -303,7 +305,7 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testAddCve() {
+    void testAddCve() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
 
@@ -312,16 +314,17 @@ public class SuppressionRuleTest extends BaseTest {
      */
     @Test
     @SuppressWarnings("squid:S2699")
-    public void testHasCve() {
+    void testHasCve() {
         //already tested, this is just left so the IDE doesn't recreate it.
     }
+
     //</editor-fold>
 
     /**
      * Test of cpeHasNoVersion method, of class SuppressionRule.
      */
     @Test
-    public void testCpeHasNoVersion() {
+    void testCpeHasNoVersion() {
         PropertyType c = new PropertyType();
         c.setValue("cpe:/a:microsoft:.net_framework:4.5");
         SuppressionRule instance = new SuppressionRule();
@@ -336,7 +339,7 @@ public class SuppressionRuleTest extends BaseTest {
      * Test of identifierMatches method, of class SuppressionRule.
      */
     @Test
-    public void testCpeMatches() throws CpeValidationException, MalformedPackageURLException {
+    void testCpeMatches() throws CpeValidationException, MalformedPackageURLException {
         CpeIdentifier identifier = new CpeIdentifier("microsoft", ".net_framework", "4.5", Confidence.HIGHEST);
 
         PropertyType cpe = new PropertyType();
@@ -412,7 +415,7 @@ public class SuppressionRuleTest extends BaseTest {
      * Test of process method, of class SuppressionRule.
      */
     @Test
-    public void testProcess() throws CpeValidationException {
+    void testProcess() throws CpeValidationException {
         //File struts = new File(this.getClass().getClassLoader().getResource("struts2-core-2.1.2.jar").getPath());
         File struts = BaseTest.getResourceAsFile(this, "struts2-core-2.1.2.jar");
         Dependency dependency = new Dependency(struts);
@@ -462,7 +465,7 @@ public class SuppressionRuleTest extends BaseTest {
         pt.setValue("cpe:/a:microsoft:.net_framework:4.0");
         instance.addCpe(pt);
         instance.process(dependency);
-        assertTrue(dependency.getVulnerableSoftwareIdentifiers().size() == 1);
+        assertEquals(1, dependency.getVulnerableSoftwareIdentifiers().size());
         pt = new PropertyType();
         pt.setValue("cpe:/a:microsoft:.net_framework:4.5");
         instance.addCpe(pt);
@@ -494,7 +497,7 @@ public class SuppressionRuleTest extends BaseTest {
      * Test of process method, of class SuppressionRule.
      */
     @Test
-    public void testProcessGAV() throws CpeValidationException, MalformedPackageURLException {
+    void testProcessGAV() throws CpeValidationException, MalformedPackageURLException {
         //File spring = new File(this.getClass().getClassLoader().getResource("spring-security-web-3.0.0.RELEASE.jar").getPath());
         File spring = BaseTest.getResourceAsFile(this, "spring-security-web-3.0.0.RELEASE.jar");
         Dependency dependency = new Dependency(spring);
@@ -529,7 +532,7 @@ public class SuppressionRuleTest extends BaseTest {
     }
 
     @Test
-    public void testProcessVulnerabilityNames() throws CpeValidationException, MalformedPackageURLException {
+    void testProcessVulnerabilityNames() throws CpeValidationException, MalformedPackageURLException {
         File spring = BaseTest.getResourceAsFile(this, "spring-security-web-3.0.0.RELEASE.jar");
         Dependency dependency = new Dependency(spring);
         dependency.addVulnerableSoftwareIdentifier(new CpeIdentifier("vmware", "springsource_spring_security", "3.0.0", Confidence.HIGH));
@@ -552,11 +555,11 @@ public class SuppressionRuleTest extends BaseTest {
         assertEquals(1, dependency.getVulnerabilities().size());
         assertEquals(0, dependency.getSuppressedVulnerabilities().size());
 
-        
+
         pt = new PropertyType();
         pt.setValue("CVE-2013-1337");
         instance.addVulnerabilityName(pt);
-        
+
         instance.process(dependency);
         assertEquals(0, dependency.getVulnerabilities().size());
         assertEquals(1, dependency.getSuppressedVulnerabilities().size());
@@ -566,7 +569,7 @@ public class SuppressionRuleTest extends BaseTest {
         Vulnerability v = new Vulnerability();
         v.addCwe("CWE-287 Improper Authentication");
         v.setName("CVE-2013-1337");
-        
+
         CvssV2 cvss = CvssUtil.vectorToCvssV2("/AV:N/AC:L/Au:N/C:P/I:P/A:P", 7.5);
         v.setCvssV2(cvss);
         return v;

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -117,7 +117,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -116,6 +116,12 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -116,7 +116,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/maven/src/test/java/org/owasp/dependencycheck/maven/ArtifactScopeExcludedTest.java
+++ b/maven/src/test/java/org/owasp/dependencycheck/maven/ArtifactScopeExcludedTest.java
@@ -17,9 +17,8 @@
  */
 package org.owasp.dependencycheck.maven;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.owasp.dependencycheck.utils.Filter;
 
 import java.util.Arrays;
@@ -38,18 +37,9 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.owasp.dependencycheck.maven.ArtifactScopeExcludedTest.ArtifactScopeExcludedTestBuilder.pluginDefaults;
 
-@RunWith(Parameterized.class)
-public class ArtifactScopeExcludedTest {
+class ArtifactScopeExcludedTest {
 
-	private final boolean skipTestScope;
-	private final boolean skipProvidedScope;
-	private final boolean skipSystemScope;
-	private final boolean skipRuntimeScope;
-	private final String testString;
-	private final boolean expectedResult;
-
-	@Parameterized.Parameters(name = "{0}")
-	public static Collection<Object[]> getParameters() {
+	static Collection<Object[]> getParameters() {
 		return Arrays.asList(new Object[][]{
 				{pluginDefaults().withTestString(SCOPE_COMPILE).withExpectedResult(false)},
 				{pluginDefaults().withTestString(SCOPE_COMPILE_PLUS_RUNTIME).withExpectedResult(false)},
@@ -66,19 +56,12 @@ public class ArtifactScopeExcludedTest {
 		});
 	}
 
-	public ArtifactScopeExcludedTest(final ArtifactScopeExcludedTestBuilder builder) {
-		this.skipTestScope = builder.skipTestScope;
-		this.skipProvidedScope = builder.skipProvidedScope;
-		this.skipSystemScope = builder.skipSystemScope;
-		this.skipRuntimeScope = builder.skipRuntimeScope;
-		this.testString = builder.testString;
-		this.expectedResult = builder.expectedResult;
-	}
-
-	@Test
-	public void shouldExcludeArtifact() {
-		final Filter<String> artifactScopeExcluded = new ArtifactScopeExcluded(skipTestScope, skipProvidedScope, skipSystemScope, skipRuntimeScope);
-		assertThat(expectedResult, is(equalTo(artifactScopeExcluded.passes(testString))));
+    @ParameterizedTest(name = "{0}")
+	@MethodSource("getParameters")
+    void shouldExcludeArtifact(final ArtifactScopeExcludedTestBuilder builder) {
+		final Filter<String> artifactScopeExcluded = new ArtifactScopeExcluded(
+				builder.skipTestScope, builder.skipProvidedScope, builder.skipSystemScope, builder.skipRuntimeScope);
+		assertThat(builder.expectedResult, is(equalTo(artifactScopeExcluded.passes(builder.testString))));
 	}
 
 	public static final class ArtifactScopeExcludedTestBuilder {

--- a/maven/src/test/java/org/owasp/dependencycheck/maven/ArtifactTypeExcludedTest.java
+++ b/maven/src/test/java/org/owasp/dependencycheck/maven/ArtifactTypeExcludedTest.java
@@ -17,20 +17,21 @@
  */
 package org.owasp.dependencycheck.maven;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author Jeremy Long
  */
-public class ArtifactTypeExcludedTest {
+class ArtifactTypeExcludedTest {
 
     /**
      * Test of passes method, of class ArtifactTypeExcluded.
      */
     @Test
-    public void testPasses() {
+    void testPasses() {
         String artifactType = null;
         ArtifactTypeExcluded instance = new ArtifactTypeExcluded(null);
         boolean expResult = false;

--- a/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
+++ b/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
@@ -17,36 +17,33 @@
  */
 package org.owasp.dependencycheck.maven;
 
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.exception.ExceptionCollection;
+
 import java.io.File;
 import java.util.Locale;
 
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.project.MavenProject;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.doReturn;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.owasp.dependencycheck.Engine;
-import org.owasp.dependencycheck.exception.ExceptionCollection;
 
 /**
  *
  * @author Jeremy Long
  */
-@RunWith(MockitoJUnitRunner.class)
-public class BaseDependencyCheckMojoTest extends BaseTest {
+@ExtendWith(MockitoExtension.class)
+class BaseDependencyCheckMojoTest extends BaseTest {
 
     @Spy
     MavenProject project;
 
     @Test
-    public void should_newDependency_get_pom_from_base_dir() {
+    void should_newDependency_get_pom_from_base_dir() {
         // Given
         BaseDependencyCheckMojo instance = new BaseDependencyCheckMojoImpl();
 
@@ -62,7 +59,7 @@ public class BaseDependencyCheckMojoTest extends BaseTest {
     }
 
     @Test
-    public void should_newDependency_get_default_virtual_dependency() {
+    void should_newDependency_get_default_virtual_dependency() {
         // Given
         BaseDependencyCheckMojo instance = new BaseDependencyCheckMojoImpl();
 
@@ -77,7 +74,7 @@ public class BaseDependencyCheckMojoTest extends BaseTest {
     }
 
     @Test
-    public void should_newDependency_get_pom_declared_as_module() {
+    void should_newDependency_get_pom_declared_as_module() {
         // Given
         BaseDependencyCheckMojo instance = new BaseDependencyCheckMojoImpl();
 
@@ -99,7 +96,7 @@ public class BaseDependencyCheckMojoTest extends BaseTest {
     public static class BaseDependencyCheckMojoImpl extends BaseDependencyCheckMojo {
 
         @Override
-        protected void runCheck() throws MojoExecutionException, MojoFailureException {
+        protected void runCheck() {
             throw new UnsupportedOperationException("Operation not supported");
         }
 
@@ -119,11 +116,11 @@ public class BaseDependencyCheckMojoTest extends BaseTest {
         }
 
         @Override
-        protected ExceptionCollection scanDependencies(Engine engine) throws MojoExecutionException {
+        protected ExceptionCollection scanDependencies(Engine engine) {
             throw new UnsupportedOperationException("Operation not supported");
         }
         @Override
-        protected ExceptionCollection scanPlugins(Engine engine, ExceptionCollection exCollection) throws MojoExecutionException {
+        protected ExceptionCollection scanPlugins(Engine engine, ExceptionCollection exCollection) {
             throw new UnsupportedOperationException("Operation not supported");
         }
     }

--- a/maven/src/test/java/org/owasp/dependencycheck/maven/BaseTest.java
+++ b/maven/src/test/java/org/owasp/dependencycheck/maven/BaseTest.java
@@ -17,11 +17,12 @@
  */
 package org.owasp.dependencycheck.maven;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.owasp.dependencycheck.utils.Settings;
+
 import java.io.IOException;
 import java.io.InputStream;
-import org.junit.After;
-import org.junit.Before;
-import org.owasp.dependencycheck.utils.Settings;
 
 /**
  *
@@ -42,7 +43,7 @@ public abstract class BaseTest {
     /**
      * Initialize the {@link Settings}.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         settings = new Settings();
         try (InputStream mojoProperties = BaseTest.class.getClassLoader().getResourceAsStream(BaseTest.PROPERTIES_FILE)) {
@@ -53,7 +54,7 @@ public abstract class BaseTest {
     /**
      * Clean the {@link Settings}.
      */
-    @After
+    @AfterEach
     public void tearDown() {
         settings.cleanup(true);
     }

--- a/maven/src/test/resources/maven_project_base_dir/pom.xml
+++ b/maven/src/test/resources/maven_project_base_dir/pom.xml
@@ -49,7 +49,19 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.12.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.12.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <version>5.12.2</version>
             <scope>test</scope>
         </dependency>

--- a/maven/src/test/resources/maven_project_base_dir/pom.xml
+++ b/maven/src/test/resources/maven_project_base_dir/pom.xml
@@ -48,9 +48,9 @@
             <version>2.1.2</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -117,14 +117,14 @@ Copyright (c) 2012 - Jeremy Long
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
-        
+
         <apache.lucene.version>9.12.0</apache.lucene.version>
         <apache.ant.version>1.10.15</apache.ant.version>
-        
+
         <!-- upgrading slf4j and logback can cause issues ;) https://github.com/dependency-check/DependencyCheck/issues/4846 -->
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.13</logback.version>
-        
+
         <maven.api.version>3.6.3</maven.api.version>
         <reporting.checkstyle-plugin.version>3.6.0</reporting.checkstyle-plugin.version>
         <reporting.checkstyle.tool.version>9.3</reporting.checkstyle.tool.version>
@@ -154,9 +154,9 @@ Copyright (c) 2012 - Jeremy Long
             https://github.com/apache/commons-jcs/pull/120 -->
         <commons-jcs-core.version>3.2.1</commons-jcs-core.version>
         <aho-corasick-double-array-trie.version>1.2.3</aho-corasick-double-array-trie.version>
-        <junit.version>4.13.2</junit.version>
+        <junit.version>5.12.2</junit.version>
         <hamcrest.version>3.0</hamcrest.version>
-        <mockito-core.version>5.12.0</mockito-core.version>
+        <mockito.version>5.12.0</mockito.version>
         <jsoup.version>1.19.1</jsoup.version>
         <commons-compress.version>1.27.1</commons-compress.version>
         <org.apache.maven.shared.file-management.version>3.2.0</org.apache.maven.shared.file-management.version>
@@ -172,7 +172,7 @@ Copyright (c) 2012 - Jeremy Long
         <gmavenplus-plugin.version>4.1.1</gmavenplus-plugin.version>
         <com.h3xstream.retirejs.core.version>3.0.4</com.h3xstream.retirejs.core.version>
         <jackson.version>2.19.0</jackson.version>
-        <!--necassary for some IDEs to be able to execute test cases (Netbeans)-->
+        <!--necessary for some IDEs to be able to execute test cases (Netbeans)-->
         <surefireArgLine />
         <mock-server.version>5.15.0</mock-server.version>
     </properties>
@@ -415,7 +415,7 @@ Copyright (c) 2012 - Jeremy Long
                             </scripts>
                         </configuration>
                     </execution>
-                    
+
                     <execution>
                         <id>add-dynamic-properties-site</id>
                         <phase>pre-site</phase>
@@ -523,6 +523,7 @@ Copyright (c) 2012 - Jeremy Long
                     <detectJavaApiLink>false</detectJavaApiLink>
                 </configuration>
             </plugin>
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -577,6 +578,7 @@ Copyright (c) 2012 - Jeremy Long
                     </execution>
                 </executions>
             </plugin>
+            -->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
@@ -952,14 +954,14 @@ Copyright (c) 2012 - Jeremy Long
             </dependency>
             <dependency>
                 <groupId>org.mock-server</groupId>
-                <artifactId>mockserver-junit-rule</artifactId>
+                <artifactId>mockserver-junit-jupiter</artifactId>
                 <version>${mock-server.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito-core.version}</version>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -1079,16 +1081,9 @@ Copyright (c) 2012 - Jeremy Long
                 <version>${logback.version}</version>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
                 <version>${junit.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <!-- deprecated coordinates, replaced by org.hamcrest:hamcrest -->
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest-core</artifactId>
-                    </exclusion>
-                </exclusions>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -1322,8 +1317,8 @@ Copyright (c) 2012 - Jeremy Long
     <dependencies>
         <!-- region generic test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,6 @@ Copyright (c) 2012 - Jeremy Long
                     <detectJavaApiLink>false</detectJavaApiLink>
                 </configuration>
             </plugin>
-            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -578,7 +577,6 @@ Copyright (c) 2012 - Jeremy Long
                     </execution>
                 </executions>
             </plugin>
-            -->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
@@ -956,6 +954,12 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.mock-server</groupId>
                 <artifactId>mockserver-junit-jupiter</artifactId>
                 <version>${mock-server.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@ Copyright (c) 2012 - Jeremy Long
         <aho-corasick-double-array-trie.version>1.2.3</aho-corasick-double-array-trie.version>
         <junit.version>5.12.2</junit.version>
         <hamcrest.version>3.0</hamcrest.version>
-        <mockito.version>5.12.0</mockito.version>
+        <mockito.version>5.17.0</mockito.version>
         <jsoup.version>1.19.1</jsoup.version>
         <commons-compress.version>1.27.1</commons-compress.version>
         <org.apache.maven.shared.file-management.version>3.2.0</org.apache.maven.shared.file-management.version>
@@ -1082,7 +1082,19 @@ Copyright (c) 2012 - Jeremy Long
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter</artifactId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -1318,7 +1330,17 @@ Copyright (c) 2012 - Jeremy Long
         <!-- region generic test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -100,7 +100,7 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-junit-rule</artifactId>
+            <artifactId>mockserver-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/BaseTest.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/BaseTest.java
@@ -15,11 +15,13 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
 import java.io.File;
 import java.net.URISyntaxException;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  *
@@ -35,7 +37,7 @@ public abstract class BaseTest {
     /**
      * Initialize the {@link Settings}.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         settings = new Settings();
     }
@@ -43,7 +45,7 @@ public abstract class BaseTest {
     /**
      * Clean the {@link Settings}.
      */
-    @After
+    @AfterEach
     public void tearDown() {
         settings.cleanup(true);
     }
@@ -56,7 +58,7 @@ public abstract class BaseTest {
     protected Settings getSettings() {
         return settings;
     }
-    
+
     /**
      * Returns the given resource as a File using the object's class loader. The
      * org.junit.Assume API is used so that test cases are skipped if the
@@ -69,7 +71,7 @@ public abstract class BaseTest {
     public static File getResourceAsFile(Object o, String resource) {
         try {
             File f = new File(o.getClass().getClassLoader().getResource(resource).toURI().getPath());
-            Assume.assumeTrue(String.format("%n%n[SEVERE] Unable to load resource for test case: %s%n%n", resource), f.exists());
+            assumeTrue(f.exists(), String.format("%n%n[SEVERE] Unable to load resource for test case: %s%n%n", resource));
             return f;
         } catch (URISyntaxException e) {
             throw new UnsupportedOperationException(e);

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/ChecksumTest.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/ChecksumTest.java
@@ -17,34 +17,32 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import org.junit.jupiter.api.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
-import org.junit.Assert;
-import static org.junit.Assert.assertArrayEquals;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class ChecksumTest {
+class ChecksumTest {
 
     /**
      * Test of getChecksum method, of class Checksum. This checks that an
      * exception is thrown when an invalid path is specified.
      *
-     * @throws Exception is thrown when an exception occurs.
      */
     @Test
-    public void testGetChecksum_FileNotFound() throws Exception {
+    void testGetChecksum_FileNotFound() {
         String algorithm = "MD5";
         File file = new File("not a valid file");
-        Exception exception = Assert.assertThrows(IOException.class, () -> Checksum.getChecksum(algorithm, file));
+        Exception exception = assertThrows(IOException.class, () -> Checksum.getChecksum(algorithm, file));
         assertTrue(exception.getMessage().contains("not a valid file"));
     }
 
@@ -52,13 +50,12 @@ public class ChecksumTest {
      * Test of getChecksum method, of class Checksum. This checks that an
      * exception is thrown when an invalid algorithm is specified.
      *
-     * @throws Exception is thrown when an exception occurs.
      */
     @Test
-    public void testGetChecksum_NoSuchAlgorithm() throws Exception {
+    void testGetChecksum_NoSuchAlgorithm() {
         String algorithm = "some unknown algorithm";
         File file = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").getPath());
-        Exception exception = Assert.assertThrows(NoSuchAlgorithmException.class, () -> Checksum.getChecksum(algorithm, file));
+        Exception exception = assertThrows(NoSuchAlgorithmException.class, () -> Checksum.getChecksum(algorithm, file));
         assertTrue(exception.getMessage().contains("some unknown algorithm"));
     }
 
@@ -68,7 +65,7 @@ public class ChecksumTest {
      * @throws Exception is thrown when an exception occurs.
      */
     @Test
-    public void testGetMD5Checksum() throws Exception {
+    void testGetMD5Checksum() throws Exception {
         File file = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").toURI().getPath());
         //String expResult = "F0915C5F46B8CFA283E5AD67A09B3793";
         String expResult = "f0915c5f46b8cfa283e5ad67a09b3793";
@@ -82,7 +79,7 @@ public class ChecksumTest {
      * @throws Exception is thrown when an exception occurs.
      */
     @Test
-    public void testGetSHA1Checksum() throws Exception {
+    void testGetSHA1Checksum() throws Exception {
         File file = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").toURI().getPath());
         //String expResult = "B8A9FF28B21BCB1D0B50E24A5243D8B51766851A";
         String expResult = "b8a9ff28b21bcb1d0b50e24a5243d8b51766851a";
@@ -94,7 +91,7 @@ public class ChecksumTest {
      * Test of getHex method, of class Checksum.
      */
     @Test
-    public void testGetHex() {
+    void testGetHex() {
         byte[] raw = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
         //String expResult = "000102030405060708090A0B0C0D0E0F10";
         String expResult = "000102030405060708090a0b0c0d0e0f10";
@@ -106,7 +103,7 @@ public class ChecksumTest {
      * Test of getChecksum method, of class Checksum.
      */
     @Test
-    public void testGetChecksum_String_File() throws Exception {
+    void testGetChecksum_String_File() throws Exception {
         String algorithm = "MD5";
         File file = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").toURI().getPath());
         String expResult = "f0915c5f46b8cfa283e5ad67a09b3793";
@@ -121,7 +118,7 @@ public class ChecksumTest {
      * Test of getMD5Checksum method, of class Checksum.
      */
     @Test
-    public void testGetMD5Checksum_File() throws Exception {
+    void testGetMD5Checksum_File() throws Exception {
         File file = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").toURI().getPath());
         String expResult = "f0915c5f46b8cfa283e5ad67a09b3793";
         String result = Checksum.getMD5Checksum(file);
@@ -132,7 +129,7 @@ public class ChecksumTest {
      * Test of getSHA1Checksum method, of class Checksum.
      */
     @Test
-    public void testGetSHA1Checksum_File() throws Exception {
+    void testGetSHA1Checksum_File() throws Exception {
         File file = new File(this.getClass().getClassLoader().getResource("checkSumTest.file").toURI().getPath());
         String expResult = "b8a9ff28b21bcb1d0b50e24a5243d8b51766851a";
         String result = Checksum.getSHA1Checksum(file);
@@ -143,7 +140,7 @@ public class ChecksumTest {
      * Test of getChecksum method, of class Checksum.
      */
     @Test
-    public void testGetChecksum_String_byteArr() {
+    void testGetChecksum_String_byteArr() {
         String algorithm = "SHA1";
         byte[] bytes = {-16, -111, 92, 95, 70, -72, -49, -94, -125, -27, -83, 103, -96, -101, 55, -109};
         String expResult = "89268a389a97f0bfba13d3ff2370d8ad436e36f6";
@@ -155,7 +152,7 @@ public class ChecksumTest {
      * Test of getMD5Checksum method, of class Checksum.
      */
     @Test
-    public void testGetMD5Checksum_String() {
+    void testGetMD5Checksum_String() {
         String text = "test string";
         String expResult = "6f8db599de986fab7a21625b7916589c";
         String result = Checksum.getMD5Checksum(text);
@@ -166,7 +163,7 @@ public class ChecksumTest {
      * Test of getSHA1Checksum method, of class Checksum.
      */
     @Test
-    public void testGetSHA1Checksum_String() {
+    void testGetSHA1Checksum_String() {
         String text = "test string";
         String expResult = "661295c9cbf9d6b2f6428414504a8deed3020641";
         String result = Checksum.getSHA1Checksum(text);

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/DownloaderIT.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/DownloaderIT.java
@@ -17,29 +17,29 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import org.apache.hc.client5.http.impl.classic.AbstractHttpClientResponseHandler;
+import org.apache.hc.core5.http.HttpEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-import org.apache.hc.client5.http.impl.classic.AbstractHttpClientResponseHandler;
-import org.apache.hc.core5.http.HttpEntity;
-import org.junit.Test;
-
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertTrue;
-import org.junit.Before;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class DownloaderIT extends BaseTest {
+class DownloaderIT extends BaseTest {
 
     /**
      * Initialize the {@link Settings}.
      */
-    @Before
+    @BeforeEach
     @Override
     public void setUp() {
         super.setUp();
@@ -51,7 +51,7 @@ public class DownloaderIT extends BaseTest {
      * @throws Exception thrown when an exception occurs.
      */
     @Test
-    public void testFetchFile() throws Exception {
+    void testFetchFile() throws Exception {
         final String str = getSettings().getString(Settings.KEYS.ENGINE_VERSION_CHECK_URL, "https://dependency-check.github.io/DependencyCheck/current.txt");
         URL url = new URL(str);
         File outputPath = new File("target/current.txt");
@@ -66,9 +66,9 @@ public class DownloaderIT extends BaseTest {
      * @throws Exception thrown when an exception occurs.
      */
     @Test
-    public void testfetchAndHandleContent() throws Exception {
+    void testfetchAndHandleContent() throws Exception {
         URL url = new URL(getSettings().getString(Settings.KEYS.ENGINE_VERSION_CHECK_URL));
-        AbstractHttpClientResponseHandler<String> versionHandler = new AbstractHttpClientResponseHandler<String>() {
+        AbstractHttpClientResponseHandler<String> versionHandler = new AbstractHttpClientResponseHandler<>() {
             @Override
             public String handleEntity(HttpEntity entity) throws IOException {
                 try (InputStream in = entity.getContent()) {

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/ExpectedObjectInputStreamTest.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/ExpectedObjectInputStreamTest.java
@@ -66,10 +66,10 @@ class ExpectedObjectInputStreamTest {
         ByteArrayOutputStream mem = new ByteArrayOutputStream();
         byte[] buf;
         try (ObjectOutputStream out = new ObjectOutputStream(new BufferedOutputStream(mem))) {
-                out.writeObject(data);
-                out.flush();
-                buf = mem.toByteArray();
-            }
+            out.writeObject(data);
+            out.flush();
+            buf = mem.toByteArray();
+        }
         ByteArrayInputStream in = new ByteArrayInputStream(buf);
         ExpectedObjectInputStream instance = new ExpectedObjectInputStream(in, "java.util.ArrayList", "org.owasp.dependencycheck.utils.SimplePojo");
         assertThrows(java.io.InvalidClassException.class, instance::readObject);

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/ExpectedObjectInputStreamTest.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/ExpectedObjectInputStreamTest.java
@@ -17,6 +17,8 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import org.junit.jupiter.api.Test;
+
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -24,21 +26,21 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
-import static org.junit.Assert.fail;
-import org.junit.Test;
-import static org.junit.Assert.fail;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
  * @author jeremy
  */
-public class ExpectedObjectInputStreamTest {
+class ExpectedObjectInputStreamTest {
 
     /**
      * Test of resolveClass method, of class ExpectedObjectInputStream.
      */
     @Test
-    public void testResolveClass() {
+    void testResolveClass() {
         List<SimplePojo> data = new ArrayList<>();
         data.add(new SimplePojo());
         try (ByteArrayOutputStream mem = new ByteArrayOutputStream();
@@ -57,21 +59,19 @@ public class ExpectedObjectInputStreamTest {
     /**
      * Test of resolveClass method, of class ExpectedObjectInputStream.
      */
-    @Test(expected = java.io.InvalidClassException.class)
-    public void testResolveClassException() throws Exception {
+    @Test
+    void testResolveClassException() throws Exception {
         List<SimplePojo> data = new ArrayList<>();
         data.add(new SimplePojo());
-
         ByteArrayOutputStream mem = new ByteArrayOutputStream();
         byte[] buf;
         try (ObjectOutputStream out = new ObjectOutputStream(new BufferedOutputStream(mem))) {
-            out.writeObject(data);
-            out.flush();
-            buf = mem.toByteArray();
-        }
+                out.writeObject(data);
+                out.flush();
+                buf = mem.toByteArray();
+            }
         ByteArrayInputStream in = new ByteArrayInputStream(buf);
-
         ExpectedObjectInputStream instance = new ExpectedObjectInputStream(in, "java.util.ArrayList", "org.owasp.dependencycheck.utils.SimplePojo");
-        instance.readObject();
+        assertThrows(java.io.InvalidClassException.class, instance::readObject);
     }
 }

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/FileUtilsTest.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/FileUtilsTest.java
@@ -17,30 +17,32 @@
  */
 package org.owasp.dependencycheck.utils;
 
+import org.junit.jupiter.api.Test;
+
 import java.io.File;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
  * @author Jeremy Long
  */
-public class FileUtilsTest extends BaseTest {
+class FileUtilsTest extends BaseTest {
 
     /**
      * Test of getFileExtension method, of class FileUtils.
      */
     @Test
-    public void testGetFileExtension() {
+    void testGetFileExtension() {
         String[] fileName = {"something-0.9.5.jar", "lib2-1.1.js", "dir.tmp/noext"};
         String[] expResult = {"jar", "js", null};
 
         for (int i = 0; i < fileName.length; i++) {
             String result = FileUtils.getFileExtension(fileName[i]);
-            assertEquals("Failed extraction on \"" + fileName[i] + "\".", expResult[i], result);
+            assertEquals(expResult[i], result, "Failed extraction on \"" + fileName[i] + "\".");
         }
     }
 
@@ -48,31 +50,31 @@ public class FileUtilsTest extends BaseTest {
      * Test of delete method, of class FileUtils.
      */
     @Test
-    public void testDelete() throws Exception {
+    void testDelete() throws Exception {
 
         File file = File.createTempFile("tmp", "deleteme", getSettings().getTempDirectory());
         if (!file.exists()) {
             fail("Unable to create a temporary file.");
         }
         boolean status = FileUtils.delete(file);
-        assertTrue("delete returned a failed status", status);
-        assertFalse("Temporary file exists after attempting deletion", file.exists());
+        assertTrue(status, "delete returned a failed status");
+        assertFalse(file.exists(), "Temporary file exists after attempting deletion");
     }
 
     /**
      * Test of delete method with a non-empty directory, of class FileUtils.
      */
     @Test
-    public void testDeleteWithSubDirectories() throws Exception {
+    void testDeleteWithSubDirectories() throws Exception {
 
         File dir = new File(getSettings().getTempDirectory(), "delete-me");
         dir.mkdirs();
         File file = File.createTempFile("tmp", "deleteme", dir);
-        assertTrue("Unable to create a temporary file " + file.getAbsolutePath(), file.exists());
+        assertTrue(file.exists(), "Unable to create a temporary file " + file.getAbsolutePath());
 
         // delete the file
         boolean status = FileUtils.delete(dir);
-        assertTrue("delete returned a failed status", status);
-        assertFalse("Temporary file exists after attempting deletion", file.exists());
+        assertTrue(status, "delete returned a failed status");
+        assertFalse(file.exists(), "Temporary file exists after attempting deletion");
     }
 }

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/FileUtilsTest.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/FileUtilsTest.java
@@ -24,7 +24,6 @@ import java.io.File;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
@@ -51,11 +50,10 @@ class FileUtilsTest extends BaseTest {
      */
     @Test
     void testDelete() throws Exception {
-
         File file = File.createTempFile("tmp", "deleteme", getSettings().getTempDirectory());
-        if (!file.exists()) {
-            fail("Unable to create a temporary file.");
-        }
+
+        assertTrue(file.exists(), "Unable to create a temporary file.");
+
         boolean status = FileUtils.delete(file);
         assertTrue(status, "delete returned a failed status");
         assertFalse(file.exists(), "Temporary file exists after attempting deletion");
@@ -66,7 +64,6 @@ class FileUtilsTest extends BaseTest {
      */
     @Test
     void testDeleteWithSubDirectories() throws Exception {
-
         File dir = new File(getSettings().getTempDirectory(), "delete-me");
         dir.mkdirs();
         File file = File.createTempFile("tmp", "deleteme", dir);

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/JsonArrayFixingInputStreamTest.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/JsonArrayFixingInputStreamTest.java
@@ -17,29 +17,28 @@
  */
 package org.owasp.dependencycheck.utils;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import java.util.Arrays;
-import jakarta.json.JsonReader;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
+import jakarta.json.JsonReader;
 import org.apache.commons.io.IOUtils;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import static org.junit.Assert.assertFalse;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class JsonArrayFixingInputStreamTest {
+class JsonArrayFixingInputStreamTest {
 
     final String sample1 = "{}";
     final String sample2 = "{}{}";
@@ -106,29 +105,13 @@ public class JsonArrayFixingInputStreamTest {
             + "\"GoMod\": \"/Users/me/go/pkg/mod/cache/download/github.com/!microsoft/hcsshim/@v/v0.8.8-0.20200421182805-c3e488f0d815.mod\"\n"
             + "}\n";
 
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
-
     /**
      * Test of read method, of class JsonArrayFixingInputStream.
      *
      * @throws Exception because one might happen
      */
     @Test
-    public void testRead_0args() throws Exception {
+    void testRead_0args() throws Exception {
         try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
                 JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             assertEquals('[', instance.read());
@@ -157,7 +140,7 @@ public class JsonArrayFixingInputStreamTest {
      * @throws Exception because one might happen
      */
     @Test
-    public void testRead_byteArr() throws Exception {
+    void testRead_byteArr() throws Exception {
         byte[] b = new byte[9];
         try (InputStream sample = new ByteArrayInputStream(sample2.getBytes());
                 JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
@@ -185,8 +168,8 @@ public class JsonArrayFixingInputStreamTest {
         }
     }
 
-    @Test()
-    public void testRead_IOUtils() throws Exception {
+    @Test
+    void testRead_IOUtils() throws Exception {
         try (InputStream sample = new ByteArrayInputStream(sample3.getBytes());
                 JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             String results = IOUtils.toString(instance, UTF_8);
@@ -195,8 +178,8 @@ public class JsonArrayFixingInputStreamTest {
         }
     }
 
-    @Test()
-    public void testRead_RealSample() throws Exception {
+    @Test
+    void testRead_RealSample() throws Exception {
         try (InputStream sample = new ByteArrayInputStream(sample4.getBytes());
                 JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             try (JsonReader reader = Json.createReader(instance)) {
@@ -211,8 +194,8 @@ public class JsonArrayFixingInputStreamTest {
      *
      * @throws Exception because one might happen
      */
-    @Test()
-    public void testRead_3args() throws Exception {
+    @Test
+    void testRead_3args() throws Exception {
         byte[] input = new byte[2048];
         Arrays.fill(input, (byte) ' ');
         input[0] = '{';
@@ -232,7 +215,7 @@ public class JsonArrayFixingInputStreamTest {
                 read = instance.read(results, pos, 2050 - pos);
                 pos += read;
             }
-            Assert.assertArrayEquals(expected, results);
+            assertArrayEquals(expected, results);
         }
     }
 
@@ -241,12 +224,14 @@ public class JsonArrayFixingInputStreamTest {
      *
      * @throws Exception because one might happen
      */
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSkip() throws Exception {
-        try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
+    @Test
+    void testSkip() {
+        assertThrows(UnsupportedOperationException.class, () -> {
+            try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
                 JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
-            instance.skip(1);
-        }
+                instance.skip(1);
+            }
+        });
     }
 
     /**
@@ -255,7 +240,7 @@ public class JsonArrayFixingInputStreamTest {
      * @throws Exception because one might happen
      */
     @Test
-    public void testAvailable() throws Exception {
+    void testAvailable() throws Exception {
         try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
                 JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             int results = instance.available();
@@ -275,7 +260,7 @@ public class JsonArrayFixingInputStreamTest {
      * @throws Exception because one might happen
      */
     @Test
-    public void testClose() throws Exception {
+    void testClose() throws Exception {
         try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
                 JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             int i = instance.read();
@@ -288,7 +273,7 @@ public class JsonArrayFixingInputStreamTest {
      * @throws Exception because one might happen
      */
     @Test
-    public void testMarkSupported() throws Exception {
+    void testMarkSupported() throws Exception {
         try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
                 JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             boolean result = instance.markSupported();
@@ -297,7 +282,7 @@ public class JsonArrayFixingInputStreamTest {
     }
 
     @Test
-    public void testIsWhiteSpace() throws Exception {
+    void testIsWhiteSpace() {
         JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(null);
         assertFalse(instance.isWhiteSpace((byte) 'a'));
         assertTrue(instance.isWhiteSpace((byte) '\n'));

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/SettingsTest.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/SettingsTest.java
@@ -17,11 +17,7 @@
  */
 package org.owasp.dependencycheck.utils;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,35 +25,42 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * @author Jeremy Long
  */
-public class SettingsTest extends BaseTest {
+class SettingsTest extends BaseTest {
 
     /**
      * Test of getString method, of class Settings.
      */
     @Test
-    public void testGetString() {
+    void testGetString() {
         String key = Settings.KEYS.NVD_API_DATAFEED_VALID_FOR_DAYS;
         String expResult = "7";
         String result = getSettings().getString(key);
-        Assert.assertTrue(result.endsWith(expResult));
+        assertTrue(result.endsWith(expResult));
     }
 
     /**
      * Test of getDataFile method, of class Settings.
      */
     @Test
-    public void testGetDataFile() throws IOException {
+    void testGetDataFile() {
         String key = Settings.KEYS.DATA_DIRECTORY;
         String expResult = "data";
         File result = getSettings().getDataFile(key);
-        Assert.assertTrue(result.getAbsolutePath().endsWith(expResult));
+        assertTrue(result.getAbsolutePath().endsWith(expResult));
     }
 
     /**
@@ -67,170 +70,170 @@ public class SettingsTest extends BaseTest {
      * @throws java.net.URISyntaxException thrown when the test fails
      */
     @Test
-    public void testMergeProperties_String() throws IOException, URISyntaxException {
+    void testMergeProperties_String() throws IOException, URISyntaxException {
         String key = Settings.KEYS.PROXY_PORT;
         String expResult = getSettings().getString(key);
         File f = new File(this.getClass().getClassLoader().getResource("test.properties").toURI());
         //InputStream in = this.getClass().getClassLoader().getResourceAsStream("test.properties");
         getSettings().mergeProperties(f.getAbsolutePath());
         String result = getSettings().getString(key);
-        Assert.assertTrue("setting didn't change?", (expResult == null && result != null) || !expResult.equals(result));
+        assertTrue((expResult == null && result != null) || !expResult.equals(result), "setting didn't change?");
     }
 
     /**
      * Test of setString method, of class Settings.
      */
     @Test
-    public void testSetString() {
+    void testSetString() {
         String key = "newProperty";
         String value = "someValue";
         getSettings().setString(key, value);
         String expResults = getSettings().getString(key);
-        Assert.assertEquals(expResults, value);
+        assertEquals(value, expResults);
     }
 
     /**
      * Test of setStringIfNotNull method, of class Settings.
      */
     @Test
-    public void testSetStringIfNotNull() {
+    void testSetStringIfNotNull() {
         String key = "nullableProperty";
         String value = "someValue";
         getSettings().setString(key, value);
         getSettings().setStringIfNotNull(key, null); // NO-OP
         String expResults = getSettings().getString(key);
-        Assert.assertEquals(expResults, value);
+        assertEquals(value, expResults);
     }
 
     /**
      * Test of setStringIfNotNull method, of class Settings.
      */
     @Test
-    public void testSetStringIfNotEmpty() {
+    void testSetStringIfNotEmpty() {
         String key = "optionalProperty";
         String value = "someValue";
         getSettings().setString(key, value);
         getSettings().setStringIfNotEmpty(key, ""); // NO-OP
         String expResults = getSettings().getString(key);
-        Assert.assertEquals(expResults, value);
+        assertEquals(value, expResults);
     }
 
     /**
      * Test of getString method, of class Settings.
      */
     @Test
-    public void testGetString_String_String() {
+    void testGetString_String_String() {
         String key = "key That Doesn't Exist";
         String defaultValue = "blue bunny";
         String expResult = "blue bunny";
         String result = getSettings().getString(key);
-        Assert.assertTrue(result == null);
+        assertNull(result);
         result = getSettings().getString(key, defaultValue);
-        Assert.assertEquals(expResult, result);
+        assertEquals(expResult, result);
     }
 
     /**
      * Test of getString method, of class Settings.
      */
     @Test
-    public void testGetString_String() {
+    void testGetString_String() {
         String key = Settings.KEYS.CONNECTION_TIMEOUT;
         String result = getSettings().getString(key);
-        Assert.assertTrue(result == null);
+        assertNull(result);
     }
 
     /**
      * Test of getInt method, of class Settings.
      */
     @Test
-    public void testGetInt() throws InvalidSettingException {
+    void testGetInt() throws InvalidSettingException {
         String key = "SomeNumber";
         int expResult = 85;
         getSettings().setString(key, "85");
         int result = getSettings().getInt(key);
-        Assert.assertEquals(expResult, result);
+        assertEquals(expResult, result);
     }
 
     /**
      * Test of getInt method, of class Settings.
      */
     @Test
-    public void testGetIntDefault() throws InvalidSettingException {
+    void testGetIntDefault() {
         String key = "SomeKey";
         int expResult = 85;
         getSettings().setString(key, "blue");
         int result = getSettings().getInt(key, expResult);
-        Assert.assertEquals(expResult, result);
+        assertEquals(expResult, result);
     }
 
     /**
      * Test of getLong method, of class Settings.
      */
     @Test
-    public void testGetLong() throws InvalidSettingException {
+    void testGetLong() throws InvalidSettingException {
         String key = "SomeNumber";
         long expResult = 300L;
         getSettings().setString(key, "300");
         long result = getSettings().getLong(key);
-        Assert.assertEquals(expResult, result);
+        assertEquals(expResult, result);
     }
 
     /**
      * Test of getBoolean method, of class Settings.
      */
     @Test
-    public void testGetBoolean() throws InvalidSettingException {
+    void testGetBoolean() throws InvalidSettingException {
         String key = "SomeBoolean";
         getSettings().setString(key, "false");
         boolean expResult = false;
         boolean result = getSettings().getBoolean(key);
-        Assert.assertEquals(expResult, result);
+        assertEquals(expResult, result);
 
         key = "something that does not exist";
         expResult = true;
         result = getSettings().getBoolean(key, true);
-        Assert.assertEquals(expResult, result);
+        assertEquals(expResult, result);
     }
 
     /**
      * Test of removeProperty method, of class Settings.
      */
     @Test
-    public void testRemoveProperty() {
+    void testRemoveProperty() {
         String key = "SomeKey";
         String value = "value";
         String dfault = "default";
         getSettings().setString(key, value);
         String ret = getSettings().getString(key);
-        Assert.assertEquals(value, ret);
+        assertEquals(value, ret);
         getSettings().removeProperty(key);
         ret = getSettings().getString(key, dfault);
-        Assert.assertEquals(dfault, ret);
+        assertEquals(dfault, ret);
     }
 
     /**
      * Test of getConnectionString.
      */
     @Test
-    public void testGetConnectionString() throws Exception {
+    void testGetConnectionString() throws Exception {
         String value = getSettings().getConnectionString(Settings.KEYS.DB_CONNECTION_STRING, Settings.KEYS.DB_FILE_NAME);
-        Assert.assertNotNull(value);
+        assertNotNull(value);
         String msg = null;
         try {
             value = getSettings().getConnectionString("invalidKey", null);
         } catch (InvalidSettingException e) {
             msg = e.getMessage();
         }
-        Assert.assertNotNull(msg);
+        assertNotNull(msg);
     }
 
     /**
      * Test of getTempDirectory.
      */
     @Test
-    public void testGetTempDirectory() throws Exception {
+    void testGetTempDirectory() throws Exception {
         File tmp = getSettings().getTempDirectory();
-        Assert.assertTrue(tmp.exists());
+        assertTrue(tmp.exists());
     }
 
     /**
@@ -238,7 +241,7 @@ public class SettingsTest extends BaseTest {
      * multiple values in an array.
      */
     @Test
-    public void testGetArrayFromADelimitedString() {
+    void testGetArrayFromADelimitedString() {
         // GIVEN a delimited string
         final String delimitedString = "value1,value2";
         getSettings().setString("key", delimitedString);
@@ -258,7 +261,7 @@ public class SettingsTest extends BaseTest {
      * property is not set.
      */
     @Test
-    public void testGetArrayWhereThePropertyIsNotSet() {
+    void testGetArrayWhereThePropertyIsNotSet() {
         // WHEN getting the array
         final String[] array = getSettings().getArray("key");
 
@@ -271,7 +274,7 @@ public class SettingsTest extends BaseTest {
      * empty array is ignored.
      */
     @Test
-    public void testSetArrayNotEmptyIgnoresAnEmptyArray() {
+    void testSetArrayNotEmptyIgnoresAnEmptyArray() {
         // GIVEN an empty array
         final String[] array = {};
 
@@ -287,7 +290,7 @@ public class SettingsTest extends BaseTest {
      * array is ignored.
      */
     @Test
-    public void testSetArrayNotEmptyIgnoresAnNullArray() {
+    void testSetArrayNotEmptyIgnoresAnNullArray() {
         // GIVEN a null array
         final String[] array = null;
 
@@ -303,7 +306,7 @@ public class SettingsTest extends BaseTest {
      * correctly stores the list as an array.
      */
     @Test
-    public void testSetArrayNotEmptyWithList() {
+    void testSetArrayNotEmptyWithList() {
         // GIVEN a null array
         final List<String> list = new ArrayList<>();
         list.add("one");
@@ -318,7 +321,7 @@ public class SettingsTest extends BaseTest {
     }
 
     @Test
-    public void testMaskedKeys() {
+    void testMaskedKeys() {
         getSettings().initMaskedKeys();
         assertThat("password should be masked",
                 getSettings().getPrintableValue("odc.database.password", "s3Cr3t!"),

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/search/FileContentSearchTest.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/search/FileContentSearchTest.java
@@ -17,22 +17,24 @@
  */
 package org.owasp.dependencycheck.utils.search;
 
-import java.io.File;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.utils.BaseTest;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  * @author Jeremy Long
  */
-public class FileContentSearchTest extends BaseTest {
+class FileContentSearchTest extends BaseTest {
 
     /**
      * Test of contains method, of class FileContentSearch.
      */
     @Test
-    public void testContains_File_String() throws Exception {
+    void testContains_File_String() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "SearchTest.txt");
         String pattern = "blue";
         boolean expResult = false;
@@ -44,7 +46,7 @@ public class FileContentSearchTest extends BaseTest {
         result = FileContentSearch.contains(file, pattern);
         assertEquals(expResult, result);
 
-        
+
         pattern = "(?i)test";
         expResult = true;
         result = FileContentSearch.contains(file, pattern);
@@ -55,14 +57,14 @@ public class FileContentSearchTest extends BaseTest {
      * Test of contains method, of class FileContentSearch.
      */
     @Test
-    public void testContains_File_List() throws Exception {
+    void testContains_File_List() throws Exception {
         File file = BaseTest.getResourceAsFile(this, "SearchTest.txt");
         String[] patterns = {"jeremy long", "blue"};
-        
+
         boolean expResult = false;
         boolean result = FileContentSearch.contains(file, patterns);
         assertEquals(expResult, result);
-        
+
         String[] patterns2 = {"jeremy long", "blue", "(?i)jeremy long"};
         expResult = true;
         result = FileContentSearch.contains(file, patterns2);


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up

I am well aware that this is a huge changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

Why this is a good change:

* JUnit 5 is the modern standard: It offers a cleaner and more powerful programming model, better extensibility, and improved support for modern Java features (like lambdas, streams, and optional parameters).
* Improved test maintainability: JUnit 5’s more expressive annotations and lifecycle management make tests easier to read, write, and debug.
* Enables use of modern extensions: Migrating paves the way to leverage powerful third-party extensions and tooling (e.g., parameterized tests, dynamic tests, conditional execution).

It is important to notice that this change should not alter the test logic, but bring the project in line with modern best practices and help keeping it future-proof.