### PR TITLE
feat: Migration to Alpine 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM azul/zulu-openjdk-alpine:21 AS jlink
 
 RUN "$JAVA_HOME/bin/jlink" --compress=2 --module-path /opt/java/openjdk/jmods --add-modules java.base,java.compiler,java.datatransfer,jdk.crypto.ec,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.scripting,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.unsupported --output /jlinked
 
-FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine3.18
+FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine3.22
 
 ARG VERSION
 ARG POSTGRES_DRIVER_VERSION=42.7.5


### PR DESCRIPTION
Hi,

The project's docker image is based on Alpine 3.18 which is [no longer supported](https://endoflife.date/alpine):

```bash
docker run --pull always --entrypoint='' owasp/dependency-check cat /etc/alpine-release
latest: Pulling from owasp/dependency-check
Digest: sha256:cfb5c429533f1da9d960c93b6f631c34bf7ecb6e2498273c00cac01f3b62a20a
Status: Image is up to date for owasp/dependency-check:latest
3.18.6
```

Here a little migration to Alpine 3.22.

Let me know if you need any further informations.

Regards