### PR TITLE
fix: improve OSS Index Error Reporting

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -162,11 +162,19 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
                     final boolean warnOnly = getSettings().getBoolean(Settings.KEYS.ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS, false);
                     this.setEnabled(false);
                     if (StringUtils.contains(message, "401")) {
-                        LOG.error("Invalid credentials for the OSS Index, disabling the analyzer");
-                        throw new AnalysisException("Invalid credentials provided for OSS Index", ex);
+                        if (warnOnly) {
+                            LOG.warn("Invalid credentials for theOSS Index, disabling the analyzer");
+                        } else {
+                            LOG.error("Invalid credentials for the OSS Index, disabling the analyzer");
+                            throw new AnalysisException("Invalid credentials provided for OSS Index", ex);
+                        }
                     } else if (StringUtils.contains(message, "403")) {
-                        LOG.error("OSS Index access forbidden, disabling the analyzer");
-                        throw new AnalysisException("OSS Index access forbidden", ex);
+                        if (warnOnly) {
+                            LOG.warn("OSS Index access forbidden, disabling the analyzer");
+                        } else {
+                            LOG.error("OSS Index access forbidden, disabling the analyzer");
+                            throw new AnalysisException("OSS Index access forbidden", ex);
+                        }
                     } else if (StringUtils.contains(message, "429")) {
                         if (warnOnly) {
                             LOG.warn("OSS Index rate limit exceeded, disabling the analyzer", ex);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -148,17 +148,26 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
                 try {
                     requestDelay();
                     reports = requestReports(engine.getDependencies());
-                } catch (TransportException ex) {
+                } catch (SocketTimeoutException e) {
+                    final boolean warnOnly = getSettings().getBoolean(Settings.KEYS.ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS, false);
+                    this.setEnabled(false);
+                    if (warnOnly) {
+                        LOG.warn("OSS Index socket timeout, disabling the analyzer", e);
+                    } else {
+                        LOG.debug("OSS Index socket timeout", e);
+                        throw new AnalysisException("Failed to establish socket to OSS Index", e);
+                    }
+                } catch (Exception ex) {
                     final String message = ex.getMessage();
                     final boolean warnOnly = getSettings().getBoolean(Settings.KEYS.ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS, false);
                     this.setEnabled(false);
-                    if (StringUtils.endsWith(message, "401")) {
+                    if (StringUtils.contains(message, "401")) {
                         LOG.error("Invalid credentials for the OSS Index, disabling the analyzer");
                         throw new AnalysisException("Invalid credentials provided for OSS Index", ex);
-                    } else if (StringUtils.endsWith(message, "403")) {
+                    } else if (StringUtils.contains(message, "403")) {
                         LOG.error("OSS Index access forbidden, disabling the analyzer");
                         throw new AnalysisException("OSS Index access forbidden", ex);
-                    } else if (StringUtils.endsWith(message, "429")) {
+                    } else if (StringUtils.contains(message, "429")) {
                         if (warnOnly) {
                             LOG.warn("OSS Index rate limit exceeded, disabling the analyzer", ex);
                         } else {
@@ -170,18 +179,6 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
                         LOG.debug("Error requesting component reports, disabling the analyzer", ex);
                         throw new AnalysisException("Failed to request component-reports", ex);
                     }
-                } catch (SocketTimeoutException e) {
-                    final boolean warnOnly = getSettings().getBoolean(Settings.KEYS.ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS, false);
-                    this.setEnabled(false);
-                    if (warnOnly) {
-                        LOG.warn("OSS Index socket timeout, disabling the analyzer", e);
-                    } else {
-                        LOG.debug("OSS Index socket timeout", e);
-                        throw new AnalysisException("Failed to establish socket to OSS Index", e);
-                    }
-                } catch (Exception e) {
-                    LOG.debug("Error requesting component reports", e);
-                    throw new AnalysisException("Failed to request component-reports", e);
                 }
             }
 

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -163,7 +163,7 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
                     this.setEnabled(false);
                     if (StringUtils.contains(message, "401")) {
                         if (warnOnly) {
-                            LOG.warn("Invalid credentials for theOSS Index, disabling the analyzer");
+                            LOG.warn("Invalid credentials for the OSS Index, disabling the analyzer");
                         } else {
                             LOG.error("Invalid credentials for the OSS Index, disabling the analyzer");
                             throw new AnalysisException("Invalid credentials provided for OSS Index", ex);

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzer.java
@@ -182,10 +182,10 @@ public class OssIndexAnalyzer extends AbstractAnalyzer {
                             throw new AnalysisException("OSS Index rate limit exceeded, disabling the analyzer", ex);
                         }
                     } else if (warnOnly) {
-                        LOG.warn("Error requesting component reports, disabling the analyzer", ex);
+                        LOG.warn("Error requesting component reports, disabling the analyzer. " + ex.getMessage(), ex);
                     } else {
                         LOG.debug("Error requesting component reports, disabling the analyzer", ex);
-                        throw new AnalysisException("Failed to request component-reports", ex);
+                        throw new AnalysisException("Failed to request component-reports. " + ex.getMessage(), ex);
                     }
                 }
             }

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/OssIndexAnalyzerTest.java
@@ -130,6 +130,39 @@ class OssIndexAnalyzerTest extends BaseTest {
     }
 
     @Test
+    void should_analyzeDependency_return_a_dedicated_error_message_when_401_response_from_sonatype() throws Exception {
+        // Given
+        OssIndexAnalyzer analyzer = new OssIndexAnalyzer();
+        Settings settings = getSettings();
+        setCredentials(settings);
+        settings.setBoolean(KEYS.ANALYZER_OSSINDEX_USE_CACHE, false);
+        try (Engine engine = new Engine(settings)) {
+
+            analyzer.initialize(settings);
+            analyzer.prepareAnalyzer(engine);
+
+            Identifier identifier = new PurlIdentifier("maven", "test", "test", "1.0",
+                    Confidence.HIGHEST);
+
+            Dependency dependency = new Dependency();
+            dependency.addSoftwareIdentifier(identifier);
+            engine.setDependencies(Collections.singletonList(dependency));
+
+            // When
+            AnalysisException output = new AnalysisException();
+            try {
+                analyzer.analyzeDependency(dependency, engine);
+            } catch (AnalysisException e) {
+                output = e;
+            }
+
+            // Then
+            assertEquals("Invalid credentials provided for OSS Index", output.getMessage());
+            analyzer.close();
+        }
+    }
+
+    @Test
     void should_analyzeDependency_return_a_dedicated_error_message_when_403_response_from_sonatype() throws Exception {
         // Given
         OssIndexAnalyzer analyzer = new OssIndexAnalyzerThrowing403();

--- a/pom.xml
+++ b/pom.xml
@@ -625,6 +625,7 @@ Copyright (c) 2012 - Jeremy Long
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>@{surefireArgLine} -Dfile.encoding=UTF-8</argLine>
+                    <failIfNoTests>false</failIfNoTests>
                     <systemPropertyVariables>
                         <data.directory>${project.build.directory}/data</data.directory>
                         <temp.directory>${project.build.directory}/temp</temp.directory>


### PR DESCRIPTION
## Description of Change

ODC was not properly reporting authorization error messages. Previously, it was looking for the message to end with 401 to report an authorization issue. However, the actual error message from the client is `Failed to request component-reports: https://ossindex.sonatype.org/api/v3/component-report - Server status: 401 - Server reason: Unauthorized`. As such, the check for 401 needed to be improved.

## Related issues

Best guess this is related to https://github.com/dependency-check/DependencyCheck/issues/7975 and possibly https://github.com/dependency-check/DependencyCheck/issues/7971

## Have test cases been added to cover the new functionality?

Yes