### PR TITLE
fix: correct bundle audit gem in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ADD cli/target/dependency-check-${VERSION}-release.zip /
 RUN apk update                                                                                       && \
     apk add --no-cache --virtual .build-deps curl tar                                                && \
     apk add --no-cache git ruby ruby-rdoc npm                                                        && \
-    gem install bundler-audit                                                                         && \
+    gem install bundler-audit                                                                        && \
     bundle audit update                                                                              && \
     mkdir /opt/yarn                                                                                  && \
     curl -Ls https://yarnpkg.com/latest.tar.gz | tar -xz --strip-components=1 --directory /opt/yarn  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ADD cli/target/dependency-check-${VERSION}-release.zip /
 RUN apk update                                                                                       && \
     apk add --no-cache --virtual .build-deps curl tar                                                && \
     apk add --no-cache git ruby ruby-rdoc npm                                                        && \
-    gem install bundle-audit                                                                         && \
+    gem install bundler-audit                                                                         && \
     bundle audit update                                                                              && \
     mkdir /opt/yarn                                                                                  && \
     curl -Ls https://yarnpkg.com/latest.tar.gz | tar -xz --strip-components=1 --directory /opt/yarn  && \


### PR DESCRIPTION
## Description of Change

The correct gem is bundler-audit, the current one is just a typo-squat wrapper gem.

## Related issues

N/A

## Have test cases been added to cover the new functionality?

N/A