### PR TITLE
docs: Bump maven-fluido-skin to latest non-milestone version

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -22,11 +22,10 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <skin>
         <groupId>org.apache.maven.skins</groupId>
         <artifactId>maven-fluido-skin</artifactId>
-        <version>2.0.0-M11</version>
+        <version>2.1.0</version>
     </skin>
     <custom>
         <fluidoSkin>
-            <!--googleSearch/-->
             <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
             <sideBarEnabled>true</sideBarEnabled>
             <gitHub>


### PR DESCRIPTION
## Description of Change

Bumps the skin version; dependabot doesn't seem to be able to handle this one.

## Related issues

N/A

## Have test cases been added to cover the new functionality?

no, validated locally that everything looks fine.