### PR TITLE
fix: Correct Archive Analyzer behaviour on certain tgz archives

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@ Copyright (c) 2012 - Jeremy Long
         <hamcrest.version>3.0</hamcrest.version>
         <mockito.version>5.19.0</mockito.version>
         <jsoup.version>1.21.2</jsoup.version>
-        <commons-compress.version>1.28.0</commons-compress.version>
+        <commons-compress.version>1.27.1</commons-compress.version>
         <org.apache.maven.shared.file-management.version>3.2.0</org.apache.maven.shared.file-management.version>
         <maven-plugin-testing-harness.version>3.3.0</maven-plugin-testing-harness.version>
         <maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>


### PR DESCRIPTION

## Description of Change

commons-compress 1.28.0 seems to have issues with changing default behaviour on some archives: https://issues.apache.org/jira/browse/COMPRESS-705

Since the release cadence for Apache Commons stuff is a bit unpredictable, even in the face of a regression, we should probably just roll this back for now?

This reverts commit 4c33e0a5

## Related issues

- fixes #7985

## Have test cases been added to cover the new functionality?

no