### PR TITLE
fix: npe when processing cve with empty configuration

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nvd/ecosystem/CveEcosystemMapper.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvd/ecosystem/CveEcosystemMapper.java
@@ -84,6 +84,7 @@ public class CveEcosystemMapper {
     private boolean hasMultipleVendorProductConfigurations(DefCveItem cve) {
         if (cve.getCve().getConfigurations() != null && !cve.getCve().getConfigurations().isEmpty()) {
             final List<CpeMatch> cpeEntries = cve.getCve().getConfigurations().stream()
+                    .filter(config -> config.getNodes() != null)
                     .map(Config::getNodes)
                     .flatMap(List::stream)
                     .filter(cpe -> cpe.getCpeMatch() != null)

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -1611,6 +1611,7 @@ public final class CveDB implements AutoCloseable {
         final List<VulnerableSoftware> software = new ArrayList<>();
 
         final List<CpeMatch> cpeEntries = cve.getCve().getConfigurations().stream()
+                .filter(config -> config.getNodes() != null)
                 .map(Config::getNodes)
                 .flatMap(List::stream)
                 .map(Node::getCpeMatch)

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveItemOperator.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveItemOperator.java
@@ -222,6 +222,7 @@ public class CveItemOperator {
         if (cve.getCve().getConfigurations() != null) {
             //cycle through to see if this is a CPE we care about (use the CPE filters
             return cve.getCve().getConfigurations().stream()
+                    .filter(config -> config.getNodes() != null)
                     .map(Config::getNodes)
                     .flatMap(List::stream)
                     .filter(Objects::nonNull)


### PR DESCRIPTION
## Description of Change

Add safety check for empty configurations

## Related issues

Fixes #7887 

## Have test cases been added to cover the new functionality?

no