### PR TITLE
fix: Simplify PHP framework suppression for Composer

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -360,27 +360,11 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per #2972
-        hyphenated PHP library vendor names
-        ]]></notes>
-        <packageUrl regex="true">^pkg:composer/php\-.*$</packageUrl>
-        <cpe>cpe:/a:php:php</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
         FP per #2972 + #7444
-        hyphenated PHP library product names (prefix)
+        hyphenated PHP library product names
+        (PHP framework will not be loaded via Composer)
         ]]></notes>
-        <packageUrl regex="true">^pkg:composer/[^/]+/php[\-_].*$</packageUrl>
-        <cpe>cpe:/a:php:php</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per #2972 + #7444
-        hyphenated PHP library product names (suffix)
-        including number suffix, e.g., `symfony/polyfill-php80`
-        ]]></notes>
-        <packageUrl regex="true">^pkg:composer/[^/]+/.*[\-_]php[0-9]*@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:composer/[^/]+/[^/]+@.*$</packageUrl>
         <cpe>cpe:/a:php:php</cpe>
     </suppress>
     <suppress base="true">


### PR DESCRIPTION
## Description of Change

The base suppression that is bundled for suppressing `php` in packages names should be expanded, as mentioned in [comment by @georgschoelly on #7444](https://github.com/dependency-check/DependencyCheck/issues/7444#issuecomment-2879279125).

All matches of PHP in Composer packages are safe to consider not being part of PHP framework `cpe:/a:php:php` because Composer is the package manager next level down.

This change removes three distinct suppressions, which are now covered by the extended regular expression.

## Related issues

- relates to #2972 
- relates to #7444 

## Have test cases been added to cover the new functionality?

*no*