### PR TITLE
fix: Correct CVSSv4 parsing for low precision OSSIndex values

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/utils/CvssUtil.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/CvssUtil.java
@@ -229,14 +229,14 @@ public final class CvssUtil {
         return cvss;
     }
 
-    private static CvssV4Data.SeverityType toSeverityType(double baseScore) {
+    public static CvssV4Data.SeverityType cvssV4ScoreToSeverity(double baseScore) {
         if (baseScore == 0.0) {
             return CvssV4Data.SeverityType.NONE;
-        } else if (baseScore >= 0.1 && baseScore <= 3.9) {
+        } else if (baseScore > 0.0 && baseScore < 4.0) {
             return CvssV4Data.SeverityType.LOW;
-        } else if (baseScore >= 4.0 && baseScore <= 6.9) {
+        } else if (baseScore >= 4.0 && baseScore < 7.0) {
             return CvssV4Data.SeverityType.MEDIUM;
-        } else if (baseScore >= 7.0 && baseScore <= 8.9) {
+        } else if (baseScore >= 7.0 && baseScore < 9.0) {
             return CvssV4Data.SeverityType.HIGH;
         } else if (baseScore >= 9.0 && baseScore <= 10.0) {
             return CvssV4Data.SeverityType.CRITICAL;
@@ -300,7 +300,7 @@ public final class CvssUtil {
         CvssV4Data.VulnerabilityResponseEffortType vulnerabilityResponseEffort = values.containsKey("RE") ? CvssV4Data.VulnerabilityResponseEffortType.fromValue(values.get("RE")) : CvssV4Data.VulnerabilityResponseEffortType.NOT_DEFINED;
         CvssV4Data.ProviderUrgencyType providerUrgency = values.containsKey("U") ? CvssV4Data.ProviderUrgencyType.fromValue(values.get("U")) : CvssV4Data.ProviderUrgencyType.NOT_DEFINED;
 
-        CvssV4Data.SeverityType baseSeverity = toSeverityType(baseScore);
+        CvssV4Data.SeverityType baseSeverity = cvssV4ScoreToSeverity(baseScore);
         // Scores and severities are not present in the vector string, set to null/defaults
         Double threatScore = null;
         CvssV4Data.SeverityType threatSeverity = null;

--- a/core/src/test/java/org/owasp/dependencycheck/utils/CvssUtilTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/CvssUtilTest.java
@@ -56,50 +56,15 @@ class CvssUtilTest {
      */
     @Test
     void testCvssV2ScoreToSeverity() {
-        Double score = -1.0;
-        String expResult = "UNKNOWN";
-        String result = CvssUtil.cvssV2ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 0.0;
-        expResult = "LOW";
-        result = CvssUtil.cvssV2ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 1.0;
-        expResult = "LOW";
-        result = CvssUtil.cvssV2ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 3.9;
-        expResult = "LOW";
-        result = CvssUtil.cvssV2ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 4.0;
-        expResult = "MEDIUM";
-        result = CvssUtil.cvssV2ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 6.9;
-        expResult = "MEDIUM";
-        result = CvssUtil.cvssV2ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 7.0;
-        expResult = "HIGH";
-        result = CvssUtil.cvssV2ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 10.0;
-        expResult = "HIGH";
-        result = CvssUtil.cvssV2ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 11.0;
-        expResult = "UNKNOWN";
-        result = CvssUtil.cvssV2ScoreToSeverity(score);
-        assertEquals(expResult, result);
+        assertEquals("UNKNOWN", CvssUtil.cvssV2ScoreToSeverity(-1.0));
+        assertEquals("LOW", CvssUtil.cvssV2ScoreToSeverity(0.0));
+        assertEquals("LOW", CvssUtil.cvssV2ScoreToSeverity(1.0));
+        assertEquals("LOW", CvssUtil.cvssV2ScoreToSeverity(3.9));
+        assertEquals("MEDIUM", CvssUtil.cvssV2ScoreToSeverity(4.0));
+        assertEquals("MEDIUM", CvssUtil.cvssV2ScoreToSeverity(6.9));
+        assertEquals("HIGH", CvssUtil.cvssV2ScoreToSeverity(7.0));
+        assertEquals("HIGH", CvssUtil.cvssV2ScoreToSeverity(10.0));
+        assertEquals("UNKNOWN", CvssUtil.cvssV2ScoreToSeverity(11.0));
     }
 
     /**
@@ -107,58 +72,17 @@ class CvssUtilTest {
      */
     @Test
     void testCvssV3ScoreToSeverity() {
-        Double score = 0.0;
-        CvssV3Data.SeverityType expResult = CvssV3Data.SeverityType.NONE;
-        CvssV3Data.SeverityType result = CvssUtil.cvssV3ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 1.0;
-        expResult = CvssV3Data.SeverityType.LOW;
-        result = CvssUtil.cvssV3ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 3.9;
-        expResult = CvssV3Data.SeverityType.LOW;
-        result = CvssUtil.cvssV3ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 4.0;
-        expResult = CvssV3Data.SeverityType.MEDIUM;
-        result = CvssUtil.cvssV3ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 6.9;
-        expResult = CvssV3Data.SeverityType.MEDIUM;
-        result = CvssUtil.cvssV3ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 7.0;
-        expResult = CvssV3Data.SeverityType.HIGH;
-        result = CvssUtil.cvssV3ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 8.9;
-        expResult = CvssV3Data.SeverityType.HIGH;
-        result = CvssUtil.cvssV3ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 9.0;
-        expResult = CvssV3Data.SeverityType.CRITICAL;
-        result = CvssUtil.cvssV3ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 10.0;
-        expResult = CvssV3Data.SeverityType.CRITICAL;
-        result = CvssUtil.cvssV3ScoreToSeverity(score);
-        assertEquals(expResult, result);
-
-        score = 11.0;
-        result = CvssUtil.cvssV3ScoreToSeverity(score);
-        assertNull(result);
-
-        score = -1.0;
-        result = CvssUtil.cvssV3ScoreToSeverity(score);
-        assertNull(result);
+        assertEquals(CvssV3Data.SeverityType.NONE, CvssUtil.cvssV3ScoreToSeverity(0.0));
+        assertEquals(CvssV3Data.SeverityType.LOW, CvssUtil.cvssV3ScoreToSeverity(1.0));
+        assertEquals(CvssV3Data.SeverityType.LOW, CvssUtil.cvssV3ScoreToSeverity(3.9));
+        assertEquals(CvssV3Data.SeverityType.MEDIUM, CvssUtil.cvssV3ScoreToSeverity(4.0));
+        assertEquals(CvssV3Data.SeverityType.MEDIUM, CvssUtil.cvssV3ScoreToSeverity(6.9));
+        assertEquals(CvssV3Data.SeverityType.HIGH, CvssUtil.cvssV3ScoreToSeverity(7.0));
+        assertEquals(CvssV3Data.SeverityType.HIGH, CvssUtil.cvssV3ScoreToSeverity(8.9));
+        assertEquals(CvssV3Data.SeverityType.CRITICAL, CvssUtil.cvssV3ScoreToSeverity(9.0));
+        assertEquals(CvssV3Data.SeverityType.CRITICAL, CvssUtil.cvssV3ScoreToSeverity(10.0));
+        assertNull(CvssUtil.cvssV3ScoreToSeverity(11.0));
+        assertNull(CvssUtil.cvssV3ScoreToSeverity(-1.0));
     }
 
     /**

--- a/core/src/test/java/org/owasp/dependencycheck/utils/CvssUtilTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/CvssUtilTest.java
@@ -21,10 +21,13 @@ import io.github.jeremylong.openvulnerability.client.nvd.CvssV2;
 import io.github.jeremylong.openvulnerability.client.nvd.CvssV2Data;
 import io.github.jeremylong.openvulnerability.client.nvd.CvssV3;
 import io.github.jeremylong.openvulnerability.client.nvd.CvssV3Data;
+import io.github.jeremylong.openvulnerability.client.nvd.CvssV4;
+import io.github.jeremylong.openvulnerability.client.nvd.CvssV4Data;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  *
@@ -58,10 +61,12 @@ class CvssUtilTest {
     void testCvssV2ScoreToSeverity() {
         assertEquals("UNKNOWN", CvssUtil.cvssV2ScoreToSeverity(-1.0));
         assertEquals("LOW", CvssUtil.cvssV2ScoreToSeverity(0.0));
+        assertEquals("LOW", CvssUtil.cvssV2ScoreToSeverity(0.05));
         assertEquals("LOW", CvssUtil.cvssV2ScoreToSeverity(1.0));
         assertEquals("LOW", CvssUtil.cvssV2ScoreToSeverity(3.9));
         assertEquals("MEDIUM", CvssUtil.cvssV2ScoreToSeverity(4.0));
         assertEquals("MEDIUM", CvssUtil.cvssV2ScoreToSeverity(6.9));
+        assertEquals("MEDIUM", CvssUtil.cvssV2ScoreToSeverity((double) 6.9f)); // test low-precision floating point values
         assertEquals("HIGH", CvssUtil.cvssV2ScoreToSeverity(7.0));
         assertEquals("HIGH", CvssUtil.cvssV2ScoreToSeverity(10.0));
         assertEquals("UNKNOWN", CvssUtil.cvssV2ScoreToSeverity(11.0));
@@ -73,10 +78,12 @@ class CvssUtilTest {
     @Test
     void testCvssV3ScoreToSeverity() {
         assertEquals(CvssV3Data.SeverityType.NONE, CvssUtil.cvssV3ScoreToSeverity(0.0));
+        assertEquals(CvssV3Data.SeverityType.LOW, CvssUtil.cvssV3ScoreToSeverity(0.05));
         assertEquals(CvssV3Data.SeverityType.LOW, CvssUtil.cvssV3ScoreToSeverity(1.0));
         assertEquals(CvssV3Data.SeverityType.LOW, CvssUtil.cvssV3ScoreToSeverity(3.9));
         assertEquals(CvssV3Data.SeverityType.MEDIUM, CvssUtil.cvssV3ScoreToSeverity(4.0));
         assertEquals(CvssV3Data.SeverityType.MEDIUM, CvssUtil.cvssV3ScoreToSeverity(6.9));
+        assertEquals(CvssV3Data.SeverityType.MEDIUM, CvssUtil.cvssV3ScoreToSeverity((double) 6.9f)); // test low-precision floating point values
         assertEquals(CvssV3Data.SeverityType.HIGH, CvssUtil.cvssV3ScoreToSeverity(7.0));
         assertEquals(CvssV3Data.SeverityType.HIGH, CvssUtil.cvssV3ScoreToSeverity(8.9));
         assertEquals(CvssV3Data.SeverityType.CRITICAL, CvssUtil.cvssV3ScoreToSeverity(9.0));
@@ -104,6 +111,54 @@ class CvssUtilTest {
         assertEquals(CvssV3Data.CiaType.HIGH, result.getCvssData().getAvailabilityImpact());
         assertEquals(CvssV3Data.SeverityType.CRITICAL, result.getCvssData().getBaseSeverity());
         assertEquals(10.0, result.getCvssData().getBaseScore(), 0);
+    }
+
+    /**
+     * Test of cvssV4ScoreToSeverity method, of class CvssUtil.
+     */
+    @Test
+    void testCvssV4ScoreToSeverity() {
+        assertEquals(CvssV4Data.SeverityType.NONE, CvssUtil.cvssV4ScoreToSeverity(0.0));
+        assertEquals(CvssV4Data.SeverityType.LOW, CvssUtil.cvssV4ScoreToSeverity(0.05));
+        assertEquals(CvssV4Data.SeverityType.LOW, CvssUtil.cvssV4ScoreToSeverity(1.0));
+        assertEquals(CvssV4Data.SeverityType.LOW, CvssUtil.cvssV4ScoreToSeverity(3.9));
+        assertEquals(CvssV4Data.SeverityType.MEDIUM, CvssUtil.cvssV4ScoreToSeverity(4.0));
+        assertEquals(CvssV4Data.SeverityType.MEDIUM, CvssUtil.cvssV4ScoreToSeverity(6.9));
+        assertEquals(CvssV4Data.SeverityType.MEDIUM, CvssUtil.cvssV4ScoreToSeverity(6.9f)); // test low-precision floating point values
+        assertEquals(CvssV4Data.SeverityType.HIGH, CvssUtil.cvssV4ScoreToSeverity(7.0));
+        assertEquals(CvssV4Data.SeverityType.HIGH, CvssUtil.cvssV4ScoreToSeverity(8.9));
+        assertEquals(CvssV4Data.SeverityType.CRITICAL, CvssUtil.cvssV4ScoreToSeverity(9.0));
+        assertEquals(CvssV4Data.SeverityType.CRITICAL, CvssUtil.cvssV4ScoreToSeverity(10.0));
+        assertThrows(IllegalArgumentException.class, () -> CvssUtil.cvssV4ScoreToSeverity(11.0));
+        assertThrows(IllegalArgumentException.class, () -> CvssUtil.cvssV4ScoreToSeverity(-1.0));
+    }
+
+    /**
+     * Test of vectorToCvssV4 method, of class CvssUtil.
+     */
+    @Test
+    void testVectorToCvssV4() {
+        String vectorString = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N";
+        Double baseScore = 8.2;
+        String source = "ossIndex";
+        CvssV4.Type type = CvssV4.Type.PRIMARY;
+        CvssV4 result = CvssUtil.vectorToCvssV4(source, type, baseScore, vectorString);
+        assertEquals(CvssV4Data.Version._4_0, result.getCvssData().getVersion());
+        assertEquals(source, result.getSource());
+        assertEquals(type, result.getType());
+        assertEquals(CvssV4Data.AttackVectorType.NETWORK, result.getCvssData().getAttackVector());
+        assertEquals(CvssV4Data.AttackComplexityType.LOW, result.getCvssData().getAttackComplexity());
+        assertEquals(CvssV4Data.AttackRequirementsType.PRESENT, result.getCvssData().getAttackRequirements());
+        assertEquals(CvssV4Data.PrivilegesRequiredType.NONE, result.getCvssData().getPrivilegesRequired());
+        assertEquals(CvssV4Data.UserInteractionType.NONE, result.getCvssData().getUserInteraction());
+        assertEquals(CvssV4Data.CiaType.HIGH, result.getCvssData().getVulnConfidentialityImpact());
+        assertEquals(CvssV4Data.CiaType.NONE, result.getCvssData().getVulnIntegrityImpact());
+        assertEquals(CvssV4Data.CiaType.NONE, result.getCvssData().getVulnAvailabilityImpact());
+        assertEquals(CvssV4Data.CiaType.NONE, result.getCvssData().getSubConfidentialityImpact());
+        assertEquals(CvssV4Data.CiaType.NONE, result.getCvssData().getSubIntegrityImpact());
+        assertEquals(CvssV4Data.CiaType.NONE, result.getCvssData().getSubAvailabilityImpact());
+        assertEquals(CvssV4Data.SeverityType.HIGH, result.getCvssData().getBaseSeverity());
+        assertEquals(8.2, result.getCvssData().getBaseScore(), 0);
     }
 
 }


### PR DESCRIPTION
## Description of Change

- corrects parsing of low precision CVSS v4 values, especially from OSSIndex
- adds tests, including for CVSSv2 and v3 parsing which are **not** subject to the same issue due to the way their comparisons are done

## Related issues

- fixes  #7934 

## Have test cases been added to cover the new functionality?

yes