### PR TITLE
docs: fix #8076 - Error in documentation "Suppressing False Positives"

### DIFF
--- a/src/site/markdown/general/suppression.md
+++ b/src/site/markdown/general/suppression.md
@@ -82,7 +82,7 @@ HTML version of the report. The other common scenario would be to ignore all CVE
         This suppresses false positives identified on spring security.
         ]]></notes>
         <gav regex="true">org\.springframework\.security:spring.*</gav>
-        <vulnerabilityName regex="true"></vulnerabilityName>
+        <vulnerabilityName regex="true">.*</vulnerabilityName>
     </suppress>
     <suppress until="2020-01-01Z">
         <notes><![CDATA[


### PR DESCRIPTION
## Description of Change

In the documentation "Suppressing False Positives", the sample to select all CVE is wrong
It is documented as:
<vulnerabilityName regex="true"></vulnerabilityName>
but it must be:
<vulnerabilityName regex="true">.*</vulnerabilityName>

## Related issues

Fix #8076 - Error in documentation "Suppressing False Positives"
