### PR TITLE
fix: Suppress noisy WARN logging from Apache Lucene within Maven and Ant plugins

### DIFF
--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Purge.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Purge.java
@@ -20,6 +20,7 @@ package org.owasp.dependencycheck.taskdefs;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
@@ -124,12 +125,15 @@ public class Purge extends Task {
     }
 
     /**
-     * Hacky method of muting the noisy logging from JCS.
+     * Hacky method of muting the noisy logging from certain libraries.
      */
     private void muteNoisyLoggers() {
-        final String[] noisyLoggers = {
+        // Mirrors the configuration within cli/src/main/resources/logback.xml
+        final List<String> noisyLoggers = List.of(
+            "org.apache.lucene",
+            "org.apache.commons.jcs3",
             "org.apache.hc"
-        };
+        );
         for (String loggerName : noisyLoggers) {
             System.setProperty("org.slf4j.simpleLogger.log." + loggerName, "error");
         }

--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -50,7 +50,6 @@ import ch.qos.logback.classic.filter.ThresholdFilter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
-import io.github.jeremylong.jcs3.slf4j.Slf4jAdapter;
 
 import java.util.TreeSet;
 

--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -10,8 +10,9 @@
         </encoder>
     </appender>
 
+    <!-- Mirrored by configuration in muteNoisyLoggers() in plugins -->
     <logger name="org.apache.lucene" level="ERROR" />
-    <logger name="org.apache.commons.jcs3" level="FATAL" />
+    <logger name="org.apache.commons.jcs3" level="ERROR" />
     <logger name="org.apache.hc" level="ERROR" />
 
     <root level="INFO">

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -1168,7 +1168,7 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     private Retirejs retirejs;
 
     /**
-     * The list of patterns to exclude from the check. This is matched against the project dependencies (and will implicitly also remove transitive dependencies from matching dependencies). 
+     * The list of patterns to exclude from the check. This is matched against the project dependencies (and will implicitly also remove transitive dependencies from matching dependencies).
      * Each pattern has the format {@code [groupId]:[artifactId]:[type]:[version]}. You can leave out unspecified parts (which is equal to using {@code *}).
      * Examples: {@code org.apache.*} would match all artifacts whose group id starts with {@code org.apache.}, and {@code :::*-SNAPSHOT} would match all snapshot artifacts.
      */
@@ -2727,12 +2727,15 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
     }
 
     /**
-     * Hacky method of muting the noisy logging from JCS
+     * Hacky method of muting the noisy logging from certain libraries.
      */
-    protected void muteNoisyLoggers() {
-        final String[] noisyLoggers = {
+    void muteNoisyLoggers() {
+        // Mirrors the configuration within cli/src/main/resources/logback.xml
+        final List<String> noisyLoggers = List.of(
+            "org.apache.lucene",
+            "org.apache.commons.jcs3",
             "org.apache.hc"
-        };
+        );
         for (String loggerName : noisyLoggers) {
             System.setProperty("org.slf4j.simpleLogger.log." + loggerName, "error");
         }


### PR DESCRIPTION
## Description of Change

These should not be of concern to users, and already suppressed within the CLI via #8003 

## Related issues

- fixes #8233 

## Have test cases been added to cover the new functionality?

yes