### PR TITLE
feat: detect unused suppression sub-entries ✅

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/UnusedSuppressionRuleAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/UnusedSuppressionRuleAnalyzer.java
@@ -88,8 +88,9 @@ public class UnusedSuppressionRuleAnalyzer extends AbstractAnalyzer {
             @SuppressWarnings("unchecked")
             final List<SuppressionRule> rules = (List<SuppressionRule>) engine.getObject(SUPPRESSION_OBJECT_KEY);
             rules.forEach((rule) -> {
-                if (!rule.isMatched() && !rule.isBase()) {
-                    final String message = String.format("Suppression Rule had zero matches: %s", rule);
+                if ((!rule.isMatched() || rule.hasUnusedSubEntries()) && !rule.isBase()) {
+                    final String message = String.format(
+        "Suppression Rule had unused entries (or zero matches): %s", rule);
                     if (failsForUnusedSuppressionRule()) {
                         LOGGER.error(message);
                     } else {

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
@@ -665,6 +665,7 @@ public boolean hasUnusedSubEntries() {
                 if (!remove && v.getName() != null) {
                     for (PropertyType entry : this.vulnerabilityNames) {
                         if (entry.matches(v.getName())) {
+                             markVulnerabilityNameUsed(entry.getValue());
                             remove = true;
                             removeVulns.add(v);
                             break;

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
@@ -129,9 +129,31 @@ private final Set<String> usedVulnerabilityNames = new HashSet<>();
      *
      * @return the value of matched
      */
-    public boolean isMatched() {
-        return matched;
+   public boolean isMatched() {
+    return matched;
+}
+public void markCveUsed(String cve) {
+    usedCves.add(cve);
+}
+public void markVulnerabilityNameUsed(String name) {
+    usedVulnerabilityNames.add(name);
+}
+public boolean hasUnusedSubEntries() {
+    for (String c : this.cve) {
+        if (!usedCves.contains(c)) {
+            return true;
+        }
     }
+
+    for (PropertyType pt : this.vulnerabilityNames) {
+        String name = pt.getValue();
+        if (!usedVulnerabilityNames.contains(name)) {
+            return true;
+        }
+    }
+
+    return false;
+}
 
     /**
      * Set the value of matched.
@@ -623,12 +645,13 @@ private final Set<String> usedVulnerabilityNames = new HashSet<>();
             for (Vulnerability v : dependency.getVulnerabilities()) {
                 boolean remove = false;
                 for (String entry : this.cve) {
-                    if (entry.equalsIgnoreCase(v.getName())) {
-                        removeVulns.add(v);
-                        remove = true;
-                        break;
-                    }
-                }
+    if (entry.equalsIgnoreCase(v.getName())) {
+        markCveUsed(entry);   // <-- ADD THIS LINE
+        removeVulns.add(v);
+        remove = true;
+        break;
+    }
+}
                 if (!remove && this.cwe != null && !v.getCwes().isEmpty()) {
                     for (String entry : this.cwe) {
                         final String toMatch = String.format("CWE-%s", entry);

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
@@ -116,9 +116,13 @@ public class SuppressionRule {
     private Calendar until;
 
     /**
-     * A flag whether or not the rule matched a dependency & CPE.
-     */
-    private boolean matched = false;
+ * A flag whether or not the rule matched a dependency & CPE.
+ */
+private boolean matched = false;
+
+// Track used sub-entries
+private final Set<String> usedCves = new HashSet<>();
+private final Set<String> usedVulnerabilityNames = new HashSet<>();
 
     /**
      * Get the value of matched.

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
@@ -115,45 +115,71 @@ public class SuppressionRule {
      */
     private Calendar until;
 
-    /**
- * A flag whether or not the rule matched a dependency & CPE.
- */
-private boolean matched = false;
-
-// Track used sub-entries
-private final Set<String> usedCves = new HashSet<>();
-private final Set<String> usedVulnerabilityNames = new HashSet<>();
-
-    /**
-     * Get the value of matched.
-     *
-     * @return the value of matched
+        /**
+     * A flag whether or not the rule matched a dependency & CPE.
      */
-   public boolean isMatched() {
-    return matched;
-}
-public void markCveUsed(String cve) {
-    usedCves.add(cve);
-}
-public void markVulnerabilityNameUsed(String name) {
-    usedVulnerabilityNames.add(name);
-}
-public boolean hasUnusedSubEntries() {
-    for (String c : this.cve) {
-        if (!usedCves.contains(c)) {
-            return true;
-        }
+    private boolean matched = false;
+
+    /**
+     * Track used CVE sub-entries.
+     */
+    private final Set<String> usedCves = new HashSet<>();
+
+    /**
+     * Track used vulnerability-name sub-entries.
+     */
+    private final Set<String> usedVulnerabilityNames = new HashSet<>();
+        /**
+     * Returns whether this suppression rule matched any dependency.
+     *
+     * @return true if the rule matched at least one dependency
+     */
+    public boolean isMatched() {
+        return matched;
+    }
+     /*
+     * Marks the given CVE identifier as used by this suppression rule.
+     *
+     * @param cve the CVE identifier that has been matched
+     */
+    public void markCveUsed(String cve) {
+        usedCves.add(cve);
     }
 
-    for (PropertyType pt : this.vulnerabilityNames) {
-        String name = pt.getValue();
-        if (!usedVulnerabilityNames.contains(name)) {
-            return true;
-        }
+    /**
+     * Marks the given vulnerability name as used by this suppression rule.
+     *
+     * @param name the vulnerability name that has been matched
+     */
+    public void markVulnerabilityNameUsed(String name) {
+        usedVulnerabilityNames.add(name);
     }
 
-    return false;
-}
+    /**
+     * Determines whether this rule contains unused CVE or vulnerability-name entries.
+     *
+     * @return true if at least one entry is unused
+     */
+    public boolean hasUnusedSubEntries() {
+        if (!matched) {
+            return false;
+        }
+
+        for (String c : this.cve) {
+            if (!usedCves.contains(c)) {
+                return true;
+            }
+        }
+
+        for (PropertyType pt : this.vulnerabilityNames) {
+            String name = pt.getValue();
+            if (!usedVulnerabilityNames.contains(name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /**
      * Set the value of matched.
@@ -644,14 +670,14 @@ public boolean hasUnusedSubEntries() {
             final Set<Vulnerability> removeVulns = new HashSet<>();
             for (Vulnerability v : dependency.getVulnerabilities()) {
                 boolean remove = false;
-                for (String entry : this.cve) {
-    if (entry.equalsIgnoreCase(v.getName())) {
-        markCveUsed(entry);   // <-- ADD THIS LINE
-        removeVulns.add(v);
-        remove = true;
-        break;
-    }
-}
+                 for (String entry : this.cve) {
+                    if (entry.equalsIgnoreCase(v.getName())) {
+                        markCveUsed(entry);
+                        removeVulns.add(v);
+                        remove = true;
+                        break;
+                    }
+                }
                 if (!remove && this.cwe != null && !v.getCwes().isEmpty()) {
                     for (String entry : this.cwe) {
                         final String toMatch = String.format("CWE-%s", entry);

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/UnusedSuppressionRuleAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/UnusedSuppressionRuleAnalyzerTest.java
@@ -55,34 +55,34 @@ class UnusedSuppressionRuleAnalyzerTest extends BaseTest {
 	}
 
     @Test
-    void testCheckUnusedRules() throws Exception {
-		// flag unset
-		boolean shouldFail = false;
-		Dependency dependency10 = getDependency("1.0");
-		Dependency dependency11 = getDependency("1.1");
+void testCheckUnusedRules() throws Exception {
+    // flag unset
+    boolean shouldFail = false;
+    Dependency dependency10 = getDependency("1.0");
+    Dependency dependency11 = getDependency("1.1");
 
-		// a run without any suppression rule ➫ no unused suppression
-		checkUnusedRules(shouldFail, 0, false, false, dependency10);
+    // a run without any suppression rule → no unused suppression
+    checkUnusedRules(shouldFail, 0, false, false, dependency10);
 
-		// a run without no matching rule ➫ one unused suppression
-		checkUnusedRules(shouldFail, 1, true, false, dependency10, dependency11);
+    // a run without matching rule → one unused suppression
+    checkUnusedRules(shouldFail, 1, true, false, dependency10, dependency11);
 
-		// a run with the vulnerable package ➫ no unused suppression
-		checkUnusedRules(shouldFail, 0, true, true, dependency10, dependency11);
+    // a run with the vulnerable package → one unused suppression (sub-entry)
+    checkUnusedRules(shouldFail, 1, true, true, dependency10, dependency11);
 
+    // set flag
+    shouldFail = true;
 
-		// set flag
-		shouldFail = true;
+    // a run without any suppression rule → no unused suppression
+    checkUnusedRules(shouldFail, 0, false, false, dependency10);
 
-		// a run without any suppression rule ➫ no unused suppression
-		checkUnusedRules(shouldFail, 0, false, false, dependency10);
+    // a run without matching rule → one unused suppression
+    checkUnusedRules(shouldFail, 1, true, false, dependency10, dependency11);
 
-		// a run without no matching rule ➫ one unused suppression
-		checkUnusedRules(shouldFail, 1, true, false, dependency10, dependency11);
+    // a run with the vulnerable package → one unused suppression (sub-entry)
+    checkUnusedRules(shouldFail, 1, true, true, dependency10, dependency11);
+}
 
-		// a run with the vulnerable package ➫ no unused suppression
-		checkUnusedRules(shouldFail, 0, true, true, dependency10, dependency11);
-    }
 
 	private void checkUnusedRules(boolean shouldFail, int expectedCount,
 		boolean withSuppressionRules, boolean matching,


### PR DESCRIPTION
Fixes #8197

## Summary
Improve unused suppression detection by tracking individual CVE and vulnerabilityName (GHSA) entries inside a suppression rule.

Previously, only whole suppression blocks were checked for usage. This change allows detecting unused sub-entries so they can be safely removed when `failBuildOnUnusedSuppressionRule` is enabled.

## Changes
- Track used CVE entries in `SuppressionRule`
- Track used vulnerabilityName entries in `SuppressionRule`
- Report rules with unused sub-entries in `UnusedSuppressionRuleAnalyzer`

## Motivation
When dependencies are upgraded, some suppressed vulnerabilities no longer apply. Currently these remain hidden because the suppression block is still considered "used". This change makes suppression maintenance more accurate and easier.

## Testing
- Existing CI tests
- Manual verification with multi-version dependency scenario