### PR TITLE
test: Fix AssemblyAnalyzerTest to be robust to Grok availability

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
@@ -427,7 +427,9 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
      */
     @Override
     public void closeAnalyzer() throws Exception {
-        FileUtils.delete(grokAssembly.getParentFile());
+        if (grokAssembly != null) {
+            FileUtils.delete(grokAssembly.getParentFile());
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description of Change

Currently `AssemblyAnalyzerTest` fails on teardown if you don't have grok available, but it does not appear to be required for the test itself.

```
[ERROR] org.owasp.dependencycheck.analyzer.AssemblyAnalyzerTest.testLog4Net -- Time elapsed: 0.089 s <<< ERROR!
org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException: java.lang.NullPointerException: Cannot invoke "java.io.File.getParentFile()" because "this.grokAssembly" is null
	at org.owasp.dependencycheck.analyzer.AssemblyAnalyzerTest.tearDown(AssemblyAnalyzerTest.java:184)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

It's also nullable during run:

https://github.com/dependency-check/DependencyCheck/blob/2bdd183050645d0963d8d7cd450e37aadd7fd018/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java#L134-L137

This prevents a basic `mvn package` run to succeed.

## Related issues

N/A

## Have test cases been added to cover the new functionality?

yes