### PR TITLE
build: Transition dependency to `org.eclipse.parsson` groupId

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -294,7 +294,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
+            <groupId>org.eclipse.parsson</groupId>
             <artifactId>jakarta.json</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@ Copyright (c) 2012 - Jeremy Long
         <maven-reporting-api.version>4.0.0</maven-reporting-api.version>
         <org.apache.velocity.version>2.4.1</org.apache.velocity.version>
         <maven-dependency-tree.version>3.3.0</maven-dependency-tree.version>
-        <org.glassfish.jakarta.json.version>2.0.1</org.glassfish.jakarta.json.version>
+        <org.eclipse.parsson.jakarta.json.version>1.1.7</org.eclipse.parsson.jakarta.json.version>
         <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
         <maven-common-artifact-filters.version>3.4.0</maven-common-artifact-filters.version>
         <groovy-all.version>2.4.21</groovy-all.version>
@@ -1234,9 +1234,9 @@ Copyright (c) 2012 - Jeremy Long
                 <version>${maven-dependency-tree.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish</groupId>
+                <groupId>org.eclipse.parsson</groupId>
                 <artifactId>jakarta.json</artifactId>
-                <version>${org.glassfish.jakarta.json.version}</version>
+                <version>${org.eclipse.parsson.jakarta.json.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -37,7 +37,7 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
     </properties>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish</groupId>
+            <groupId>org.eclipse.parsson</groupId>
             <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
## Description of Change

Switches `org.glassfish:jakarta.json` is `org.eclipse.parsson:jakarta.json` as proposed by the [Eclipse Parsson project](https://projects.eclipse.org/projects/ee4j.parsson/releases/1.0.0/plan).

A security scanner in use flagged CVE-2023-4043 and CVE-2023-7272 for org.glassfish:jakarta.json. My guess is that it creates an association between those dependencies automatically.

**Why the Switch?**

  1. Official Project Transition (June 2021): The Jakarta JSON Processing implementation was officially moved from org.glassfish to Eclipse Parsson as a standalone project under Eclipse Foundation governance.
  2. Provider Implementation Change: In Jakarta JSON API 2.1.2, the default provider changed from:
    - Old: org.glassfish.json.JsonProviderImpl
    - New: org.eclipse.parsson.JsonProviderImpl
  3. End of GlassFish Releases: org.glassfish:jakarta.json stopped at version 2.0.1 (4+ years ago) when the project transitioned to Eclipse Parsson.
  4. Active vs. Frozen Development:
    - org.glassfish:jakarta.json - Frozen at 2.0.1 (no security updates)
    - org.eclipse.parsson:jakarta.json - Active (regular security patches and updates)
  5. Security Vulnerabilities: The frozen GlassFish version won't receive fixes for vulnerabilities like CVE-2023-4043 and CVE-2023-7272, which were fixed in Eclipse Parsson 1.1.4+.

**Bottom Line**

  Eclipse Parsson is not an alternative—it's the official successor. Continuing to use org.glassfish:jakarta.json means using an abandoned artifact that won't receive security updates or compatibility improvements for newer Jakarta EE specifications.

## Related issues

https://github.com/dependency-check/DependencyCheck/issues/8127

## Have test cases been added to cover the new functionality?

no