### PR TITLE
fix: Suppress JVM warnings from Lucene within CLI

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -92,6 +92,14 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                     <configurationDirectory>plugins/*</configurationDirectory>
                     <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
                     <unixScriptTemplate>${project.basedir}/src/main/conf/unixBinTemplate</unixScriptTemplate>
+                    <!--
+                       enable-native-access=ALL-UNNAMED
+                            Java 21+: Needed by Lucene indexes unless we do -Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false
+                                      to go back to regular ByteBuffer (non-native) usage.
+                       -XX:+IgnoreUnrecognizedVMOptions
+                            Java <21: Allow use of enable-native-access on Java 11 JVMs without errors
+                    -->
+                    <extraJvmArguments>--enable-native-access=ALL-UNNAMED -XX:+IgnoreUnrecognizedVMOptions</extraJvmArguments>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
## Description of Change

Follow-up to #7979 to remove remaining JVM warnings from the normal log output on JDK 21/25 CLI/Docker usage.

Alternate is to consider the use of all of these native Lucene features and whether it is worthwhile given the
scale of ODC's Lucene usage. (e.g the vector API probably isn't accessible/usable right now in some configurations) 

## Related issues

- fixes #7759 

## Have test cases been added to cover the new functionality?

no