### PR TITLE
fix(fp): Fix broad Python regex to suppress packages ending in `-python`

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -3880,10 +3880,10 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        several python-* PyPI packages hit a FP CPE match #3233 & #3017 & #5335
+        several python-* PyPI packages hit a FP CPE match #3233 & #3017 & #5335 & #7968
         as Python itself is not a PyPI package suppress it with a broad regex
         ]]></notes>
-        <packageUrl regex="true">^pkg:pypi/.*python\-.*$</packageUrl>
+        <packageUrl regex="true">^pkg:pypi/.*python.*$</packageUrl>
         <cpe>cpe:/a:python:python</cpe>
         <cpe>cpe:/a:python_software_foundation:python</cpe>
     </suppress>


### PR DESCRIPTION
## Description of Change

Extends broad python suppression to handle packages ending in `-python` as well, e.g `snowflake-snowpark-python`

## Related issues

- fixes #7968 

## Have test cases been added to cover the new functionality?

N/A