### PR TITLE
fix(cli): Patch generated Windows shell script for JAVACMD installs with spaces

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -96,9 +96,33 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                 <executions>
                     <execution>
                         <id>assemble</id>
+                        <phase>package</phase>
                         <goals>
                             <goal>assemble</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>fix-windows-shell-script</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Hack/workaround for https://github.com/mojohaus/appassembler/issues/114 -->
+                            <target>
+                                <replace file="${project.build.directory}/release/bin/dependency-check.bat"
+                                         token="%JAVACMD% %JAVA_OPTS%"
+                                         value="&quot;%JAVACMD%&quot; %JAVA_OPTS%"
+                                         failOnNoReplacements="true"
+                                />
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Description of Change

Workaround for https://github.com/mojohaus/appassembler/issues/114 which seems to be unmaintained and stuck upstream. Essentially does the same as https://github.com/mojohaus/appassembler/pull/115

Not ideal, but not sure if there is a better way to address the issue given the upstream status.

`%CLASSPATH%` will still have issues, but don't think it's worth the hassle to patch this given it should not be used with dep check.

## Related issues

- fixes #7651
- fixes #5668 (properly)

## Have test cases been added to cover the new functionality?

no

Manually compared generated zip before/after:
![image](https://github.com/user-attachments/assets/50def68b-97d3-4418-ae8c-8b288cd9246c)


```
[INFO] --- appassembler:2.1.0:assemble (assemble) @ dependency-check-cli ---
[INFO] <omitted>
[INFO] --- antrun:3.1.0:run (fix-windows-shell-script) @ dependency-check-cli ---
[INFO] Executing tasks
[INFO] Executed tasks
[INFO]
[INFO] --- assembly:3.7.1:single (create-distribution) @ dependency-check-cli ---
[INFO] Reading assembly descriptor: src/main/assembly/release.xml
[INFO] Building zip: /Users/chad/Projects/community/DependencyCheck/cli/target/dependency-check-12.1.2-SNAPSHOT-release.zip
[INFO]
```
