### PR TITLE
fix(fp): Consolidate false positive suppressions for graphql-java

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1,65 +1,9 @@
 <suppress base="true">
    <notes><![CDATA[
-   FP per issue #4852
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-kickstart@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
    FP per issue #4803
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/net\.sourceforge\.htmlunit/htmlunit-cssparser@.*$</packageUrl>
    <cpe>cpe:/a:htmlunit_project:htmlunit</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #4853
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-servlet@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #4859
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.apollographql\.federation/federation-graphql-java-support@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #4851
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java/graphql-java-extended-scalars@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #4860
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.apollographql\.federation/federation-graphql-java-support-api@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #4862
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/io\.github\.graphql-java/graphql-java-annotations@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #4863
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java/java-dataloader@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #4854
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-tools@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
 </suppress>
 <suppress base="true">
    <notes><![CDATA[
@@ -209,7 +153,6 @@
    <cpe>cpe:/a:pagehelper_project:pagehelper</cpe>
 </suppress>
 <!-- suppressions above this entry were included in the 7.3.1 release -->
-
 <suppress base="true">
        <notes><![CDATA[
            FP per issue https://github.com/jeremylong/DependencyCheck/issues/5060
@@ -500,13 +443,6 @@
 </suppress>
 <suppress base="true">
    <notes><![CDATA[
-   FP per issue #5275
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-spring-boot-starter@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
    FP per issue #5276
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop\.thirdparty/hadoop-shaded-guava@.*$</packageUrl>
@@ -542,13 +478,6 @@
 </suppress>
 <!-- suppressions above this entry will be included in the 8.0.0 release (see #5304) -->
 
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #5333
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-kickstart-spring-support@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java_project:graphql-java</cpe>
-</suppress>
 <suppress base="true">
    <notes><![CDATA[
    FP per issue #5336
@@ -770,41 +699,6 @@
 </suppress>
 <suppress base="true">
    <notes><![CDATA[
-   FP per issue #5636
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java/graphql-java-extended-scalars@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #5639
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-tools@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #5638
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-servlet@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #5637
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-kickstart@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #5657
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-kickstart-spring-support@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
    FP per issue #5685
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/org\.bouncycastle/bcpg-jdk15on@.*$</packageUrl>
@@ -830,13 +724,6 @@
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.api/api-ldap-net-mina@.*$</packageUrl>
    <cpe>cpe:/a:apache:mina</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #5719
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-webclient@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java:graphql-java</cpe>
 </suppress>
 <suppress base="true">
    <notes><![CDATA[
@@ -973,41 +860,6 @@
    ]]></notes>
    <packageUrl regex="true">^pkg:nuget/RazorEngine\.NetCore@.*$</packageUrl>
    <cpe>cpe:/a:razorengine_project:razorengine</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #5648
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/io\.github\.graphql-java/graphql-java-annotations@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #5643
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-spring-boot-starter@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #5641
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.graphql-java/java-dataloader@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #5647
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.apollographql\.federation/federation-graphql-java-support-api@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #5646
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.apollographql\.federation/federation-graphql-java-support@.*$</packageUrl>
-   <cpe>cpe:/a:graphql-java:graphql-java</cpe>
 </suppress>
 <suppress base="true">
    <notes><![CDATA[
@@ -1906,7 +1758,16 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
    <cpe>cpe:/a:python:python</cpe>
 </suppress>
 <!-- suppressions above this entry were included in the 11.0.0 release -->
-
+<suppress base="true">
+   <notes><![CDATA[
+   FP per issue #4852, #4803, #4853, #4851, #4859, #4860, #4862, #4863, #4854, #5275, #5333, #5636, #5639, #5638,
+                #5637, #5657, #5646, #5647, #5641, #5643, #5648, #5719, #8094, #8093, #8091, #8089
+   Consolidated suppression. Only com.graphql-java/graphql-java represents graphql-java project, the rest are other
+   artifacts independently versioned and released.
+   ]]></notes>
+   <packageUrl regex="true">^pkg:(?!maven/com\.graphql-java/graphql-java@).*$</packageUrl>
+   <cpe>cpe:/a:graphql-java:graphql-java:</cpe>
+</suppress>
 <suppress base="true">
    <notes><![CDATA[
    FP per issue #7066


### PR DESCRIPTION
## Description of Change

Consolidates the many FP suppressions for graphql-java CPE into a single negative lookahead. There is a single package that represents this project and its CPE.

## Related issues

- fixes #8089
- fixes #8091
- fixes #8093 
- fixes #8094

## Have test cases been added to cover the new functionality?

N/A - note **merging to generated/hosted suppressions only**