### PR TITLE
chore: Replace deprecated lucene methods

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/cpe/AbstractMemoryIndex.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/cpe/AbstractMemoryIndex.java
@@ -39,7 +39,6 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
@@ -282,15 +281,15 @@ public abstract class AbstractMemoryIndex implements MemoryIndex {
         Query query;
         try {
             query = queryParser.parse(searchString);
-        } catch (BooleanQuery.TooManyClauses ex) {
-            BooleanQuery.setMaxClauseCount(Integer.MAX_VALUE);
+        } catch (IndexSearcher.TooManyClauses ex) {
+            IndexSearcher.setMaxClauseCount(Integer.MAX_VALUE);
             query = queryParser.parse(searchString);
         } catch (ParseException ex) {
             if (ex.getMessage() != null && ex.getMessage().contains("too many boolean clauses")) {
-                BooleanQuery.setMaxClauseCount(Integer.MAX_VALUE);
+                IndexSearcher.setMaxClauseCount(Integer.MAX_VALUE);
                 query = queryParser.parse(searchString);
             } else {
-                LOGGER.debug("Parse Excepction", ex);
+                LOGGER.debug("Parse Exception", ex);
                 throw ex;
             }
         }
@@ -325,7 +324,7 @@ public abstract class AbstractMemoryIndex implements MemoryIndex {
      */
     @Override
     public synchronized Document getDocument(int documentId) throws IOException {
-        return indexSearcher.doc(documentId);
+        return indexSearcher.storedFields().document(documentId);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ Copyright (c) 2012 - Jeremy Long
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
 
-        <apache.lucene.version>9.12.0</apache.lucene.version>
+        <apache.lucene.version>9.12.3</apache.lucene.version>
         <apache.ant.version>1.10.15</apache.ant.version>
 
         <!-- upgrading slf4j and logback can cause issues ;) https://github.com/dependency-check/DependencyCheck/issues/4846 -->


### PR DESCRIPTION
## Description of Change
- bump lucene.version from 9.12.0 to 9.12.3 (patch)
- Replaced existing deprecated Lucene API calls with their current equivalents.
- Verified build and tests pass using mvn test.
- No functional or behavioral changes introduced.

## Have test cases been added to cover the new functionality?

no new functionality