### PR TITLE
refactor: improve logs and add exception stack trace for YarnAuditAnalyzer

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/NodePackageAnalyzer.java
@@ -196,7 +196,8 @@ public class NodePackageAnalyzer extends AbstractNpmAnalyzer {
                     try {
                         ((AbstractNpmAnalyzer) a).prepareFileTypeAnalyzer(engine);
                     } catch (InitializationException ex) {
-                        LOGGER.debug("Error initializing the {}", a.getName());
+                        String message = "Error initializing the " + a.getName();
+                        LOGGER.debug(message, ex);
                     }
                 }
                 return a.isEnabled();

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzer.java
@@ -188,12 +188,14 @@ public class YarnAuditAnalyzer extends AbstractNpmAnalyzer {
                     case yarnExecutableNotFoundExitValue:
                     default:
                         this.setEnabled(false);
-                        LOGGER.warn("The {} has been disabled. Yarn executable was not found.", getName());
+                        LOGGER.warn("The {} has been disabled after receiving exit value {}. Yarn executable was not " +
+                                        "found or received a non-zero exit value.", getName(), exitValue);
                 }
             }
         } catch (Exception ex) {
             this.setEnabled(false);
-            LOGGER.warn("The {} has been disabled. Yarn executable was not found.", getName());
+            LOGGER.warn("The {} has been disabled after receiving an exception. This can occur when Yarn executable " +
+                    "is not found.", getName());
             throw new InitializationException("Unable to read yarn audit output.", ex);
         }
     }


### PR DESCRIPTION
## Description of Change

The purpose of this PR is to change 2 identical log messages to help understand what actually happened when an issue is encountered by a user. DependencyCheck will now display the exit value when receiving a non-zero exit value from Yarn. In case an `InitializationException` is encountered when initializing the `YarnAuditAnalyzer`, `NodeAuditAnalyzer`, `NodePackageAnalyzer` or the `PnpmAuditAnalyzer`, this exception stack trace will be printed at debug level.

## Related issues

- Linked to #7692 

## Have test cases been added to cover the new functionality?

*no*