### PR TITLE
fix: Update NVD CPE search URLs to match new search interface

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/dependency/VulnerableSoftware.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/VulnerableSoftware.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException;
+import org.owasp.dependencycheck.dependency.naming.CpeIdentifier;
 import org.owasp.dependencycheck.utils.DependencyVersion;
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.ICpe;
@@ -516,5 +517,9 @@ public class VulnerableSoftware extends Cpe implements Serializable {
             sb.append(" version is NOT VULNERABLE");
         }
         return sb.toString();
+    }
+
+    public String toNvdSearchUrl() {
+        return CpeIdentifier.nvdSearchUrlFor(this);
     }
 }

--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -945,7 +945,6 @@ Getting Help: <a href="https://github.com/dependency-check/DependencyCheck/issue
                         #end
                         #set($cnt=$cnt+1)
                         <h4 id="header$cnt" class="subsectionheader white">Identifiers</h4>
-                        ##:&nbsp;<a href="https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=$enc.url($cpevalue)" target="_blank">$enc.html($cpevalue)</a></h4>
                         <div id="content$cnt" class="subsectioncontent standardsubsection">
                         #set($supressPkgUrl='')
                         #if ($dependency.getSoftwareIdentifiers().size()==0 && $dependency.getVulnerableSoftwareIdentifiers().size()==0)
@@ -1060,14 +1059,14 @@ Getting Help: <a href="https://github.com/dependency-check/DependencyCheck/issue
                             #if ($vuln.getSource().name().equals("NVD") && $vuln.matchedVulnerableSoftware)
                                 #if ($vuln.getVulnerableSoftware().size()<2)
                                     <p>Vulnerable Software &amp; Versions:<ul>
-                                        <li class="vs$vsctr"><a target="_blank" href="https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=$enc.url($vuln.matchedVulnerableSoftware.toCpe22Uri())">$enc.html($vuln.matchedVulnerableSoftware.toString())</a></li>
+                                        <li class="vs$vsctr"><a target="_blank" href="$enc.html($vuln.matchedVulnerableSoftware.toNvdSearchUrl())">$enc.html($vuln.matchedVulnerableSoftware.toString())</a></li>
                                     </ul></p>
                                 #else
                                     <p>Vulnerable Software &amp; Versions:&nbsp;(<a href="#" class="versionToggle" data-toggle=".vs$vsctr">show all</a>)<ul>
-                                        <li class="vs$vsctr"><a target="_blank" href="https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=$enc.url($vuln.matchedVulnerableSoftware.toCpe22Uri())">$enc.html($vuln.matchedVulnerableSoftware.toString())</a></li>
+                                        <li class="vs$vsctr"><a target="_blank" href="$enc.html($vuln.matchedVulnerableSoftware.toNvdSearchUrl())">$enc.html($vuln.matchedVulnerableSoftware.toString())</a></li>
                                         <li class="vs$vsctr">...</li>
                                     #foreach($vs in $vuln.getVulnerableSoftware(true))
-                                        <li class="vs$vsctr hidden"><a target="_blank" href="https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=$enc.url($vs.toCpe22Uri())">$enc.html($vs.toString())</a></li>
+                                        <li class="vs$vsctr hidden"><a target="_blank" href="$enc.html($vs.toNvdSearchUrl())">$enc.html($vs.toString())</a></li>
                                     #end
                                     </ul></p>
                                 #end
@@ -1174,7 +1173,6 @@ Getting Help: <a href="https://github.com/dependency-check/DependencyCheck/issue
                                 #end
                                 #set($cnt=$cnt+1)
                                 <h4 id="header$cnt" class="subsectionheader white">Suppressed Identifiers</h4>
-                                ##:&nbsp;<a href="https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=$enc.url($cpevalue)" target="_blank">$enc.html($cpevalue)</a></h4>
                                 <div id="content$cnt" class="subsectioncontent standardsubsection">
                                 #if ($dependency.getSuppressedIdentifiers().size()==0)
                                     <ul><li><b>None</b></li></ul>
@@ -1267,14 +1265,14 @@ Getting Help: <a href="https://github.com/dependency-check/DependencyCheck/issue
                                      #if ($vuln.getSource().name().equals("NVD") && $vuln.matchedVulnerableSoftware)
                                         #if ($vuln.getVulnerableSoftware().size()<2)
                                             <p>Vulnerable Software &amp; Versions:<ul>
-                                                <li class="vs$vsctr"><a target="_blank" href="https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=$enc.url($vuln.matchedVulnerableSoftware.toCpe22Uri())">$enc.html($vuln.matchedVulnerableSoftware.toString())</a></li>
+                                                <li class="vs$vsctr"><a target="_blank" href="$enc.html($vuln.matchedVulnerableSoftware.toNvdSearchUrl())">$enc.html($vuln.matchedVulnerableSoftware.toString())</a></li>
                                             </ul></p>
                                         #else
                                             <p>Vulnerable Software &amp; Versions:&nbsp;(<a href="#" class="versionToggle" data-toggle=".vs$vsctr">show all</a>)<ul>
-                                                <li class="vs$vsctr"><a target="_blank" href="https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=$enc.url($vuln.matchedVulnerableSoftware.toCpe22Uri())">$enc.html($vuln.matchedVulnerableSoftware.toString())</a></li>
+                                                <li class="vs$vsctr"><a target="_blank" href="$enc.html($vuln.matchedVulnerableSoftware.toNvdSearchUrl())">$enc.html($vuln.matchedVulnerableSoftware.toString())</a></li>
                                                 <li class="vs$vsctr">...</li>
                                             #foreach($vs in $vuln.getVulnerableSoftware(true))
-                                                <li class="vs$vsctr hidden"><a target="_blank" href="https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=$enc.url($vs.toCpe22Uri())">$enc.html($vs.toString())</a></li>
+                                                <li class="vs$vsctr hidden"><a target="_blank" href="$enc.html($vs.toNvdSearchUrl())">$enc.html($vs.toString())</a></li>
                                             #end
                                             </ul></p>
                                         #end

--- a/core/src/main/resources/templates/jenkinsReport.vsl
+++ b/core/src/main/resources/templates/jenkinsReport.vsl
@@ -670,7 +670,6 @@ Getting Help: <a href="https://github.com/dependency-check/DependencyCheck/issue
                         #end
                         #set($cnt=$cnt+1)
                         <h4 id="header$cnt" class="subsectionheader white">Identifiers</h4>
-                        ##:&nbsp;<a href="https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=$enc.url($cpevalue)" target="_blank">$enc.html($cpevalue)</a></h4>
                         <div id="content$cnt" class="subsectioncontent standardsubsection">
                         #if ($dependency.getSoftwareIdentifiers().size()==0 && $dependency.getVulnerableSoftwareIdentifiers().size()==0)
                             <ul><li><b>None</b></li></ul>
@@ -764,13 +763,13 @@ Getting Help: <a href="https://github.com/dependency-check/DependencyCheck/issue
                             #if ($vuln.getSource().name().equals("NVD") && $vuln.matchedVulnerableSoftware)
                                 #if ($vuln.getVulnerableSoftware().size()<2)
                                     <p>Vulnerable Software &amp; Versions:<ul>
-                                        <li class="vs$vsctr"><a target="_blank" href="https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=$enc.url($vuln.matchedVulnerableSoftware.toCpe22Uri())">$enc.html($vuln.matchedVulnerableSoftware.toString())</a></li>
+                                        <li class="vs$vsctr"><a target="_blank" href="$enc.html($vuln.matchedVulnerableSoftware.toNvdSearchUrl())">$enc.html($vuln.matchedVulnerableSoftware.toString())</a></li>
                                     </ul></p>
                                 #else
                                     <p>Vulnerable Software &amp; Versions:<ul>
-                                        <li class="vs$vsctr"><a target="_blank" href="https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=$enc.url($vuln.matchedVulnerableSoftware.toCpe22Uri())">$enc.html($vuln.matchedVulnerableSoftware.toString())</a></li>
+                                        <li class="vs$vsctr"><a target="_blank" href="$enc.html($vuln.matchedVulnerableSoftware.toNvdSearchUrl())">$enc.html($vuln.matchedVulnerableSoftware.toString())</a></li>
                                     #foreach($vs in $vuln.getVulnerableSoftware(true))
-                                        <li class="vs$vsctr"><a target="_blank" href="https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=$enc.url($vs.toCpe22Uri())">$enc.html($vs.toString())</a></li>
+                                        <li class="vs$vsctr"><a target="_blank" href="$enc.html($vuln.matchedVulnerableSoftware.toNvdSearchUrl())">$enc.html($vs.toString())</a></li>
                                     #end
                                     </ul></p>
                                 #end

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/VulnerableSoftwareTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/VulnerableSoftwareTest.java
@@ -23,6 +23,12 @@ import us.springett.parsers.cpe.exceptions.CpeValidationException;
 import us.springett.parsers.cpe.values.LogicalValue;
 import us.springett.parsers.cpe.values.Part;
 
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -105,7 +111,7 @@ class VulnerableSoftwareTest extends BaseTest {
     }
 
     @Test
-    void testcompareUpdateAttributes() {
+    void testCompareUpdateAttributes() {
 
         assertTrue(VulnerableSoftware.compareUpdateAttributes("update1", "u1"));
         assertTrue(VulnerableSoftware.compareUpdateAttributes("u1", "update1"));
@@ -115,6 +121,13 @@ class VulnerableSoftwareTest extends BaseTest {
         assertTrue(VulnerableSoftware.compareUpdateAttributes("b-1", "beta1"));
         assertFalse(VulnerableSoftware.compareUpdateAttributes("a1", "beta1"));
 
+    }
+
+    @Test
+    void testToNvdSearchUrl() throws Exception {
+        String encodedURL = new VulnerableSoftwareBuilder().part(Part.APPLICATION).vendor("apache").version("1.2.3").build().toNvdSearchUrl();
+        assertEquals("https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=3&sortDirection=2&cpeFilterMode=applicability&resultType=records&cpeName=cpe%3A2.3%3Aa%3Aapache%3A%2A%3A1.2.3%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A", encodedURL);
+        assertEquals("https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=3&sortDirection=2&cpeFilterMode=applicability&resultType=records&cpeName=cpe:2.3:a:apache:*:1.2.3:*:*:*:*:*:*:*", URLDecoder.decode(encodedURL, UTF_8));
     }
 
 }

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/naming/CpeIdentifierTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/naming/CpeIdentifierTest.java
@@ -1,0 +1,50 @@
+package org.owasp.dependencycheck.dependency.naming;
+
+import org.junit.jupiter.api.Test;
+import us.springett.parsers.cpe.CpeBuilder;
+import us.springett.parsers.cpe.exceptions.CpeValidationException;
+import us.springett.parsers.cpe.values.Part;
+
+import java.net.URLDecoder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CpeIdentifierTest {
+
+    @Test
+    void testNvdSearchUrlFormatting() throws CpeValidationException {
+        String encodedUrl = CpeIdentifier.nvdSearchUrlFor(new CpeBuilder().part(Part.APPLICATION).vendor("apache").product("struts").version("1.9.0").build());
+        assertEquals("https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=3&sortDirection=2&cpeFilterMode=applicability&resultType=records&" +
+                "cpeName=cpe%3A2.3%3Aa%3Aapache%3Astruts%3A1.9.0%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A", encodedUrl);
+        assertEquals("https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=3&sortDirection=2&cpeFilterMode=applicability&resultType=records&" +
+                "cpeName=cpe:2.3:a:apache:struts:1.9.0:*:*:*:*:*:*:*", URLDecoder.decode(encodedUrl, UTF_8));
+    }
+
+    @Test
+    void testNvdSearchUrlFormattingEncodesChars() throws CpeValidationException {
+        String encodedUrl = CpeIdentifier.nvdSearchUrlFor(new CpeBuilder().part(Part.APPLICATION).vendor("apache$").product("struts$").version("1.9.0$").build());
+        assertEquals("https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=3&sortDirection=2&cpeFilterMode=applicability&resultType=records&" +
+                "cpeName=cpe%3A2.3%3Aa%3Aapache%5C%24%3Astruts%5C%24%3A1.9.0%5C%24%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A", encodedUrl);
+        assertEquals("https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=3&sortDirection=2&cpeFilterMode=applicability&resultType=records&" +
+                "cpeName=cpe:2.3:a:apache\\$:struts\\$:1.9.0\\$:*:*:*:*:*:*:*", URLDecoder.decode(encodedUrl, UTF_8));
+    }
+
+    @Test
+    void testNvdProductSearchFormatting() throws CpeValidationException {
+        String encodedUrl = CpeIdentifier.nvdProductSearchUrlFor(new CpeBuilder().part(Part.APPLICATION).vendor("apache").product("struts").version("1.9.0").build());
+        assertEquals("https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=3&sortDirection=2&cpeFilterMode=applicability&resultType=records&" +
+                "cpeName=cpe%3A2.3%3Aa%3Aapache%3Astruts%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A", encodedUrl);
+        assertEquals("https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=3&sortDirection=2&cpeFilterMode=applicability&resultType=records&" +
+                "cpeName=cpe:2.3:a:apache:struts:*:*:*:*:*:*:*:*", URLDecoder.decode(encodedUrl, UTF_8));
+    }
+
+    @Test
+    void testNvdProductSearchUrlFormattingEncodesChars() throws CpeValidationException {
+        String encodedUrl = CpeIdentifier.nvdProductSearchUrlFor(new CpeBuilder().part(Part.APPLICATION).vendor("apache$").product("struts$").version("1.9.0$").build());
+        assertEquals("https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=3&sortDirection=2&cpeFilterMode=applicability&resultType=records&" +
+                "cpeName=cpe%3A2.3%3Aa%3Aapache%5C%24%3Astruts%5C%24%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A", encodedUrl);
+        assertEquals("https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=3&sortDirection=2&cpeFilterMode=applicability&resultType=records&" +
+                "cpeName=cpe:2.3:a:apache\\$:struts\\$:*:*:*:*:*:*:*:*", URLDecoder.decode(encodedUrl, UTF_8));
+    }
+}


### PR DESCRIPTION
## Description of Change

NVD appear to have updated their search interface in a way that breaks our earlier generated deep links from reports etc.

The new interface is similar, but the URLs build CPE identifiers rather than individual components. The "applicability" mode appears to be correct (otherwise you get matches where a given vuln is running on/with a CPE but not affecting that CPE?)

Version-specific search
https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=3&sortDirection=2&cpeFilterMode=applicability&cpeName=cpe:2.3:a:vmware:spring_framework:5.0.0:*:*:*:*:*:*:*&resultType=records

Broad search
https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=3&sortDirection=2&cpeFilterMode=applicability&cpeName=cpe:2.3:a:vmware:spring_framework:*:*:*:*:*:*:*:*&resultType=records

Open questions 
- [x] should I add a default sort order? Order seems random/database order otherwise.
  - ~~Sort by identifier? descending? ascending?~~
  - Published Date? Descending ✅
- [x] Need to update URLs inside the HTML and Jenkins report templates?
  - These ones go to [URLs like this](https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=cpe%3A%2Fa%3Aghostscript%3Aghostscript%3A8.64) - but they are totally broken/404ed so I am not sure if that recently happened or if they have been broken for a while.

## Related issues

- fixes #7962

## Have test cases been added to cover the new functionality?

yes

Example report generated via Gradle plugin locally:
[dependency-check-report.html](https://github.com/user-attachments/files/22558375/dependency-check-report.html)
