### PR TITLE
feat: add new suppression xsd allowing grouping of suppressions

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionHandler.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionHandler.java
@@ -20,6 +20,7 @@ package org.owasp.dependencycheck.xml.suppression;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.owasp.dependencycheck.exception.ParseException;
 import org.owasp.dependencycheck.utils.DateUtil;
@@ -30,7 +31,8 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 /**
- * A handler to load suppression rules.
+ * A handler to load suppression rules. In the input xml a suppression rule can be part of a {@code suppressionGroup}. In that
+ * case the attributes set on group element will act as default values for child suppressions.
  *
  * @author Jeremy Long
  */
@@ -42,6 +44,10 @@ public class SuppressionHandler extends DefaultHandler {
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(SuppressionHandler.class);
 
+    /**
+     * The suppressionGroup node, indicates the start of a new suppressionGroup.
+     */
+    public static final String SUPPRESSION_GROUP = "suppressionGroup";
     /**
      * The suppress node, indicates the start of a new rule.
      */
@@ -105,6 +111,10 @@ public class SuppressionHandler extends DefaultHandler {
      */
     private StringBuilder currentText;
 
+    private Boolean groupBase = null;
+    private Calendar groupUntil = null;
+
+
     /**
      * Get the value of suppressionRules.
      *
@@ -127,22 +137,40 @@ public class SuppressionHandler extends DefaultHandler {
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
         currentAttributes = attributes;
         currentText = new StringBuilder();
+
+        if (SUPPRESSION_GROUP.equals(qName)) {
+            groupBase = attributes.getValue("base") != null ? Boolean.parseBoolean(attributes.getValue("base")) : null;
+            groupUntil = parseUntilAttribute(attributes).orElse(null);
+        }
+
         if (SUPPRESS.equals(qName)) {
+            Boolean base = attributes.getValue("base") != null ? Boolean.parseBoolean(attributes.getValue("base")) : null;
+            Calendar until = parseUntilAttribute(attributes).orElse(null);
+
             rule = new SuppressionRule();
-            final String base = currentAttributes.getValue("base");
-            if (base != null) {
-                rule.setBase(Boolean.parseBoolean(base));
-            } else {
-                rule.setBase(false);
+            //If suppression doesn't have attribute set, use that of the group (if in group).
+            rule.setBase(base != null ? base : groupBase);
+            rule.setUntil(until != null ? until : groupUntil);
+        }
+    }
+
+    /**
+     * Read the provided {@code attributes} for attribute {@code until}. Return {@link Calendar} object if attribute is
+     * present and can be parsed.
+     *
+     * @return empty if attribute {@code until} is not present.
+     * @throws SAXException if attribute {@code until} is present but value can not be parsed to  {@link Calendar}.
+     */
+    private static Optional<Calendar> parseUntilAttribute(Attributes attributes) throws SAXException {
+        String untilStr = attributes.getValue("until");
+        if (untilStr != null) {
+            try {
+                return Optional.of(DateUtil.parseXmlDate(untilStr));
+            } catch (ParseException ex) {
+                throw new SAXException("Unable to parse group 'until' date: " + untilStr, ex);
             }
-            final String until = currentAttributes.getValue("until");
-            if (until != null) {
-                try {
-                    rule.setUntil(DateUtil.parseXmlDate(until));
-                } catch (ParseException ex) {
-                    throw new SAXException("Unable to parse until date in suppression file: " + until, ex);
-                }
-            }
+        } else {
+            return Optional.empty();
         }
     }
 
@@ -165,6 +193,10 @@ public class SuppressionHandler extends DefaultHandler {
                         suppressionRules.add(rule);
                     }
                     rule = null;
+                    break;
+                case SUPPRESSION_GROUP:
+                    groupBase = null;
+                    groupUntil = null;
                     break;
                 case FILE_PATH:
                     rule.setFilePath(processPropertyType());
@@ -191,7 +223,10 @@ public class SuppressionHandler extends DefaultHandler {
                     rule.addVulnerabilityName(processPropertyType());
                     break;
                 case NOTES:
-                    rule.setNotes(currentText.toString().trim());
+                    // Check that the notes element is from a suppression and not a suppressionGroup.
+                    if(rule != null) {
+                        rule.setNotes(currentText.toString().trim());
+                    }
                     break;
                 case CVSS_BELOW:
                     final Double cvss = Double.valueOf(currentText.toString().trim());

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionHandler.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionHandler.java
@@ -159,7 +159,7 @@ public class SuppressionHandler extends DefaultHandler {
      * present and can be parsed.
      *
      * @return empty if attribute {@code until} is not present.
-     * @throws SAXException if attribute {@code until} is present but value can not be parsed to  {@link Calendar}.
+     * @throws SAXException if attribute {@code until} is present but value can not be parsed as {@link Calendar}.
      */
     private static Optional<Calendar> parseUntilAttribute(Attributes attributes) throws SAXException {
         String untilStr = attributes.getValue("until");
@@ -167,7 +167,7 @@ public class SuppressionHandler extends DefaultHandler {
             try {
                 return Optional.of(DateUtil.parseXmlDate(untilStr));
             } catch (ParseException ex) {
-                throw new SAXException("Unable to parse group 'until' date: " + untilStr, ex);
+                throw new SAXException("Unable to parse attribute 'until': " + untilStr, ex);
             }
         } else {
             return Optional.empty();

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionParser.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.util.Calendar;
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.xml.parsers.ParserConfigurationException;
@@ -54,6 +55,11 @@ public class SuppressionParser {
      * The logger.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(SuppressionParser.class);
+
+    /**
+     * The suppression schema file location for v 1.4.
+     */
+    public static final String SUPPRESSION_SCHEMA_1_4 = "schema/dependency-suppression.1.4.xsd";
     /**
      * The suppression schema file location for v 1.3.
      */
@@ -101,6 +107,7 @@ public class SuppressionParser {
     public List<SuppressionRule> parseSuppressionRules(InputStream inputStream)
             throws SuppressionParseException, SAXException {
         try (
+                InputStream schemaStream14 = FileUtils.getResourceAsStream(SUPPRESSION_SCHEMA_1_4);
                 InputStream schemaStream13 = FileUtils.getResourceAsStream(SUPPRESSION_SCHEMA_1_3);
                 InputStream schemaStream12 = FileUtils.getResourceAsStream(SUPPRESSION_SCHEMA_1_2);
                 InputStream schemaStream11 = FileUtils.getResourceAsStream(SUPPRESSION_SCHEMA_1_1);
@@ -112,7 +119,7 @@ public class SuppressionParser {
             final String charsetName = bom == null ? defaultEncoding : bom.getCharsetName();
 
             final SuppressionHandler handler = new SuppressionHandler();
-            final SAXParser saxParser = XmlUtils.buildSecureSaxParser(schemaStream13, schemaStream12, schemaStream11, schemaStream10);
+            final SAXParser saxParser = XmlUtils.buildSecureSaxParser(schemaStream14, schemaStream13, schemaStream12, schemaStream11, schemaStream10);
             final XMLReader xmlReader = saxParser.getXMLReader();
             xmlReader.setErrorHandler(new SuppressionErrorHandler());
             xmlReader.setContentHandler(handler);

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionParser.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionParser.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import java.util.Calendar;
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.xml.parsers.ParserConfigurationException;

--- a/core/src/main/resources/schema/dependency-suppression.1.4.xsd
+++ b/core/src/main/resources/schema/dependency-suppression.1.4.xsd
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema id="suppressions"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           targetNamespace="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+           xmlns:dc="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+
+    <xs:complexType name="regexStringType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="regex" use="optional" type="xs:boolean" default="false"/>
+                <xs:attribute name="caseSensitive" use="optional" type="xs:boolean" default="false"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:simpleType name="cvssScoreType">
+        <xs:restriction base="xs:decimal">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="10"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="cveType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="((\w+\-)?CVE\-\d\d\d\d\-\d+|\d+)"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="sha1Type">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-fA-F0-9]{40}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="suppressType">
+        <xs:sequence>
+            <xs:sequence minOccurs="0" maxOccurs="1">
+                <xs:element name="notes" type="xs:string"/>
+            </xs:sequence>
+
+            <xs:choice minOccurs="0" maxOccurs="1">
+                <xs:element name="filePath" type="dc:regexStringType"/>
+                <xs:element name="sha1" type="dc:sha1Type"/>
+                <xs:element name="gav" type="dc:regexStringType"/>
+                <xs:element name="packageUrl" type="dc:regexStringType"/>
+            </xs:choice>
+
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:element name="cpe" type="dc:regexStringType"/>
+                <xs:element name="cve" type="dc:cveType"/>
+                <xs:element name="vulnerabilityName" type="dc:regexStringType"/>
+                <xs:element name="cwe" type="xs:positiveInteger"/>
+                <xs:element name="cvssBelow" type="dc:cvssScoreType"/>
+            </xs:choice>
+        </xs:sequence>
+
+        <xs:attributeGroup ref="dc:suppressAttrs"/>
+    </xs:complexType>
+
+    <xs:complexType name="suppressionGroupType">
+        <xs:sequence>
+            <xs:sequence minOccurs="0" maxOccurs="1">
+                <xs:element name="notes" type="xs:string"/>
+            </xs:sequence>
+            <xs:element name="suppress" type="dc:suppressType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="optional"/>
+        <xs:attributeGroup ref="dc:suppressAttrs">
+            <xs:annotation>
+                <xs:documentation>
+                    Attributes on a group element act as defaults for all child suppression elements.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attributeGroup>
+    </xs:complexType>
+
+    <xs:attributeGroup name="suppressAttrs">
+        <xs:attribute name="base"  type="xs:boolean" default="false"/>
+        <xs:attribute name="until" type="xs:date">
+            <xs:annotation>
+                <xs:documentation>
+                    When specified the suppression will only be active when the specified date is still in the future. On and after the 'until' date the suppression will no longer be active.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+
+    <xs:element name="suppressions">
+        <xs:complexType>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="suppress" type="dc:suppressType"/>
+                <xs:element name="suppressionGroup" type="dc:suppressionGroupType"/>
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/core/src/main/resources/schema/dependency-suppression.1.4.xsd
+++ b/core/src/main/resources/schema/dependency-suppression.1.4.xsd
@@ -51,8 +51,7 @@
                 <xs:element name="cvssBelow" type="dc:cvssScoreType"/>
             </xs:choice>
         </xs:sequence>
-
-        <xs:attributeGroup ref="dc:suppressAttrs"/>
+        <xs:attribute name="until" type="xs:date"/>
     </xs:complexType>
 
     <xs:complexType name="suppressionGroupType">
@@ -60,33 +59,35 @@
             <xs:sequence minOccurs="0" maxOccurs="1">
                 <xs:element name="notes" type="xs:string"/>
             </xs:sequence>
-            <xs:element name="suppress" type="dc:suppressType" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element name="suppress" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="dc:suppressType">
+                            <!-- Suppression has no default value for "base" when part of a group. Group value is used as default. -->
+                            <xs:attribute name="base" type="xs:boolean"/>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
         </xs:sequence>
-        <xs:attribute name="name" type="xs:string" use="optional"/>
-        <xs:attributeGroup ref="dc:suppressAttrs">
-            <xs:annotation>
-                <xs:documentation>
-                    Attributes on a group element act as defaults for all child suppression elements.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attributeGroup>
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="until" type="xs:date"/>
+        <xs:attribute name="base" type="xs:boolean" default="false"/>
     </xs:complexType>
-
-    <xs:attributeGroup name="suppressAttrs">
-        <xs:attribute name="base"  type="xs:boolean" default="false"/>
-        <xs:attribute name="until" type="xs:date">
-            <xs:annotation>
-                <xs:documentation>
-                    When specified the suppression will only be active when the specified date is still in the future. On and after the 'until' date the suppression will no longer be active.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
 
     <xs:element name="suppressions">
         <xs:complexType>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                <xs:element name="suppress" type="dc:suppressType"/>
+                <xs:element name="suppress" >
+                    <xs:complexType>
+                        <xs:complexContent>
+                            <xs:extension base="dc:suppressType">
+                                <!-- Default values present in standalone suppression -->
+                                <xs:attribute use="optional" name="base" default="false"/>
+                            </xs:extension>
+                        </xs:complexContent>
+                    </xs:complexType>
+                </xs:element>
                 <xs:element name="suppressionGroup" type="dc:suppressionGroupType"/>
             </xs:choice>
         </xs:complexType>

--- a/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionParserTest.java
@@ -21,9 +21,13 @@ import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 
 import java.io.File;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test of the suppression parser.
@@ -83,4 +87,78 @@ class SuppressionParserTest extends BaseTest {
         List<SuppressionRule> result = instance.parseSuppressionRules(file);
         assertEquals(4, result.size());
     }
+
+    /**
+     * Test of parseSuppressionRules method, of class SuppressionParser for the
+     * v1.4 suppression XML Schema.
+     */
+    @Test
+    void testParseSuppressionRulesV1dot4() throws SuppressionParseException {
+        File file = BaseTest.getResourceAsFile(this, "suppressions_1_4.xml");
+        SuppressionParser instance = new SuppressionParser();
+        List<SuppressionRule> suppressionRules = instance.parseSuppressionRules(file);
+
+        assertEquals(7, suppressionRules.size());
+    }
+
+    /**
+     * Any content that follows Schema 1.3 is also valid content according to Schema 1.4
+     */
+    @Test
+    void testParseSuppressionRulesV1dot4BackwardsCompability() throws SuppressionParseException {
+        // 'suppressions_1_4_no_groups.xml' has the same content as 'suppressions_1_3.xml'. But follows schema 1.4
+        File file = BaseTest.getResourceAsFile(this, "suppressions_1_4_no_groups.xml");
+        SuppressionParser instance = new SuppressionParser();
+        List<SuppressionRule> suppressionRules = instance.parseSuppressionRules(file);
+
+        assertEquals(4, suppressionRules.size());
+    }
+
+    /**
+     * If a suppression is present in a group and does not have attributes set, then it the ones from the group are used
+     * as default values.
+     */
+    @Test
+    void testParseSuppressionV1dot4Inherits() throws SuppressionParseException {
+        File file = BaseTest.getResourceAsFile(this, "suppressions_1_4.xml");
+        SuppressionParser instance = new SuppressionParser();
+        List<SuppressionRule> suppressionRules = instance.parseSuppressionRules(file);
+
+        // CVE-2013-1338 in test xml has no attributes and should inherit the ones set on group level.
+        List<SuppressionRule> filteredSuppressions = suppressionRules.stream().
+                filter(s -> s.getCve().contains("CVE-2013-1338"))
+                .collect(Collectors.toList());
+        assertEquals(1, filteredSuppressions.size());
+        SuppressionRule rule = filteredSuppressions.get(0);
+
+        Instant expectedTime = LocalDate.of(2026, 1, 1)
+                .atStartOfDay(ZoneOffset.UTC)
+                .toInstant();
+        assertEquals(expectedTime, rule.getUntil().toInstant());
+        assertTrue(rule.isBase());
+    }
+
+    /**
+     * If a suppression has attributes set, then it should override those of the suppressionGroup it is present in.
+     */
+    @Test
+    void testParseSuppressionV1dot4AttributeOverrides() throws SuppressionParseException {
+        File file = BaseTest.getResourceAsFile(this, "suppressions_1_4.xml");
+        SuppressionParser instance = new SuppressionParser();
+        List<SuppressionRule> suppressionRules = instance.parseSuppressionRules(file);
+
+        // CVE-2013-1339 in test xml has attribute {code (until="2027-01-01Z")} set and is present in  suppressionGroup.
+        List<SuppressionRule> filteredSuppressions = suppressionRules.stream().
+                filter(s -> s.getCve().contains("CVE-2013-1339"))
+                .collect(Collectors.toList());
+        assertEquals(1, filteredSuppressions.size());
+        SuppressionRule rule = filteredSuppressions.get(0);
+
+        Instant expectedTime = LocalDate.of(2027, 1, 1)
+                .atStartOfDay(ZoneOffset.UTC)
+                .toInstant();
+        assertEquals(expectedTime, rule.getUntil().toInstant());
+        assertFalse(rule.isBase());
+    }
+
 }

--- a/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionParserTest.java
@@ -115,8 +115,8 @@ class SuppressionParserTest extends BaseTest {
     }
 
     /**
-     * If a suppression is present in a group and does not have attributes set, then it the ones from the group are used
-     * as default values.
+     * If a suppression is present in a group and does not have attributes set, then the ones from the group are used
+     * as defaults.
      */
     @Test
     void testParseSuppressionV1dot4Inherits() throws SuppressionParseException {
@@ -139,7 +139,7 @@ class SuppressionParserTest extends BaseTest {
     }
 
     /**
-     * If a suppression has attributes set, then it should override those of the suppressionGroup it is present in.
+     * If a suppression in a suppression group has attributes set, then those override those of the suppressionGroup.
      */
     @Test
     void testParseSuppressionV1dot4AttributeOverrides() throws SuppressionParseException {

--- a/core/src/test/resources/suppressions_1_4.xml
+++ b/core/src/test/resources/suppressions_1_4.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+
+    <!-- Suppressions can be provided individually as in earlier schemas -->
+    <suppress base="true">
+        <notes><![CDATA[
+        This suppresses any jboss:jboss cpe for any test.jar in any directory.
+        ]]></notes>
+        <filePath regex="true">.*\btest\.jar</filePath>
+        <cpe>cpe:/a:jboss:jboss</cpe>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[This suppresses a specific cve for any test.jar in any directory.]]></notes>
+        <filePath regex="true">.*\btest\.jar</filePath>
+        <cve>CVE-2013-1337</cve>
+    </suppress>
+
+    <suppress until="9999-03-25Z">
+        <notes><![CDATA[
+            This suppresses all CVE entries that have a score below CVSS 7.
+            But only if current date is not yet on or beyond 31 Dec 9999
+            (which is expected to be sufficiently far in the future to have this
+                rule still be active when the test-cases run)
+            ]]></notes>
+        <cvssBelow>7</cvssBelow>
+    </suppress>
+
+    <!-- suppression in the past won't be parsed -->
+    <suppress until="2014-01-01Z">
+        <notes><![CDATA[
+        This suppresses a specific cve for any dependency in any directory that has the specified sha1 checksum. If current date is not yet on or beyond 1 Jan 2014
+        ]]></notes>
+        <sha1>384FAA82E193D4E4B0546059CA09572654BC3970</sha1>
+        <cve>CVE-2013-1337</cve>
+    </suppress>
+
+    <!-- Suppression can be provided in groups -->
+    <suppressionGroup name="Temporary Suppressions" until="2026-01-01Z" base="true">
+        <!-- Suppression has no attributes set and should inherit those from the group -->
+        <notes>Temporary Suppressions to be reexamined later</notes>
+        <suppress>
+            <notes><![CDATA[This suppresses a specific cve for any dependency in any directory that has the specified sha1 checksum. If current date is not yet on or beyond 1 Jan 2014]]></notes>
+            <sha1>384FAA82E193D4E4B0546059CA09572654BC3970</sha1>
+            <cve>CVE-2013-1338</cve>
+        </suppress>
+        <!-- Suppression has attributes set which should override those provided in the group -->
+        <suppress until="2027-01-01Z" base="false">
+            <notes><![CDATA[This suppresses a specific cve for any dependency in any directory that has the specified sha1 checksum. If current date is not yet on or beyond 1 Jan 2014]]></notes>
+            <sha1>384FAA82E193D4E4B0546059CA09572654BC3970</sha1>
+            <cve>CVE-2013-1339</cve>
+        </suppress>
+
+    </suppressionGroup>
+
+    <suppressionGroup name="Permanent Suppressions" >
+        <suppress>
+            <notes><![CDATA[This suppresses cpe:/a:csv:csv:1.0 for some.jar in the "c:\path\to" directory.]]></notes>
+            <filePath>c:\path\to\some.jar</filePath>
+            <cpe>cpe:/a:csv:csv:1.0</cpe>
+        </suppress>
+        <suppress>
+            <notes><![CDATA[This suppresses a specific cve for any test.jar in any directory.]]></notes>
+            <filePath regex="true">.*\btest\.jar</filePath>
+            <cve>CVE-2013-1337</cve>
+        </suppress>
+    </suppressionGroup>
+
+</suppressions>

--- a/core/src/test/resources/suppressions_1_4.xml
+++ b/core/src/test/resources/suppressions_1_4.xml
@@ -3,7 +3,7 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
 
-    <!-- Suppressions can be provided individually as in earlier schemas -->
+    <!-- Suppressions can be provided individually. -->
     <suppress base="true">
         <notes><![CDATA[
         This suppresses any jboss:jboss cpe for any test.jar in any directory.
@@ -28,7 +28,7 @@
         <cvssBelow>7</cvssBelow>
     </suppress>
 
-    <!-- suppression in the past won't be parsed -->
+    <!-- suppression in the past is not parsed -->
     <suppress until="2014-01-01Z">
         <notes><![CDATA[
         This suppresses a specific cve for any dependency in any directory that has the specified sha1 checksum. If current date is not yet on or beyond 1 Jan 2014

--- a/core/src/test/resources/suppressions_1_4_no_groups.xml
+++ b/core/src/test/resources/suppressions_1_4_no_groups.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+    <!-- Contentwise same as suppression_1_3.xml. For verifying backwards compability. -->
+    <suppress>
+        <notes><![CDATA[
+        This suppresses cpe:/a:csv:csv:1.0 for some.jar in the "c:\path\to" directory.
+        ]]></notes>
+        <filePath>c:\path\to\some.jar</filePath>
+        <cpe>cpe:/a:csv:csv:1.0</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        This suppresses any jboss:jboss cpe for any test.jar in any directory.
+        ]]></notes>
+        <filePath regex="true">.*\btest\.jar</filePath>
+        <cpe>cpe:/a:jboss:jboss</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        This suppresses a specific cve for any test.jar in any directory.
+        ]]></notes>
+        <filePath regex="true">.*\btest\.jar</filePath>
+        <cve>CVE-2013-1337</cve>
+    </suppress>
+    <suppress until="2014-01-01Z">
+        <notes><![CDATA[
+        This suppresses a specific cve for any dependency in any directory that has the specified sha1 checksum. If current date is not yet on or beyond 1 Jan 2014
+        ]]></notes>
+        <sha1>384FAA82E193D4E4B0546059CA09572654BC3970</sha1>
+        <cve>CVE-2013-1337</cve>
+    </suppress>
+    <suppress until="9999-03-25Z">
+        <notes><![CDATA[
+        This suppresses all CVE entries that have a score below CVSS 7.  
+        But only if current date is not yet on or beyond 31 Dec 9999 
+        (which is expected to be sufficiently far in the future to have this 
+            rule still be active when the test-cases run)
+        ]]></notes>
+        <cvssBelow>7</cvssBelow>
+    </suppress>
+</suppressions>

--- a/core/src/test/resources/suppressions_1_4_no_groups.xml
+++ b/core/src/test/resources/suppressions_1_4_no_groups.xml
@@ -2,7 +2,7 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
-    <!-- Contentwise same as suppression_1_3.xml. For verifying backwards compability. -->
+    <!-- Contentwise same as suppression_1_3.xml. Still valid according to schema 1.4 -->
     <suppress>
         <notes><![CDATA[
         This suppresses cpe:/a:csv:csv:1.0 for some.jar in the "c:\path\to" directory.


### PR DESCRIPTION
## Description of Change

Added new version (1.4) of suppression xsd. This allows the grouping of suppressions and metadata about the groupings. Groupings are optional. Suppression xml can be used as earlier. See [issue](https://github.com/dependency-check/DependencyCheck/issues/7898) for reasoning.

## Related issues

[Issue 7898](https://github.com/dependency-check/DependencyCheck/issues/7898)

## Have test cases been added to cover the new functionality?

*yes*