### PR TITLE
fix: correct reliability of Central etc (JCS cache) analyzers on Java 25/Docker by making CLI classpath deterministic 

### DIFF
--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -223,10 +223,6 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.jeremylong</groupId>
-            <artifactId>jcs3-slf4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-core</artifactId>
             <version>${project.parent.version}</version>

--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Purge.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Purge.java
@@ -17,7 +17,6 @@
  */
 package org.owasp.dependencycheck.taskdefs;
 
-import io.github.jeremylong.jcs3.slf4j.Slf4jAdapter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -128,9 +127,6 @@ public class Purge extends Task {
      * Hacky method of muting the noisy logging from JCS.
      */
     private void muteNoisyLoggers() {
-        System.setProperty("jcs.logSystem", "slf4j");
-        Slf4jAdapter.muteLogging(true);
-
         final String[] noisyLoggers = {
             "org.apache.hc"
         };

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -67,7 +67,11 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                     <archive>
                         <manifest>
                             <mainClass>org.owasp.dependencycheck.App</mainClass>
+                            <addClasspath>true</addClasspath>
                         </manifest>
+                        <manifestEntries>
+                            <Premain-Class>org.owasp.dependencycheck.PluginLoader</Premain-Class>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>
@@ -79,6 +83,11 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                         <program>
                             <mainClass>org.owasp.dependencycheck.App</mainClass>
                             <id>dependency-check</id>
+                            <commandLineArguments>
+                                <commandLineArgument>-javaagent:@REPO@/${project.artifactId}-${project.version}.jar=@BASEDIR@/plugins</commandLineArgument>
+                                <commandLineArgument>-jar</commandLineArgument>
+                                <commandLineArgument>@REPO@/${project.artifactId}-${project.version}.jar</commandLineArgument>
+                            </commandLineArguments>
                         </program>
                     </programs>
                     <assembleDirectory>${project.build.directory}/release</assembleDirectory>
@@ -88,10 +97,8 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                     </binFileExtensions>
                     <repositoryLayout>flat</repositoryLayout>
                     <repositoryName>lib</repositoryName>
-                    <useWildcardClassPath>true</useWildcardClassPath>
-                    <configurationDirectory>plugins/*</configurationDirectory>
-                    <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
-                    <unixScriptTemplate>${project.basedir}/src/main/conf/unixBinTemplate</unixScriptTemplate>
+                    <unixScriptTemplate>${project.basedir}/src/main/conf/unixBinTemplate.sh</unixScriptTemplate>
+                    <windowsScriptTemplate>${project.basedir}/src/main/conf/windowsBinTemplate.bat</windowsScriptTemplate>
                     <!--
                        enable-native-access=ALL-UNNAMED
                             Java 21+: Needed by Lucene indexes unless we do -Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false
@@ -107,25 +114,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                         <goals>
                             <goal>assemble</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>fix-windows-shell-script</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <!-- Hack/workaround for https://github.com/mojohaus/appassembler/issues/114 -->
-                            <target>
-                                <replace file="${project.build.directory}/release/bin/dependency-check.bat" token="%JAVACMD% %JAVA_OPTS%" value="&quot;%JAVACMD%&quot; %JAVA_OPTS%" failOnNoReplacements="true" />
-                            </target>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -197,6 +185,11 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                     <artifactId>tools</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -180,10 +180,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.jeremylong</groupId>
-            <artifactId>jcs3-slf4j</artifactId>
-        </dependency>
-        <dependency>
             <!-- not visible in imports due to method chaining, but App code uses classes from this library -->
             <groupId>io.github.jeremylong</groupId>
             <artifactId>open-vulnerability-clients</artifactId>

--- a/cli/src/main/conf/unixBinTemplate.sh
+++ b/cli/src/main/conf/unixBinTemplate.sh
@@ -53,7 +53,6 @@ fi
 # For Cygwin and MINGW, ensure paths are in UNIX format before anything is touched
 if $cygwin || $mingw; then
   [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
-  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
 fi
 
 # If a specific java binary isn't specified search for the standard 'java' binary
@@ -81,20 +80,8 @@ then
   REPO="$BASEDIR"/@REPO@
 fi
 
-CLASSPATH=@CLASSPATH@
-
-ENDORSED_DIR=@ENDORSED_DIR@
-if [ -n "$ENDORSED_DIR" ] ; then
-  CLASSPATH=$BASEDIR/$ENDORSED_DIR/*:$CLASSPATH
-fi
-
-if [ -n "$CLASSPATH_PREFIX" ] ; then
-  CLASSPATH=$CLASSPATH_PREFIX:$CLASSPATH
-fi
-
 # For Cygwin and Mingw, switch paths to Windows format before running java
 if $cygwin || $mingw; then
-  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
   [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
   [ -n "$HOME" ] && HOME=`cygpath --path --windows "$HOME"`
   [ -n "$BASEDIR" ] && BASEDIR=`cygpath --path --windows "$BASEDIR"`
@@ -110,11 +97,9 @@ fi
 done
 
 exec "$JAVACMD" $JAVA_OPTS $DEBUG @EXTRA_JVM_ARGUMENTS@ \
-  -classpath "$CLASSPATH" \
   -Dapp.name="@APP_NAME@" \
   -Dapp.pid="$$" \
   -Dapp.repo="$REPO" \
   -Dapp.home="$BASEDIR" \
   -Dbasedir="$BASEDIR" \
-  @MAINCLASS@ \
   @APP_ARGUMENTS@"$@"@UNIX_BACKGROUND@

--- a/cli/src/main/conf/windowsBinTemplate.bat
+++ b/cli/src/main/conf/windowsBinTemplate.bat
@@ -1,0 +1,88 @@
+#LICENSE_HEADER#
+@echo off
+
+set ERROR_CODE=0
+
+:init
+@REM Decide how to startup depending on the version of windows
+
+@REM -- Win98ME
+if NOT "%OS%"=="Windows_NT" goto Win9xArg
+
+@REM set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" @setlocal
+
+@REM -- 4NT shell
+if "%eval[2+2]" == "4" goto 4NTArgs
+
+@REM -- Regular WinNT shell
+set CMD_LINE_ARGS=%*
+goto WinNTGetScriptDir
+
+@REM The 4NT Shell from jp software
+:4NTArgs
+set CMD_LINE_ARGS=%$
+goto WinNTGetScriptDir
+
+:Win9xArg
+@REM Slurp the command line arguments.  This loop allows for an unlimited number
+@REM of arguments (up to the command line limit, anyway).
+set CMD_LINE_ARGS=
+:Win9xApp
+if %1a==a goto Win9xGetScriptDir
+set CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
+shift
+goto Win9xApp
+
+:Win9xGetScriptDir
+set SAVEDIR=%CD%
+%0\
+cd %0\..\..
+set BASEDIR=%CD%
+cd %SAVEDIR%
+set SAVE_DIR=
+goto repoSetup
+
+:WinNTGetScriptDir
+for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
+
+:repoSetup
+set REPO=
+#ENV_SETUP#
+
+if "%JAVACMD%"=="" set JAVACMD=#JAVA_BINARY#
+
+if "%REPO%"=="" set REPO=%BASEDIR%\#REPO#
+
+@REM Reaching here means variables are defined and arguments have been captured
+:endInit
+
+"%JAVACMD%" %JAVA_OPTS% #EXTRA_JVM_ARGUMENTS# -Dapp.name="#APP_NAME#" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" #APP_ARGUMENTS#%CMD_LINE_ARGS%
+if %ERRORLEVEL% NEQ 0 goto error
+goto end
+
+:error
+if "%OS%"=="Windows_NT" @endlocal
+set ERROR_CODE=%ERRORLEVEL%
+
+:end
+@REM set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" goto endNT
+
+@REM For old DOS remove the set variables from ENV - we assume they were not set
+@REM before we started - at least we don't leave any baggage around
+set CMD_LINE_ARGS=
+goto postExec
+
+:endNT
+@REM If error code is set to 1 then the endlocal was done already in :error.
+if %ERROR_CODE% EQU 0 @endlocal
+
+
+:postExec
+
+if "%FORCE_EXIT_ON_ERROR%" == "on" (
+  if %ERROR_CODE% NEQ 0 exit %ERROR_CODE%
+)
+
+exit /B %ERROR_CODE%

--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -48,7 +48,6 @@ import ch.qos.logback.classic.filter.ThresholdFilter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
-import io.github.jeremylong.jcs3.slf4j.Slf4jAdapter;
 import java.util.TreeSet;
 import org.owasp.dependencycheck.utils.SeverityUtil;
 
@@ -84,10 +83,6 @@ public class App {
      */
     @SuppressWarnings("squid:S4823")
     public static void main(String[] args) {
-        System.setProperty("jcs.logSystem", "slf4j");
-        if (!LOGGER.isDebugEnabled()) {
-            Slf4jAdapter.muteLogging(true);
-        }
         final int exitCode;
         final App app = new App();
         exitCode = app.run(args);

--- a/cli/src/main/java/org/owasp/dependencycheck/PluginLoader.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/PluginLoader.java
@@ -1,0 +1,38 @@
+package org.owasp.dependencycheck;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.instrument.Instrumentation;
+import java.util.jar.JarFile;
+
+/**
+ * Java agent for loading plugin JARs from a specified directory into the system classpath
+ * before the main application starts. This allows additional plugins to be available at runtime
+ * by appending their JAR files to the system class loader search path; while allowing use of an
+ * executable jar with deterministic classpath ordering.
+ * <p/>
+ * To use, specify this class as a Java agent and provide the plugins directory as the -javaagent argument
+ */
+public class PluginLoader {
+    /**
+     * Java agent entry point. Loads all JAR files from the specified plugins directory
+     * and appends them to the system class loader search path.
+     *
+     * @param agentArg the path to the plugins directory containing JAR files to load, e.g `-javaagent:cli.jar=/usr/share/dependency-check/plugins`
+     * @param inst     the instrumentation instance provided by the JVM
+     */
+    public static void premain(String agentArg, Instrumentation inst) {
+        File pluginsDir = new File(agentArg);
+        if (pluginsDir.isDirectory()) {
+            File[] files = pluginsDir.listFiles((dir, name) -> name.endsWith(".jar"));
+            for (File file : files == null ? new File[0] : files) {
+                try (JarFile jar = new JarFile(file)) {
+                    inst.appendToSystemClassLoaderSearch(jar);
+                } catch (IOException e) {
+                    System.err.printf("[WARN] Failed to read plugin jar file at %s. Jar will not be available on classpath: %s%n", file, e);
+                    e.printStackTrace(System.err);
+                }
+            }
+        }
+    }
+}

--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -11,7 +11,7 @@
     </appender>
 
     <logger name="org.apache.lucene" level="ERROR" />
-    <logger name="org.apache.commons.jcs" level="ERROR" />
+    <logger name="org.apache.commons.jcs3" level="FATAL" />
     <logger name="org.apache.hc" level="ERROR" />
 
     <root level="INFO">

--- a/cli/src/test/java/org/owasp/dependencycheck/PluginLoaderTest.java
+++ b/cli/src/test/java/org/owasp/dependencycheck/PluginLoaderTest.java
@@ -1,0 +1,72 @@
+package org.owasp.dependencycheck;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.instrument.Instrumentation;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class PluginLoaderTest {
+
+    private final Instrumentation instrumentation = Mockito.mock(Instrumentation.class);
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void shouldDoNothingIfDirectoryDoesntExist() {
+        PluginLoader.premain("blah", instrumentation);
+        verifyNoInteractions(instrumentation);
+    }
+
+    @Test
+    void shouldDoNothingIfDirectoryIsEmpty() {
+        PluginLoader.premain(tempDir.toString(), instrumentation);
+        verifyNoInteractions(instrumentation);
+    }
+
+    @Test
+    void shouldAddJarToClassPath() throws Exception {
+        createEmptyValidJar();
+        createEmptyValidJar();
+        PluginLoader.premain(tempDir.toString(), instrumentation);
+        verify(instrumentation, times(2))
+                .appendToSystemClassLoaderSearch(assertArg(jar -> assertThat(jar.getName(), matchesPattern(".*/dummy.*\\.jar"))));
+    }
+
+    @Test
+    void shouldStopLoadingPluginsOnBadJarButSucceed() throws Exception {
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(errContent));
+        try {
+            createEmptyBadJar();
+            PluginLoader.premain(tempDir.toString(), instrumentation);
+            assertThat(errContent.toString(), matchesPattern(Pattern.compile("\\[WARN\\] Failed to read plugin jar file at .*/dummy.*\\.jar\\. Jar will not be available on classpath.*zip file is empty.*", Pattern.DOTALL)));
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
+
+    private Path createEmptyBadJar() throws IOException {
+        return Files.createTempFile(tempDir, "dummy", ".jar");
+    }
+
+    private void createEmptyValidJar() throws IOException {
+        new ZipArchiveOutputStream(createEmptyBadJar().toFile()).close();
+    }
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -197,14 +197,14 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <groupId>org.whitesource</groupId>
             <artifactId>pecoff4j</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-jcs3-core</artifactId>
-        </dependency>
+        <!-- JCS 3 logging adapter; intentionally higher on classpath than JCS itself -->
         <dependency>
             <groupId>io.github.jeremylong</groupId>
             <artifactId>jcs3-slf4j</artifactId>
-            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-jcs3-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.package-url</groupId>

--- a/core/src/main/java/org/owasp/dependencycheck/data/cache/DataCache.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/cache/DataCache.java
@@ -38,7 +38,7 @@ public class DataCache<T> {
      *
      * @param cache a reference to the underlying cache implementation.
      */
-    public DataCache(CacheAccess<String, T> cache) {
+    DataCache(CacheAccess<String, T> cache) {
         this.cache = cache;
     }
 

--- a/core/src/main/java/org/owasp/dependencycheck/data/cache/DataCacheFactory.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/cache/DataCacheFactory.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Properties;
+
+import io.github.jeremylong.jcs3.slf4j.Slf4jAdapter;
 import org.apache.commons.jcs3.JCS;
 import org.apache.commons.jcs3.access.CacheAccess;
 import org.apache.commons.jcs3.access.exception.CacheException;
@@ -75,6 +77,13 @@ public class DataCacheFactory {
          * Used to store POM files retrieved from central.
          */
         POM
+    }
+
+    static {
+        System.setProperty("jcs.logSystem", "slf4j");
+        if (!LOGGER.isTraceEnabled()) {
+            Slf4jAdapter.muteLogging(true);
+        }
     }
 
     /**

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -125,10 +125,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.github.jeremylong</groupId>
-            <artifactId>jcs3-slf4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <scope>provided</scope>

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -20,7 +20,6 @@ package org.owasp.dependencycheck.maven;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL.StandardTypes;
 import com.github.packageurl.PackageURL;
-import io.github.jeremylong.jcs3.slf4j.Slf4jAdapter;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -2731,11 +2730,6 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
      * Hacky method of muting the noisy logging from JCS
      */
     protected void muteNoisyLoggers() {
-        System.setProperty("jcs.logSystem", "slf4j");
-        if (!getLog().isDebugEnabled()) {
-            Slf4jAdapter.muteLogging(true);
-        }
-
         final String[] noisyLoggers = {
             "org.apache.hc"
         };


### PR DESCRIPTION
## Description of Change

- Moves the JCS3 logging adapter setting into the single place that needs it - the `DataCacheFactory`.
  - Changes it to mute logging unless `DataCacheFactory` itself is set to `TRACE` logging. This effective mutes it everywhere by default.
  - This allows us to set the dependency in a deterministic place on the classpath; to ensure the `Slf4jAdapter` is discovered before the default JCS3 `LogFactory` providers, which is a workaround for the JDK 24+ issue https://bugs.openjdk.org/browse/JDK-8350481 , still not fixed as of `25.0.1`.
- changes the CLI to use an executable jar to start, which allows for a deterministic classpath; unlike using a wildcard lib dir
- so that we can still allow the use of plugins (basically additional classpath entries), it registers the CLI jar with a rudimentary Java agent to append to the classpath before the main class is created

Ancillary changes
- bake the Windows script template in source control, same as the Linux one
  - [appassembler is EOL](https://github.com/mojohaus/appassembler) now, so there will be no more changes. We will need to find another solution at some point; perhaps jpackage or something - but this will do for now. 

## Related issues

- fixes #8108

## Have test cases been added to cover the new functionality?

yes

Manually tested on
- Docker image
- MacOS - JDK 11 / 21 / 25
  - with and without trying to load an extra `plugins` jar 
- Windows 11
  - with and without trying to load an extra `plugins` jar

## Additional detail

`.sh` diff:
<img width="2218" height="661" alt="image" src="https://github.com/user-attachments/assets/cf799c31-4e20-4f50-80fc-9a2bf3a1e211" />

`.bat` diff: (view word wrap on)
<img width="2089" height="382" alt="image" src="https://github.com/user-attachments/assets/56ff053b-6ecb-49b9-97a3-67478c1e4d8f" />

Manifest for CLI looks like the below (80 jars, same as in `lib` dir)
```
Manifest-Version: 1.0
Created-By: Maven JAR Plugin 3.4.2
Build-Jdk-Spec: 11
Class-Path: logback-core-1.2.13.jar logback-classic-1.2.13.jar commons-c
 li-1.10.0.jar dependency-check-core-12.1.9-SNAPSHOT.jar jdiagnostics-1.
 0.7.jar pecoff4j-0.0.2.1.jar jcs3-slf4j-1.0.5.jar commons-jcs3-core-3.2
 .1.jar packageurl-java-1.5.0.jar cpe-parser-3.0.0.jar semver4j-5.8.0.ja
 r commons-collections4-4.5.0.jar commons-compress-1.27.1.jar commons-co
 dec-1.19.0.jar commons-io-2.20.0.jar commons-lang3-3.19.0.jar commons-t
 ext-1.14.0.jar commons-dbcp2-2.13.0.jar commons-pool2-2.12.0.jar common
 s-logging-1.3.4.jar jakarta.transaction-api-1.3.3.jar lucene-core-9.12.
 3.jar lucene-analysis-common-9.12.3.jar lucene-queryparser-9.12.3.jar l
 ucene-queries-9.12.3.jar lucene-sandbox-9.12.3.jar lucene-facet-9.12.3.
 jar jul-to-slf4j-1.7.36.jar velocity-engine-core-2.4.1.jar h2-2.4.240.j
 ar jakarta.json-2.0.1.jar jsoup-1.21.2.jar jackson-databind-2.20.1.jar 
 jackson-datatype-jsr310-2.20.1.jar jackson-module-blackbird-2.20.1.jar 
 jackson-dataformat-yaml-2.20.1.jar snakeyaml-2.4.jar retirejs-core-3.0.
 4.jar compiler-0.9.6.jar ossindex-service-client-1.8.2.jar javax.inject
 -1.jar gson-2.9.0.jar jaxb-api-2.3.1.jar javax.activation-api-1.2.0.jar
  guava-33.5.0-jre.jar failureaccess-1.0.3.jar listenablefuture-9999.0-e
 mpty-to-avoid-conflict-with-guava.jar error_prone_annotations-2.41.0.ja
 r j2objc-annotations-3.1.jar toml4j-0.7.2.jar aho-corasick-double-array
 -trie-1.2.3.jar commons-validator-1.10.0.jar commons-digester-2.1.jar c
 ommons-collections-3.2.2.jar packager-rpm-0.21.0.jar packager-core-0.21
 .0.jar bcprov-jdk18on-1.78.jar bcpg-jdk18on-1.78.jar xz-1.9.jar httpcor
 e5-5.3.6.jar httpclient5-5.5.1.jar httpcore5-h2-5.3.6.jar jackson-core-
 2.20.1.jar jackson-annotations-2.20.jar package-url-java-1.2.0.jar joda
 -time-2.14.0.jar ossindex-service-api-1.8.2.jar javax.ws.rs-api-2.0.1.j
 ar minlog-1.3.1.jar android-json-0.0.20131108.vaadin1.jar dependency-ch
 eck-utils-12.1.9-SNAPSHOT.jar slf4j-api-1.7.36.jar open-vulnerability-c
 lients-7.3.2.jar jspecify-1.0.0.jar httpclient5-cache-5.4.3.jar jmustac
 he-1.16.jar ant-1.10.15.jar annotations-26.0.2-1.jar spotbugs-annotatio
 ns-4.9.8.jar jsr305-3.0.2.jar
Implementation-Title: Dependency-Check Command Line
Implementation-Version: 12.1.9-SNAPSHOT
Implementation-Vendor: OWASP
Main-Class: org.owasp.dependencycheck.App
Premain-Class: org.owasp.dependencycheck.PluginLoader
```