### PR TITLE
build(deps): Downgrade azul/zulu-openjdk-alpine from 25 to 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.25.4-alpine AS go
 
-FROM azul/zulu-openjdk-alpine:25 AS jlink
+FROM azul/zulu-openjdk-alpine:21 AS jlink
 
 RUN "$JAVA_HOME/bin/jlink" --compress=zip-6 --module-path /opt/java/openjdk/jmods --add-modules java.base,java.compiler,java.datatransfer,jdk.crypto.ec,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.scripting,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.unsupported --output /jlinked
 


### PR DESCRIPTION
Reverts dependency-check/DependencyCheck#7928

Fixes #8108 

Restores stability until we can get a proper fix in via riskier #8117 .