### PR TITLE
fix: class loading problem with fat jars (#7786)

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
@@ -200,6 +200,10 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
         String suppressionFileLocation = jarLocation.getFile();
         if (suppressionFileLocation.endsWith(".jar")) {
             suppressionFileLocation = "jar:file:" + suppressionFileLocation + "!/" + BASE_SUPPRESSION_FILE;
+        } else if (suppressionFileLocation.startsWith("nested:") && suppressionFileLocation.endsWith(".jar!/")) {
+            // suppressionFileLocation -> nested:/app/app.jar/!BOOT-INF/lib/dependency-check-core-<version>.jar!/
+            // goal->                 jar:nested:/app/app.jar/!BOOT-INF/lib/dependency-check-core-<version>.jar!/dependencycheck-base-suppression.xml
+            suppressionFileLocation = "jar:" + suppressionFileLocation + BASE_SUPPRESSION_FILE;
         } else {
             suppressionFileLocation = "file:" + suppressionFileLocation + BASE_SUPPRESSION_FILE;
         }


### PR DESCRIPTION
## Description of Change

Instead of using URL.openStream(), we propose to use the class or classloader getResourceAsStream to load resources from class path.

## Related issues

- fixes #7786

## Have test cases been added to cover the new functionality?

*no* - if you have any idea how to test a fat jar problem, I would be happy