### PR TITLE
docs: document external data sources and hostnames

### DIFF
--- a/src/site/markdown/data/index.md
+++ b/src/site/markdown/data/index.md
@@ -3,6 +3,30 @@
 Dependency-check, by default, requires access to several externally
 hosted resources.
 
+## External Data Sources and Hostnames
+
+Dependency-Check may contact the following external hosts depending on the enabled analyzers and configuration:
+
+| Purpose | Hostname |
+|--------|----------|
+| NVD API (CVE data) | nvd.nist.gov |
+| NVD Data Feeds | services.nvd.nist.gov |
+| CISA KEV catalog | www.cisa.gov |
+| Hosted suppressions file | dependency-check.github.io |
+| Maven Central metadata | repo.maven.apache.org |
+| Sonatype OSS Index API | ossindex.sonatype.org |
+| RetireJS definitions | raw.githubusercontent.com |
+| RetireJS repository | github.com |
+| Package metadata (NPM) | registry.npmjs.org |
+| Ruby advisories | rubysec.com |
+| Python advisories | pypi.org |
+| NuGet metadata | api.nuget.org |
+| Go vulnerability DB | vuln.go.dev |
+| Scarf telemetry (optional) | api.scarf.sh |
+
+Note: Not all hosts are contacted in every run. Access depends on configuration, enabled analyzers, and plugin type.
+Organizations with restricted network access should allowlist the required hosts or configure local mirrors where supported.
+
 ## The NVD Database
 
 OWASP dependency-check maintains a local copy of the NVD API's CVE data hosted by NIST. By default,

--- a/src/site/markdown/data/index.md
+++ b/src/site/markdown/data/index.md
@@ -9,23 +9,27 @@ Dependency-Check may contact the following external hosts depending on the enabl
 
 | Purpose | Hostname |
 |--------|----------|
-| NVD API (CVE data) | nvd.nist.gov |
-| NVD Data Feeds | services.nvd.nist.gov |
+| NVD API (CVE data) | services.nvd.nist.gov |
 | CISA KEV catalog | www.cisa.gov |
 | Hosted suppressions file | dependency-check.github.io |
 | Maven Central metadata | repo.maven.apache.org |
+| Maven Central search | search.maven.org |
 | Sonatype OSS Index API | ossindex.sonatype.org |
 | RetireJS definitions | raw.githubusercontent.com |
-| RetireJS repository | github.com |
 | Package metadata (NPM) | registry.npmjs.org |
-| Ruby advisories | rubysec.com |
-| Python advisories | pypi.org |
-| NuGet metadata | api.nuget.org |
-| Go vulnerability DB | vuln.go.dev |
+| NPM audit advisories   | registry.npmjs.org |
 | Scarf telemetry (optional) | api.scarf.sh |
 
-Note: Not all hosts are contacted in every run. Access depends on configuration, enabled analyzers, and plugin type.
-Organizations with restricted network access should allowlist the required hosts or configure local mirrors where supported.
+### Methodology
+
+The hostnames listed above were identified by reviewing the Dependency-Check source code (default endpoints and analyzers),
+configuration properties, and existing official documentation.
+
+Some entries (such as NPM audit data) are accessed indirectly via ecosystem-specific analyzers or external CLI tools rather
+than by the Dependency-Check core itself.
+
+To avoid documenting incorrect or misleading network dependencies, only hosts that could be reasonably verified through
+code inspection, configuration defaults, or authoritative project documentation are included.
 
 ## The NVD Database
 

--- a/src/site/markdown/data/index.md
+++ b/src/site/markdown/data/index.md
@@ -7,23 +7,23 @@ hosted resources.
 
 Dependency-Check may contact the following external hosts depending on the enabled analyzers and configuration:
 
-| Purpose | Hostname |
-|--------|----------|
-| NVD API (CVE data) | services.nvd.nist.gov |
-| CISA KEV catalog | www.cisa.gov |
-| Hosted suppressions file | dependency-check.github.io |
-| Maven Central metadata | repo.maven.apache.org |
-| Maven Central search | search.maven.org |
-| Sonatype OSS Index API | ossindex.sonatype.org |
-| RetireJS definitions | raw.githubusercontent.com |
-| Package metadata (NPM) | registry.npmjs.org |
-| NPM audit advisories   | registry.npmjs.org |
-| Scarf telemetry (optional) | api.scarf.sh |
+| Purpose                              | Hostname                               | Relevant Analyzers                 | Primary Ecosystem | Configurable / Proxyable? | Mirrorable? |
+|--------------------------------------|----------------------------------------|------------------------------------|-------------------|---------------------------|-------------|
+| NVD API (CVE & CPE data)             | `services.nvd.nist.gov`                | All                                | All               | ✅                         | ✅           |
+| CISA Known Exploited Vulnerabilities | `www.cisa.gov`                         | Known Exploited Vulnerabilities    | All               | ✅                         | ✅           |
+| ODC Hosted suppressions file         | `dependency-check.github.io`           | Hosted Suppressions                | All               | ✅                         | ✅           |
+| Sonatype OSS Index API               | `ossindex.sonatype.org`                | OSS Index                          | All               | ✅                         | ❌           |
+| RetireJS definitions                 | `raw.githubusercontent.com`            | RetireJS                           | Javascript        | ✅                         | ✅           |
+| NPM audit advisories                 | `registry.npmjs.org`                   | Node Audit, Yarn Audit, PNPM Audit | Javascript        | ✅                         | ❌           |
+| Maven Central search                 | `search.maven.org` / `repo1.maven.org` | Central                            | Java / JVM        | ✅                         | ❌           |
+| Ruby Security advisories             | `github.com`                           | Ruby Bundle Audit                  | Ruby              | *️⃣                       | *️⃣         |
+| Elixir Security advisories           | `github.com`                           | Elixir Mix Audit                   | Elixir            | *️⃣                       | *️⃣         |
+| Scarf telemetry (optional)           | `api.scarf.sh`                         | N/A                                | All               | ❌                         | ❌           |
 
-### Methodology
+#### Methodology
 
-The hostnames listed above were identified by reviewing the Dependency-Check source code (default endpoints and analyzers),
-configuration properties, and existing official documentation.
+**Configurable / Proxyable** - can be configured directly within ODC to use an alternate URL, e.g some kind of caching/forwarding proxy (*️⃣ - may be possible via third-party tool configuration)
+**Mirrorable** - data source can be mirrored somewhere locally to completely avoid direct access (*️⃣ - requires alternate data source/analyzer)
 
 Some entries (such as NPM audit data) are accessed indirectly via ecosystem-specific analyzers or external CLI tools rather
 than by the Dependency-Check core itself.

--- a/src/site/markdown/data/index.md
+++ b/src/site/markdown/data/index.md
@@ -1,9 +1,9 @@
-# Internet Access Required
+Remote Data Sources
+====================
 
-Dependency-check, by default, requires access to several externally
-hosted resources.
+Dependency-check, by default, requires internet access to several externally hosted resources.
 
-## External Data Sources and Hostnames
+### External Hosts
 
 Dependency-Check may contact the following external hosts depending on the enabled analyzers and configuration:
 
@@ -31,7 +31,7 @@ than by the Dependency-Check core itself.
 To avoid documenting incorrect or misleading network dependencies, only hosts that could be reasonably verified through
 code inspection, configuration defaults, or authoritative project documentation are included.
 
-## The NVD Database
+### The NVD Database
 
 OWASP dependency-check maintains a local copy of the NVD API's CVE data hosted by NIST. By default,
 a local [H2 database](http://www.h2database.com/html/main.html) instance is used.
@@ -52,21 +52,24 @@ have a few options:
 4. Use a more robust [centralized database](./database.html) with a single update node
 5. In GitHub Actions utilize the cache action; [example here](./cache-action.md).
 
-## CISA Known Exploited Vulnerabilities
+### CISA Known Exploited Vulnerabilities
 
-with version 8.0.0 access to the CISA Known Exploited Vulnerabilities Catalog is required.
+With version 8.0.0 access to the CISA Known Exploited Vulnerabilities Catalog is required.
 If running on a system with limited network access there are three options:
 
 1. Add `https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json` to the allow list.
 2. Mirror `https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json` locally.
 3. Disable the CISA Known Exploited Vulnerabilities Analyzer.
 
-## Retire JS Repository
+### Retire JS Repository
 
-The RetireJS Analyzes must download the RetireJS Repository. If this is blocked users
-must either mirror the [JS Repository](./mirrornvd.html) or disable the Retire JS Analyzer.
+The RetireJS Analyzers must download the RetireJS Repository from `https://raw.githubusercontent.com/Retirejs/retire.js/master/repository/jsrepository.json`. If this is blocked users
+must either mirror the repository or disable the Retire JS Analyzer.
 
-## Hosted base suppressions file
+The Retire JS repository can be configured using the `retireJsUrl` configuration option.
+See the configuration for the specific dependency-check client used for more information.
+
+### Hosted base suppressions file
 
 For a faster roundtrip time ([issue #4723](https://github.com/dependency-check/DependencyCheck/issues/4723)) to get false-positive report 
 solution out to the users dependency-check starting from version 8.0.0 is using an online hosted 
@@ -77,22 +80,24 @@ for the exact advanced configuration flag to specify the custom location.
 Failure to download the hosted suppressions file will result in only a warning from the tool, but may result in false positives 
 being reported by your scan that have already been mitigated by the hosted suppressions file.
 
-## Downloading Additional Information
+### Maven Central Repository
 
-### Central Repository
+Using CLI, Docker or Ant plugin scanners to scan Java / JVM artifacts without access to reach the [Maven Central Repository](http://search.maven.org) 
+may result in significant numbers of false positives and negatives. 
 
-If the machine that is running dependency-check cannot reach the [Central Repository](http://search.maven.org)
-the analysis may result in false negatives. This is because some POM files, that are not
-contained within the JAR file itself, contain evidence that is used to accurately identify
-a library. If using the Ant plugin or CLI and Central cannot be reached, it is highly recommended to setup a
-Nexus server within your organization and to configure dependency-check to use the local
-Nexus server. **Notes:**
-1. If using any build plugin except Ant - there is no benefit to setting up a Nexus server for use by dependency-check.
-2. Even with a Nexus server setup we have seen dependency-check CLI be
-re-directed to other repositories on the Internet to download the actual POM file; this
-happened due to a rare circumstance where the Nexus instance used by dependency-check
-was not the instance of Nexus used to build the application (i.e. the dependencies
-were not actually present in the Nexus used by dependency-check).
+This is because many JAR files do not contain the necessary POM metadata evidence required to accurately identify a library.
+
+If Maven Central cannot be reached, it is highly recommended to setup a Nexus or Artifactory server within your 
+organization and to configure dependency-check to use the alternative Nexus or Artifactory analyzers with your local server in place of the Maven Central analyzer.
+
+**Notes:**
+1. When using Maven or Gradle plugins - there is typically little benefit to setting up a Nexus or Artifactory server 
+   for use by dependency-check - except when scanning artfifacts such as "uber-jars". This is because the Maven and 
+   Gradle plugins typically provide the necessary metadata directly, and looking inside JAR files is unnecessary.
+2. Even with a Nexus or Artifactory server configured it is possible for dependency-check CLI to be re-directed to other
+   repositories on the Internet to download the actual POM file; this can happen due to a rare circumstance where an 
+   Nexus instance used by dependency-check was not the instance of Nexus used to build the application (i.e. the 
+   dependencies were not actually present in the Nexus used by dependency-check).
 
 ### Sonatype OSS Index
 
@@ -101,6 +106,6 @@ to enrich the report with supplemental vulnerability information.
 
 For more details on this integration see [Sonatype OSS Index](./ossindex.html).
 
-## Telemetry
+### Telemetry
 
 See the [telemetry documentation](../general/telemetry.html) for more information about telemetry data collection.

--- a/src/site/markdown/data/mirrornvd.md
+++ b/src/site/markdown/data/mirrornvd.md
@@ -10,15 +10,3 @@ Creating an offline cache for the NVD API
 The Open Vulnerability Project's [vuln CLI](https://github.com/jeremylong/open-vulnerability-cli/blob/main/README.md)
 can be used to create an offline copy of the data obtained from the NVD API.
 Then configure dependency-check to use the NVD Datafeed URL.
-
-
-Mirroring Retire JS Repository
-------------------------------------------------------------
-The Retire JS Repository is located at:
-
-```
-https://raw.githubusercontent.com/Retirejs/retire.js/master/repository/jsrepository.json
-```
-
-The Retire JS repository can be configured using the `retireJsUrl` configuration option.
-See the configuration for the specific dependency-check client used for more information.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -80,7 +80,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                 <item name="Reading the Report" href="./general/thereport.html"/>
                 <item name="False Positives" href="./general/suppression.html"/>
                 <item name="False Negatives" href="./general/hints.html"/>
-                <item collapse="true" name="Internet Access Required" href="./data/index.html">
+                <item collapse="true" name="Remote Data Sources" href="./data/index.html">
                     <item name="Proxy" href="./data/proxy.html" />
                     <item name="Mirroring NVD" href="./data/mirrornvd.html" />
                     <item name="Snapshotting the NVD" href="./data/cachenvd.html" />


### PR DESCRIPTION
This PR documents the external data sources and hostnames that Dependency-Check may contact depending on enabled analyzers and configuration.

It adds a table to the "Internet Access Required" documentation to help organizations with restricted networks create accurate allow-lists.

Fixes #6600
