### PR TITLE
fix(fp): Correct GRPC java suppressions for newer C/C++/native false positives

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -296,34 +296,41 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per #3002
+        FP per #3002 CPE is for GRPC core
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.opencensus/opencensus\-contrib\-grpc\-metrics@.*$</packageUrl>
         <cpe>cpe:/a:grpc:grpc</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per #3002, CVE is for grpc-js and c
+        FP per #3002 and #5890 - CVE are for GRPC C/ruby/python etc. Suppressing individual CVEs because ODC cannot understand the target SW
+        field. NVD search to review in future (not that some are marked incorrectly as affecting all languages)
+        --> https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=1&sortDirection=1&cpeFilterMode=applicability&cpeName=cpe:2.3:a:grpc:grpc:*:*:*:*:*:*:*:*&resultType=records
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.grpc/grpc\-.*$</packageUrl>
-        <cve>CVE-2020-7768</cve>
+        <cve>CVE-2017-7860</cve>
         <cve>CVE-2017-7861</cve>
         <cve>CVE-2017-8359</cve>
         <cve>CVE-2017-9431</cve>
+        <cve>CVE-2020-7768</cve>
+        <cve>CVE-2023-1428</cve>
+        <cve>CVE-2023-32731</cve>
+        <cve>CVE-2023-32732</cve>
+        <cve>CVE-2023-33953</cve>
+        <cve>CVE-2023-4785</cve>
+        <cve>CVE-2024-11407</cve>
+        <cve>CVE-2024-7246</cve>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per #3002, CVE is for grpc-js and c
+        FP per #3002, CPE is for GRPC core
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.google\.api\.grpc/grpc\-google\-common\-protos@.*$</packageUrl>
-        <cve>CVE-2020-7768</cve>
-        <cve>CVE-2017-7861</cve>
-        <cve>CVE-2017-8359</cve>
-        <cve>CVE-2017-9431</cve>
+        <cpe>cpe:/a:grpc:grpc</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per #3002, CVE is for grpc-js
+        FP per #3002, CPE is for GRPC core
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.lightstep\.tracer/.*$</packageUrl>
         <cpe>cpe:/a:grpc:grpc</cpe>


### PR DESCRIPTION
## Description of Change

Updates the list of suppressions for GRPC java for newer C++/native vulns after review. See https://github.com/dependency-check/DependencyCheck/issues/5890#issuecomment-1869933910, however at this time I didn't realise we already had a CVE-by-CVE suppression list. I suppose we chose to do so since grpc is such a big/popular library.

Can [review the CVEs at NVD](https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=1&sortDirection=1&cpeFilterMode=applicability&cpeName=cpe:2.3:a:grpc:grpc:*:*:*:*:*:*:*:*&resultType=records).

## Related issues

- fixes #5890

## Have test cases been added to cover the new functionality?

N/A