### PR TITLE
build: Replace Maven Enforcer byte code rule with extra-enforcer-rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -520,9 +520,9 @@ Copyright (c) 2012 - Jeremy Long
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <dependencies>
                     <dependency>
-                        <groupId>org.owasp.maven.enforcer</groupId>
-                        <artifactId>class-file-format-rule</artifactId>
-                        <version>2.0.0</version>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>extra-enforcer-rules</artifactId>
+                        <version>1.11.0</version>
                     </dependency>
                 </dependencies>
                 <inherited>true</inherited>
@@ -535,23 +535,23 @@ Copyright (c) 2012 - Jeremy Long
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>1.8.0</version>
+                                    <version>${maven.compiler.release}</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>enforce-classfileformat</id>
-                        <configuration>
-                            <rules>
-                                <byteCodeRule implementation="org.owasp.maven.enforcer.rule.ClassFileFormatRule">
-                                    <supportedClassFileFormat>55</supportedClassFileFormat>
-                                </byteCodeRule>
-                            </rules>
-                        </configuration>
+                        <id>enforce-bytecode-version</id>
                         <goals>
                             <goal>enforce</goal>
                         </goals>
+                        <configuration>
+                            <rules>
+                                <enforceBytecodeVersion>
+                                    <maxJdkVersion>${maven.compiler.release}</maxJdkVersion>
+                                </enforceBytecodeVersion>
+                            </rules>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>enforce-maven-3</id>


### PR DESCRIPTION
## Description of Change

Also corrects the required Java version (it's moot, as we were targeting 11 anyway so you can't compile with Java 8)

Following Jeremy's own advice :-) https://github.com/jeremylong/class-file-format-rule
See https://www.mojohaus.org/extra-enforcer-rules/enforceBytecodeVersion.html

Fixes these warnings:
```
Warning:  ruleName byteCodeRule with implementation org.owasp.maven.enforcer.rule.ClassFileFormatRuleuses the deprecated Maven Enforcer Plugin API. This will not be supported in a future version of the plugin. Please contact the rule maintainer to upgrade the rule implementation to the current API.
```

## Related issues

N/A

## Have test cases been added to cover the new functionality?

yes

If you change it to `8` you'll get, for example

```
[INFO] --- enforcer:3.6.1:enforce (enforce-bytecode-version) @ dependency-check-utils ---
[INFO] Restricted to JDK 8 yet com.sun.xml.bind:jaxb-impl:jar:4.0.1:test contains org/glassfish/jaxb/runtime/api/AccessorException.class targeted to JDK 11
[INFO] Restricted to JDK 8 yet com.sun.xml.bind:jaxb-core:jar:4.0.1:test contains org/glassfish/jaxb/core/marshaller/Messages.class targeted to JDK 11
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.6.1:enforce (enforce-bytecode-version) on project dependency-check-utils:
[ERROR] Rule 0: org.codehaus.mojo.extraenforcer.dependencies.EnforceBytecodeVersion failed with message:
[ERROR] Found Banned Dependency: com.sun.xml.bind:jaxb-impl:jar:4.0.1
[ERROR] Found Banned Dependency: com.sun.xml.bind:jaxb-core:jar:4.0.1
[ERROR] Use 'mvn dependency:tree' to locate the source of the banned dependencies.
```