### PR TITLE
fix(fp): Suppress false positives across PyPi Sentry-adjacent libraries

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -2522,3 +2522,11 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
    <packageUrl regex="true">^pkg:maven/com\.pinterest\.ktlint/ktlint-cli-reporter-checkstyle@.*$</packageUrl>
    <cpe>cpe:/a:checkstyle:checkstyle</cpe>
 </suppress>
+<suppress base="true">
+    <notes><![CDATA[
+       hand-curated better suppression for FP per issue #8057. The sentry server is/was only available on the specific
+       pypi package here. Not suppressed for other ecosystems as Sentry Server is still available open-source elsewhere.
+       ]]></notes>
+    <packageUrl regex="true">^pkg:pypi/(?!sentry@).*$</packageUrl>
+    <cpe>cpe:/a:sentry:sentry:</cpe>
+</suppress>


### PR DESCRIPTION
## Description of Change

The Sentry server was released on PyPi directly at https://pypi.org/project/sentry/ at some point but yanked some time ago. All of the other packages are definitely not the Sentry server. All of the CVEs [at this CPE relate to the server](https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=5&sortDirection=2&cpeFilterMode=applicability&cpeName=cpe:2.3:a:sentry:sentry:*:*:*:*:*:*:*:*&resultType=records), not to any SDKs - also confirmed via their [GHSA entries](https://github.com/getsentry/sentry/security).

## Related issues

- fixes #8057

## Have test cases been added to cover the new functionality?
N/A