### PR TITLE
Update generatedSuppressions.xml

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -2442,3 +2442,10 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
    <packageUrl regex="true">^pkg:maven/io\.quarkiverse\.wiremock/quarkus-wiremock@.*$</packageUrl>
    <cpe>cpe:/a:wire:wire</cpe>
 </suppress>
+<suppress base="true">
+   <notes><![CDATA[
+   FP per issue #7892
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.jooq.*/jooq-meta-extensions-liquibase@.*$</packageUrl>
+   <cpe>cpe:/a:liquibase:liquibase</cpe>
+</suppress>


### PR DESCRIPTION
Fixes #7892

Contrary to the generated FP suppression in #7892, this uses a wildcard for the group ID in the package URL. jOOQ differentiates their pro versions by dedicated group IDs (`org.jooq` vs. `org.jooq.pro` vs. `org.jooq.trial` etc.).