### PR TITLE
feat: support multple cvssBelow thesholds per version (#2563)

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/VulnerabilitySuppressionAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/VulnerabilitySuppressionAnalyzer.java
@@ -76,7 +76,7 @@ public class VulnerabilitySuppressionAnalyzer extends AbstractSuppressionAnalyze
 
     @Override
     public boolean filter(SuppressionRule rule) {
-        return rule.hasCve() || rule.hasCvssBelow() || rule.hasCwe() || rule.hasVulnerabilityName();
+        return rule.hasCve() || rule.hasCvssBelow() || rule.hasCvssV2Below() || rule.hasCvssV3Below()  || rule.hasCvssV4Below() || rule.hasCwe() || rule.hasVulnerabilityName();
     }
 
     @Override

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionHandler.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionHandler.java
@@ -95,6 +95,18 @@ public class SuppressionHandler extends DefaultHandler {
      */
     public static final String CVSS_BELOW = "cvssBelow";
     /**
+     * The cvssV2Below element name.
+     */
+    public static final String CVSS_V2_BELOW = "cvssV2Below";
+    /**
+     * The cvssV3Below element name.
+     */
+    public static final String CVSS_V3_BELOW = "cvssV3Below";
+    /**
+     * The cvssV4Below element name.
+     */
+    public static final String CVSS_V4_BELOW = "cvssV4Below";
+    /**
      * A list of suppression rules.
      */
     private final List<SuppressionRule> suppressionRules = new ArrayList<>();
@@ -231,6 +243,18 @@ public class SuppressionHandler extends DefaultHandler {
                 case CVSS_BELOW:
                     final Double cvss = Double.valueOf(currentText.toString().trim());
                     rule.addCvssBelow(cvss);
+                    break;
+                case CVSS_V2_BELOW:
+                    final Double cvssV2 = Double.valueOf(currentText.toString().trim());
+                    rule.addCvssV2Below(cvssV2);
+                    break;
+                case CVSS_V3_BELOW:
+                    final Double cvssV3 = Double.valueOf(currentText.toString().trim());
+                    rule.addCvssV3Below(cvssV3);
+                    break;
+                case CVSS_V4_BELOW:
+                    final Double cvssV4 = Double.valueOf(currentText.toString().trim());
+                    rule.addCvssV4Below(cvssV4);
                     break;
                 default:
                     break;

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
@@ -64,6 +64,18 @@ public class SuppressionRule {
      */
     private List<Double> cvssBelow = new ArrayList<>();
     /**
+     * The list of cvssV2Below scores.
+     */
+    private List<Double> cvssV2Below = new ArrayList<>();
+    /**
+     * The list of cvssV3Below scores.
+     */
+    private List<Double> cvssV3Below = new ArrayList<>();
+    /**
+     * The list of cvssV4Below scores.
+     */
+    private List<Double> cvssV4Below = new ArrayList<>();
+    /**
      * The list of CWE entries to suppress.
      */
     private List<String> cwe = new ArrayList<>();
@@ -259,6 +271,114 @@ public class SuppressionRule {
      */
     public boolean hasCvssBelow() {
         return !cvssBelow.isEmpty();
+    }
+
+    /**
+     * Get the value of cvssV2Below.
+     *
+     * @return the value of cvssV2Below
+     */
+    public List<Double> getCvssV2Below() {
+        return cvssV2Below;
+    }
+
+    /**
+     * Set the value of cvssV2Below.
+     *
+     * @param cvssV2Below new value of cvssV2Below
+     */
+    public void setCvssV2Below(List<Double> cvssV2Below) {
+        this.cvssV2Below = cvssV2Below;
+    }
+
+    /**
+     * Adds the CVSS to the cvssV2Below list.
+     *
+     * @param cvss the CVSS to add
+     */
+    public void addCvssV2Below(Double cvss) {
+        this.cvssV2Below.add(cvss);
+    }
+
+    /**
+     * Returns whether or not this suppression rule has CVSS v2 suppression criteria.
+     *
+     * @return whether or not this suppression rule has CVSS v2 suppression criteria.
+     */
+    public boolean hasCvssV2Below() {
+        return !cvssV2Below.isEmpty();
+    }
+
+    /**
+     * Get the value of cvssV3Below.
+     *
+     * @return the value of cvssV3Below
+     */
+    public List<Double> getCvssV3Below() {
+        return cvssV3Below;
+    }
+
+    /**
+     * Set the value of cvssV3Below.
+     *
+     * @param cvssV3Below new value of cvssV3Below
+     */
+    public void setCvssV3Below(List<Double> cvssV3Below) {
+        this.cvssV3Below = cvssV3Below;
+    }
+
+    /**
+     * Adds the CVSS to the cvssV3Below list.
+     *
+     * @param cvss the CVSS to add
+     */
+    public void addCvssV3Below(Double cvss) {
+        this.cvssV3Below.add(cvss);
+    }
+
+    /**
+     * Returns whether or not this suppression rule has CVSS v3 suppression criteria.
+     *
+     * @return whether or not this suppression rule has CVSS v3 suppression criteria.
+     */
+    public boolean hasCvssV3Below() {
+        return !cvssV3Below.isEmpty();
+    }
+
+    /**
+     * Get the value of cvssV4Below.
+     *
+     * @return the value of cvssV4Below
+     */
+    public List<Double> getCvssV4Below() {
+        return cvssV4Below;
+    }
+
+    /**
+     * Set the value of cvssV4Below.
+     *
+     * @param cvssV4Below new value of cvssV4Below
+     */
+    public void setCvssV4Below(List<Double> cvssV4Below) {
+        this.cvssV4Below = cvssV4Below;
+    }
+
+    /**
+     * Adds the CVSS to the cvssV4Below list.
+     *
+     * @param cvss the CVSS to add
+     */
+    public void addCvssV4Below(Double cvss) {
+        this.cvssV4Below.add(cvss);
+    }
+
+    /**
+     * Returns whether or not this suppression rule has CVSS v4 suppression criteria.
+     *
+     * @return whether or not this suppression rule has CVSS v4 suppression criteria.
+     */
+    public boolean hasCvssV4Below() {
+        return !cvssV4Below.isEmpty();
     }
 
     /**
@@ -494,7 +614,7 @@ public class SuppressionRule {
             }
             removalList.forEach(dependency::removeVulnerableSoftwareIdentifier);
         }
-        if (hasCve() || hasVulnerabilityName() || hasCwe() || hasCvssBelow()) {
+        if (hasCve() || hasVulnerabilityName() || hasCwe() || hasCvssBelow() || hasCvssV2Below() || hasCvssV3Below() || hasCvssV4Below()) {
             final Set<Vulnerability> removeVulns = new HashSet<>();
             for (Vulnerability v : dependency.getVulnerabilities()) {
                 boolean remove = false;
@@ -525,23 +645,9 @@ public class SuppressionRule {
                     }
                 }
                 if (!remove) {
-                    for (Double cvss : this.cvssBelow) {
-                        //TODO validate this comparison
-                        if (v.getCvssV2() != null && v.getCvssV2().getCvssData().getBaseScore().compareTo(cvss) < 0) {
-                            remove = true;
-                            removeVulns.add(v);
-                            break;
-                        }
-                        if (v.getCvssV3() != null && v.getCvssV3().getCvssData().getBaseScore().compareTo(cvss) < 0) {
-                            remove = true;
-                            removeVulns.add(v);
-                            break;
-                        }
-                        if (v.getCvssV4() != null && v.getCvssV4().getCvssData().getBaseScore().compareTo(cvss) < 0) {
-                            remove = true;
-                            removeVulns.add(v);
-                            break;
-                        }
+                    if (suppressedBasedOnScore(v)) {
+                        remove = true;
+                        removeVulns.add(v);
                     }
                 }
                 if (remove && !isBase()) {
@@ -554,6 +660,44 @@ public class SuppressionRule {
             }
             removeVulns.forEach(dependency::removeVulnerability);
         }
+    }
+
+    boolean suppressedBasedOnScore(Vulnerability v) {
+        if (!cvssBelow.isEmpty()) {
+            for (Double cvss : this.cvssBelow) {
+                //TODO validate this comparison
+                if (v.getCvssV2() != null && v.getCvssV2().getCvssData().getBaseScore().compareTo(cvss) < 0) {
+                    return true;
+                }
+                if (v.getCvssV3() != null && v.getCvssV3().getCvssData().getBaseScore().compareTo(cvss) < 0) {
+                    return true;
+                }
+                if (v.getCvssV4() != null && v.getCvssV4().getCvssData().getBaseScore().compareTo(cvss) < 0) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if (hasCvssV2Below() || hasCvssV3Below() || hasCvssV4Below()) {
+            Double v2SuppressionThreshold = this.cvssV2Below.stream().max(Double::compare).orElse(11.0);
+            Double v3SuppressionThreshold = this.cvssV3Below.stream().max(Double::compare).orElse(11.0);
+            Double v4SuppressionThreshold = this.cvssV4Below.stream().max(Double::compare).orElse(11.0);
+
+            Double v2Score = v.getCvssV2() != null ? v.getCvssV2().getCvssData().getBaseScore() : null;
+            Double v3Score = v.getCvssV3() != null ? v.getCvssV3().getCvssData().getBaseScore() : null;
+            Double v4Score = v.getCvssV4() != null ? v.getCvssV4().getCvssData().getBaseScore() : null;
+
+            // only if all version indicate suppression will the vulnerability be suppressed
+            // so if we are missing data (score or threshold) for a specific version we assume suppression
+            boolean cvssV2CheckSuppressing = v2Score == null || v2Score < v2SuppressionThreshold;
+            boolean cvssV3CheckSuppressing = v3Score == null || v3Score < v3SuppressionThreshold;
+            boolean cvssV4CheckSuppressing = v4Score == null || v4Score < v4SuppressionThreshold;
+
+            return cvssV2CheckSuppressing && cvssV3CheckSuppressing && cvssV4CheckSuppressing;
+        }
+
+        return false;
     }
 
     /**
@@ -692,6 +836,21 @@ public class SuppressionRule {
         if (cvssBelow != null && !cvssBelow.isEmpty()) {
             sb.append("cvssBelow={");
             cvssBelow.forEach((s) -> sb.append(s).append(','));
+            sb.append('}');
+        }
+        if (cvssV2Below != null && !cvssV2Below.isEmpty()) {
+            sb.append("cvssV2Below={");
+            cvssV2Below.forEach((s) -> sb.append(s).append(','));
+            sb.append('}');
+        }
+        if (cvssV3Below != null && !cvssV3Below.isEmpty()) {
+            sb.append("cvssV3Below={");
+            cvssV3Below.forEach((s) -> sb.append(s).append(','));
+            sb.append('}');
+        }
+        if (cvssV4Below != null && !cvssV4Below.isEmpty()) {
+            sb.append("cvssV4Below={");
+            cvssV4Below.forEach((s) -> sb.append(s).append(','));
             sb.append('}');
         }
         sb.append('}');

--- a/core/src/main/resources/schema/dependency-suppression.1.4.xsd
+++ b/core/src/main/resources/schema/dependency-suppression.1.4.xsd
@@ -49,6 +49,9 @@
                 <xs:element name="vulnerabilityName" type="dc:regexStringType"/>
                 <xs:element name="cwe" type="xs:positiveInteger"/>
                 <xs:element name="cvssBelow" type="dc:cvssScoreType"/>
+                <xs:element name="cvssV2Below" type="dc:cvssScoreType" />
+                <xs:element name="cvssV3Below" type="dc:cvssScoreType" />
+                <xs:element name="cvssV4Below" type="dc:cvssScoreType" />
             </xs:choice>
         </xs:sequence>
         <xs:attribute name="until" type="xs:date"/>

--- a/src/site/markdown/general/suppression.md
+++ b/src/site/markdown/general/suppression.md
@@ -109,6 +109,39 @@ It is also possible to set an expiration date for a suppression rule:
 </suppressions>
 ```
 
+Suppressions can also be configured based on CVSS scores.  The element cvssScore specifies
+a score threshold.  Vulnerabilities that have any score below this threshold will be suppressed.
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+    <suppress until="2020-01-01Z">
+        <notes><![CDATA[
+        Suppress any vulnerability with a score below 7
+        ]]></notes>
+        <cvssScore>7</cvssScore>
+    </suppress>
+</suppressions>
+```
+
+Suppressions can also be configured per CVSS score version.  In the example that follows a vulnerability
+will be suppressed only if its CVSS v2 score is below 7, its CVSS v3 score is below 8,
+and its CVSS v4 score is below 9.  If the vulnerability does not have a score for a given
+version the threshold not be applied to the suppression decision.  If you specify a cvssScore 
+element and cvssVnScore elements, the later will be ignored.
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+    <suppress until="2020-01-01Z">
+        <notes><![CDATA[
+        Suppress any vulnerability with different threshold per CVSS version
+        ]]></notes>
+        <cvssV2Score>7</cvssV2Score>
+        <cvssV3Score>8</cvssV3Score>
+        <cvssV4Score>9</cvssV4Score>
+    </suppress>
+</suppressions>
+```
+
 The full schema for suppression files can be found here: [suppression.xsd](https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.3.xsd "Suppression Schema")
 
 Please see the appropriate configuration option in each interfaces configuration guide:


### PR DESCRIPTION
## Description of Change

Implements the proposed changes in #2563.  Adds 3 cvssVnBelow thresholds in the suppression configuration, one for each version (n=2, 3 and 4).  The suppression logic is updated so that a vulnerability will only be suppressed if all the version scores are below their cvssVnBelow values.   For existing suppressions using cvssBelow nothing changes, only when cvssVnBelow elements are included in the suppression with the new functionality be applied.

For example, in the existing implementation if a vulnerability has a scores of say 5 (V2) and 9 (V3) and cvssBelow is set to 7.  The vulnerability is suppressed due to the V2 score of 5.  This new functionality will allow a suppression to be configured with cvssV2Below=7, cvssV3Below=7, and then the same vulnerability will not get suppressed since all the cvssBelow checks do not agree to suppress.


## Related issues

Fixes #2563 

## Have test cases been added to cover the new functionality?

yes