### PR TITLE
fix(fp): resolves several false positives related to CVE-2021-41033

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -7056,4 +7056,11 @@
         <packageUrl regex="true">^pkg:nuget/.+\.Redis\..*$</packageUrl>
         <cpe>cpe:2.3:a:redis:redis</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #7664
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/(?!.*org\.eclipse\.equinox\.p2).*$</packageUrl>
+        <cve>CVE-2021-41033</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
resolves #7664
resolves #7667
resolves #7668
resolves #7669
resolves #7670
resolves #7671
resolves #7672
resolves #7673
resolves #7674
resolves #7675
resolves #7676
resolves #7677
resolves #7678
