### PR TITLE
docs: Implement #7808 to make changelog links clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,103 +2,103 @@
 
 ## [Version 12.1.5](https://github.com/dependency-check/DependencyCheck/releases/tag/v12.1.5) (2025-09-20)
 
-- **fix**: Update to support OSS Index Authentication Requirements (#7920)
+- **fix**: Update to support OSS Index Authentication Requirements ([#7920](https://github.com/dependency-check/DependencyCheck/pull/7920))
   - Note: OSS Index will require authentication starting 9/22/2025. Users must configure a free account to continue using the OSS Index Analyzer. See https://ossindex.sonatype.org/doc/auth-required.
-- fix: add CVSSv4 to suppressed entries in JSON report (#7900)
-- fix: correctly utilize CVSSv4 from ossindex (#7899)
-- fix: npe when processing cve with empty configuration (#7888)
-- fix: Return unsorted vulnerabilities in new HashSet, avoiding CoMod (#7848)
+- fix: add CVSSv4 to suppressed entries in JSON report ([#7900](https://github.com/dependency-check/DependencyCheck/pull/7900))
+- fix: correctly utilize CVSSv4 from ossindex ([#7899](https://github.com/dependency-check/DependencyCheck/pull/7899))
+- fix: npe when processing cve with empty configuration ([#7888](https://github.com/dependency-check/DependencyCheck/pull/7888))
+- fix: Return unsorted vulnerabilities in new HashSet, avoiding CoMod ([#7848](https://github.com/dependency-check/DependencyCheck/pull/7848))
 - fix: Return unsorted vulnerabilities in new HashSet, avoiding CoMod
-- fix: class loading problem with fat jars (#7786) (#7787)
-- fix: Improve Artifactory handler log message (#7838)
-- fix: classloading problem with fat jars (#7786)
-- fix: Add null checking when parsing the license json in AbstractNpmAnalyzer. (#7784)
-- fix(fp): resolves several false positives related to CVE-2021-41033 (#7736)
-- docs: Clarify format of exclude patterns (#7879)
-- docs: Document poetry-based analysis behaviour in Python analyzer (#7855)
-- docs: request FP reporters use the latest version of ODC. (#7820)
-- docs: update development pre-reqs (#7792)
-- docs: fix minor typos in false positive issue template (#7763)
+- fix: class loading problem with fat jars ([#7786](https://github.com/dependency-check/DependencyCheck/pull/7786)) ([#7787](https://github.com/dependency-check/DependencyCheck/pull/7787))
+- fix: Improve Artifactory handler log message ([#7838](https://github.com/dependency-check/DependencyCheck/pull/7838))
+- fix: classloading problem with fat jars ([#7786](https://github.com/dependency-check/DependencyCheck/pull/7786))
+- fix: Add null checking when parsing the license json in AbstractNpmAnalyzer. ([#7784](https://github.com/dependency-check/DependencyCheck/pull/7784))
+- fix(fp): resolves several false positives related to CVE-2021-41033 ([#7736](https://github.com/dependency-check/DependencyCheck/pull/7736))
+- docs: Clarify format of exclude patterns ([#7879](https://github.com/dependency-check/DependencyCheck/pull/7879))
+- docs: Document poetry-based analysis behaviour in Python analyzer ([#7855](https://github.com/dependency-check/DependencyCheck/pull/7855))
+- docs: request FP reporters use the latest version of ODC. ([#7820](https://github.com/dependency-check/DependencyCheck/pull/7820))
+- docs: update development pre-reqs ([#7792](https://github.com/dependency-check/DependencyCheck/pull/7792))
+- docs: fix minor typos in false positive issue template ([#7763](https://github.com/dependency-check/DependencyCheck/pull/7763))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/98?closed=1)
 
 ## [Version 12.1.3](https://github.com/dependency-check/DependencyCheck/releases/tag/v12.1.3) (2025-06-10)
 
-- fix: correct regex matches introduced in 12.1.2 (#7726)
-- build(deps): bump org.semver4j:semver4j from 5.7.0 to 5.7.1 (#7718)
-- build(deps): bump junit.version from 5.13.0 to 5.13.1 (#7719)
+- fix: correct regex matches introduced in 12.1.2 ([#7726](https://github.com/dependency-check/DependencyCheck/pull/7726))
+- build(deps): bump org.semver4j:semver4j from 5.7.0 to 5.7.1 ([#7718](https://github.com/dependency-check/DependencyCheck/pull/7718))
+- build(deps): bump junit.version from 5.13.0 to 5.13.1 ([#7719](https://github.com/dependency-check/DependencyCheck/pull/7719))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/97?closed=1)
 
 ## [Version 12.1.2](https://github.com/dependency-check/DependencyCheck/releases/tag/v12.1.2) (2025-06-07)
 
-- fix: Allow configuring OSS Index user/pw directly (#7640)
-- fix: remove vulnerable transitive dependency - beanutils (#7705)
-- fix: Simplify PHP framework suppression for Composer (#7693)
-- fix: update CPE pattern to remove FP (#7684)
-- fix(cli): Patch generated Windows shell script for JAVACMD installs with spaces (#7653)
-- fix: Resolve various WCAG accessibility / css issues in the HTML report (#7629)
-- fix: #7510 Display a dedicated message when receiving an HTTP 403 (#7575)
-- docs: Make `Vulnerability Sources` in `Related Work` clearer (#7691)
-- docs: #7610 add a reference to NVD mirroring in getting started documentation (#7611)
+- fix: Allow configuring OSS Index user/pw directly ([#7640](https://github.com/dependency-check/DependencyCheck/pull/7640))
+- fix: remove vulnerable transitive dependency - beanutils ([#7705](https://github.com/dependency-check/DependencyCheck/pull/7705))
+- fix: Simplify PHP framework suppression for Composer ([#7693](https://github.com/dependency-check/DependencyCheck/pull/7693))
+- fix: update CPE pattern to remove FP ([#7684](https://github.com/dependency-check/DependencyCheck/pull/7684))
+- fix(cli): Patch generated Windows shell script for JAVACMD installs with spaces ([#7653](https://github.com/dependency-check/DependencyCheck/pull/7653))
+- fix: Resolve various WCAG accessibility / css issues in the HTML report ([#7629](https://github.com/dependency-check/DependencyCheck/pull/7629))
+- fix: [#7510](https://github.com/dependency-check/DependencyCheck/pull/7510) Display a dedicated message when receiving an HTTP 403 ([#7575](https://github.com/dependency-check/DependencyCheck/pull/7575))
+- docs: Make `Vulnerability Sources` in `Related Work` clearer ([#7691](https://github.com/dependency-check/DependencyCheck/pull/7691))
+- docs: [#7610](https://github.com/dependency-check/DependencyCheck/pull/7610) add a reference to NVD mirroring in getting started documentation ([#7611](https://github.com/dependency-check/DependencyCheck/pull/7611))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/96?closed=1)
 
 ## [Version 12.1.1](https://github.com/dependency-check/DependencyCheck/releases/tag/v12.1.1) (2025-04-05)
 
 - fix: resolve NVD data Parse error `com.fasterxml.jackson.core.JsonParseException: Unexpected character (']' (code 93))`
-  - bump open-vulnerability-client from 7.3.1 to 7.3.2  (#7577)
-- fix: update links for repository move from `jeremylong` to the `dependency-check` organization (#7373)
-- fix: resolve NPE when processing CVE-2025-2682 (#7558)
-- fix: prevent rogue base suppression files (#7544)
-- fix: #6819 handle invalid toml file (#7548)
-- fix: Use unscored severity only in absence of any CVSS baseScore (#7530)
-- fix: protect against exotic version number of yarn (#7525)
-- fix: Ignore require-bundle MANIFEST.MF entry for evidence (#7523)
-- fix: avoid error on yarn berry audit when no vulnerability found (#7501)
-- fix: improve null checks in Downloader (#7493)
+  - bump open-vulnerability-client from 7.3.1 to 7.3.2  ([#7577](https://github.com/dependency-check/DependencyCheck/pull/7577))
+- fix: update links for repository move from `jeremylong` to the `dependency-check` organization ([#7373](https://github.com/dependency-check/DependencyCheck/pull/7373))
+- fix: resolve NPE when processing CVE-2025-2682 ([#7558](https://github.com/dependency-check/DependencyCheck/pull/7558))
+- fix: prevent rogue base suppression files ([#7544](https://github.com/dependency-check/DependencyCheck/pull/7544))
+- fix: [#6819](https://github.com/dependency-check/DependencyCheck/pull/6819) handle invalid toml file ([#7548](https://github.com/dependency-check/DependencyCheck/pull/7548))
+- fix: Use unscored severity only in absence of any CVSS baseScore ([#7530](https://github.com/dependency-check/DependencyCheck/pull/7530))
+- fix: protect against exotic version number of yarn ([#7525](https://github.com/dependency-check/DependencyCheck/pull/7525))
+- fix: Ignore require-bundle MANIFEST.MF entry for evidence ([#7523](https://github.com/dependency-check/DependencyCheck/pull/7523))
+- fix: avoid error on yarn berry audit when no vulnerability found ([#7501](https://github.com/dependency-check/DependencyCheck/pull/7501))
+- fix: improve null checks in Downloader ([#7493](https://github.com/dependency-check/DependencyCheck/pull/7493))
 - fix: improve null checks resolves https://github.com/dependency-check/dependency-check-gradle/issues/441
-- fix: Avoid FPs when Composer product name has php (#7486)
-- fix: cli not honoring window paths correctly (#7470)
-- fix: Also apply muteNoisyLoggers to UpdateMojo (#7469)
-- fix: Make HC5 Downloader honor the connection- and readTimeout settings that the old URLConnectionFactory based downloads observed (#7437) 
-- docs: sync the supported Maven version with the one stated in the system requirement section (#7570)
-- docs: update proxy config documentation (#7550)
+- fix: Avoid FPs when Composer product name has php ([#7486](https://github.com/dependency-check/DependencyCheck/pull/7486))
+- fix: cli not honoring window paths correctly ([#7470](https://github.com/dependency-check/DependencyCheck/pull/7470))
+- fix: Also apply muteNoisyLoggers to UpdateMojo ([#7469](https://github.com/dependency-check/DependencyCheck/pull/7469))
+- fix: Make HC5 Downloader honor the connection- and readTimeout settings that the old URLConnectionFactory based downloads observed ([#7437](https://github.com/dependency-check/DependencyCheck/pull/7437)) 
+- docs: sync the supported Maven version with the one stated in the system requirement section ([#7570](https://github.com/dependency-check/DependencyCheck/pull/7570))
+- docs: update proxy config documentation ([#7550](https://github.com/dependency-check/DependencyCheck/pull/7550))
 - docs: Remove copyright as requested by the Apache foundation
-- docs: drop redundant text in the Internet Access Required section (#7521)
-- docs: correct gradle documentation (#7511)
+- docs: drop redundant text in the Internet Access Required section ([#7521](https://github.com/dependency-check/DependencyCheck/pull/7521))
+- docs: correct gradle documentation ([#7511](https://github.com/dependency-check/DependencyCheck/pull/7511))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/95?closed=1)
 
 ## [Version 12.1.0](https://github.com/dependency-check/DependencyCheck/releases/tag/v12.1.0) (2025-02-16)
 
-- build(deps): bump open-vulnerability-client to 7.2.2 (#7407)
-  - resolves issue with downloading data from the NVD (#7406)
-- fix: Improve thread safety issue #7338 alternative (#7367)
-- feat: Implement Yarn Berry Analyser (#7319)
+- build(deps): bump open-vulnerability-client to 7.2.2 ([#7407](https://github.com/dependency-check/DependencyCheck/pull/7407))
+  - resolves issue with downloading data from the NVD ([#7406](https://github.com/dependency-check/DependencyCheck/pull/7406))
+- fix: Improve thread safety issue [#7338](https://github.com/dependency-check/DependencyCheck/pull/7338) alternative ([#7367](https://github.com/dependency-check/DependencyCheck/pull/7367))
+- feat: Implement Yarn Berry Analyser ([#7319](https://github.com/dependency-check/DependencyCheck/pull/7319))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/94?closed=1)
 
 ## [Version 12.0.2](https://github.com/dependency-check/DependencyCheck/releases/tag/v12.0.2) (2025-01-29)
 
-- fix: correct JSON report error (#7350)
-- fix: some compatability issues in the gitlab report (#7349)
-- fix: ArtifactoryAnalyzer updated to use the HTTPClient5-based Downloader and skip unusable results (#7293)
-- chore: allow messages via EngineVersionCheck (#7353)
-- chore: switch from javax.json to jakarta.json (#7326)
+- fix: correct JSON report error ([#7350](https://github.com/dependency-check/DependencyCheck/pull/7350))
+- fix: some compatability issues in the gitlab report ([#7349](https://github.com/dependency-check/DependencyCheck/pull/7349))
+- fix: ArtifactoryAnalyzer updated to use the HTTPClient5-based Downloader and skip unusable results ([#7293](https://github.com/dependency-check/DependencyCheck/pull/7293))
+- chore: allow messages via EngineVersionCheck ([#7353](https://github.com/dependency-check/DependencyCheck/pull/7353))
+- chore: switch from javax.json to jakarta.json ([#7326](https://github.com/dependency-check/DependencyCheck/pull/7326))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/93?closed=1).
 
 ## [Version 12.0.1](https://github.com/dependency-check/DependencyCheck/releases/tag/v12.0.1) (2025-01-19)
 
-- docs: Fix OSS Index Maven config documentation (#7322)
+- docs: Fix OSS Index Maven config documentation ([#7322](https://github.com/dependency-check/DependencyCheck/pull/7322))
 - Fix OSS Index Maven config documentation
-- chore(docs): Document Gradle plugin support for failBuildOnUnusedSuppressionRule (#7307)
-- chore(docs): Correct analyzers config example to use Gradle dot-syntax (#7305)
-- fix: improve error message on improperly configured serverId credentials in settings.xml (#7313)
+- chore(docs): Document Gradle plugin support for failBuildOnUnusedSuppressionRule ([#7307](https://github.com/dependency-check/DependencyCheck/pull/7307))
+- chore(docs): Correct analyzers config example to use Gradle dot-syntax ([#7305](https://github.com/dependency-check/DependencyCheck/pull/7305))
+- fix: improve error message on improperly configured serverId credentials in settings.xml ([#7313](https://github.com/dependency-check/DependencyCheck/pull/7313))
 - fix: Lower Basic serverId when Bearer was expected to a warning
 - fix: improve error message on improperly configured serverId credentials
-- fix: Correct nonProxyHosts support when no sys properties set (#7306)
+- fix: Correct nonProxyHosts support when no sys properties set ([#7306](https://github.com/dependency-check/DependencyCheck/pull/7306))
 - core(docs): Group failBuildOnUnusedSuppressionRule flag next to suppression file configuration
 - core(docs): Update Gradle plugin documentation for failBuildOnUnusedSuppressionRule support
 - fix: Correct nonProxyHosts support when no sys properties set
@@ -108,100 +108,100 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ## [Version 12.0.0](https://github.com/dependency-check/DependencyCheck/releases/tag/v12.0.0) (2025-01-11)
 
-- BREAKING CHANGE: report on CVSS v4 (#7204)
+- BREAKING CHANGE: report on CVSS v4 ([#7204](https://github.com/dependency-check/DependencyCheck/pull/7204))
   - the schema has been updated to include CVSS v4 for JSON and XML reports
-- feat: show from which dependency the CVE comes in failure report (#7224)
-- feat: Use Maven settings decryption API for decrypting secrets from settings.xml (#7284)
-- feat: Extend authentication to support Bearer token for many resources (#7277)
-- feat: Add a flag to fail when one or more suppression rules are not used (#7244)
-- fix: add product evidence as vendor to reduce FN (#7295)
-- fix: Make the HTTP-Client use pre-emptive authentication (#7255)
+- feat: show from which dependency the CVE comes in failure report ([#7224](https://github.com/dependency-check/DependencyCheck/pull/7224))
+- feat: Use Maven settings decryption API for decrypting secrets from settings.xml ([#7284](https://github.com/dependency-check/DependencyCheck/pull/7284))
+- feat: Extend authentication to support Bearer token for many resources ([#7277](https://github.com/dependency-check/DependencyCheck/pull/7277))
+- feat: Add a flag to fail when one or more suppression rules are not used ([#7244](https://github.com/dependency-check/DependencyCheck/pull/7244))
+- fix: add product evidence as vendor to reduce FN ([#7295](https://github.com/dependency-check/DependencyCheck/pull/7295))
+- fix: Make the HTTP-Client use pre-emptive authentication ([#7255](https://github.com/dependency-check/DependencyCheck/pull/7255))
 - fix: Add the missing proxy credentials for suppressionFileUser/Password authentication scenario
-- fix: increase max retry count (#7252)
+- fix: increase max retry count ([#7252](https://github.com/dependency-check/DependencyCheck/pull/7252))
 - fix: Make the HTTP-Client use pre-emptive authentication for configured server credentials and extend HTTPClient usage to Nexus search
-- fix: Tranform into UTC the last modified date from database (#7222)
+- fix: Tranform into UTC the last modified date from database ([#7222](https://github.com/dependency-check/DependencyCheck/pull/7222))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/91?closed=1). 
 
 ## [Version 11.1.1](https://github.com/dependency-check/DependencyCheck/releases/tag/v11.1.1) (2024-12-04)
 
-- fix: re-enable issue locking (#7220)
-- fix: add username/password properties to be able to authenticate for central.content.url and analyzer.central.url again (#7169)
-- fix: rework replaceOrAddVulnerability (#7177)
-- fix: do not log loading of JDBC driver (#7155)
-- fix: expose flag to disable version check (#7147)
-- fix: Gracefully handle CVEs with bad configuration nodes missing CPE match expressions (#7125)
-- chore: cleanup base suppression (#7138)
-- docs: update gradle configuration documentation (#7176)
-- docs: update documentation for Gradle plugin (#7143)
-- docs: improve false positive issue templat (#7130)
+- fix: re-enable issue locking ([#7220](https://github.com/dependency-check/DependencyCheck/pull/7220))
+- fix: add username/password properties to be able to authenticate for central.content.url and analyzer.central.url again ([#7169](https://github.com/dependency-check/DependencyCheck/pull/7169))
+- fix: rework replaceOrAddVulnerability ([#7177](https://github.com/dependency-check/DependencyCheck/pull/7177))
+- fix: do not log loading of JDBC driver ([#7155](https://github.com/dependency-check/DependencyCheck/pull/7155))
+- fix: expose flag to disable version check ([#7147](https://github.com/dependency-check/DependencyCheck/pull/7147))
+- fix: Gracefully handle CVEs with bad configuration nodes missing CPE match expressions ([#7125](https://github.com/dependency-check/DependencyCheck/pull/7125))
+- chore: cleanup base suppression ([#7138](https://github.com/dependency-check/DependencyCheck/pull/7138))
+- docs: update gradle configuration documentation ([#7176](https://github.com/dependency-check/DependencyCheck/pull/7176))
+- docs: update documentation for Gradle plugin ([#7143](https://github.com/dependency-check/DependencyCheck/pull/7143))
+- docs: improve false positive issue templat ([#7130](https://github.com/dependency-check/DependencyCheck/pull/7130))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/90?closed=1). 
 
 ## [Version 11.1.0](https://github.com/dependency-check/DependencyCheck/releases/tag/v11.1.0) (2024-10-30)
 
-- feat: PHP Composer Analyzer now scans packages-dev by default (#7114)
+- feat: PHP Composer Analyzer now scans packages-dev by default ([#7114](https://github.com/dependency-check/DependencyCheck/pull/7114))
   - Users can configure if packages-dev should be skipped
-- fix(regression): re-add h2 database driver name (#7115) 
-- fix(regression): Make the Downloader honour the proxy.nonproxyhosts ODC Setting (#7077)
-- fix: do not set legacy proxy from maven or env (#7072) (#7074)
-- docs: add missing documentation for the MS Build Analyzer (#7113)
-- docs: Document the breaking change for Maven plugin as reporting plugin (#7079)
+- fix(regression): re-add h2 database driver name ([#7115](https://github.com/dependency-check/DependencyCheck/pull/7115)) 
+- fix(regression): Make the Downloader honour the proxy.nonproxyhosts ODC Setting ([#7077](https://github.com/dependency-check/DependencyCheck/pull/7077))
+- fix: do not set legacy proxy from maven or env ([#7072](https://github.com/dependency-check/DependencyCheck/pull/7072)) ([#7074](https://github.com/dependency-check/DependencyCheck/pull/7074))
+- docs: add missing documentation for the MS Build Analyzer ([#7113](https://github.com/dependency-check/DependencyCheck/pull/7113))
+- docs: Document the breaking change for Maven plugin as reporting plugin ([#7079](https://github.com/dependency-check/DependencyCheck/pull/7079))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/89?closed=1). 
 
 ## [Version 11.0.0](https://github.com/dependency-check/DependencyCheck/releases/tag/v11.0.0) (2024-10-21)
 
-- **breaking change**: Switch from JMockit to Mockito & build target to Java 11 (#6922)
+- **breaking change**: Switch from JMockit to Mockito & build target to Java 11 ([#6922](https://github.com/dependency-check/DependencyCheck/pull/6922))
   - dependency-check now requires a minimum of Java 11.0 to run
-- **breaking change**: bump com.h2database:h2 from 2.1.214 to 2.3.232 (#6132)
+- **breaking change**: bump com.h2database:h2 from 2.1.214 to 2.3.232 ([#6132](https://github.com/dependency-check/DependencyCheck/pull/6132))
   - H2 databases generated with an older version of ODC will not work with ODC 11.0.0; a new H2 db must be generated
 - **breaking change**: Maven plugin updated to Doxia 2.x reporting stack
-  - Users of the Maven plugin that configure it as a reporting plugin will need to use maven-site-plugin 3.20.0 or later (#6959)
+  - Users of the Maven plugin that configure it as a reporting plugin will need to use maven-site-plugin 3.20.0 or later ([#6959](https://github.com/dependency-check/DependencyCheck/pull/6959))
 - feat: Replace old Downloader by an Apache HTTPClient based downloader
-- feat: Use Apache HTTPClient for downloads of public resources (#6949)
+- feat: Use Apache HTTPClient for downloads of public resources ([#6949](https://github.com/dependency-check/DependencyCheck/pull/6949))
 - feat: Also make NodeAuditSearch usr our HTTPClient based connections
 - feat: Also make OSSIndexAnalyzer use our HTTPClient based connections
 - feat: Migrate CentralSearch to use Apache HTTP-client via Downloader
 - feat: Extend apache HTTP-client usage to EngineVersionCheck
-- feat: Remove the need to specify dbDriver for external databases using JDBCv4 ServiceLoader supporting JDBC drivers (#6938)
-- fix: use latest generated suppressions (#7064)
-- fix: Fixup parameter sequence for Dowloader credentials (#7033)
+- feat: Remove the need to specify dbDriver for external databases using JDBCv4 ServiceLoader supporting JDBC drivers ([#6938](https://github.com/dependency-check/DependencyCheck/pull/6938))
+- fix: use latest generated suppressions ([#7064](https://github.com/dependency-check/DependencyCheck/pull/7064))
+- fix: Fixup parameter sequence for Dowloader credentials ([#7033](https://github.com/dependency-check/DependencyCheck/pull/7033))
 - fix: Fixup the missing addition of NVD API Datafeed credentials (if configured)
 - fix: Fixup broken proxy authentication in first attempt; extend to include KEV downloads
-- fix: store timestamps locally for local resources (#6936)
-- build: Remove the animal-sniffer, propagate java version to plugin-archetype (#6950)
-- build: Update Checkstyle configuration and Suppression DTD references (#6951)
-- chore: Update test db schema (#7036)
+- fix: store timestamps locally for local resources ([#6936](https://github.com/dependency-check/DependencyCheck/pull/6936))
+- build: Remove the animal-sniffer, propagate java version to plugin-archetype ([#6950](https://github.com/dependency-check/DependencyCheck/pull/6950))
+- build: Update Checkstyle configuration and Suppression DTD references ([#6951](https://github.com/dependency-check/DependencyCheck/pull/6951))
+- chore: Update test db schema ([#7036](https://github.com/dependency-check/DependencyCheck/pull/7036))
 - chore: remove old, unneeded database upgrade script
-- docs: reformat javadoc (#7009)
-- docs: Fixup javadoc warnings (#6995)
-- chore: Replace use of several deprecated methods/classes by their successors (#6933)
+- docs: reformat javadoc ([#7009](https://github.com/dependency-check/DependencyCheck/pull/7009))
+- docs: Fixup javadoc warnings ([#6995](https://github.com/dependency-check/DependencyCheck/pull/6995))
+- chore: Replace use of several deprecated methods/classes by their successors ([#6933](https://github.com/dependency-check/DependencyCheck/pull/6933))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/87?closed=1). 
 
 ## [Version 10.0.4](https://github.com/dependency-check/DependencyCheck/releases/tag/v10.0.4) (2024-09-01)
 
- - build(deps): exclude unused dependency (#6916)
- - fix: improve regex (#6917)
- - fix: correctly handle null values in cpeMatch (#6915)
- - fix(site): Update Fluido skin to resolve broken fork-me-on-github image (#6914)
- - fix: do not report over 100% download complete (#6899)
- - fix: Correct spelling of occurring in NvdApiDataSource.java (#6883)
- - fix: skip blank lines in requirements.txt (#6867)
- - fix: correct percentage calculation (#6868)
- - docs: remove old recommendation (#6860)
+ - build(deps): exclude unused dependency ([#6916](https://github.com/dependency-check/DependencyCheck/pull/6916))
+ - fix: improve regex ([#6917](https://github.com/dependency-check/DependencyCheck/pull/6917))
+ - fix: correctly handle null values in cpeMatch ([#6915](https://github.com/dependency-check/DependencyCheck/pull/6915))
+ - fix(site): Update Fluido skin to resolve broken fork-me-on-github image ([#6914](https://github.com/dependency-check/DependencyCheck/pull/6914))
+ - fix: do not report over 100% download complete ([#6899](https://github.com/dependency-check/DependencyCheck/pull/6899))
+ - fix: Correct spelling of occurring in NvdApiDataSource.java ([#6883](https://github.com/dependency-check/DependencyCheck/pull/6883))
+ - fix: skip blank lines in requirements.txt ([#6867](https://github.com/dependency-check/DependencyCheck/pull/6867))
+ - fix: correct percentage calculation ([#6868](https://github.com/dependency-check/DependencyCheck/pull/6868))
+ - docs: remove old recommendation ([#6860](https://github.com/dependency-check/DependencyCheck/pull/6860))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/88?closed=1). 
 
 ## [Version 10.0.3](https://github.com/dependency-check/DependencyCheck/releases/tag/v10.0.3) (2024-07-16)
 
-- feat: Enable configuration of a lower resultsPerPage on NVD API (#6843)
-- build(deps): bump open-vulnerability-clients from 6.1.6 to 6.1.7 (#6848)
-- build(deps): bump JamesIves/github-pages-deploy-action from 4.6.1 to 4.6.3 (#6814)
-- build(deps): bump org.codehaus.mojo:versions-maven-plugin from 2.16.2 to 2.17.0 (#6762)
-- build(deps): bump org.apache.maven.plugins:maven-checkstyle-plugin from 3.3.1 to 3.4.0 (#6815)
-- build(deps): bump golang from 1.22.4-alpine to 1.22.5-alpine (#6805)
+- feat: Enable configuration of a lower resultsPerPage on NVD API ([#6843](https://github.com/dependency-check/DependencyCheck/pull/6843))
+- build(deps): bump open-vulnerability-clients from 6.1.6 to 6.1.7 ([#6848](https://github.com/dependency-check/DependencyCheck/pull/6848))
+- build(deps): bump JamesIves/github-pages-deploy-action from 4.6.1 to 4.6.3 ([#6814](https://github.com/dependency-check/DependencyCheck/pull/6814))
+- build(deps): bump org.codehaus.mojo:versions-maven-plugin from 2.16.2 to 2.17.0 ([#6762](https://github.com/dependency-check/DependencyCheck/pull/6762))
+- build(deps): bump org.apache.maven.plugins:maven-checkstyle-plugin from 3.3.1 to 3.4.0 ([#6815](https://github.com/dependency-check/DependencyCheck/pull/6815))
+- build(deps): bump golang from 1.22.4-alpine to 1.22.5-alpine ([#6805](https://github.com/dependency-check/DependencyCheck/pull/6805))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/84?closed=1). 
 
@@ -209,164 +209,164 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 **Mandatory Upgrade** - due to older versions of dependency-check causing numerous, spurious requests that end in processing failures, this upgrade is mandatory so that the NVD can differentiate valid requests and block the old clients.
 
-- build(deps): bump open-vulnerability-clients (#6810)
-- fix(db): #6788 removing redundant db index "idxVulnerability" on "vulnerability.cve" (#6807)
-- docs: Further improve formatting and docs of H2 database caching strats (#6804)
-- fix: update_vulnerability in dbStatements_oracle.properties (#6803)
-- fix: fix NPE  (#6778)
-- fix: add hint to resolve false negative (#6802)
-- chore: update configure (#6794)
+- build(deps): bump open-vulnerability-clients ([#6810](https://github.com/dependency-check/DependencyCheck/pull/6810))
+- fix(db): [#6788](https://github.com/dependency-check/DependencyCheck/pull/6788) removing redundant db index "idxVulnerability" on "vulnerability.cve" ([#6807](https://github.com/dependency-check/DependencyCheck/pull/6807))
+- docs: Further improve formatting and docs of H2 database caching strats ([#6804](https://github.com/dependency-check/DependencyCheck/pull/6804))
+- fix: update_vulnerability in dbStatements_oracle.properties ([#6803](https://github.com/dependency-check/DependencyCheck/pull/6803))
+- fix: fix NPE  ([#6778](https://github.com/dependency-check/DependencyCheck/pull/6778))
+- fix: add hint to resolve false negative ([#6802](https://github.com/dependency-check/DependencyCheck/pull/6802))
+- chore: update configure ([#6794](https://github.com/dependency-check/DependencyCheck/pull/6794))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/86?closed=1). 
 
 ## [Version 10.0.1](https://github.com/dependency-check/DependencyCheck/releases/tag/v10.0.1) (2024-07-02)
 
-- build(deps): bump open-vulnerability-client (#6772)
-- fix: remove debug logging (#6770)
-- fix: postgresql column count error (#6773)
-- fix: mssql column name and version (#6761)
-- docs: update supported versions (#6771)
+- build(deps): bump open-vulnerability-client ([#6772](https://github.com/dependency-check/DependencyCheck/pull/6772))
+- fix: remove debug logging ([#6770](https://github.com/dependency-check/DependencyCheck/pull/6770))
+- fix: postgresql column count error ([#6773](https://github.com/dependency-check/DependencyCheck/pull/6773))
+- fix: mssql column name and version ([#6761](https://github.com/dependency-check/DependencyCheck/pull/6761))
+- docs: update supported versions ([#6771](https://github.com/dependency-check/DependencyCheck/pull/6771))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/85?closed=1). 
 
 ## [Version 10.0.0](https://github.com/dependency-check/DependencyCheck/releases/tag/v10.0.0) (2024-07-01)
 
-- **breaking change**: upgrade to dotnet 8.0 (#6580)
+- **breaking change**: upgrade to dotnet 8.0 ([#6580](https://github.com/dependency-check/DependencyCheck/pull/6580))
   - Users of the AssemblyAnalyzer must upgrade/utilize dotnet 8 to analyze assemblies
-- feat: fix the NVD API related errors by adding cvssV4 support (#6756)
+- feat: fix the NVD API related errors by adding cvssV4 support ([#6756](https://github.com/dependency-check/DependencyCheck/pull/6756))
    - **breaking changes**: anyone utilizing a centralized database will need to upgrade the schema; see changes in [PR #6756](https://github.com/dependency-check/DependencyCheck/pull/6756/files#diff-ca432c4b41d39caa84d140e06694b09c7e6394c8a2db72ba27516dc77ee3bd67)
-- fix: avoid escaping unnecessary chars in HTML report suppression regexes (#6749)
-- fix: #6688 Trim version number when parsin POM (#6705)
-- fix: change request if lockfile is file v3 (#6690)
-- fix: skip pyproject.toml unless it contains `tool.poetry` before ensuring lockfiles (#6681)
+- fix: avoid escaping unnecessary chars in HTML report suppression regexes ([#6749](https://github.com/dependency-check/DependencyCheck/pull/6749))
+- fix: [#6688](https://github.com/dependency-check/DependencyCheck/pull/6688) Trim version number when parsing POM ([#6705](https://github.com/dependency-check/DependencyCheck/pull/6705))
+- fix: change request if lockfile is file v3 ([#6690](https://github.com/dependency-check/DependencyCheck/pull/6690))
+- fix: skip pyproject.toml unless it contains `tool.poetry` before ensuring lockfiles ([#6681](https://github.com/dependency-check/DependencyCheck/pull/6681))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/83?closed=1). 
 
 ## [Version 9.2.0](https://github.com/dependency-check/DependencyCheck/releases/tag/v9.2.0) (2024-05-15)
 
- - docs: update logo per intellj (#6660)
- - feat: Carthage analyzer (#6614)
- - fix: Ensure valid JSON output for gitlab report (#6630)
- - feat: Support Package.swift version 3 Specification (#6578)
- - chore: Update the packaged suppressions to include new hosted suppressions (#6567)
+ - docs: update logo per intellj ([#6660](https://github.com/dependency-check/DependencyCheck/pull/6660))
+ - feat: Carthage analyzer ([#6614](https://github.com/dependency-check/DependencyCheck/pull/6614))
+ - fix: Ensure valid JSON output for gitlab report ([#6630](https://github.com/dependency-check/DependencyCheck/pull/6630))
+ - feat: Support Package.swift version 3 Specification ([#6578](https://github.com/dependency-check/DependencyCheck/pull/6578))
+ - chore: Update the packaged suppressions to include new hosted suppressions ([#6567](https://github.com/dependency-check/DependencyCheck/pull/6567))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/82?closed=1). 
 
 ## [Version 9.1.0](https://github.com/dependency-check/DependencyCheck/releases/tag/v9.1.0) (2024-03-31)
 
-- feat: Add v2 support for maven_install.json (#6528)
-- build(deps): bump open-vulnerability-client (#6554)
+- feat: Add v2 support for maven_install.json ([#6528](https://github.com/dependency-check/DependencyCheck/pull/6528))
+- build(deps): bump open-vulnerability-client ([#6554](https://github.com/dependency-check/DependencyCheck/pull/6554))
   - resolves update issues due to CVSS Metrics 4.0
-- build(deps): bump jackson.version from 2.16.0 to 2.16.1 (#6353)
-- build(deps): bump org.jsoup:jsoup from 1.16.2 to 1.17.2 (#6362)
-- build(deps): bump golang from 1.21.5-alpine to 1.22.1-alpine (#6506)
+- build(deps): bump jackson.version from 2.16.0 to 2.16.1 ([#6353](https://github.com/dependency-check/DependencyCheck/pull/6353))
+- build(deps): bump org.jsoup:jsoup from 1.16.2 to 1.17.2 ([#6362](https://github.com/dependency-check/DependencyCheck/pull/6362))
+- build(deps): bump golang from 1.21.5-alpine to 1.22.1-alpine ([#6506](https://github.com/dependency-check/DependencyCheck/pull/6506))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/81?closed=1).
 
 ## [Version 9.0.10](https://github.com/dependency-check/DependencyCheck/releases/tag/v9.0.10) (2024-03-15)
 
-- fix: #4321 Suppress redis server CVEs for client libraries (#4321) (#6489)
-- fix: bump commons-compress from 1.25.0 to 1.26.0 to fix CVE-2024-25710 and CVE-2024-26308 (#6492)
-- feat: Allow to pass NVD API key via environment variable (#6454)
-- fix: issue 5452 - ConcurrentModificationException in NodePackageAnalyzer.processDependencies - adding synchronized block  (#6501)
-- docs: document the default data directory (#6484)
-- fix: prevent NPE in bundler audit (#6462)
-- fix: #6441 Improve suppression rule to not restrict to a single version (#6442)
+- fix: [#4321](https://github.com/dependency-check/DependencyCheck/pull/4321) Suppress redis server CVEs for client libraries ([#4321](https://github.com/dependency-check/DependencyCheck/pull/4321)) ([#6489](https://github.com/dependency-check/DependencyCheck/pull/6489))
+- fix: bump commons-compress from 1.25.0 to 1.26.0 to fix CVE-2024-25710 and CVE-2024-26308 ([#6492](https://github.com/dependency-check/DependencyCheck/pull/6492))
+- feat: Allow to pass NVD API key via environment variable ([#6454](https://github.com/dependency-check/DependencyCheck/pull/6454))
+- fix: issue 5452 - ConcurrentModificationException in NodePackageAnalyzer.processDependencies - adding synchronized block  ([#6501](https://github.com/dependency-check/DependencyCheck/pull/6501))
+- docs: document the default data directory ([#6484](https://github.com/dependency-check/DependencyCheck/pull/6484))
+- fix: prevent NPE in bundler audit ([#6462](https://github.com/dependency-check/DependencyCheck/pull/6462))
+- fix: [#6441](https://github.com/dependency-check/DependencyCheck/pull/6441) Improve suppression rule to not restrict to a single version ([#6442](https://github.com/dependency-check/DependencyCheck/pull/6442))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/80?closed=1).
 
 ## [Version 9.0.9](https://github.com/dependency-check/DependencyCheck/releases/tag/v9.0.9) (2024-01-17)
 
-- fix: for #6374 to delete non-empty directories (#6375)
-- fix: NoSuchMethodError closeQuietly(java.io.Closeable[]) (#6377)
-- chore: close stream to prevent possible resource leak (#6382)
-- docs: Document default for CLI --data (#6359)
-- docs: document gradle build (#6371)
+- fix: for [#6374](https://github.com/dependency-check/DependencyCheck/pull/6374) to delete non-empty directories ([#6375](https://github.com/dependency-check/DependencyCheck/pull/6375))
+- fix: NoSuchMethodError closeQuietly(java.io.Closeable[]) ([#6377](https://github.com/dependency-check/DependencyCheck/pull/6377))
+- chore: close stream to prevent possible resource leak ([#6382](https://github.com/dependency-check/DependencyCheck/pull/6382))
+- docs: Document default for CLI --data ([#6359](https://github.com/dependency-check/DependencyCheck/pull/6359))
+- docs: document gradle build ([#6371](https://github.com/dependency-check/DependencyCheck/pull/6371))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/79?closed=1).
 
 ## [Version 9.0.8](https://github.com/dependency-check/DependencyCheck/releases/tag/v9.0.8) (2024-01-06)
 
-- fix: favor stability over performance (#6349)
-- chore: replace commons-io with core java calls (#6343)
-- fix: improve error reporting for invalid H2 database (#6339)
-- fix: rework fix for closing input streams on errors correctly (#6338)
-- fix: reduce chance NVD API block updates due to rate limit (#6333)
-- fix: ensure open handles will not leak on errors (#6326)
-- fix: improve error reporting (#6324)
+- fix: favor stability over performance ([#6349](https://github.com/dependency-check/DependencyCheck/pull/6349))
+- chore: replace commons-io with core java calls ([#6343](https://github.com/dependency-check/DependencyCheck/pull/6343))
+- fix: improve error reporting for invalid H2 database ([#6339](https://github.com/dependency-check/DependencyCheck/pull/6339))
+- fix: rework fix for closing input streams on errors correctly ([#6338](https://github.com/dependency-check/DependencyCheck/pull/6338))
+- fix: reduce chance NVD API block updates due to rate limit ([#6333](https://github.com/dependency-check/DependencyCheck/pull/6333))
+- fix: ensure open handles will not leak on errors ([#6326](https://github.com/dependency-check/DependencyCheck/pull/6326))
+- fix: improve error reporting ([#6324](https://github.com/dependency-check/DependencyCheck/pull/6324))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/78?closed=1).
 
 ## [Version 9.0.7](https://github.com/dependency-check/DependencyCheck/releases/tag/v9.0.7) (2023-12-18)
 
-- docs: document insecure configuration for GHSA-qqhq-8r2c-c3f5 (#6315)
-- fix: improve memory usage on NVD update (#6321)
-- fix: skip pyproject.toml unless it contains `tool.poetry` (#6316)
-- fix: resolve build error that may cause an issue on some JDK versions (#6312)
+- docs: document insecure configuration for GHSA-qqhq-8r2c-c3f5 ([#6315](https://github.com/dependency-check/DependencyCheck/pull/6315))
+- fix: improve memory usage on NVD update ([#6321](https://github.com/dependency-check/DependencyCheck/pull/6321))
+- fix: skip pyproject.toml unless it contains `tool.poetry` ([#6316](https://github.com/dependency-check/DependencyCheck/pull/6316))
+- fix: resolve build error that may cause an issue on some JDK versions ([#6312](https://github.com/dependency-check/DependencyCheck/pull/6312))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/77?closed=1).
 
 ## [Version 9.0.6](https://github.com/dependency-check/DependencyCheck/releases/tag/v9.0.6) (2023-12-15)
 
-- build: bump open-vulnerability-clients@5.1.1 (#6308)
-- fix: mask nvd.api.key in logs; see GHSA-qqhq-8r2c-c3f5 (#6307)
-- fix: update java version check (#6297)
-- fix: more efficient memory usage (#6299)
-- fix: stream NVD data via Jackson to reduce memory footprint (#6275)
-- docs: document github action caching (#6301)
+- build: bump open-vulnerability-clients@5.1.1 ([#6308](https://github.com/dependency-check/DependencyCheck/pull/6308))
+- fix: mask nvd.api.key in logs; see GHSA-qqhq-8r2c-c3f5 ([#6307](https://github.com/dependency-check/DependencyCheck/pull/6307))
+- fix: update java version check ([#6297](https://github.com/dependency-check/DependencyCheck/pull/6297))
+- fix: more efficient memory usage ([#6299](https://github.com/dependency-check/DependencyCheck/pull/6299))
+- fix: stream NVD data via Jackson to reduce memory footprint ([#6275](https://github.com/dependency-check/DependencyCheck/pull/6275))
+- docs: document github action caching ([#6301](https://github.com/dependency-check/DependencyCheck/pull/6301))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/76?closed=1).
 
 ## [Version 9.0.5](https://github.com/dependency-check/DependencyCheck/releases/tag/v9.0.5) (2023-12-13)
 
-- fix: make NVD API endpoint configurable (#6287)
-- fix: synch last modified timestamp for NVD API (#6281)
-- fix: read NVD cache meta files if cache.properties does not exist (#6282)
-- fix: correct property for nonProxyHosts (#6285)
-- fix: reduce apache http logging (#6280)
-- fix: store last modified timestamp for RetireJS and the Hosted Suppression File in db (#6271)
-- build: bump golang in the docker image (#6274)
-- fix: use temporary files to reduce memory usage during the NVD Update (#6270)
-- fix: use BIT for Oracle DB instead of Boolean when calling prepared statements (#6264)
-- fix: showing all reference tags in reports (#6259)
+- fix: make NVD API endpoint configurable ([#6287](https://github.com/dependency-check/DependencyCheck/pull/6287))
+- fix: synch last modified timestamp for NVD API ([#6281](https://github.com/dependency-check/DependencyCheck/pull/6281))
+- fix: read NVD cache meta files if cache.properties does not exist ([#6282](https://github.com/dependency-check/DependencyCheck/pull/6282))
+- fix: correct property for nonProxyHosts ([#6285](https://github.com/dependency-check/DependencyCheck/pull/6285))
+- fix: reduce apache http logging ([#6280](https://github.com/dependency-check/DependencyCheck/pull/6280))
+- fix: store last modified timestamp for RetireJS and the Hosted Suppression File in db ([#6271](https://github.com/dependency-check/DependencyCheck/pull/6271))
+- build: bump golang in the docker image ([#6274](https://github.com/dependency-check/DependencyCheck/pull/6274))
+- fix: use temporary files to reduce memory usage during the NVD Update ([#6270](https://github.com/dependency-check/DependencyCheck/pull/6270))
+- fix: use BIT for Oracle DB instead of Boolean when calling prepared statements ([#6264](https://github.com/dependency-check/DependencyCheck/pull/6264))
+- fix: showing all reference tags in reports ([#6259](https://github.com/dependency-check/DependencyCheck/pull/6259))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/75?closed=1).
 
 ## [Version 9.0.4](https://github.com/dependency-check/DependencyCheck/releases/tag/v9.0.4) (2023-12-08)
 
-- fix: utilize maven proxy if present (#6255)
-- fix: allow api key in cli to be quoted (#6253)
-- fix: use correct maven plugin reporting plugin (#6244)
-- fix: correct trailing comma in JSON report (#6245)
+- fix: utilize maven proxy if present ([#6255](https://github.com/dependency-check/DependencyCheck/pull/6255))
+- fix: allow api key in cli to be quoted ([#6253](https://github.com/dependency-check/DependencyCheck/pull/6253))
+- fix: use correct maven plugin reporting plugin ([#6244](https://github.com/dependency-check/DependencyCheck/pull/6244))
+- fix: correct trailing comma in JSON report ([#6245](https://github.com/dependency-check/DependencyCheck/pull/6245))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/74?closed=1).
 
 ## [Version 9.0.3](https://github.com/dependency-check/DependencyCheck/releases/tag/v9.0.3) (2023-12-06)
 
-- fix: use Java properties for proxy configuration (#6238)
-- docs: update proxy configuration documentation (#6237)
-- docs: add documentation on caching (#6204)
-- docs: Clarify H2 database caching strategy (#6220)
-- docs: Update list of supported report formats (#6224)
-- docs: example 5 with new nvdDatafeedUrl parameter (#6215)
-- fix: prevent NPEs (#6232 and #6206)
-- fix: check valid for hours for NVD API (#6225)
-- fix: correct NVD cache last checked logic (#6218)
-- fix: nvd datafeed should process current year (#6213)
-- fix: correct references to cvssv2 and cvssv3 fields in json and xml reports (#6212)
-- fix: correct name on reference links in report (#6205)
-- fix: flaws int the gitlab report (#6193)
+- fix: use Java properties for proxy configuration ([#6238](https://github.com/dependency-check/DependencyCheck/pull/6238))
+- docs: update proxy configuration documentation ([#6237](https://github.com/dependency-check/DependencyCheck/pull/6237))
+- docs: add documentation on caching ([#6204](https://github.com/dependency-check/DependencyCheck/pull/6204))
+- docs: Clarify H2 database caching strategy ([#6220](https://github.com/dependency-check/DependencyCheck/pull/6220))
+- docs: Update list of supported report formats ([#6224](https://github.com/dependency-check/DependencyCheck/pull/6224))
+- docs: example 5 with new nvdDatafeedUrl parameter ([#6215](https://github.com/dependency-check/DependencyCheck/pull/6215))
+- fix: prevent NPEs ([#6232](https://github.com/dependency-check/DependencyCheck/pull/6232) and [#6206](https://github.com/dependency-check/DependencyCheck/pull/6206))
+- fix: check valid for hours for NVD API ([#6225](https://github.com/dependency-check/DependencyCheck/pull/6225))
+- fix: correct NVD cache last checked logic ([#6218](https://github.com/dependency-check/DependencyCheck/pull/6218))
+- fix: nvd datafeed should process current year ([#6213](https://github.com/dependency-check/DependencyCheck/pull/6213))
+- fix: correct references to cvssv2 and cvssv3 fields in json and xml reports ([#6212](https://github.com/dependency-check/DependencyCheck/pull/6212))
+- fix: correct name on reference links in report ([#6205](https://github.com/dependency-check/DependencyCheck/pull/6205))
+- fix: flaws int the gitlab report ([#6193](https://github.com/dependency-check/DependencyCheck/pull/6193))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/73?closed=1).
 
 ## [Version 9.0.2](https://github.com/dependency-check/DependencyCheck/releases/tag/v9.0.2) (2023-12-01)
 
-- fix: remove virtual match string on NVD API Request (#6177)
-- fix: correct meta data in report after switching the NVD API (#6154)
-- fix: retry HTTP connections to NVD on 502 and 504 errors (#6151)
-- fix: Gitlab report format needs severity capitalized (#6182)
-- fix: improve JDK update version parsing (#6163)
-- fix: mute JCS logging (again) (#6153)
+- fix: remove virtual match string on NVD API Request ([#6177](https://github.com/dependency-check/DependencyCheck/pull/6177))
+- fix: correct meta data in report after switching the NVD API ([#6154](https://github.com/dependency-check/DependencyCheck/pull/6154))
+- fix: retry HTTP connections to NVD on 502 and 504 errors ([#6151](https://github.com/dependency-check/DependencyCheck/pull/6151))
+- fix: Gitlab report format needs severity capitalized ([#6182](https://github.com/dependency-check/DependencyCheck/pull/6182))
+- fix: improve JDK update version parsing ([#6163](https://github.com/dependency-check/DependencyCheck/pull/6163))
+- fix: mute JCS logging (again) ([#6153](https://github.com/dependency-check/DependencyCheck/pull/6153))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/72?closed=1).
 
@@ -374,14 +374,14 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 **breaking changes**: See the [upgrade notice](https://github.com/dependency-check/DependencyCheck#900-upgrade-notice)
 
-- fix: check java 8 update version; minimum JRE is 8 update 251 (#6118)
-- fix: add retry for failed NVD API requests (#6136)
-- docs: add default values to documentation for the NVD API Delay (#6135)
-- chore: Revert "build(deps): bump com.h2database:h2 from 2.1.214 to 2.2.224" (#6131)
+- fix: check java 8 update version; minimum JRE is 8 update 251 ([#6118](https://github.com/dependency-check/DependencyCheck/pull/6118))
+- fix: add retry for failed NVD API requests ([#6136](https://github.com/dependency-check/DependencyCheck/pull/6136))
+- docs: add default values to documentation for the NVD API Delay ([#6135](https://github.com/dependency-check/DependencyCheck/pull/6135))
+- chore: Revert "build(deps): bump com.h2database:h2 from 2.1.214 to 2.2.224" ([#6131](https://github.com/dependency-check/DependencyCheck/pull/6131))
   - this is a **breaking change** for anyone that successfully created the H2 database with 9.0.0.
-- fix: mute jcs logging (#6130)
-- docs: update NVD notice (#6110)
-- fix: Use the correct key for NVD API-Key from Maven Settings serverId (#6109)
+- fix: mute jcs logging ([#6130](https://github.com/dependency-check/DependencyCheck/pull/6130))
+- docs: update NVD notice ([#6110](https://github.com/dependency-check/DependencyCheck/pull/6110))
+- fix: Use the correct key for NVD API-Key from Maven Settings serverId ([#6109](https://github.com/dependency-check/DependencyCheck/pull/6109))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/71?closed=1).
 
@@ -389,22 +389,22 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 **breaking changes**: See the [upgrade notice](https://github.com/dependency-check/DependencyCheck#900-upgrade-notice)
 
-- feat: Utilize NVD API (#5978)
-- feat: gitlab dependency scanner report format #5919 (#5920)
-- fix: Use ASCII apostrophe for console message (#6076)
+- feat: Utilize NVD API ([#5978](https://github.com/dependency-check/DependencyCheck/pull/5978))
+- feat: gitlab dependency scanner report format [#5919](https://github.com/dependency-check/DependencyCheck/pull/5919) ([#5920](https://github.com/dependency-check/DependencyCheck/pull/5920))
+- fix: Use ASCII apostrophe for console message ([#6076](https://github.com/dependency-check/DependencyCheck/pull/6076))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/68?closed=1).
 
 ## [Version 8.4.3](https://github.com/dependency-check/DependencyCheck/releases/tag/v8.4.3) (2023-11-15)
 
-- fix: bump jcs3 (#6047)
-- docs: Corrected docs on hostedSuppressions (#6035)
+- fix: bump jcs3 ([#6047](https://github.com/dependency-check/DependencyCheck/pull/6047))
+- docs: Corrected docs on hostedSuppressions ([#6035](https://github.com/dependency-check/DependencyCheck/pull/6035))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/70?closed=1).
 
 ## [Version 8.4.2](https://github.com/dependency-check/DependencyCheck/releases/tag/v8.4.2) (2023-10-22)
 
-- fix: correct log configuration in cli (#6002)
+- fix: correct log configuration in cli ([#6002](https://github.com/dependency-check/DependencyCheck/pull/6002))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/69?closed=1).
 
@@ -412,11 +412,11 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Fixed
 
-- fix: upgrade to JCS3 (#5114)
-- fix: Support ~= version specifier in requirements.txt and pipfile (#5902)
-- fix: Version of dependency no longer ignored when CPE product has a 'java' suffix in a product name (#5901)
-- fix: Do not filter out evidences added by hints (#5900)
-- fix: fixes FP #5925 (#5927)
+- fix: upgrade to JCS3 ([#5114](https://github.com/dependency-check/DependencyCheck/pull/5114))
+- fix: Support ~= version specifier in requirements.txt and pipfile ([#5902](https://github.com/dependency-check/DependencyCheck/pull/5902))
+- fix: Version of dependency no longer ignored when CPE product has a 'java' suffix in a product name ([#5901](https://github.com/dependency-check/DependencyCheck/pull/5901))
+- fix: Do not filter out evidences added by hints ([#5900](https://github.com/dependency-check/DependencyCheck/pull/5900))
+- fix: fixes FP [#5925](https://github.com/dependency-check/DependencyCheck/pull/5925) ([#5927](https://github.com/dependency-check/DependencyCheck/pull/5927))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/67?closed=1).
 
@@ -424,17 +424,17 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Added
 
-- feat: Add support for Nexus v3 to NexusAnalyzer (#5849)
+- feat: Add support for Nexus v3 to NexusAnalyzer ([#5849](https://github.com/dependency-check/DependencyCheck/pull/5849))
 
 ### Fixed
 
-- fix: Hint Analyzer should run before VersionFilter Analyzer (#5818)
+- fix: Hint Analyzer should run before VersionFilter Analyzer ([#5818](https://github.com/dependency-check/DependencyCheck/pull/5818))
 - chore: switch to sha1-pinning as suggested by Semgrep
-- fix: OSS Index Analyzer SocketTimeoutException exception handling based on warn only parameter (#5845)
-- fix: use curl with -L to follow github redirect (#5808)
+- fix: OSS Index Analyzer SocketTimeoutException exception handling based on warn only parameter ([#5845](https://github.com/dependency-check/DependencyCheck/pull/5845))
+- fix: use curl with -L to follow github redirect ([#5808](https://github.com/dependency-check/DependencyCheck/pull/5808))
 - fix: use curl with -L to follow github redirect
-- fix: #5671 out of memory error (#5789)
-- fix: #5671 Exit method as soon as we detect a loop to prevent an infinite loop leading to an OutOfMemoryError
+- fix: [#5671](https://github.com/dependency-check/DependencyCheck/pull/5671) out of memory error ([#5789](https://github.com/dependency-check/DependencyCheck/pull/5789))
+- fix: [#5671](https://github.com/dependency-check/DependencyCheck/pull/5671) Exit method as soon as we detect a loop to prevent an infinite loop leading to an OutOfMemoryError
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/66?closed=1).
 
@@ -446,16 +446,16 @@ Re-release of 8.3.0 as 8.3.1.
 
 ### Added
 
- - Add LibmanAnalyzer (#5652)
- - Update HTML report Dependencies header based on display settings (#5619)
- - Add link to suppressed vulnerabilities header in HTML report (#5620)
- - Enable local proxy configuration in maven plugin configuration (#5696)
+ - Add LibmanAnalyzer ([#5652](https://github.com/dependency-check/DependencyCheck/pull/5652))
+ - Update HTML report Dependencies header based on display settings ([#5619](https://github.com/dependency-check/DependencyCheck/pull/5619))
+ - Add link to suppressed vulnerabilities header in HTML report ([#5620](https://github.com/dependency-check/DependencyCheck/pull/5620))
+ - Enable local proxy configuration in maven plugin configuration ([#5696](https://github.com/dependency-check/DependencyCheck/pull/5696))
 
 ### Fixed
 
- - Fix npm alias present in requires of dependencies (#5703)
- - Make Central URL configurable via CLI (#5667)
- - Ensure support of CVSSv3.1 (#5602)
+ - Fix npm alias present in requires of dependencies ([#5703](https://github.com/dependency-check/DependencyCheck/pull/5703))
+ - Make Central URL configurable via CLI ([#5667](https://github.com/dependency-check/DependencyCheck/pull/5667))
+ - Ensure support of CVSSv3.1 ([#5602](https://github.com/dependency-check/DependencyCheck/pull/5602))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/65?closed=1).
 
@@ -463,9 +463,9 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Fixed
 
- - NullPointerException in MSBuildAnalyzer (#5589)
- - SQL Syntax for Oracle (#5590)
- - Use `https://` URLs in report templates (#5582)
+ - NullPointerException in MSBuildAnalyzer ([#5589](https://github.com/dependency-check/DependencyCheck/pull/5589))
+ - SQL Syntax for Oracle ([#5590](https://github.com/dependency-check/DependencyCheck/pull/5590))
+ - Use `https://` URLs in report templates ([#5582](https://github.com/dependency-check/DependencyCheck/pull/5582))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/64?closed=1).
 
@@ -473,14 +473,14 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Added
 
- - Support msbuild Directory.build.props (#5475)
+ - Support msbuild Directory.build.props ([#5475](https://github.com/dependency-check/DependencyCheck/pull/5475))
  - better display of NPM audit references
  - Add CVSS V3 results from NPM Audit results
 
 ### Fixed
 
- - Fix several issues on NPM Audit reporting (#5546)
- - Case issue in SQL (#5557)
+ - Fix several issues on NPM Audit reporting ([#5546](https://github.com/dependency-check/DependencyCheck/pull/5546))
+ - Case issue in SQL ([#5557](https://github.com/dependency-check/DependencyCheck/pull/5557))
  - Fix CWE(s) extraction for NPM Audit advisories
  - Use the stable github_advisory_id instead of the now unstable id in NPM audit results
 
@@ -490,7 +490,7 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Fixed
 
- - Fix `NullPointerException` in the Jar Analyzer introduced in 8.1.1 (#5512)
+ - Fix `NullPointerException` in the Jar Analyzer introduced in 8.1.1 ([#5512](https://github.com/dependency-check/DependencyCheck/pull/5512))
  
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/62?closed=1).
 
@@ -498,13 +498,13 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Fixed
 
- - allow hosted suppressions file to be disabled (#5509)
- - Several FPs not suitable for our automation (#5504)
- - Fix incorrect defaults for nexus and central-analyzer in gradle plugin documentation (#5503)
- - Erroneous error-log for deprecated CLI flag usage when using properyfile based disablement of Node Audit Analyzer (#5487)
- - Prefer pom.properties G/A/V over pom.xml G/A/V to resolve GAV interpolation issues (#5473)
- - Node package dependencies ending up as related dependency of the wrong version of the package (#5479)
- - do not throw error if pyproject.toml is in node_modules (#5470)
+ - allow hosted suppressions file to be disabled ([#5509](https://github.com/dependency-check/DependencyCheck/pull/5509))
+ - Several FPs not suitable for our automation ([#5504](https://github.com/dependency-check/DependencyCheck/pull/5504))
+ - Fix incorrect defaults for nexus and central-analyzer in gradle plugin documentation ([#5503](https://github.com/dependency-check/DependencyCheck/pull/5503))
+ - Erroneous error-log for deprecated CLI flag usage when using properyfile based disablement of Node Audit Analyzer ([#5487](https://github.com/dependency-check/DependencyCheck/pull/5487))
+ - Prefer pom.properties G/A/V over pom.xml G/A/V to resolve GAV interpolation issues ([#5473](https://github.com/dependency-check/DependencyCheck/pull/5473))
+ - Node package dependencies ending up as related dependency of the wrong version of the package ([#5479](https://github.com/dependency-check/DependencyCheck/pull/5479))
+ - do not throw error if pyproject.toml is in node_modules ([#5470](https://github.com/dependency-check/DependencyCheck/pull/5470))
  
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/61?closed=1).
 
@@ -586,7 +586,7 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Fixed
 
-- Resolved issue processing NVD CVE data due to column width (#5229)
+- Resolved issue processing NVD CVE data due to column width ([#5229](https://github.com/dependency-check/DependencyCheck/pull/5229))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/56?closed=1).
 
@@ -594,8 +594,8 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Fixed
 
-- Fixed NPE when analyzing version ranges in NPM (#5158 & #5190)
-- Resolved several FP (#5191)
+- Fixed NPE when analyzing version ranges in NPM ([#5158](https://github.com/dependency-check/DependencyCheck/pull/5158) & [#5190](https://github.com/dependency-check/DependencyCheck/pull/5190))
+- Resolved several FP ([#5191](https://github.com/dependency-check/DependencyCheck/pull/5191))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/55?closed=1).
 
@@ -603,11 +603,11 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Fixed
 
-- Fixes maven 3.1 compatibility issue (#5152)
-- Fixed issue with invalid `node_module` paths in some scans (#5135)
-- Fixed missing option to disable the Poetry Analyzer in the CLI (#5160)
-- Fixed missing option to configure the OSS Index URL in the CLI (#5180)
-- Fixed NPE when analyzing version ranges in NPM (#5158)
+- Fixes maven 3.1 compatibility issue ([#5152](https://github.com/dependency-check/DependencyCheck/pull/5152))
+- Fixed issue with invalid `node_module` paths in some scans ([#5135](https://github.com/dependency-check/DependencyCheck/pull/5135))
+- Fixed missing option to disable the Poetry Analyzer in the CLI ([#5160](https://github.com/dependency-check/DependencyCheck/pull/5160))
+- Fixed missing option to configure the OSS Index URL in the CLI ([#5180](https://github.com/dependency-check/DependencyCheck/pull/5180))
+- Fixed NPE when analyzing version ranges in NPM ([#5158](https://github.com/dependency-check/DependencyCheck/pull/5158))
 - Fixed issue with non-proxy host in the gradle plugin (https://github.com/dependency-check/dependency-check-gradle/pull/298)
 - Resolved several FP
 
@@ -617,8 +617,8 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Fixed
 
-- Fixed bug when setting the proxy port in gradle (#5123)
-- Fixed issue with invalid `node_module` paths in some scans (#5127)
+- Fixed bug when setting the proxy port in gradle ([#5123](https://github.com/dependency-check/DependencyCheck/pull/5123))
+- Fixed issue with invalid `node_module` paths in some scans ([#5127](https://github.com/dependency-check/DependencyCheck/pull/5127))
 - Resolved several FP
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/53?closed=1).
@@ -627,20 +627,20 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Added
 
-- Add support for npm package lock v2 and v3 (#5078)
-- Added experimental support for Python Poetry (#5025)
-- Added a vanilla HTML report for use in Jenkins (#5053)
+- Add support for npm package lock v2 and v3 ([#5078](https://github.com/dependency-check/DependencyCheck/pull/5078))
+- Added experimental support for Python Poetry ([#5025](https://github.com/dependency-check/DependencyCheck/pull/5025))
+- Added a vanilla HTML report for use in Jenkins ([#5053](https://github.com/dependency-check/DependencyCheck/pull/5053))
 
 ### Changed
 
 - Renamed `RELEASE_NOTES.md` to `CHANGELOG.md` to be more conventional
-- Optimized checksum calculation to improve performance (#5112)
-- Added support for scanning .NET assemblies when only the dotnet runtime is installed (#5087)
+- Optimized checksum calculation to improve performance ([#5112](https://github.com/dependency-check/DependencyCheck/pull/5112))
+- Added support for scanning .NET assemblies when only the dotnet runtime is installed ([#5087](https://github.com/dependency-check/DependencyCheck/pull/5087))
 - Bumped several dependencies
 
 ### Fixed
 
-- Fixed bug when setting the proxy port (#5076)
+- Fixed bug when setting the proxy port ([#5076](https://github.com/dependency-check/DependencyCheck/pull/5076))
 - Resolved several FP and FN
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/52?closed=1).
@@ -651,8 +651,8 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 - Automated release of 7.3.1 failed and only published to Central; 7.3.2 is a re-release of 7.3.1.
 - Resolved several false positives and false negatives.
-- Use Jackson Afterburner if still on Java 8 (#4966).
-- Exclude `node_modules` from the Maven plugin's scan path (#4974).
+- Use Jackson Afterburner if still on Java 8 ([#4966](https://github.com/dependency-check/DependencyCheck/pull/4966)).
+- Exclude `node_modules` from the Maven plugin's scan path ([#4974](https://github.com/dependency-check/DependencyCheck/pull/4974)).
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/51?closed=1).
 
@@ -661,8 +661,8 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 ### Changed
 
 - Resolved several false positives and false negatives.
-- Use Jackson Afterburner if still on Java 8 (#4966).
-- Exclude `node_modules` from the Maven plugin's scan path (#4974).
+- Use Jackson Afterburner if still on Java 8 ([#4966](https://github.com/dependency-check/DependencyCheck/pull/4966)).
+- Exclude `node_modules` from the Maven plugin's scan path ([#4974](https://github.com/dependency-check/DependencyCheck/pull/4974)).
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/51?closed=1).
 
@@ -670,15 +670,15 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Added
 
-- Added an experimental Dart analyzer (#4869).
+- Added an experimental Dart analyzer ([#4869](https://github.com/dependency-check/DependencyCheck/pull/4869)).
 
 ### Changed
 
-- Migrated from Jackson Afterburner to Blackbird (#4905).
+- Migrated from Jackson Afterburner to Blackbird ([#4905](https://github.com/dependency-check/DependencyCheck/pull/4905)).
 
 ### Fixed
 
-- Fixed issue with the Maven plugin that caused concurrent modification exceptions (#4935).
+- Fixed issue with the Maven plugin that caused concurrent modification exceptions ([#4935](https://github.com/dependency-check/DependencyCheck/pull/4935)).
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/50?closed=1).
 
@@ -686,7 +686,7 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Fixed
 
-- Fixed logging issue (#4846).
+- Fixed logging issue ([#4846](https://github.com/dependency-check/DependencyCheck/pull/4846)).
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/49?closed=1).
 
@@ -694,8 +694,8 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Changed
 
-- Add support for Bazel's pinned `maven_install.json` (#4772).
-- Fixed bug preventing the use of custom report templates (#4800).
+- Add support for Bazel's pinned `maven_install.json` ([#4772](https://github.com/dependency-check/DependencyCheck/pull/4772)).
+- Fixed bug preventing the use of custom report templates ([#4800](https://github.com/dependency-check/DependencyCheck/pull/4800)).
 - Updated several dependencies including upgrades for dependencies with CVEs.
 - Several bug fixes made and suppression rules were added.
 
@@ -705,8 +705,8 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Changed
 
-- The maven plugin now includes pnpm and yarn lock files in the scan by default (#4753).
-- If a suppression rule is no longer used a log entry will be written (#4685).
+- The maven plugin now includes pnpm and yarn lock files in the scan by default ([#4753](https://github.com/dependency-check/DependencyCheck/pull/4753)).
+- If a suppression rule is no longer used a log entry will be written ([#4685](https://github.com/dependency-check/DependencyCheck/pull/4685)).
 - Several bug fixes made and suppression rules added.
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/47?closed=1).
@@ -734,7 +734,7 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Changed
 
-- Update to `jackson-databind` (see #4285).
+- Update to `jackson-databind` (see [#4285](https://github.com/dependency-check/DependencyCheck/pull/4285)).
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/43?closed=1).
 
@@ -742,7 +742,7 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Changed
 
-- Update to `jackson-databind` (see #4285).
+- Update to `jackson-databind` (see [#4285](https://github.com/dependency-check/DependencyCheck/pull/4285)).
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/42?closed=1).
 
@@ -769,7 +769,7 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 - **Breaking:** The H2 database version has been upgraded.
   - if you use the `dataDirectory` option you will need to run a purge after upgrading.
 - **Breaking:** Upgraded to dotnet core 6.0. If analyzing dotnet assemblies the system will need to have the dotnet core 6.0.x runtime available.
-- The Sarif report format has been fixed and can now be imported into GitHub if desired (See #3993).
+- The Sarif report format has been fixed and can now be imported into GitHub if desired (See [#3993](https://github.com/dependency-check/DependencyCheck/pull/3993)).
 - Introduced IssueOps for False Positive reports to assist the team in evaluating FP reports.
   - [Create New FP Report Issue](https://github.com/dependency-check/DependencyCheck/issues/new?assignees=&labels=FP+Report&template=false-positive-report.yml&title=%5BFP%5D%3A+).
 - When analyzing Java projects ODC now includes data from the developers section. 
@@ -782,9 +782,9 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Changed
 
-- Performance improvements for some Maven projects (see #3923 and #3931).
-- Fixed bug in npm version handling introduced in 6.5.2 (see #3956).
-- Improved the node package analyzer to correctly report the origin of a dependency (see #3970).
+- Performance improvements for some Maven projects (see [#3923](https://github.com/dependency-check/DependencyCheck/pull/3923) and [#3931](https://github.com/dependency-check/DependencyCheck/pull/3931)).
+- Fixed bug in npm version handling introduced in 6.5.2 (see [#3956](https://github.com/dependency-check/DependencyCheck/pull/3956)).
+- Improved the node package analyzer to correctly report the origin of a dependency (see [#3970](https://github.com/dependency-check/DependencyCheck/pull/3970)).
 - General code maintenance and false positive reductions.
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/39?closed=1).
@@ -793,9 +793,9 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Changed
 
-- Fixed false positives around log4j-api and Log4j-web (#3910 & #3937).
-- Bug fix when processing NPM lock files (#3893).
-- Added missing `pnpm` argmument to the CLI (#3916).
+- Fixed false positives around log4j-api and Log4j-web ([#3910](https://github.com/dependency-check/DependencyCheck/pull/3910) & [#3937](https://github.com/dependency-check/DependencyCheck/pull/3937)).
+- Bug fix when processing NPM lock files ([#3893](https://github.com/dependency-check/DependencyCheck/pull/3893)).
+- Added missing `pnpm` argmument to the CLI ([#3916](https://github.com/dependency-check/DependencyCheck/pull/3916)).
 - General code maintenance and false positive reductions.
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/38?closed=1).
@@ -804,8 +804,8 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Changed
 
-- Updated the dependency-check-maven plugin to correctly support SNAPSHOT version when a classifier is specified (#3787).
-- Improved the analysis of Swift package manager (package.resolved - see #3813).
+- Updated the dependency-check-maven plugin to correctly support SNAPSHOT version when a classifier is specified ([#3787](https://github.com/dependency-check/DependencyCheck/pull/3787)).
+- Improved the analysis of Swift package manager (package.resolved - see [#3813](https://github.com/dependency-check/DependencyCheck/pull/3813)).
 - General code maintenance and false positive reductions.
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/37?closed=1).
@@ -817,8 +817,8 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 - Updated build configuration to create [reproducible builds](https://reproducible-builds.org/).
 - Updated automated release process to work with branch protection.
 - Resolved several false positives in the Java ecosystem.
-- Enabled the Swift Resolved analyzer per #3735
-- Improved iOS support per #3168 and #3765
+- Enabled the Swift Resolved analyzer per [#3735](https://github.com/dependency-check/DependencyCheck/pull/3735)
+- Improved iOS support per [#3168](https://github.com/dependency-check/DependencyCheck/pull/3168) and [#3765](https://github.com/dependency-check/DependencyCheck/pull/3765)
 - Added the a new pnpm Analyzer
 - Fixed issue with some npm and yarn analysis failing due to large audit output
 
@@ -903,8 +903,8 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Fixed
 
-- Resolved issue with Sarif report (#3243)
-- Resolved issue with Ruby Bundle Audit (#3256)
+- Resolved issue with Sarif report ([#3243](https://github.com/dependency-check/DependencyCheck/pull/3243))
+- Resolved issue with Ruby Bundle Audit ([#3256](https://github.com/dependency-check/DependencyCheck/pull/3256))
 - Several minor bug fixes and updates to reduce false positives
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/26?closed=1).
@@ -913,7 +913,7 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Fixed
 
-- Fixed a second NPE introduced in 6.1.3 (see #3246)
+- Fixed a second NPE introduced in 6.1.3 (see [#3246](https://github.com/dependency-check/DependencyCheck/pull/3246))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/25?closed=1).
 
@@ -921,7 +921,7 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Changed
 
-- Fixed an NPE introduced in 6.1.3 (see #3212)
+- Fixed an NPE introduced in 6.1.3 (see [#3212](https://github.com/dependency-check/DependencyCheck/pull/3212))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/24?closed=1).
 
@@ -929,8 +929,8 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Changed
 
-- Modified the new CPE matching strategy to be more performant (#3207)
-- Upgraded a vulnerable dependency (velocity-engine-core/CVE-2020-13936) (#3205)
+- Modified the new CPE matching strategy to be more performant ([#3207](https://github.com/dependency-check/DependencyCheck/pull/3207))
+- Upgraded a vulnerable dependency (velocity-engine-core/CVE-2020-13936) ([#3205](https://github.com/dependency-check/DependencyCheck/pull/3205))
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/23?closed=1).
 
@@ -969,7 +969,7 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Changed
 
-- Added missing command line arguments per #3028 and #3035.
+- Added missing command line arguments per [#3028](https://github.com/dependency-check/DependencyCheck/pull/3028) and [#3035](https://github.com/dependency-check/DependencyCheck/pull/3035).
 - False positive reduction and minor bug fixes.
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/19?closed=1).
@@ -986,20 +986,20 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 ### Changed
 
-- Added a bash command completion script (see #2916); to add completion to your shell
+- Added a bash command completion script (see [#2916](https://github.com/dependency-check/DependencyCheck/pull/2916)); to add completion to your shell
   `completion-for-dependency-check.sh` can be found in the bin directory of the CLI:
 
    ```bash
    $ source completion-for-dependency-check.sh
    ```
 
-- An experimental PIP File Analyzer was added (see #2877).
-- Analysis of Node JS produced several false positives (see #2796); the analysis has
+- An experimental PIP File Analyzer was added (see [#2877](https://github.com/dependency-check/DependencyCheck/pull/2877)).
+- Analysis of Node JS produced several false positives (see [#2796](https://github.com/dependency-check/DependencyCheck/pull/2796)); the analysis has
   been updated to reduce the number of false positives.
   - If analyzing Node JS projects it is highly recommended to disable the Node JS Analyzer
     and solely rely on the Node Audit Analyzer. There are plans to rework Node JS analysis
     in a future release.
-- Support for external Oracle databases has been add for the 6.x releases (see #2899)
+- Support for external Oracle databases has been add for the 6.x releases (see [#2899](https://github.com/dependency-check/DependencyCheck/pull/2899))
 - Resolved several reported false positives.
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/17?closed=1).
@@ -1010,8 +1010,8 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 
 - The project is migrating from hosting the release archives on Bintray and moving them to Github under the assets for each [release](https://github.com/dependency-check/DependencyCheck/releases)
   - **Please update any automation you have to point to the new location.**
-- Npm Audit Analyzer now correctly skips dev dependencies (`--nodeAuditSkipDevDependencies`); see #2482.
-- GoLang Analyzer now scans transitive dependencies; see #2680.
+- Npm Audit Analyzer now correctly skips dev dependencies (`--nodeAuditSkipDevDependencies`); see [#2482](https://github.com/dependency-check/DependencyCheck/pull/2482).
+- GoLang Analyzer now scans transitive dependencies; see [#2680](https://github.com/dependency-check/DependencyCheck/pull/2680).
 - Several bug fixes found in 6.0.1.
 
 See the full listing of [changes](https://github.com/dependency-check/DependencyCheck/milestone/16?closed=1).
@@ -1034,7 +1034,7 @@ See the full listing of [changes](https://github.com/dependency-check/Dependency
 - Updated database schema; this is a *breaking change* and anyone using an external database or those whom
   specify the data directory will need recreate the database (including users of the docker image). The schema
   changes were made to:
-  - Improve the CVSS data, when available, per #2547
+  - Improve the CVSS data, when available, per [#2547](https://github.com/dependency-check/DependencyCheck/pull/2547)
   - Improve the way that ecosystems are determined
   - Improve the update performance of external databases
 - Users with an **external Oracle** database will not be able to upgrade as https://github.com/dependency-check/DependencyCheck/issues/2755
@@ -1065,10 +1065,10 @@ See the full listing of [changes](https://github.com/jeremylong/DependencyCheck/
 
 ### Changed
 
-- Updated the JSON report to include a new field for unscored vulnerabilities (see #2392).
-- Updated the XML report to include a new attribute to flag unscored vulnerabilities (see #2392)
+- Updated the JSON report to include a new field for unscored vulnerabilities (see [#2392](https://github.com/dependency-check/DependencyCheck/pull/2392)).
+- Updated the XML report to include a new attribute to flag unscored vulnerabilities (see [#2392](https://github.com/dependency-check/DependencyCheck/pull/2392))
   - see https://github.com/jeremylong/DependencyCheck/blob/main/core/src/main/resources/schema/dependency-check.2.3.xsd
-- Added an experimental analyzer that will lookup Node libraries in the NVD data feeds (see #1249)
+- Added an experimental analyzer that will lookup Node libraries in the NVD data feeds (see [#1249](https://github.com/dependency-check/DependencyCheck/pull/1249))
   - `NpmCPEAnalyzer`, experimental analyzers must be enabled, controlled via property `analyzer.npm.cpe.enabled` which will be exposed as a configuration option in the next release.
 
 See the full listing of [changes](https://github.com/jeremylong/DependencyCheck/milestone/11?closed=1).
@@ -1350,11 +1350,11 @@ See the full listing of [resolved issues](https://github.com/jeremylong/Dependen
 
 ### Fixed
 
-- In some cases when using the Maven or Gradle plugins the GAV coordinates were not being added as an Identifier causing suppression rules to fail; this has been resolved (#1298)
-- Documentation Update (SCM links in the maven site were broken) (#1297)
-- False positive reduction (#1290)
-- Enhanced logging output for TLS failures to better assist with debugging (#1269)
-- Resolved a Null Pointer Exception (#1296)
+- In some cases when using the Maven or Gradle plugins the GAV coordinates were not being added as an Identifier causing suppression rules to fail; this has been resolved ([#1298](https://github.com/dependency-check/DependencyCheck/pull/1298))
+- Documentation Update (SCM links in the maven site were broken) ([#1297](https://github.com/dependency-check/DependencyCheck/pull/1297))
+- False positive reduction ([#1290](https://github.com/dependency-check/DependencyCheck/pull/1290))
+- Enhanced logging output for TLS failures to better assist with debugging ([#1269](https://github.com/dependency-check/DependencyCheck/pull/1269))
+- Resolved a Null Pointer Exception ([#1296](https://github.com/dependency-check/DependencyCheck/pull/1296))
 
 ## [Version 3.2.0](https://github.com/jeremylong/DependencyCheck/releases/tag/v3.2.0) (2018-05-21)
 

--- a/list-changes.sh
+++ b/list-changes.sh
@@ -1,3 +1,5 @@
 #!/bin/bash -e
 ##https://blogs.sap.com/2018/06/22/generating-release-notes-from-git-commit-messages-using-basic-shell-commands-gitgrep/
-git --no-pager log $(git describe --tags --abbrev=0)..HEAD --pretty=format:" - %s" | grep -v ' - Bump'
+git --no-pager log $(git describe --tags --abbrev=0)..HEAD --pretty=format:" - %s" \
+  | grep -v ' - Bump' \
+  | sed -E 's/#([0-9]+)/[#\1](https:\/\/github.com\/dependency-check\/DependencyCheck\/pull\/\1)/g'


### PR DESCRIPTION
## Description of Change

Updates all issue/pull numbers in changelog to make them clickable. Uses the `pull` link by default; GitHub will redirect to an issue if it is an issue.

Updates script used for generating changelog to help generate the right markdown from commits in future.

## Related issues

- fixes #7808

## Have test cases been added to cover the new functionality?

N/A