### PR TITLE
chore: Allow passing ossIndex credentials during false positive ops workflow

### DIFF
--- a/.github/workflows/false-positive-ops.yml
+++ b/.github/workflows/false-positive-ops.yml
@@ -140,6 +140,8 @@ jobs:
           args: >
             --failOnCVSS 11
             --enableExperimental
+            --ossIndexUsername ${{ secrets.OSS_INDEX_USERNAME }}
+            --ossIndexPassword ${{ secrets.OSS_INDEX_API_TOKEN }}
       - name: Upload FP Report
         if: steps.check_files.outputs.files_exists == 'true'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description of Change

Propagates secrets for OSS Index through to false positive ops (for now). This would need the relevant secrets populated in GHA. I believe this is safe and GHA will redact them in the args to the docker container etc, but might want to do a sanity test run first.

## Related issues

- fixes #7939

## Have test cases been added to cover the new functionality?

N/A