### PR TITLE
feat: override pnpm audit registry parameter

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PnpmAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PnpmAuditAnalyzer.java
@@ -61,6 +61,11 @@ public class PnpmAuditAnalyzer extends AbstractNpmAnalyzer {
     public static final String PNPM_PACKAGE_LOCK = "pnpm-lock.yaml";
 
     /**
+     * The default registry parameter to pass to the pnpm audit execution.
+     */
+    public static final String DEFAULT_REGISTRY = "https://registry.npmjs.org/";
+
+    /**
      * Filter that detects files named "pnpm-lock.yaml"
      */
     private static final FileFilter LOCK_FILE_FILTER = FileFilterBuilder.newInstance()
@@ -202,9 +207,9 @@ public class PnpmAuditAnalyzer extends AbstractNpmAnalyzer {
             }
             // pnpm audit returns a json compliant with NpmAuditParser
             args.add("--json");
-            // ensure we are using the right registry despite .npmrc
+            // ensure we are using the right registry despite .npmrc, but allow override
             args.add("--registry");
-            args.add("https://registry.npmjs.org/");
+            args.add(getSettings().getString(Settings.KEYS.ANALYZER_PNPM_AUDIT_REGISTRY, DEFAULT_REGISTRY));
             final ProcessBuilder builder = new ProcessBuilder(args);
             builder.directory(folder);
             // Workaround 64k limitation of InputStream, redirect stdout to a file that we will read later

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -118,6 +118,7 @@ analyzer.node.package.enabled=true
 analyzer.node.audit.enabled=true
 analyzer.yarn.audit.enabled=true
 analyzer.pnpm.audit.enabled=true
+analyzer.pnpm.audit.registry=https://registry.npmjs.org/
 analyzer.golang.dep.enabled=true
 analyzer.retirejs.enabled=true
 analyzer.retirejs.repo.validforhours=24

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -429,6 +429,10 @@ public final class Settings {
          */
         public static final String ANALYZER_PNPM_AUDIT_ENABLED = "analyzer.pnpm.audit.enabled";
         /**
+         * The properties key for the Pnpm registry url.
+         */
+        public static final String ANALYZER_PNPM_AUDIT_REGISTRY = "analyzer.pnpm.audit.registry";
+        /**
          * The properties key for supplying the URL to the Node Audit API.
          */
         public static final String ANALYZER_NODE_AUDIT_URL = "analyzer.node.audit.url";


### PR DESCRIPTION
## Description of Change

Allows overriding the value of the --registry parameter that is passed to pnpm audit.
The current behavior always goes to https://registry.npmjs.org/ which is not always allowed.

## Related issues

- fixes #5664

## Have test cases been added to cover the new functionality?

no