### PR TITLE
docs: Update SBT plugin link; fix dead report link

### DIFF
--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -32,7 +32,9 @@ OWASP dependency-check's core analysis engine can be used as:
 - [Gradle Plugin](dependency-check-gradle/index.html)
 - [Jenkins Plugin](dependency-check-jenkins/index.html)
 - [Maven Plugin](dependency-check-maven/index.html) - Maven 3.6.3 or newer required
-- [SBT Plugin](https://github.com/albuch/sbt-dependency-check)
+
+Unofficial (Not endorsed by OWASP)
+- [SBT Plugin](https://github.com/nMoncho/sbt-dependency-check)
 
 For help with dependency-check the following resource can be used:
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -12,7 +12,7 @@ configuration.
 
 The problem with using known vulnerable components was covered in a paper by
 Jeff Williams and Arshan Dabirsiaghi titled, "[The Unfortunate Reality of
-Insecure Libraries](http://www1.contrastsecurity.com/the-unfortunate-reality-of-insecure-libraries?&amp;__hssc=92971330.1.1412763139545&amp;__hstc=92971330.5d71a97ce2c038f53e4109bfd029b71e.1412763139545.1412763139545.1412763139545.1&amp;hsCtaTracking=7bbb964b-eac1-454d-9d5b-cc1089659590%7C816e01cf-4d75-449a-8691-bd0c6f9946a5)"
+Insecure Libraries](https://www.scribd.com/document/175866686/Aspect-Security-the-Unfortunate-Reality-of-Insecure-Libraries)"
 (registration required). The gist of the paper is that we as a development
 community include third party libraries in our applications that contain well
 known published vulnerabilities \(such as those at the

--- a/src/site/markdown/modules.md
+++ b/src/site/markdown/modules.md
@@ -8,7 +8,9 @@ build and reporting process:
 - [Gradle Plugin](dependency-check-gradle/index.html)
 - [Jenkins Plugin](dependency-check-jenkins/index.html)
 - [Maven Plugin](dependency-check-maven/index.html)
-- [SBT Plugin](https://github.com/albuch/sbt-dependency-check)
+
+Unofficial (Not endorsed by OWASP)
+- [SBT Plugin](https://github.com/nMoncho/sbt-dependency-check)
 
 In addition, dependency-check can be executed from the 
 [command line](dependency-check-cli/index.html).


### PR DESCRIPTION
## Description of Change

- Update SBT plugin link as the old plugin is unmaintained
- fix dead link to earlier report on insecure libraries
 
## Related issues

Mirror to what was done in https://github.com/OWASP/www-project-dependency-check/pull/6

## Have test cases been added to cover the new functionality?

N/A