### PR TITLE
fix: Return unsorted vulnerabilities in new HashSet, avoiding CoMod

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -625,7 +625,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
         if (sorted) {
             vulnerabilitySet = new TreeSet<>(vulnerabilities);
         } else {
-            vulnerabilitySet = vulnerabilities;
+            vulnerabilitySet = new HashSet<>(vulnerabilities);
         }
         return Collections.unmodifiableSet(vulnerabilitySet);
     }


### PR DESCRIPTION
## Description of Change

Dependency.java getVulnerabilities(boolean sorted) method when sorted=false returns the vulnerabilities HashSet global to the Dependency object.  It is returned wrapped in an UnmodifiableSet, but this does not protect against concurrent modifications as it just wraps the original set.  Any future calls to add or remove vulnerabilities will proceed, as we are outside the synchronized methods, while someone is potentially iterating over the UnmodifiableSet retrieved earlier.

I came across this intermittent issue during my builds while in AbstractNpmAnalyzer.replaceOrAddVulnerability.  I assume one AbstractNpmAnalyzer instance is performing a stream.anyMatch on the Set while another instance, or some other mechanism, is adding or removing vulnerabilities from the same dependency.

Note:  In this same line of code (AbstractNpmAnalyzer.replaceOrAddVulnerability) there is another stream operation to locate references for a vulnerability by name, however I think the references Set is thread-safe.  It also uses Collections.unmodifiableSet, but in this case the Set being wrapped is ConcurrentHashMap.newKeySet which should remain thread-safe.  A similar approach could be taken in Dependency.java with the vulnerabilitySet, but would be more invasive.

## Related issues

[ERROR] 
java.util.ConcurrentModificationException
    at java.util.HashMap$KeySpliterator.tryAdvance (HashMap.java:1738)
    at java.util.stream.ReferencePipeline.forEachWithCancel (ReferencePipeline.java:129)
    at java.util.stream.AbstractPipeline.copyIntoWithCancel (AbstractPipeline.java:527)
    at java.util.stream.AbstractPipeline.copyInto (AbstractPipeline.java:513)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto (AbstractPipeline.java:499)
    at java.util.stream.MatchOps$MatchOp.evaluateSequential (MatchOps.java:230)
    at java.util.stream.MatchOps$MatchOp.evaluateSequential (MatchOps.java:196)
    at java.util.stream.AbstractPipeline.evaluate (AbstractPipeline.java:234)
    at java.util.stream.ReferencePipeline.anyMatch (ReferencePipeline.java:632)
    at org.owasp.dependencycheck.analyzer.AbstractNpmAnalyzer.replaceOrAddVulnerability (AbstractNpmAnalyzer.java:508)
    at org.owasp.dependencycheck.analyzer.AbstractNpmAnalyzer.processResults (AbstractNpmAnalyzer.java:494)
    at org.owasp.dependencycheck.analyzer.NodeAuditAnalyzer.analyzeDependency (NodeAuditAnalyzer.java:151)
    at org.owasp.dependencycheck.analyzer.AbstractAnalyzer.analyze (AbstractAnalyzer.java:131)
    at org.owasp.dependencycheck.AnalysisTask.call (AnalysisTask.java:88)
    at org.owasp.dependencycheck.AnalysisTask.call (AnalysisTask.java:37)
    at java.util.concurrent.FutureTask.run (FutureTask.java:317)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1144)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:642)
    at java.lang.Thread.run (Thread.java:1583)


## Have test cases been added to cover the new functionality?

no