### PR TITLE
fix: Resolve various WCAG accessibility / css issues in the HTML report

### DIFF
--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -211,7 +211,14 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             } else {
                 dependenciesHeader.text(dependenciesHeaderAllText);
             }
-            return toggleDisplay(event.target, '.notvulnerable', 'Vulnerable Dependencies (click to show all)', 'All Dependencies (click to show less)');
+            const plainCaptionPart = $('#tablecaption-plain');
+            const plainCaptionPartAllText = 'Summary of All Dependencies';
+            if (plainCaptionPart.text() == plainCaptionPartAllText) {
+                plainCaptionPart.text('Summary of Vulnerable Dependencies');
+            } else {
+                plainCaptionPart.text(plainCaptionPartAllText);
+            }
+            return toggleDisplay(event.target, '.notvulnerable', '(click to show all)', '(click to show less)');
           });
           $( ".versionToggle" ).bind( "click", function( event ) {
             var lnk = event.target;
@@ -278,9 +285,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             }
             #modal-text:focus {
                 outline: none;
-            }
-            #summaryTable > caption {
-                text-align: left;
             }
             .suppresstype {
                 display: none;
@@ -756,10 +760,9 @@ Getting Help: <a href="https://github.com/dependency-check/DependencyCheck/issue
         <br/>
 #end
 <h2>Summary</h2>
-
+                <p><span id="tablecaption-plain">Summary of Vulnerable Dependencies </span><a href="#" title="Click to toggle display" id="vulnerabilityDisplayToggle">(click to show all)</a></p>
                 #set($lnkcnt=0)
-                <table id="summaryTable" class="lined" summary="">
-                    <caption>Summary of&nbsp;<a href="#" title="Click to toggle display" id="vulnerabilityDisplayToggle">Vulnerable Dependencies (click to show all)</a><br/><br/></caption>
+                <table id="summaryTable" class="lined" aria-labelledby="tablecaption-plain">
                     <thead><tr style="text-align:left">
                         <th class="sortable" data-sort="string" title="The name of the dependency">Dependency</th>
                         <th class="sortable" data-sort="string" title="The Common Platform Enumeration">Vulnerability&nbsp;IDs</th>

--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -624,7 +624,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                 float:right;
             }
             .disclaimer {
-                color: #888888;
+                color: #595959;
                 font: 9px "Droid Sans",Arial,"Helvetica Neue","Lucida Grande",sans-serif
             }
             .sortable {

--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -22,7 +22,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
 
 #[[
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <title>Dependency-Check Report</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
@@ -211,7 +211,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             } else {
                 dependenciesHeader.text(dependenciesHeaderAllText);
             }
-            return toggleDisplay(event.target, '.notvulnerable', 'Showing Vulnerable Dependencies (click to show all)', 'Showing All Dependencies (click to show less)');
+            return toggleDisplay(event.target, '.notvulnerable', 'Vulnerable Dependencies (click to show all)', 'All Dependencies (click to show less)');
           });
           $( ".versionToggle" ).bind( "click", function( event ) {
             var lnk = event.target;
@@ -230,7 +230,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
 
 
         </script>
-        <style type="text/css">
+        <style>
             #modal-background {
                 display: none;
                 position: fixed;
@@ -278,6 +278,9 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             }
             #modal-text:focus {
                 outline: none;
+            }
+            #summaryTable > caption {
+                text-align: left;
             }
             .suppresstype {
                 display: none;
@@ -606,9 +609,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             .notvulnerable {
                 display:none;
             }
-            .hidden {
-                display:none;
-            }
             .infolink {
                 text-decoration:none;
                 color: blue;
@@ -756,9 +756,10 @@ Getting Help: <a href="https://github.com/dependency-check/DependencyCheck/issue
         <br/>
 #end
 <h2>Summary</h2>
-                Display:&nbsp;<a href="#" title="Click to toggle display" id="vulnerabilityDisplayToggle">Showing Vulnerable Dependencies (click to show all)</a><br/><br/>
+
                 #set($lnkcnt=0)
-                <table id="summaryTable" class="lined">
+                <table id="summaryTable" class="lined" summary="">
+                    <caption>Summary of&nbsp;<a href="#" title="Click to toggle display" id="vulnerabilityDisplayToggle">Vulnerable Dependencies (click to show all)</a><br/><br/></caption>
                     <thead><tr style="text-align:left">
                         <th class="sortable" data-sort="string" title="The name of the dependency">Dependency</th>
                         <th class="sortable" data-sort="string" title="The Common Platform Enumeration">Vulnerability&nbsp;IDs</th>


### PR DESCRIPTION
## Description of Change

* Set the html lang attribute
* Adapt the original summary text intro into one that is useable to provide the table description as an aria-labelledby and adapt the vulnerabilityDisplayToggle onClick event accordingly
* Remove the duplicated .hidden css class rule
* Increased contrast-ratio of the disclaimer text from 3.85 (not WCAG compliant) to 7.0 (WCAG AAA compliant)

Other items reported by Firefox are not taken up now, these concern the lack of proper keyboard support in the JQuery plugin that is currently used to make the summary table sortable. Resolving those would require replacement of the plugin by some other plugin that would offer full WCAG compliancy.


## Related issues

- fixes #7618 

## Have test cases been added to cover the new functionality?

no, some base testing performed with Firefox and Safari using MacOS VoiceOver to check that navigation works and the table description gets used as expected.
