### PR TITLE
build(deps): bump us.springett:cpe-parser from 3.0.0 to 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1005,7 +1005,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>us.springett</groupId>
                 <artifactId>cpe-parser</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.whitesource</groupId>


### PR DESCRIPTION
See https://github.com/stevespringett/CPE-Parser/releases/tag/cpe-parser-3.0.1

Primary change is an update to prevent somewhat random comparison errors.