### PR TITLE
fix: #7683 Extend supression for xstream / mxparser due to CPE configuration change in NVD

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -199,9 +199,10 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per #3230
+        FP per #3230, extended per #7683
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.github\.x\-stream/mxparser@.*$</packageUrl>
+        <cpe>cpe:/a:xstream:xstream</cpe>
         <cpe>cpe:/a:xstream_project:xstream</cpe>
         <cpe>cpe:/a:oracle:jdk</cpe>
     </suppress>


### PR DESCRIPTION
## Description of Change

Extend supression for xstream / mxparser due to CPE configuration change in NVD.

## Related issues

- fixes #7683
- relates to #3230 

## Have test cases been added to cover the new functionality?

No.