### PR TITLE
fix(ant): resolve relative paths against basedir

### DIFF
--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -202,7 +202,7 @@ public class Check extends Update {
      * Specifies the destination directory for the generated Dependency-Check
      * report.
      */
-    private String reportOutputDirectory = ".";
+    private String reportOutputDirectory;
     /**
      * If using the JUNIT report format the junitFailOnCVSS sets the CVSS score
      * threshold that is considered a failure. The default is 0.
@@ -528,7 +528,7 @@ public class Check extends Update {
      * @param suppressionFile the suppression file to add.
      */
     public void addConfiguredSuppressionFile(final SuppressionFile suppressionFile) {
-        suppressionFiles.add(suppressionFile.getPath());
+        suppressionFiles.add(resolveRelative(suppressionFile.getPath()));
     }
 
     /**
@@ -573,13 +573,26 @@ public class Check extends Update {
         this.projectName = projectName;
     }
 
+    private String resolveRelative(String path) {
+        if (path == null) {
+            return null;
+        }
+
+        File file = new File(path);
+        if (file.isAbsolute()) {
+            return path;
+        }
+
+        return new File(getProject().getBaseDir(), path).getPath();
+    }
+
     /**
      * Set the value of reportOutputDirectory.
      *
      * @param reportOutputDirectory new value of reportOutputDirectory
      */
     public void setReportOutputDirectory(String reportOutputDirectory) {
-        this.reportOutputDirectory = reportOutputDirectory;
+        this.reportOutputDirectory = resolveRelative(reportOutputDirectory);
     }
 
     /**
@@ -646,7 +659,7 @@ public class Check extends Update {
      * @param suppressionFile new value of suppressionFile
      */
     public void setSuppressionFile(String suppressionFile) {
-        suppressionFiles.add(suppressionFile);
+        suppressionFiles.add(resolveRelative(suppressionFile));
     }
 
     /**

--- a/ant/src/site/markdown/index.md.vm
+++ b/ant/src/site/markdown/index.md.vm
@@ -32,6 +32,45 @@ Installation
     * [dependency-check-purge](config-purge.html) - deletes the local copy of the NVD; this should rarely be used (if ever).
     * [dependency-check-update](config-update.html) - downloads and updates the local copy of the NVD.
 
+Installation Using Apache Ivy
+====================
+
+Instead of manually downloading and managing the Dependency-Check Ant JARs,
+Apache Ivy can be used to automatically provision the required dependencies.
+This approach helps ensure consistent versions across multiple environments
+and simplifies setup.
+
+Below is an example `build.xml` configuration using Apache Ivy.
+
+#[[
+```xml
+<project name="dependency-check-ivy" default="check"
+         xmlns:ivy="antlib:org.apache.ivy.ant">
+
+    <!-- Load Ivy -->
+    <taskdef resource="org/apache/ivy/ant/antlib.xml"/>
+
+    <!-- Resolve Dependency-Check Ant dependencies -->
+    <ivy:settings/>
+    <ivy:retrieve pattern="lib/[artifact]-[revision].[ext]"/>
+
+    <!-- Register Dependency-Check Ant task -->
+    <taskdef
+        resource="dependency-check-taskdefs.properties">
+        <classpath>
+            <fileset dir="lib">
+                <include name="*.jar"/>
+            </fileset>
+        </classpath>
+    </taskdef>
+
+    <target name="check">
+        <dependency-check
+            projectName="Example Project"
+            scanSet="src"
+            format="HTML"/>
+    </target>
+</project>
 
 It is important to understand that the first time this task is executed it may
 take 10 minutes or more as it downloads and processes the data from the National


### PR DESCRIPTION
## Description of Change

This change fixes how relative paths are resolved in the Dependency-Check Ant task.

Previously, when running Ant from a different working directory (for example using
`ant -f /path/to/build.xml`), relative paths provided for `suppressionFile` and
`reportOutputDirectory` were resolved against the current working directory instead
of the Ant project `basedir`.

This update ensures that all non-absolute paths are resolved relative to the
project `basedir`, which is consistent with standard Ant behavior and user
expectations.

## Related issues

- Fixes #7918
- 
## Have test cases been added to cover the new functionality?

No

Manual verification was performed because this change affects runtime behavior
that depends on how Ant resolves paths when invoked from different working
directories (for example using `ant -f /path/to/build.xml`). This scenario is
difficult to reliably simulate in unit tests.

Verification was done by executing Ant from outside the project directory and
confirming that suppression files and report output directories are correctly
resolved relative to the project `basedir` (the directory containing the
`build.xml` file).
