### PR TITLE
fix: add hint for Elastic APM Java agent CPE mapping

### DIFF
--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -456,4 +456,18 @@
             <evidence type="product" source="hint analyzer" name="vendor" value="net" confidence="MEDIUM"/>
         </add>
     </hint>
+    <hint>
+        <given>
+            <evidence type="vendor" source="pom" name="groupid"
+                      value="co.elastic.apm" confidence="HIGHEST"/>
+            <evidence type="product" source="pom" name="artifactid"
+                      value="elastic-apm-agent" confidence="HIGHEST"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer"
+                      name="product" value="apm_java_agent"
+                      confidence="HIGHEST"/>
+        </add>
+    </hint>
+
 </hints>

--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -457,17 +457,13 @@
         </add>
     </hint>
     <hint>
+       <!-- false negative per issue #8008 -->
         <given>
-            <evidence type="vendor" source="pom" name="groupid"
-                      value="co.elastic.apm" confidence="HIGHEST"/>
-            <evidence type="product" source="pom" name="artifactid"
-                      value="elastic-apm-agent" confidence="HIGHEST"/>
+            <evidence type="vendor" source="pom" name="groupid" value="co.elastic.apm" confidence="HIGHEST"/>
+            <evidence type="product" source="pom" name="artifactid" value="elastic-apm-agent" confidence="HIGHEST"/>
         </given>
         <add>
-            <evidence type="product" source="hint analyzer"
-                      name="product" value="apm_java_agent"
-                      confidence="HIGHEST"/>
+            <evidence type="product" source="hint analyzer" name="product" value="apm_java_agent" confidence="HIGHEST"/>
         </add>
     </hint>
-
 </hints>


### PR DESCRIPTION
## Description of Change

This change adds a small hint to help Dependency-Check correctly
identify the Elastic APM Java agent as `apm_java_agent`.

Without this hint, the Java agent may be matched to the generic
`elastic:apm_agent`, which can cause Java-specific CVEs to be missed.

## Related issues
Relates to dependency-check/DependencyCheck#8008

## Have test cases been added to cover the new functionality?
No
