### PR TITLE
fix: suppress false positives for zabbix-utils #8087

### DIFF
--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -469,7 +469,14 @@
                       confidence="HIGHEST"/>
         </add>
     </hint>
-  
+    <hint>
+        <given>
+            <evidence type="product" source="pypi" name="name" value="zabbix-utils" confidence="HIGHEST" />
+        </given>
+        <remove>
+            <evidence type="product" source="pypi" name="name" value="zabbix" confidence="HIGHEST" />
+        </remove>
+    </hint>
 
 </hints>
 

--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -458,7 +458,7 @@
     </hint>
     <hint>
         <given>
-            <evidence type="vendor" source="pom" name="groupid"
+            <evidence type="product" source="pom" name="groupid"
                       value="co.elastic.apm" confidence="HIGHEST"/>
             <evidence type="product" source="pom" name="artifactid"
                       value="elastic-apm-agent" confidence="HIGHEST"/>
@@ -469,5 +469,7 @@
                       confidence="HIGHEST"/>
         </add>
     </hint>
+  
 
 </hints>
+

--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -456,4 +456,18 @@
             <evidence type="product" source="hint analyzer" name="vendor" value="net" confidence="MEDIUM"/>
         </add>
     </hint>
+    <hint>
+        <given>
+            <evidence type="vendor" source="pom" name="groupid"
+                      value="co.elastic.apm" confidence="HIGHEST"/>
+            <evidence type="product" source="pom" name="artifactid"
+                      value="elastic-apm-agent" confidence="HIGHEST"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer"
+                      name="product" value="apm_java_agent"
+                      confidence="HIGHEST"/>
+        </add>
+    </hint>
+
 </hints>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5622,7 +5622,7 @@
         <cpe>cpe:/a:protobuf:protobuf:</cpe>
         <cpe>cpe:/a:google:protobuf:</cpe>
     </suppress>
-    <suppress>
+    <suppress base="true">
         <notes><![CDATA[
    file name: zabbix-utils:2.0.3
    ]]></notes>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5622,4 +5622,11 @@
         <cpe>cpe:/a:protobuf:protobuf:</cpe>
         <cpe>cpe:/a:google:protobuf:</cpe>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: zabbix-utils:2.0.3
+   ]]></notes>
+        <packageUrl regex="true">^pkg:pypi/zabbix-utils@.*$</packageUrl>
+        <cpe>cpe:/a:zabbix:zabbix</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Description of Change

Modified the identification and suppression rules to fix false positive vulnerabilities for the zabbix-utils Python package.

Previously, zabbix-utils was being incorrectly identified as the main zabbix product (CPE cpe:/a:zabbix:zabbix), leading to 18 false positive critical vulnerabilities.

Changes made:

Added a suppression rule in dependencycheck-base-suppression.xml to ignore cpe:/a:zabbix:zabbix specifically for pkg:pypi/zabbix-utils.

Added a hint in dependencycheck-base-hint.xml to help the analyzer distinguish between the utility library and the main product.

Related issues
fixes #8087


Have test cases been added to cover the new functionality?
yes Verified by running a local scan on a project containing zabbix-utils:2.0.3. The scan results confirmed that the 18 vulnerabilities previously found are now successfully suppressed, resulting in 0 vulnerable dependencies.
(when vulnerability found)
<img width="1919" height="918" alt="Screenshot 2026-01-11 120544" src="https://github.com/user-attachments/assets/728c66c5-7b22-4b09-a05c-b4880504b374" />
(when vulnerability suppressed)
<img width="1915" height="893" alt="Screenshot 2026-01-11 120641" src="https://github.com/user-attachments/assets/5fdbf1ea-da1a-49a9-a2ab-58f1ef5ada78" />
