### PR TITLE
fix: Add null checking when parsing the license json in AbstractNpmAnalyzer.

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractNpmAnalyzer.java
@@ -393,8 +393,11 @@ public abstract class AbstractNpmAnalyzer extends AbstractFileTypeAnalyzer {
                     }
                 }
                 dependency.setLicense(sb.toString());
-            } else {
-                dependency.setLicense(json.getJsonObject("license").getString("type"));
+            } else if (value instanceof JsonObject) {
+                final JsonObject object = (JsonObject) value;
+                if (object.containsKey("type") && !object.isNull("type")) {
+                    dependency.setLicense(object.getString("type"));
+                }
             }
         }
     }


### PR DESCRIPTION
## Description of Change

Adds null checking when the license block is defined as a json object but the type is still missing

## Related issues

fixes: #7783 

## Have test cases been added to cover the new functionality?

no