### PR TITLE
build: Build amd64 and arm64 multi-platform Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,6 +141,18 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: archive-snapshot
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build Docker Image
         run: ./build-docker.sh
       - name: build scan target

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -64,7 +64,19 @@ jobs:
         with:
           sarif_file: core/target/spotbugsSarif.json
           category: spotbugs-core
-          
+      - name: Archive Snapshot
+        id: archive-snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: archive-snapshot
+          retention-days: 1
+          path: |
+            **/target/*.asc
+            **/target/*.jar
+            **/target/*.pom
+            ant/target/*.zip
+            cli/target/*.zip
+
   maven:
     name: Regression Test Maven Plugin
     permissions: 
@@ -144,3 +156,44 @@ jobs:
         with:
           sarif_file: target/checkstyle-result.sarif
           category: checkstyle
+
+  docker:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+
+    name: Build and Test Docker
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Check Maven Cache
+        id: maven-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Download release build
+        uses: actions/download-artifact@v5
+        with:
+          name: archive-snapshot
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker Image
+        run: ./build-docker.sh
+      - name: build scan target
+        run: mvn -V -s settings.xml package -DskipTests=true --no-transfer-progress --batch-mode
+      - name: Test Docker Image
+        run: ./test-docker.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,18 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: archive-release
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build Docker Image
         run: ./build-docker.sh
       - name: build scan target

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN apk update                                                                  
     apk del .build-deps
 
 ### remove any suid sgid - we don't need them
-RUN find / -perm +6000 -type f -exec chmod a-s {} \;
+RUN find / -path /proc -prune -perm +6000 -type f -exec chmod a-s {} \;
 USER ${UID}
 
 VOLUME ["/src", "/report"]

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -8,10 +8,11 @@ VERSION=$(mvn -q \
 
 FILE=./cli/target/dependency-check-$VERSION-release.zip
 if [ -f "$FILE" ]; then
-    docker build . --build-arg VERSION=$VERSION -t owasp/dependency-check:$VERSION
-    if [[ ! $VERSION = *"SNAPSHOT"* ]]; then
-        docker tag owasp/dependency-check:$VERSION owasp/dependency-check:latest
-    fi
+    extra_tag_args="$([[ ! $VERSION = *"SNAPSHOT"* ]] && echo "--tag owasp/dependency-check:latest" || echo "")"
+
+    docker buildx build --pull --load --platform linux/amd64,linux/arm64 . \
+      --build-arg VERSION=$VERSION \
+      --tag owasp/dependency-check:$VERSION ${extra_tag_args}
 else 
     echo "$FILE does not exist - run 'mvn package' first"
     exit 1

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -euo pipefail
 
 VERSION=$(mvn -q \
     -Dexec.executable="echo" \
@@ -7,13 +8,20 @@ VERSION=$(mvn -q \
     org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
 
 FILE=./cli/target/dependency-check-$VERSION-release.zip
-if [ -f "$FILE" ]; then
-    extra_tag_args="$([[ ! $VERSION = *"SNAPSHOT"* ]] && echo "--tag owasp/dependency-check:latest" || echo "")"
-
-    docker buildx build --pull --load --platform linux/amd64,linux/arm64 . \
-      --build-arg VERSION=$VERSION \
-      --tag owasp/dependency-check:$VERSION ${extra_tag_args}
-else 
+if [ ! -f "$FILE" ]; then
     echo "$FILE does not exist - run 'mvn package' first"
     exit 1
 fi
+
+if ! docker info -f '{{ .DriverStatus }}' | grep "driver-type io.containerd.snapshotter" >/dev/null; then
+    echo "Docker Engine is not running with the containerd snapshotter - this is currently needed to build and test ODC multi-platform images using docker buildx."
+    echo "If using Docker Desktop, enable \"Use containerd for pulling and storing images\" per https://docs.docker.com/desktop/settings-and-maintenance/settings/#general"
+    echo "For more technical information on Docker Engine, see https://docs.docker.com/engine/storage/containerd/"
+    exit 1
+fi
+
+extra_tag_args="$([[ ! $VERSION = *"SNAPSHOT"* ]] && echo "--tag owasp/dependency-check:latest" || echo "")"
+
+docker buildx build --pull --load --platform linux/amd64,linux/arm64 . \
+    --build-arg VERSION=$VERSION \
+    --tag owasp/dependency-check:$VERSION ${extra_tag_args}

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -5,7 +5,7 @@ VERSION=$(mvn -q \
     -Dexec.executable="echo" \
     -Dexec.args='${project.version}' \
     --non-recursive \
-    org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+    org.codehaus.mojo:exec-maven-plugin:3.5.1:exec)
 
 FILE=./cli/target/dependency-check-$VERSION-release.zip
 if [ ! -f "$FILE" ]; then

--- a/publish-docker.sh
+++ b/publish-docker.sh
@@ -4,7 +4,7 @@ VERSION=$(mvn -q \
     -Dexec.executable="echo" \
     -Dexec.args='${project.version}' \
     --non-recursive \
-    org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+    org.codehaus.mojo:exec-maven-plugin:3.5.1:exec)
 
 if [[ $VERSION = *"SNAPSHOT"* ]]; then
     echo "Do not publish a snapshot version of dependency-check"

--- a/publish-docker.sh
+++ b/publish-docker.sh
@@ -7,19 +7,12 @@ VERSION=$(mvn -q \
     org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
 
 if [[ $VERSION = *"SNAPSHOT"* ]]; then
-  echo "Do not publish a snapshot version of dependency-check"
-  exit 1
-fi
-docker inspect --type=image owasp/dependency-check:$VERSION  > /dev/null 2>&1
-if [[ "$?" -ne 0 ]] ; then
-  echo "docker image owasp/dependency-check:$VERSION does not exist - run build_docker.sh first"
-  exit 1
-fi
-docker inspect --type=image owasp/dependency-check:latest  > /dev/null 2>&1
-if [[ "$?" -ne 0 ]] ; then
-  echo "docker image owasp/dependency-check:latest does not exist - run build_docker.sh first"
-  exit 1
+    echo "Do not publish a snapshot version of dependency-check"
+    exit 1
 fi
 
-docker push owasp/dependency-check:$VERSION 
-docker push owasp/dependency-check:latest
+# Build args should match ./build-docker.sh so the builder cache is re-used
+docker buildx build --push --platform linux/amd64,linux/arm64 . \
+    --build-arg VERSION=$VERSION \
+    --tag owasp/dependency-check:$VERSION \
+    --tag owasp/dependency-check:latest

--- a/shell-docker.sh
+++ b/shell-docker.sh
@@ -4,7 +4,7 @@ VERSION=$(mvn -q \
     -Dexec.executable="echo" \
     -Dexec.args='${project.version}' \
     --non-recursive \
-    org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+    org.codehaus.mojo:exec-maven-plugin:3.5.1:exec)
 
 SCAN_TARGET="./cli/target/release/lib"
 

--- a/test-docker.sh
+++ b/test-docker.sh
@@ -4,13 +4,13 @@ VERSION=$(mvn -q \
     -Dexec.executable="echo" \
     -Dexec.args='${project.version}' \
     --non-recursive \
-    org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+    org.codehaus.mojo:exec-maven-plugin:3.5.1:exec)
 
 SCAN_TARGET="./cli/target/release/lib"
 
 if [ ! -d "$SCAN_TARGET" ]; then 
-  echo "Scan target does not exist: $SCAN_TARGET"
-  exit 1
+    echo "Scan target does not exist: $SCAN_TARGET"
+    exit 1
 fi
 
 if [ -f "$HOME/OWASP-Dependency-Check/reports/dependency-check-report.json" ]; then
@@ -73,8 +73,8 @@ cd -
 echo ""
 grep -oF "dependency-check-core-$VERSION.jar" $HOME/OWASP-Dependency-Check/reports/dependency-check-report.json  > /dev/null 2>&1
 if [[ "$?" -eq 0 ]] ; then
-  echo "SUCCESS - dependency-check docker test passed"
+    echo "SUCCESS - dependency-check docker test passed"
 else
-  echo "FAILED - dependency-check docker test failed"
-  exit 1
+    echo "FAILED - dependency-check docker test failed"
+    exit 1
 fi


### PR DESCRIPTION
## Description of Change

Uses docker buildx to build and push the docker image for `linux/arm64` as well as existing `linux/amd64`

- No changes to docker workflow secrets should be needed
- Implementation builds the image for both platforms, and then loads into docker for the native platform (`--load`)
- Adds testing of the docker image to the PR workflow so contributors can also tweak the docker build more safely
- Currently only runs docker tests for the "native" image for the platform, i.e `linux/amd64` on default runners.
  - If we want to specifically test the arm64 image, we could split to test on arm runners and/or force a test of the emulated images. However, it's a bit clunky with the current scripting based docker build (as opposed to using the docker actions that make this easier) - especially if you want to build once, and then test/push the exact same built image, rather than rebuilding.
- Since my local platform is arm64-native, I have run `test-docker.sh` locally on the arm64 image though

Sample images built and pushed using this approach: https://hub.docker.com/repository/docker/chadwilson/dependency-check/tags

See sample actions run at https://github.com/dependency-check/DependencyCheck/actions/runs/17936406550/job/51003624010?pr=7952

## Related issues

- fixes #6420 

## Have test cases been added to cover the new functionality?

yes