### PR TITLE
chore: remove suppression rules that were deleted from the generatedSuppression branch

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -4962,68 +4962,12 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per issue #4852
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-kickstart@.*$</packageUrl>
-        <cpe regex="true">cpe:/a:graphql-java(_project)?:graphql-java.*</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
         FP per issue #4803
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/net\.sourceforge\.htmlunit/htmlunit-cssparser@.*$</packageUrl>
         <cpe regex="true">cpe:/a:htmlunit(_project)?:htmlunit.*</cpe>
     </suppress>
 
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #4853
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-servlet@.*$</packageUrl>
-        <cpe regex="true">cpe:/a:graphql-java(_project)?:graphql-java.*</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #4859
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.apollographql\.federation/federation-graphql-java-support@.*$</packageUrl>
-        <cpe regex="true">cpe:/a:graphql-java(_project)?:graphql-java.*</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #4851
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java/graphql-java-extended-scalars@.*$</packageUrl>
-        <cpe regex="true">cpe:/a:graphql-java(_project)?:graphql-java.*</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #4860
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.apollographql\.federation/federation-graphql-java-support-api@.*$</packageUrl>
-        <cpe regex="true">cpe:/a:graphql-java(_project)?:graphql-java.*</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #4862
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/io\.github\.graphql-java/graphql-java-annotations@.*$</packageUrl>
-        <cpe regex="true">cpe:/a:graphql-java(_project)?:graphql-java.*</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #4863
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java/java-dataloader@.*$</packageUrl>
-        <cpe regex="true">cpe:/a:graphql-java(_project)?:graphql-java.*</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #4854
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-tools@.*$</packageUrl>
-        <cpe regex="true">cpe:/a:graphql-java(_project)?:graphql-java.*</cpe>
-    </suppress>
     <suppress base="true">
         <notes><![CDATA[
         FP per issue #4806
@@ -5277,13 +5221,6 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per issue #5027
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/software\.aws\.rds/aws-mysql-jdbc@.*$</packageUrl>
-        <cpe>cpe:/a:mysql:mysql</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
         FP per issue #5024
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/net\.openhft/chronicle-wire@.*$</packageUrl>
@@ -5312,13 +5249,6 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per issue #4949
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.curioswitch\.curiostack/protobuf-jackson@.*$</packageUrl>
-        <cpe>cpe:/a:grpc:grpc</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
         FP per issue #5014
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.ejbca\.cvc/cert-cvc@.*$</packageUrl>
@@ -5330,13 +5260,6 @@
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.twill/twill-zookeeper@.*$</packageUrl>
         <cpe>cpe:/a:apache:zookeeper</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #4948
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/io\.opentracing\.contrib/opentracing-grpc@.*$</packageUrl>
-        <cpe>cpe:/a:grpc:grpc</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
@@ -5410,13 +5333,6 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per issue #5017
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.google\.api\.grpc/grpc-google-iam-v1@.*$</packageUrl>
-        <cpe>cpe:/a:grpc:grpc</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
         FP per issue #4681
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws-java-sdk-prometheus@.*$</packageUrl>
@@ -5453,14 +5369,6 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per issue #5097
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/software\.aws\.rds/aws-mysql-jdbc@.*$</packageUrl>
-        <cpe>cpe:/a:mariadb:mariadb</cpe>
-        <cpe>cpe:/a:mysql:mysql</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
         FP per issue #5108
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.jfrog\.artifactory\.client/artifactory-java-client-httpClient@.*$</packageUrl>
@@ -5479,20 +5387,6 @@
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson-xc@.*$</packageUrl>
         <cpe>cpe:/a:fasterxml:jackson-databind</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per #5118
-        ]]></notes>
-        <sha1>5b8f86fea035328fc9e8c660773037a3401ce25f</sha1>
-        <cpe regex="true">.*</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #4575
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.wildfly\.wildfly-http-client/wildfly-http-ejb-client@.*$</packageUrl>
-        <cpe>cpe:/a:redhat:jboss-ejb-client</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
@@ -5545,13 +5439,6 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-       FP per issue #5169
-       ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.google\.crypto\.tink/apps-webpush@.*$</packageUrl>
-        <cpe>cpe:/a:google:google_apps</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
        FP per issue #5212
        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.github\.java-json-tools/json-patch@.*$</packageUrl>
@@ -5563,13 +5450,6 @@
        ]]></notes>
         <packageUrl regex="true">^pkg:maven/net\.pwall\.json/json-pointer@.*$</packageUrl>
         <cpe regex="true">cpe:/a:json-pointer(_project)?:json-pointer.*</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-       FP per issue #5275
-       ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-spring-boot-starter@.*$</packageUrl>
-        <cpe regex="true">cpe:/a:graphql-java(_project)?:graphql-java.*</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
@@ -5678,13 +5558,6 @@
     <!-- generated suppressions added to main in 8.1.1 -->
     <suppress base="true">
         <notes><![CDATA[
-        FP per issue #5333
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-kickstart-spring-support@.*$</packageUrl>
-        <cpe regex="true">cpe:/a:graphql-java(_project)?:graphql-java.*</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
         FP per issue #5336
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.openrewrite\.recipe/rewrite-jhipster@.*$</packageUrl>
@@ -5787,13 +5660,6 @@
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.googlecode\.javaewah/JavaEWAH@.*$</packageUrl>
         <cpe>cpe:/a:google:google_search</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #5497
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.google\.cloud/grpc-gcp@.*$</packageUrl>
-        <cpe>cpe:/a:grpc:grpc</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
@@ -5911,41 +5777,6 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per issue #5636
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java/graphql-java-extended-scalars@.*$</packageUrl>
-        <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #5639
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-tools@.*$</packageUrl>
-        <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #5638
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-servlet@.*$</packageUrl>
-        <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #5637
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-java-kickstart@.*$</packageUrl>
-        <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #5657
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-kickstart-spring-support@.*$</packageUrl>
-        <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
         FP per issue #5685
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.bouncycastle/bcpg-jdk15on@.*$</packageUrl>
@@ -5971,13 +5802,6 @@
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.api/api-ldap-net-mina@.*$</packageUrl>
         <cpe>cpe:/a:apache:mina</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #5719
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-webclient@.*$</packageUrl>
-        <cpe>cpe:/a:graphql-java:graphql-java</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
@@ -6117,41 +5941,6 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per issue #5648
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/io\.github\.graphql-java/graphql-java-annotations@.*$</packageUrl>
-        <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #5643
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java-kickstart/graphql-spring-boot-starter@.*$</packageUrl>
-        <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #5641
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.graphql-java/java-dataloader@.*$</packageUrl>
-        <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #5647
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.apollographql\.federation/federation-graphql-java-support-api@.*$</packageUrl>
-        <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #5646
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.apollographql\.federation/federation-graphql-java-support@.*$</packageUrl>
-        <cpe>cpe:/a:graphql-java:graphql-java</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
         FP per issue #5543
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.cxf/cxf-rt-bindings-soap@.*$</packageUrl>
@@ -6239,16 +6028,6 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per issue #5854
-        akka-grpc libraries are neither part of the akka actor system nor gRPC
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.lightbend\.akka\.grpc/.*$</packageUrl>
-        <cpe>cpe:/a:akka:akka</cpe>
-        <cpe>cpe:/a:lightbend:akka</cpe>
-        <cpe>cpe:/a:grpc:grpc</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
         FP per issue #5855;  akka-persistence-r2dbc is not part of the akka actor system projects
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.lightbend\.akka/akka-persistence-r2dbc.*$</packageUrl>
@@ -6262,13 +6041,6 @@
         <packageUrl regex="true">^pkg:maven/com\.lightbend\.akka/akka-projection-.*$</packageUrl>
         <cpe>cpe:/a:akka:akka</cpe>
         <cpe>cpe:/a:lightbend:akka</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #5857; akka-projection-grpc is not grpc itself
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.lightbend\.akka/akka-projection-grpc.*$</packageUrl>
-        <cpe>cpe:/a:grpc:grpc</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
@@ -6394,13 +6166,6 @@
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring-plugin-core@.*$</packageUrl>
         <cpe>cpe:/a:vmware:spring</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-   FP per issue #5915 - suppress the CVE only to avoid clash when cpe:/a:vmware:spring were to get broader use
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework(?!\.kafka).*$</packageUrl>
-        <cve>CVE-2023-34040</cve>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
@@ -6694,14 +6459,6 @@
         <cve>CVE-2023-46749</cve>
         <cve>CVE-2023-46750</cve>
     </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #6438
-        only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
-        ]]></notes>
-        <packageUrl regex="true">^pkg:(?!maven/org\.clojure/clojure@).*$</packageUrl>
-        <cpe>cpe:/a:clojure:clojure</cpe>
-    </suppress>
 
     <suppress base="true">
         <notes><![CDATA[
@@ -6737,14 +6494,6 @@
         ]]></notes>
         <packageUrl regex="true">^pkg:nuget/dbup-postgresql@.*$</packageUrl>
         <cpe>cpe:/a:postgresql:postgresql</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #6666, #6798, #6812
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/.*@.*$</packageUrl>
-        <cpe>cpe:/a:jetty:jetty</cpe>
-        <cpe>cpe:/a:eclipse:jetty</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
@@ -6829,14 +6578,6 @@
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring-boot-jarmode-tools@.*$</packageUrl>
         <cpe>cpe:/a:vmware:tools</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #6757 + manual improvement for related
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.sandesha2/sandesha2.*$</packageUrl>
-        <cpe>cpe:/a:apache:axis2</cpe>
-        <cpe>cpe:/a:apache:axis</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
@@ -6964,13 +6705,6 @@
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.azure/azure-identity@.*$</packageUrl>
         <cpe>cpe:/a:microsoft:azure_cli</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        FP per issue #6991
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.apollographql\.federation/federation-graphql-java-support@.*$</packageUrl>
-        <cpe regex="true">cpe:/a:apollo(_project)?:apollo.*</cpe>
     </suppress>
     <suppress base="true">
         <notes><![CDATA[


### PR DESCRIPTION
These suppressions were copied into the base suppression file and then deleted or updated from the generated suppression file. Note that the deletions are all part of a consolidation that occurred within the generated suppression file. See https://github.com/dependency-check/DependencyCheck/pull/8118 for the utility used to make these changes.

This change should be released in combination with https://github.com/dependency-check/DependencyCheck/pull/8116

------------

Removed 37 obsolete suppressions from `core/src/main/resources/dependencycheck-base-suppression.xml`

=== Removal Summary ===
Suppressions removed based on changes from commits:

  81c68b08b - fix(fp): Consolidate false positive suppressions for graphql-java (#8095)
    Date: 2025-11-10 23:35:54 +0800
    URL: https://github.com/dependency-check/DependencyCheck/commit/81c68b08bff91a37692e3605d3d8960effd5a500
    Removed 21 suppression(s)

  767778fb2 - fix(fp): FP per issue #5945 (#7272)
    Date: 2024-12-24 22:01:10 +0800
    URL: https://github.com/dependency-check/DependencyCheck/commit/767778fb2d688a000a89b7f4724c867b4f4c4f5b
    Removed 2 suppression(s)

  f06535955 - fix(fp): Better FP fix per issue #7250
    Date: 2024-12-18 19:13:49 +0100
    URL: https://github.com/dependency-check/DependencyCheck/commit/f06535955a0782e7af63de805cd2513e5973c9e8
    Removed 7 suppression(s)

  5fa08fc12 - fix(fp): FP per issue #6812
    Date: 2024-07-06 11:28:29 -0400
    URL: https://github.com/dependency-check/DependencyCheck/commit/5fa08fc12e4373201d0a516d098f1a34ff18bd4f
    Removed 1 suppression(s)

  743b3a1dd - fix(fp): FP per issue #6138 and #6139 (#6140)
    Date: 2023-11-27 21:09:07 +0800
    URL: https://github.com/dependency-check/DependencyCheck/commit/743b3a1dd8551427cfebc235ddfbf33fd3f3b2d3
    Removed 1 suppression(s)

  81e149c03 - Update generatedSuppressions.xml
    Date: 2023-01-07 13:58:15 +0100
    URL: https://github.com/dependency-check/DependencyCheck/commit/81e149c0327f124b436dda799dc2431f7c54ac32
    Removed 2 suppression(s)

  a78157ec0 - chore: release suppressions to core
    Date: 2022-12-09 05:55:14 -0500
    URL: https://github.com/dependency-check/DependencyCheck/commit/a78157ec02b4815fd1ee0e33df2f6876ff64520c
    Removed 3 suppression(s)

37 total suppression(s) removed from 7 commit(s)