### PR TITLE
fix: Disable OSS Index if its credentials are missing

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -134,7 +134,8 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
       synchronized (FETCH_MUTIX) {
         if (StringUtils.isEmpty(getSettings().getString(KEYS.ANALYZER_OSSINDEX_USER, StringUtils.EMPTY)) ||
             StringUtils.isEmpty(getSettings().getString(KEYS.ANALYZER_OSSINDEX_PASSWORD, StringUtils.EMPTY))) {
-          throw new InitializationException("Error initializing OSS Index analyzer due to missing user/password credentials. Authentication is now required: https://ossindex.sonatype.org/doc/auth-required");
+          LOG.warn("Disabling OSS Index analyzer due to missing user/password credentials. Authentication is now required: https://ossindex.sonatype.org/doc/auth-required");
+          setEnabled(false);
         }
       }
     }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
@@ -8,7 +8,6 @@ import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.naming.Identifier;
 import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
-import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.Settings;
 import org.owasp.dependencycheck.utils.Settings.KEYS;
 
@@ -30,7 +29,7 @@ import java.util.concurrent.Future;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OssIndexAnalyzerTest extends BaseTest {
@@ -252,18 +251,20 @@ class OssIndexAnalyzerTest extends BaseTest {
     }
 
     @Test
-    void should_prepareAnalyzer_fail_when_credentials_not_set() throws Exception {
+    void should_prepareAnalyzer_disable_when_credentials_not_set() throws Exception {
+        // Given
         OssIndexAnalyzer analyzer = new OssIndexAnalyzer();
         Settings settings = getSettings();
         Engine engine = new Engine(settings);
         analyzer.initialize(settings);
-        try {
-            analyzer.prepareAnalyzer(engine);
-            assertThrows(InitializationException.class, () -> analyzer.prepareAnalyzer(engine));
-        } catch (InitializationException e) {
-          analyzer.close();
-          engine.close();
-        }
+
+        // When
+        analyzer.prepareAnalyzer(engine);
+
+        // Then
+        assertFalse(analyzer.isEnabled());
+        analyzer.close();
+        engine.close();
     }
 
     private static void setCredentials(final Settings settings) {

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
@@ -262,9 +262,10 @@ class OssIndexAnalyzerTest extends BaseTest {
         analyzer.prepareAnalyzer(engine);
 
         // Then
-        assertFalse(analyzer.isEnabled());
+        boolean enabled = analyzer.isEnabled();
         analyzer.close();
         engine.close();
+        assertFalse(enabled);
     }
 
     private static void setCredentials(final Settings settings) {

--- a/src/site/markdown/analyzers/oss-index-analyzer.md
+++ b/src/site/markdown/analyzers/oss-index-analyzer.md
@@ -14,3 +14,5 @@ Sonatype [announced](https://ossindex.sonatype.org/doc/auth-required) that OSS I
 You can get an API Token following these steps:
 1. [Sign In](https://ossindex.sonatype.org/user/signin) or [Sign Up](https://ossindex.sonatype.org/user/register) for free.
 2. Get the API Token from user Settings.
+
+If no credentials are provided, this analyzer will be disabled.


### PR DESCRIPTION
## Description of Change

This disables the OSS Index analyzer if no credentials are provided. Feel free to drop this PR if it doesn't make sense.

## Related issues

Relates to #7920

## Have test cases been added to cover the new functionality?

yes