### PR TITLE
build(deps): Bump container-packaged Postgres and MySQL drivers to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,14 +143,6 @@ jobs:
           name: archive-snapshot
       - name: Set up Docker
         uses: docker/setup-docker-action@v4
-        with:
-          daemon-config: |
-            {
-              "debug": true,
-              "features": {
-                "containerd-snapshotter": true
-              }
-            }
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build Docker Image

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -181,14 +181,6 @@ jobs:
           name: archive-snapshot
       - name: Set up Docker
         uses: docker/setup-docker-action@v4
-        with:
-          daemon-config: |
-            {
-              "debug": true,
-              "features": {
-                "containerd-snapshotter": true
-              }
-            }
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build Docker Image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,14 +151,6 @@ jobs:
           name: archive-release
       - name: Set up Docker
         uses: docker/setup-docker-action@v4
-        with:
-          daemon-config: |
-            {
-              "debug": true,
-              "features": {
-                "containerd-snapshotter": true
-              }
-            }
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build Docker Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN "$JAVA_HOME/bin/jlink" --compress=zip-6 --module-path /opt/java/openjdk/jmod
 FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine3.22
 
 ARG VERSION
-ARG POSTGRES_DRIVER_VERSION=42.7.5
-ARG MYSQL_DRIVER_VERSION=9.2.0
+ARG POSTGRES_DRIVER_VERSION=42.7.8
+ARG MYSQL_DRIVER_VERSION=9.5.0
 ARG UID=1000
 ARG GID=1000
 


### PR DESCRIPTION
## Description of Change

Bump the bundled drivers to latest versions:
- https://dev.mysql.com/doc/relnotes/connector-j/en/news-9-x.html (no vulnerabilities; just fixes)
- https://jdbc.postgresql.org/ ([security fix](https://jdbc.postgresql.org/changelogs/2025-06-11-42/) in `42.7.7`)

## Related issues

N/A

## Have test cases been added to cover the new functionality?

N/A