### PR TITLE
feat: Add params to obtain content from an alternative repository

### DIFF
--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -641,6 +641,14 @@ public class App {
                 cli.getStringArgument(CliParser.ARGUMENT.CENTRAL_PASSWORD));
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_CENTRAL_BEARER_TOKEN,
                 cli.getStringArgument(CliParser.ARGUMENT.CENTRAL_BEARER_TOKEN));
+        settings.setStringIfNotEmpty(Settings.KEYS.CENTRAL_CONTENT_URL,
+                cli.getStringArgument(CliParser.ARGUMENT.CENTRAL_CONTENT_URL));
+        settings.setStringIfNotEmpty(Settings.KEYS.CENTRAL_CONTENT_USER,
+                cli.getStringArgument(CliParser.ARGUMENT.CENTRAL_CONTENT_USER));
+        settings.setStringIfNotEmpty(Settings.KEYS.CENTRAL_CONTENT_PASSWORD,
+                cli.getStringArgument(CliParser.ARGUMENT.CENTRAL_CONTENT_PASSWORD));
+        settings.setStringIfNotEmpty(Settings.KEYS.CENTRAL_CONTENT_BEARER_TOKEN,
+                cli.getStringArgument(CliParser.ARGUMENT.CENTRAL_CONTENT_BEARER_TOKEN)); 
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_OSSINDEX_URL,
                 cli.getStringArgument(CliParser.ARGUMENT.OSSINDEX_URL));
         settings.setStringIfNotEmpty(Settings.KEYS.ANALYZER_OSSINDEX_USER,

--- a/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
@@ -430,6 +430,15 @@ public final class CliParser {
                         "Credentials for basic auth towards the --centralUrl"))
                 .addOption(newOptionWithArg(ARGUMENT.CENTRAL_BEARER_TOKEN, "token",
                         "Token for bearer auth towards the --centralUrl"))
+                .addOption(newOptionWithArg(ARGUMENT.CENTRAL_CONTENT_URL, "url",
+                        "Alternative URL to obtain content from an alternative repository. If not set the public Sonatype Maven Central will be used."
+                        + "Use a repository endpoint, such as https://artifactory.com/artifactory/mvn-release/."))
+                .addOption(newOptionWithArg(ARGUMENT.CENTRAL_CONTENT_USERNAME, "username",
+                        "Credentials for basic auth towards the --centralContentUrl."))
+                .addOption(newOptionWithArg(ARGUMENT.CENTRAL_CONTENT_PASSWORD, "password",
+                        "Credentials for basic auth towards the --centralContentUrl"))
+                .addOption(newOptionWithArg(ARGUMENT.CENTRAL_CONTENT_BEARER_TOKEN, "token",
+                        "Token for bearer auth towards the --centralContentUrl"))
                 .addOption(newOptionWithArg(ARGUMENT.OSSINDEX_URL, "url",
                         "Alternative URL for the OSS Index. If not set the public Sonatype OSS Index will be used."))
                 .addOption(newOptionWithArg(ARGUMENT.OSSINDEX_USERNAME, "username",
@@ -1428,6 +1437,22 @@ public final class CliParser {
          * The token for bearer authentication to the alternative Maven Central Search.
          */
         public static final String CENTRAL_BEARER_TOKEN = "centralBearerToken";
+        /**
+         * The alternative URL to obtain content from an alternative repository.
+         */
+        public static final String CENTRAL_CONTENT_URL = "centralContentUrl";
+        /**
+         * The username for basic authentication to obtain content from an alternative repository.
+         */
+        public static final String CENTRAL_CONTENT_USER = "centralContentUsername";
+        /**
+         * The Password for basic authentication to obtain content from an alternative repository.
+         */
+        public static final String CENTRAL_CONTENT_PASSWORD = "centralContentPassword";
+        /**
+         * The token for bearer authentication to obtain content from an alternative repository.
+         */
+        public static final String CENTRAL_CONTENT_BEARER_TOKEN = "centralContentBearerToken";
         /**
          * Disables the Nexus Analyzer.
          */

--- a/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
@@ -441,7 +441,7 @@ public final class CliParser {
                         "Token for bearer auth towards the --centralContentUrl"))
                 .addOption(newOptionWithArg(ARGUMENT.OSSINDEX_URL, "url",
                         "Alternative URL for the OSS Index. If not set the public Sonatype OSS Index will be used."))
-                .addOption(newOptionWithArg(ARGUMENT.OSSINDEX_USERNAME, "username",
+                .addOption(newOptionWithArg(ARGUMENT.OSSINDEX_USER, "username",
                         "The username to authenticate to Sonatype's OSS Index. If not set the Sonatype OSS Index "
                                 + "Analyzer will use an unauthenticated connection."))
                 .addOption(newOptionWithArg(ARGUMENT.OSSINDEX_PASSWORD, "password", ""

--- a/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
@@ -433,7 +433,7 @@ public final class CliParser {
                 .addOption(newOptionWithArg(ARGUMENT.CENTRAL_CONTENT_URL, "url",
                         "Alternative URL to obtain content from an alternative repository. If not set the public Sonatype Maven Central will be used."
                         + "Use a repository endpoint, such as https://artifactory.com/artifactory/mvn-release/."))
-                .addOption(newOptionWithArg(ARGUMENT.CENTRAL_CONTENT_USERNAME, "username",
+                .addOption(newOptionWithArg(ARGUMENT.CENTRAL_CONTENT_USER, "username",
                         "Credentials for basic auth towards the --centralContentUrl."))
                 .addOption(newOptionWithArg(ARGUMENT.CENTRAL_CONTENT_PASSWORD, "password",
                         "Credentials for basic auth towards the --centralContentUrl"))
@@ -441,7 +441,7 @@ public final class CliParser {
                         "Token for bearer auth towards the --centralContentUrl"))
                 .addOption(newOptionWithArg(ARGUMENT.OSSINDEX_URL, "url",
                         "Alternative URL for the OSS Index. If not set the public Sonatype OSS Index will be used."))
-                .addOption(newOptionWithArg(ARGUMENT.OSSINDEX_USER, "username",
+                .addOption(newOptionWithArg(ARGUMENT.OSSINDEX_USERNAME, "username",
                         "The username to authenticate to Sonatype's OSS Index. If not set the Sonatype OSS Index "
                                 + "Analyzer will use an unauthenticated connection."))
                 .addOption(newOptionWithArg(ARGUMENT.OSSINDEX_PASSWORD, "password", ""


### PR DESCRIPTION
## Description of Change

This MR adds a new parameter for retrieving content from alternative sources.
This solves the problem where, especially recently, search.maven.org was returning a 502 error.
For example
https://search.maven.org/remotecontent?filepath=org/apache/ant/ant/1.10.14/ant-1.10.14.pom
<img width="1154" height="205" alt="image" src="https://github.com/user-attachments/assets/f983fca0-93d6-4e4c-aaef-4e7c717e6398" />


## Related issues

- relates to https://github.com/dependency-check/DependencyCheck/issues/7989


## Have test cases been added to cover the new functionality?

*no*