### PR TITLE
build: replace deprecated jlink argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.25.1-alpine AS go
 
 FROM azul/zulu-openjdk-alpine:21 AS jlink
 
-RUN "$JAVA_HOME/bin/jlink" --compress=2 --module-path /opt/java/openjdk/jmods --add-modules java.base,java.compiler,java.datatransfer,jdk.crypto.ec,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.scripting,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.unsupported --output /jlinked
+RUN "$JAVA_HOME/bin/jlink" --compress=zip-6 --module-path /opt/java/openjdk/jmods --add-modules java.base,java.compiler,java.datatransfer,jdk.crypto.ec,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.scripting,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.unsupported --output /jlinked
 
 FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine3.22
 


### PR DESCRIPTION
## Description of Change

`--compress=2` is deprecated with JDK 21. It is equivalent to `zip-6` (the default).

https://github.com/openjdk/jdk/blob/61c5245bf7d6626b0c816612adcb0d94d6863644/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties#L316

Removes docker build warning `Warning: The 2 argument for --compress is deprecated and may be removed in a future release`

## Related issues

N/A

## Have test cases been added to cover the new functionality?

yes