### PR TITLE
fix(fp): consolidate suppressions for the Validator.nu (VNU) HTML checker

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -2498,29 +2498,8 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
 </suppress>
 <suppress base="true">
    <notes><![CDATA[
-   FP per issue #8243
+   FP per issue #8243, #8244, #8247, #8249
    ]]></notes>
-   <packageUrl regex="true">^pkg:maven/isorelax/isorelax@.*$</packageUrl>
-   <cpe>cpe:/a:validator:validator</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #8244
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/nu\.validator/jing@.*$</packageUrl>
-   <cpe>cpe:/a:validator:validator</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #8247
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.networknt/json-schema-validator@.*$</packageUrl>
-   <cpe>cpe:/a:validator:validator</cpe>
-</suppress>
-<suppress base="true">
-   <notes><![CDATA[
-   FP per issue #8249
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.hibernate\.validator/hibernate-validator@.*$</packageUrl>
+   <packageUrl regex="true">^pkg:(?!maven/nu\.validator/validator@|npm/vnu-jar).*</packageUrl>
    <cpe>cpe:/a:validator:validator</cpe>
 </suppress>


### PR DESCRIPTION
## Description of Change

A [new CVE](https://nvd.nist.gov/vuln/detail/CVE-2025-15104) in a generic named CPE is leading to a lot of FPs
- #8243
- #8244
- #8247 
- #8249

Consolidate to a negative-lookahead suppression.

The library is released as
- a single artifact library: https://mvnrepository.com/artifact/nu.validator/validator
- inside an npm package at https://www.npmjs.com/package/vnu-jar
- inside an executable uber jar

Vulnerability is categorised against the first two package types: https://github.com/advisories/GHSA-fccg-7w3p-w66f so this should be good enough, to also stop the CPE matching against "**validator**"s in all manner of other package types. The executable jar should match against the jar if indeed a PURL can be inferred for it (if not, a hint can be added)

## Related issues

- #8243
- #8244
- #8247 
- #8249
 
## Have test cases been added to cover the new functionality?

N/A