### PR TITLE
fix: log GrokAssembly output when dotnet invocation fails

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
@@ -373,7 +373,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
                 if (p.exitValue() != 1 || !StringUtils.isBlank(error)) {
                     LOGGER.warn("An error occurred with the .NET AssemblyAnalyzer, please see the log for more details.\n"
                     + "dependency-check requires dotnet 8.0 core runtime or sdk to be installed to analyze assemblies.");
-                    LOGGER.debug("GrokAssembly.dll is not working properly");
+                    LOGGER.debug("GrokAssembly.dll is not working properly: {}", error);
                     grokAssembly = null;
                     setEnabled(false);
                     throw new InitializationException("Could not execute .NET AssemblyAnalyzer, is the dotnet 8.0 runtime or sdk installed?");


### PR DESCRIPTION
## Description of Change

Currently the output is swallowed, making debugging difficult since it deletes the temporarily assembly afterwards - in my case had two separate errors:
- had dotnet 10 installed, but not 8 (which the output shows)
- had arm64 on path, but needed x64 (which the output shows)

## Related issues

N/A

## Have test cases been added to cover the new functionality?

N/A