### PR TITLE
fix: Clean up Apache Lucene logging via SLF4j redirect

### DIFF
--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -10,6 +10,7 @@
         </encoder>
     </appender>
 
+    <logger name="org.apache.lucene" level="ERROR" />
     <logger name="org.apache.commons.jcs" level="ERROR" />
     <logger name="org.apache.hc" level="ERROR" />
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -279,6 +279,11 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queryparser</artifactId>
         </dependency>
+        <!-- Allow redirection of lucene logs to slf4j -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>

--- a/core/src/main/java/org/owasp/dependencycheck/data/cpe/AbstractMemoryIndex.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/cpe/AbstractMemoryIndex.java
@@ -50,6 +50,7 @@ import org.owasp.dependencycheck.utils.Pair;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 /**
  * <p>
@@ -66,6 +67,12 @@ import org.slf4j.LoggerFactory;
  */
 @ThreadSafe
 public abstract class AbstractMemoryIndex implements MemoryIndex {
+
+    static {
+        // Ensure Lucene uses SLF4J for logging
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+    }
 
     /**
      * The logger.

--- a/pom.xml
+++ b/pom.xml
@@ -1255,7 +1255,7 @@ Copyright (c) 2012 - Jeremy Long
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
+                <artifactId>jul-to-slf4j</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Also suppresses the default logs for users.

## Description of Change

Currently there are occasional logs (especially from the Apache Lucene indexing) that are coming through in an consistent format. They are mostly due to warnings about the JVM-in-use (due to use of Azul/Zulu JVM within the docker image rather than Hotspot/Temurin/OpenJDK etc).

- Added `jul-to-slf4j` bridge
- Initialised during Lucene initialization as this seems to be the main JUL dependency, and I couldn't think of a better init location that works across CLI, Maven, Gradle etc.
  - Technically there do seem to be other libraries potentially using java.util.logging, so it might be a better idea to get the logging set up within the `Engine` or the `AbstractAnalyzer` if these are the main entry points to `core`
- Removed slf4j-simple dependency management definition (unused)
- Stopped logging lucene errors unless at ERROR level on CLI since these errors are somewhat far from being user-addressable, and inevitable on the Docker image. This change is up for debate.

Before (via CLI on **temurin-21** in docker image)

```
[INFO] Finished Version Filter Analyzer (0 seconds)
Sep 25, 2025 8:40:55 AM org.apache.lucene.util.HotspotVMOptions <clinit>
WARNING: Lucene cannot optimize algorithms or calculate object sizes for JVMs that are not based on Hotspot or a compatible implementation.
WARNING: A restricted method in java.lang.foreign.Linker has been called
WARNING: java.lang.foreign.Linker::downcallHandle has been called by the unnamed module
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for this module

Sep 25, 2025 8:40:56 AM org.apache.lucene.store.MemorySegmentIndexInputProvider <init>
INFO: Using MemorySegmentIndexInput and native madvise support with Java 21 or later; to disable start with -Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false
Sep 25, 2025 8:40:56 AM org.apache.lucene.internal.vectorization.VectorizationProvider lookup
WARNING: Java runtime is not using Hotspot VM; Java vector incubator API can't be enabled.
```

You'll get varying different warnings depending on OpenJDK vs Zulu and different versions.

After - **without** Lucene log suppression (via CLI)
```
[INFO] Finished Version Filter Analyzer (0 seconds)
[WARN] Lucene cannot optimize algorithms or calculate object sizes for JVMs that are not based on Hotspot or a compatible implementation.
WARNING: A restricted method in java.lang.foreign.Linker has been called
WARNING: java.lang.foreign.Linker::downcallHandle has been called by the unnamed module
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for this module

[INFO] Using MemorySegmentIndexInput and native madvise support with Java 21 or later; to disable start with -Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false
[WARN] Java runtime is not using Hotspot VM; Java vector incubator API can't be enabled.
```

After - with warning suppression (via CLI)
```
[INFO] Finished Version Filter Analyzer (0 seconds)
WARNING: A restricted method in java.lang.foreign.Linker has been called
WARNING: java.lang.foreign.Linker::downcallHandle has been called by the unnamed module
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for this module
```

## Related issues

Partially addresses #7759 but does not address the JVM warnings.

## Have test cases been added to cover the new functionality?

no