### PR TITLE
docs: fix minor typos in false positive issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/false-positive-report.yml
+++ b/.github/ISSUE_TEMPLATE/false-positive-report.yml
@@ -27,7 +27,7 @@ body:
     id: cpe
     attributes:
       label: CPE
-      description: Please enter the single Common Platform enumeration (CPE) as identified in the HTML Report. Only a **single CPE** can be specified. **Please put backtic characters around the CPE to ensure it displays correctly**.
+      description: Please enter the single Common Platform enumeration (CPE) as identified in the HTML Report. Only a **single CPE** can be specified. **Please put backtick characters around the CPE to ensure it displays correctly**.
       placeholder: ex. `cpe:2.3:a:apache:log4j:2.12.1:*:*:*:*:*:*:*`
     validations:
       required: true
@@ -35,7 +35,7 @@ body:
     id: cve
     attributes:
       label: CVE
-      description: The vulnerability name as identified in the HTML Report. If specifying a CPE this is not necassary; if entered please enter only a **signle CVE**; if multiple CVE should be suppressed please enter multiple FP reports. This is optional and may not be needed as most FP reports are due to an incorrect CPE.
+      description: The vulnerability name as identified in the HTML Report. If specifying a CPE this is not necessary; if entered please enter only a **single CVE**; if multiple CVE should be suppressed please enter multiple FP reports. This is optional and may not be needed as most FP reports are due to an incorrect CPE.
       placeholder: ex. CVE-2021-44228
     validations:
       required: false


### PR DESCRIPTION
Thanks for your long-time dedication to this project @jeremylong 😄

When I went to open a False Positive Report, I noticed these few typos in the GitHub issue template. Hope this change is helpful.

Thanks!