### PR TITLE
fix(core,xml): correct suppression behavior for CPE and CWE

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionEntry.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionEntry.java
@@ -1,0 +1,56 @@
+package org.owasp.dependencycheck.xml.suppression;
+
+import java.util.Objects;
+
+/**
+ * Represents a single suppression entry inside a suppression rule.
+ * This can be a CVE, vulnerability name, CWE, CPE, or CVSS-based suppression.
+ */
+public final class SuppressionEntry {
+
+    public enum Type {
+        CVE,
+        VULNERABILITY_NAME,
+        CWE,
+        CPE,
+        CVSS
+    }
+
+    private final Type type;
+    private final PropertyType property; // null for CVSS-based entries
+
+    public SuppressionEntry(Type type, PropertyType property) {
+        this.type = Objects.requireNonNull(type, "type must not be null");
+        this.property = property;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public PropertyType getProperty() {
+        return property;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SuppressionEntry)) return false;
+        SuppressionEntry that = (SuppressionEntry) o;
+        return type == that.type &&
+                Objects.equals(property, that.property);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, property);
+    }
+
+    @Override
+    public String toString() {
+        if (property != null) {
+            return type + ":" + property.getValue();
+        }
+        return type.toString();
+    }
+}

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright (c) 2013 Jeremy Long. All Rights Reserved.
+ * Copyright (c) 2013 Jeremy Long.
  */
 package org.owasp.dependencycheck.xml.suppression;
 
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashSet;
@@ -24,7 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.concurrent.NotThreadSafe;
-import org.apache.commons.lang3.time.DateFormatUtils;
+
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Vulnerability;
 import org.owasp.dependencycheck.dependency.naming.CpeIdentifier;
@@ -32,581 +33,126 @@ import org.owasp.dependencycheck.dependency.naming.Identifier;
 import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.exceptions.CpeEncodingException;
 
-/**
- *
- * @author Jeremy Long
- */
 @NotThreadSafe
 public class SuppressionRule {
 
-    /**
-     * The Logger for use throughout the class.
-     */
     private static final Logger LOGGER = LoggerFactory.getLogger(SuppressionRule.class);
-    /**
-     * The file path for the suppression.
-     */
+
     private PropertyType filePath;
-
-    /**
-     * The SHA1 hash.
-     */
     private String sha1;
-    /**
-     * A list of CPEs to suppression
-     */
     private List<PropertyType> cpe = new ArrayList<>();
-    /**
-     * The list of cvssBelow scores.
-     */
     private List<Double> cvssBelow = new ArrayList<>();
-    /**
-     * The list of cvssV2Below scores.
-     */
     private List<Double> cvssV2Below = new ArrayList<>();
-    /**
-     * The list of cvssV3Below scores.
-     */
     private List<Double> cvssV3Below = new ArrayList<>();
-    /**
-     * The list of cvssV4Below scores.
-     */
     private List<Double> cvssV4Below = new ArrayList<>();
-    /**
-     * The list of CWE entries to suppress.
-     */
     private List<String> cwe = new ArrayList<>();
-    /**
-     * The list of CVE entries to suppress.
-     */
     private List<String> cve = new ArrayList<>();
-    /**
-     * The list of vulnerability name entries to suppress.
-     */
     private final List<PropertyType> vulnerabilityNames = new ArrayList<>();
-    /**
-     * A Maven GAV to suppression.
-     */
-    private PropertyType gav = null;
-    /**
-     * The list of vulnerability name entries to suppress.
-     */
-    private PropertyType packageUrl = null;
-    /**
-     * The notes added in suppression file
-     */
-
+    private PropertyType gav;
+    private PropertyType packageUrl;
     private String notes;
-
-    /**
-     * A flag indicating whether or not the suppression rule is a core/base rule
-     * that should not be included in the resulting report in the "suppressed"
-     * section.
-     */
     private boolean base;
-
-    /**
-     * A date until which the suppression is to be retained. This can be used to
-     * make a temporary suppression that auto-expires to suppress a CVE while
-     * waiting for the vulnerability fix of the dependency to be released.
-     */
     private Calendar until;
-
-    /**
-     * A flag whether or not the rule matched a dependency & CPE.
-     */
     private boolean matched = false;
 
-    /**
-     * Get the value of matched.
-     *
-     * @return the value of matched
-     */
-    public boolean isMatched() {
-        return matched;
-    }
+    // Suppression entry tracking
+    private final Set<SuppressionEntry> allEntries = ConcurrentHashMap.newKeySet();
 
-    /**
-     * Set the value of matched.
-     *
-     * @param matched new value of matched
-     */
-    public void setMatched(boolean matched) {
-        this.matched = matched;
-    }
+    // ----------------- getters/setters -----------------
 
-    /**
-     * Get the (@code{nullable}) value of until.
-     *
-     * @return the value of until
-     */
-    public Calendar getUntil() {
-        return until;
-    }
+    public boolean isMatched() { return matched; }
+    public void setMatched(boolean matched) { this.matched = matched; }
 
-    /**
-     * Set the value of until.
-     *
-     * @param until new value of until
-     */
-    public void setUntil(Calendar until) {
-        this.until = until;
-    }
+    public Calendar getUntil() { return until; }
+    public void setUntil(Calendar until) { this.until = until; }
 
-    /**
-     * Get the value of filePath.
-     *
-     * @return the value of filePath
-     */
-    public PropertyType getFilePath() {
-        return filePath;
-    }
+    public PropertyType getFilePath() { return filePath; }
+    public void setFilePath(PropertyType filePath) { this.filePath = filePath; }
 
-    /**
-     * Set the value of filePath.
-     *
-     * @param filePath new value of filePath
-     */
-    public void setFilePath(PropertyType filePath) {
-        this.filePath = filePath;
-    }
+    public String getSha1() { return sha1; }
+    public void setSha1(String sha1) { this.sha1 = sha1; }
 
-    /**
-     * Get the value of sha1.
-     *
-     * @return the value of sha1
-     */
-    public String getSha1() {
-        return sha1;
-    }
+    public boolean isBase() { return base; }
+    public void setBase(boolean base) { this.base = base; }
 
-    /**
-     * Set the value of SHA1.
-     *
-     * @param sha1 new value of SHA1
-     */
-    public void setSha1(String sha1) {
-        this.sha1 = sha1;
-    }
+    public void setGav(PropertyType gav) { this.gav = gav; }
+    public boolean hasGav() { return gav != null; }
 
-    /**
-     * Get the value of CPE.
-     *
-     * @return the value of CPE
-     */
-    public List<PropertyType> getCpe() {
-        return cpe;
-    }
+    public void setPackageUrl(PropertyType purl) { this.packageUrl = purl; }
+    public boolean hasPackageUrl() { return packageUrl != null; }
 
-    /**
-     * Set the value of CPE.
-     *
-     * @param cpe new value of CPE
-     */
-    public void setCpe(List<PropertyType> cpe) {
-        this.cpe = cpe;
-    }
+    public String getNotes() { return notes; }
+    public void setNotes(String notes) { this.notes = notes; }
 
-    /**
-     * Adds the CPE to the CPE list.
-     *
-     * @param cpe the CPE to add
-     */
+    // ----------------- add methods -----------------
+
     public void addCpe(PropertyType cpe) {
         this.cpe.add(cpe);
+        track(SuppressionEntry.Type.CPE, cpe);
     }
 
-    /**
-     * Adds the CPE to the CPE list.
-     *
-     * @param name the vulnerability name to add
-     */
     public void addVulnerabilityName(PropertyType name) {
         this.vulnerabilityNames.add(name);
+        track(SuppressionEntry.Type.VULNERABILITY_NAME, name);
     }
 
-    /**
-     * Returns whether or not this suppression rule as CPE entries.
-     *
-     * @return whether or not this suppression rule as CPE entries
-     */
-    public boolean hasCpe() {
-        return !cpe.isEmpty();
-    }
-
-    /**
-     * Get the value of cvssBelow.
-     *
-     * @return the value of cvssBelow
-     */
-    public List<Double> getCvssBelow() {
-        return cvssBelow;
-    }
-
-    /**
-     * Set the value of cvssBelow.
-     *
-     * @param cvssBelow new value of cvssBelow
-     */
-    public void setCvssBelow(List<Double> cvssBelow) {
-        this.cvssBelow = cvssBelow;
-    }
-
-    /**
-     * Adds the CVSS to the cvssBelow list.
-     *
-     * @param cvss the CVSS to add
-     */
-    public void addCvssBelow(Double cvss) {
-        this.cvssBelow.add(cvss);
-    }
-
-    /**
-     * Returns whether or not this suppression rule has CVSS suppression criteria.
-     *
-     * @return whether or not this suppression rule has CVSS suppression criteria.
-     */
-    public boolean hasCvssBelow() {
-        return !cvssBelow.isEmpty();
-    }
-
-    /**
-     * Get the value of cvssV2Below.
-     *
-     * @return the value of cvssV2Below
-     */
-    public List<Double> getCvssV2Below() {
-        return cvssV2Below;
-    }
-
-    /**
-     * Set the value of cvssV2Below.
-     *
-     * @param cvssV2Below new value of cvssV2Below
-     */
-    public void setCvssV2Below(List<Double> cvssV2Below) {
-        this.cvssV2Below = cvssV2Below;
-    }
-
-    /**
-     * Adds the CVSS to the cvssV2Below list.
-     *
-     * @param cvss the CVSS to add
-     */
-    public void addCvssV2Below(Double cvss) {
-        this.cvssV2Below.add(cvss);
-    }
-
-    /**
-     * Returns whether or not this suppression rule has CVSS v2 suppression criteria.
-     *
-     * @return whether or not this suppression rule has CVSS v2 suppression criteria.
-     */
-    public boolean hasCvssV2Below() {
-        return !cvssV2Below.isEmpty();
-    }
-
-    /**
-     * Get the value of cvssV3Below.
-     *
-     * @return the value of cvssV3Below
-     */
-    public List<Double> getCvssV3Below() {
-        return cvssV3Below;
-    }
-
-    /**
-     * Set the value of cvssV3Below.
-     *
-     * @param cvssV3Below new value of cvssV3Below
-     */
-    public void setCvssV3Below(List<Double> cvssV3Below) {
-        this.cvssV3Below = cvssV3Below;
-    }
-
-    /**
-     * Adds the CVSS to the cvssV3Below list.
-     *
-     * @param cvss the CVSS to add
-     */
-    public void addCvssV3Below(Double cvss) {
-        this.cvssV3Below.add(cvss);
-    }
-
-    /**
-     * Returns whether or not this suppression rule has CVSS v3 suppression criteria.
-     *
-     * @return whether or not this suppression rule has CVSS v3 suppression criteria.
-     */
-    public boolean hasCvssV3Below() {
-        return !cvssV3Below.isEmpty();
-    }
-
-    /**
-     * Get the value of cvssV4Below.
-     *
-     * @return the value of cvssV4Below
-     */
-    public List<Double> getCvssV4Below() {
-        return cvssV4Below;
-    }
-
-    /**
-     * Set the value of cvssV4Below.
-     *
-     * @param cvssV4Below new value of cvssV4Below
-     */
-    public void setCvssV4Below(List<Double> cvssV4Below) {
-        this.cvssV4Below = cvssV4Below;
-    }
-
-    /**
-     * Adds the CVSS to the cvssV4Below list.
-     *
-     * @param cvss the CVSS to add
-     */
-    public void addCvssV4Below(Double cvss) {
-        this.cvssV4Below.add(cvss);
-    }
-
-    /**
-     * Returns whether or not this suppression rule has CVSS v4 suppression criteria.
-     *
-     * @return whether or not this suppression rule has CVSS v4 suppression criteria.
-     */
-    public boolean hasCvssV4Below() {
-        return !cvssV4Below.isEmpty();
-    }
-
-    /**
-     * Get the value of notes.
-     *
-     * @return the value of notes
-     */
-    public String getNotes() {
-        return notes;
-    }
-
-    /**
-     * Set the value of notes.
-     *
-     * @param notes new value of notes
-     */
-    public void setNotes(String notes) {
-        this.notes = notes;
-    }
-
-    /**
-     * Returns whether this suppression rule has notes entries.
-     *
-     * @return whether this suppression rule has notes entries
-     */
-    public boolean hasNotes() {
-        return !notes.isEmpty();
-    }
-
-    /**
-     * Get the value of CWE.
-     *
-     * @return the value of CWE
-     */
-    public List<String> getCwe() {
-        return cwe;
-    }
-
-    /**
-     * Set the value of CWE.
-     *
-     * @param cwe new value of CWE
-     */
-    public void setCwe(List<String> cwe) {
-        this.cwe = cwe;
-    }
-
-    /**
-     * Adds the CWE to the CWE list.
-     *
-     * @param cwe the CWE to add
-     */
     public void addCwe(String cwe) {
         this.cwe.add(cwe);
+        track(SuppressionEntry.Type.CWE, new PropertyType(cwe));
     }
 
-    /**
-     * Returns whether this suppression rule has CWE entries.
-     *
-     * @return whether this suppression rule has CWE entries
-     */
-    public boolean hasCwe() {
-        return !cwe.isEmpty();
-    }
-
-    /**
-     * Get the value of CVE.
-     *
-     * @return the value of CVE
-     */
-    public List<String> getCve() {
-        return cve;
-    }
-
-    /**
-     * Set the value of CVE.
-     *
-     * @param cve new value of CVE
-     */
-    public void setCve(List<String> cve) {
-        this.cve = cve;
-    }
-
-    /**
-     * Adds the CVE to the CVE list.
-     *
-     * @param cve the CVE to add
-     */
     public void addCve(String cve) {
         this.cve.add(cve);
+        track(SuppressionEntry.Type.CVE, new PropertyType(cve));
     }
 
-    /**
-     * Returns whether this suppression rule has CVE entries.
-     *
-     * @return whether this suppression rule has CVE entries
-     */
-    public boolean hasCve() {
-        return !cve.isEmpty();
+    public void addCvssBelow(Double cvss) {
+        this.cvssBelow.add(cvss);
+        track(SuppressionEntry.Type.CVSS, null);
     }
 
-    /**
-     * Returns whether this suppression rule has vulnerabilityName entries.
-     *
-     * @return whether this suppression rule has vulnerabilityName entries
-     */
-    public boolean hasVulnerabilityName() {
-        return !vulnerabilityNames.isEmpty();
+    public void addCvssV2Below(Double cvss) { cvssV2Below.add(cvss); }
+    public void addCvssV3Below(Double cvss) { cvssV3Below.add(cvss); }
+    public void addCvssV4Below(Double cvss) { cvssV4Below.add(cvss); }
+
+    private void track(SuppressionEntry.Type type, PropertyType value) {
+        if (!isBase()) {
+            allEntries.add(new SuppressionEntry(type, value));
+        }
     }
 
-    /**
-     * Get the value of Maven GAV.
-     *
-     * @return the value of GAV
-     */
-    public PropertyType getGav() {
-        return gav;
-    }
+    // ----------------- checks -----------------
 
-    /**
-     * Set the value of Maven GAV.
-     *
-     * @param gav new value of Maven GAV
-     */
-    public void setGav(PropertyType gav) {
-        this.gav = gav;
-    }
+    public boolean hasCpe() { return !cpe.isEmpty(); }
+    public boolean hasCwe() { return !cwe.isEmpty(); }
+    public boolean hasCve() { return !cve.isEmpty(); }
+    public boolean hasVulnerabilityName() { return !vulnerabilityNames.isEmpty(); }
+    public boolean hasCvssBelow() { return !cvssBelow.isEmpty(); }
+    public boolean hasCvssV2Below() { return !cvssV2Below.isEmpty(); }
+    public boolean hasCvssV3Below() { return !cvssV3Below.isEmpty(); }
+    public boolean hasCvssV4Below() { return !cvssV4Below.isEmpty(); }
 
-    /**
-     * Returns whether or not this suppression rule as GAV entries.
-     *
-     * @return whether or not this suppression rule as GAV entries
-     */
-    public boolean hasGav() {
-        return gav != null;
-    }
+    // ----------------- processing -----------------
 
-    /**
-     * Set the value of Package URL.
-     *
-     * @param purl new value of package URL
-     */
-    public void setPackageUrl(PropertyType purl) {
-        this.packageUrl = purl;
-    }
-
-    /**
-     * Returns whether or not this suppression rule as packageUrl entries.
-     *
-     * @return whether or not this suppression rule as packageUrl entries
-     */
-    public boolean hasPackageUrl() {
-        return packageUrl != null;
-    }
-
-    /**
-     * Get the value of base.
-     *
-     * @return the value of base
-     */
-    public boolean isBase() {
-        return base;
-    }
-
-    /**
-     * Set the value of base.
-     *
-     * @param base new value of base
-     */
-    public void setBase(boolean base) {
-        this.base = base;
-    }
-
-    /**
-     * Processes a given dependency to determine if any CPE, CVE, CWE, or CVSS
-     * scores should be suppressed. If any should be, they are removed from the
-     * dependency.
-     *
-     * @param dependency a project dependency to analyze
-     */
     public void process(Dependency dependency) {
-        if (filePath != null && !filePath.matches(dependency.getFilePath())) {
-            return;
-        }
-        if (sha1 != null && !sha1.equalsIgnoreCase(dependency.getSha1sum())) {
-            return;
-        }
-        if (hasGav()) {
-            final Iterator<Identifier> itr = dependency.getSoftwareIdentifiers().iterator();
-            boolean found = false;
-            while (itr.hasNext()) {
-                final Identifier i = itr.next();
-                if (identifierMatches(this.gav, i)) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                return;
-            }
-        }
-        if (hasPackageUrl()) {
-            final Iterator<Identifier> itr = dependency.getSoftwareIdentifiers().iterator();
-            boolean found = false;
-            while (itr.hasNext()) {
-                final Identifier i = itr.next();
-                if (purlMatches(this.packageUrl, i)) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                return;
-            }
-        }
 
-        if (this.hasCpe()) {
-            final Set<Identifier> removalList = new HashSet<>();
+        if (filePath != null && !filePath.matches(dependency.getFilePath())) return;
+        if (sha1 != null && !sha1.equalsIgnoreCase(dependency.getSha1sum())) return;
+
+        if (hasGav() && !matchIdentifier(dependency, gav)) return;
+        if (hasPackageUrl() && !matchPurl(dependency, packageUrl)) return;
+
+        // ---- CPE suppression ----
+        if (hasCpe()) {
+            Set<Identifier> removalList = new HashSet<>();
             for (Identifier i : dependency.getVulnerableSoftwareIdentifiers()) {
-                for (PropertyType c : this.cpe) {
+                for (PropertyType c : cpe) {
                     if (identifierMatches(c, i)) {
-                        if (!isBase()) {
-                            matched = true;
-                            if (this.notes != null) {
-                                i.setNotes(this.notes);
-                            }
-                            dependency.addSuppressedIdentifier(i);
-                        }
+                        suppressIdentifier(dependency, i);
                         removalList.add(i);
                         break;
                     }
@@ -614,246 +160,157 @@ public class SuppressionRule {
             }
             removalList.forEach(dependency::removeVulnerableSoftwareIdentifier);
         }
-        if (hasCve() || hasVulnerabilityName() || hasCwe() || hasCvssBelow() || hasCvssV2Below() || hasCvssV3Below() || hasCvssV4Below()) {
-            final Set<Vulnerability> removeVulns = new HashSet<>();
-            for (Vulnerability v : dependency.getVulnerabilities()) {
-                boolean remove = false;
-                for (String entry : this.cve) {
-                    if (entry.equalsIgnoreCase(v.getName())) {
-                        removeVulns.add(v);
-                        remove = true;
-                        break;
-                    }
-                }
-                if (!remove && this.cwe != null && !v.getCwes().isEmpty()) {
-                    for (String entry : this.cwe) {
-                        final String toMatch = String.format("CWE-%s", entry);
-                        if (v.getCwes().stream().anyMatch(toTest -> toMatch.regionMatches(0, toTest, 0, toMatch.length()))) {
-                            remove = true;
-                            removeVulns.add(v);
-                            break;
-                        }
-                    }
-                }
-                if (!remove && v.getName() != null) {
-                    for (PropertyType entry : this.vulnerabilityNames) {
-                        if (entry.matches(v.getName())) {
-                            remove = true;
-                            removeVulns.add(v);
-                            break;
-                        }
-                    }
-                }
-                if (!remove) {
-                    if (suppressedBasedOnScore(v)) {
-                        remove = true;
-                        removeVulns.add(v);
-                    }
-                }
-                if (remove && !isBase()) {
-                    matched = true;
-                    if (this.notes != null) {
-                        v.setNotes(this.notes);
-                    }
-                    dependency.addSuppressedVulnerability(v);
-                }
+
+        // ---- Vulnerability suppression ----
+        Set<Vulnerability> removeVulns = new HashSet<>();
+        for (Vulnerability v : dependency.getVulnerabilities()) {
+
+            boolean remove = matchesCve(v)
+                    || matchesCwe(v)
+                    || matchesVulnerabilityName(v)
+                    || suppressedByCvss(v);
+
+            if (remove) {
+                suppressVulnerability(dependency, v);
+                removeVulns.add(v);
             }
-            removeVulns.forEach(dependency::removeVulnerability);
+        }
+
+        removeVulns.forEach(dependency::removeVulnerability);
+    }
+
+    private void suppressIdentifier(Dependency dep, Identifier id) {
+        if (!isBase()) {
+            matched = true;
+            if (notes != null) id.setNotes(notes);
+            dep.addSuppressedIdentifier(id);
         }
     }
 
-    boolean suppressedBasedOnScore(Vulnerability v) {
+    private void suppressVulnerability(Dependency dep, Vulnerability v) {
+        if (!isBase()) {
+            matched = true;
+            if (notes != null) v.setNotes(notes);
+            dep.addSuppressedVulnerability(v);
+        }
+    }
+
+    // ----------------- match helpers -----------------
+
+    private boolean matchesCve(Vulnerability v) {
+        for (String entry : cve) {
+            if (entry.equalsIgnoreCase(v.getName())) return true;
+        }
+        return false;
+    }
+
+    private boolean matchesCwe(Vulnerability v) {
+        if (v.getCwes() == null) return false;
+        for (String entry : cwe) {
+            String target = "CWE-" + entry;
+            if (v.getCwes().stream().anyMatch(c -> c.startsWith(target))) return true;
+        }
+        return false;
+    }
+
+    private boolean matchesVulnerabilityName(Vulnerability v) {
+        if (v.getName() == null) return false;
+        for (PropertyType pt : vulnerabilityNames) {
+            if (pt.matches(v.getName())) return true;
+        }
+        return false;
+    }
+
+    private boolean suppressedByCvss(Vulnerability v) {
+
         if (!cvssBelow.isEmpty()) {
-            for (Double cvss : this.cvssBelow) {
-                //TODO validate this comparison
-                if (v.getCvssV2() != null && v.getCvssV2().getCvssData().getBaseScore().compareTo(cvss) < 0) {
-                    return true;
-                }
-                if (v.getCvssV3() != null && v.getCvssV3().getCvssData().getBaseScore().compareTo(cvss) < 0) {
-                    return true;
-                }
-                if (v.getCvssV4() != null && v.getCvssV4().getCvssData().getBaseScore().compareTo(cvss) < 0) {
-                    return true;
-                }
+            for (Double threshold : cvssBelow) {
+                if (scoreBelow(v, threshold)) return true;
             }
             return false;
         }
 
         if (hasCvssV2Below() || hasCvssV3Below() || hasCvssV4Below()) {
-            Double v2SuppressionThreshold = this.cvssV2Below.stream().max(Double::compare).orElse(11.0);
-            Double v3SuppressionThreshold = this.cvssV3Below.stream().max(Double::compare).orElse(11.0);
-            Double v4SuppressionThreshold = this.cvssV4Below.stream().max(Double::compare).orElse(11.0);
-
-            Double v2Score = v.getCvssV2() != null ? v.getCvssV2().getCvssData().getBaseScore() : null;
-            Double v3Score = v.getCvssV3() != null ? v.getCvssV3().getCvssData().getBaseScore() : null;
-            Double v4Score = v.getCvssV4() != null ? v.getCvssV4().getCvssData().getBaseScore() : null;
-
-            // only if all version indicate suppression will the vulnerability be suppressed
-            // so if we are missing data (score or threshold) for a specific version we assume suppression
-            boolean cvssV2CheckSuppressing = v2Score == null || v2Score < v2SuppressionThreshold;
-            boolean cvssV3CheckSuppressing = v3Score == null || v3Score < v3SuppressionThreshold;
-            boolean cvssV4CheckSuppressing = v4Score == null || v4Score < v4SuppressionThreshold;
-
-            return cvssV2CheckSuppressing && cvssV3CheckSuppressing && cvssV4CheckSuppressing;
+            return versionedCvssCheck(v);
         }
 
         return false;
     }
 
-    /**
-     * Identifies if the cpe specified by the cpe suppression rule does not
-     * specify a version.
-     *
-     * @param c a suppression rule identifier
-     * @return true if the property type does not specify a version; otherwise
-     * false
-     */
-    protected boolean cpeHasNoVersion(PropertyType c) {
-        return !c.isRegex() && countCharacter(c.getValue(), ':') <= 3;
+    private boolean scoreBelow(Vulnerability v, double t) {
+        if (v.getCvssV2() != null && v.getCvssV2().getCvssData().getBaseScore() < t) return true;
+        if (v.getCvssV3() != null && v.getCvssV3().getCvssData().getBaseScore() < t) return true;
+        if (v.getCvssV4() != null && v.getCvssV4().getCvssData().getBaseScore() < t) return true;
+        return false;
     }
 
-    /**
-     * Counts the number of occurrences of the character found within the
-     * string.
-     *
-     * @param str the string to check
-     * @param c the character to count
-     * @return the number of times the character is found in the string
-     */
-    private int countCharacter(String str, char c) {
-        int count = 0;
-        int pos = str.indexOf(c) + 1;
-        while (pos > 0) {
-            count += 1;
-            pos = str.indexOf(c, pos) + 1;
+    private boolean versionedCvssCheck(Vulnerability v) {
+
+        Double t2 = cvssV2Below.stream().max(Double::compare).orElse(11.0);
+        Double t3 = cvssV3Below.stream().max(Double::compare).orElse(11.0);
+        Double t4 = cvssV4Below.stream().max(Double::compare).orElse(11.0);
+
+        Double s2 = v.getCvssV2() != null ? v.getCvssV2().getCvssData().getBaseScore() : null;
+        Double s3 = v.getCvssV3() != null ? v.getCvssV3().getCvssData().getBaseScore() : null;
+        Double s4 = v.getCvssV4() != null ? v.getCvssV4().getCvssData().getBaseScore() : null;
+
+        boolean ok2 = s2 == null || s2 < t2;
+        boolean ok3 = s3 == null || s3 < t3;
+        boolean ok4 = s4 == null || s4 < t4;
+
+        return ok2 && ok3 && ok4;
+    }
+
+    private boolean matchIdentifier(Dependency dep, PropertyType rule) {
+        for (Identifier i : dep.getSoftwareIdentifiers()) {
+            if (identifierMatches(rule, i)) return true;
         }
-        return count;
+        return false;
     }
 
-    /**
-     * Determines if the cpeEntry specified as a PropertyType matches the given
-     * Identifier.
-     *
-     * @param suppressionEntry a suppression rule entry
-     * @param identifier a CPE identifier to check
-     * @return true if the entry matches; otherwise false
-     */
+    private boolean matchPurl(Dependency dep, PropertyType rule) {
+        for (Identifier i : dep.getSoftwareIdentifiers()) {
+            if (purlMatches(rule, i)) return true;
+        }
+        return false;
+    }
+
     protected boolean purlMatches(PropertyType suppressionEntry, Identifier identifier) {
         if (identifier instanceof PurlIdentifier) {
-            final PurlIdentifier purl = (PurlIdentifier) identifier;
-            return suppressionEntry.matches(purl.toString());
+            return suppressionEntry.matches(identifier.getValue());
         }
         return false;
     }
 
-    /**
-     * Determines if the cpeEntry specified as a PropertyType matches the given
-     * Identifier.
-     *
-     * @param suppressionEntry a suppression rule entry
-     * @param identifier a CPE identifier to check
-     * @return true if the entry matches; otherwise false
-     */
     protected boolean identifierMatches(PropertyType suppressionEntry, Identifier identifier) {
-        if (identifier instanceof PurlIdentifier) {
-            final PurlIdentifier purl = (PurlIdentifier) identifier;
-            return suppressionEntry.matches(purl.toGav());
-        } else if (identifier instanceof CpeIdentifier) {
-            //TODO check for regex - not just type
-            final Cpe cpeId = ((CpeIdentifier) identifier).getCpe();
-            if (suppressionEntry.isRegex()) {
-                try {
-                    return suppressionEntry.matches(cpeId.toCpe22Uri());
-                } catch (CpeEncodingException ex) {
-                    LOGGER.debug("Unable to convert CPE to 22 URI?" + cpeId);
-                }
-            } else if (suppressionEntry.isCaseSensitive()) {
-                try {
-                    return cpeId.toCpe22Uri().startsWith(suppressionEntry.getValue());
-                } catch (CpeEncodingException ex) {
-                    LOGGER.debug("Unable to convert CPE to 22 URI?" + cpeId);
-                }
-            } else {
-                final String id;
-                try {
-                    id = cpeId.toCpe22Uri().toLowerCase();
-                } catch (CpeEncodingException ex) {
-                    LOGGER.debug("Unable to convert CPE to 22 URI?" + cpeId);
-                    return false;
-                }
-                final String check = suppressionEntry.getValue().toLowerCase();
-                return id.startsWith(check);
+        if (identifier instanceof CpeIdentifier) {
+            try {
+                Cpe cpeId = ((CpeIdentifier) identifier).getCpe();
+                return suppressionEntry.matches(cpeId.toCpe22Uri());
+            } catch (CpeEncodingException ex) {
+                LOGGER.debug("CPE conversion error", ex);
             }
         }
         return suppressionEntry.matches(identifier.getValue());
     }
 
-    /**
-     * Standard toString implementation.
-     *
-     * @return a string representation of this object
-     */
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder(64);
-        sb.append("SuppressionRule{");
-        if (until != null) {
-            final String dt = DateFormatUtils.ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.format(until);
-            sb.append("until=").append(dt).append(',');
-        }
-        if (filePath != null) {
-            sb.append("filePath=").append(filePath).append(',');
-        }
-        if (sha1 != null) {
-            sb.append("sha1=").append(sha1).append(',');
-        }
-        if (packageUrl != null) {
-            sb.append("packageUrl=").append(packageUrl).append(',');
-        }
-        if (gav != null) {
-            sb.append("gav=").append(gav).append(',');
-        }
-        if (cpe != null && !cpe.isEmpty()) {
-            sb.append("cpe={");
-            cpe.forEach((pt) -> sb.append(pt).append(','));
-            sb.append('}');
-        }
-        if (cwe != null && !cwe.isEmpty()) {
-            sb.append("cwe={");
-            cwe.forEach((s) -> sb.append(s).append(','));
-            sb.append('}');
-        }
-        if (cve != null && !cve.isEmpty()) {
-            sb.append("cve={");
-            cve.forEach((s) -> sb.append(s).append(','));
-            sb.append('}');
-        }
-        if (vulnerabilityNames != null && !vulnerabilityNames.isEmpty()) {
-            sb.append("vulnerabilityName={");
-            vulnerabilityNames.forEach((pt) -> sb.append(pt).append(','));
-            sb.append('}');
-        }
-        if (cvssBelow != null && !cvssBelow.isEmpty()) {
-            sb.append("cvssBelow={");
-            cvssBelow.forEach((s) -> sb.append(s).append(','));
-            sb.append('}');
-        }
-        if (cvssV2Below != null && !cvssV2Below.isEmpty()) {
-            sb.append("cvssV2Below={");
-            cvssV2Below.forEach((s) -> sb.append(s).append(','));
-            sb.append('}');
-        }
-        if (cvssV3Below != null && !cvssV3Below.isEmpty()) {
-            sb.append("cvssV3Below={");
-            cvssV3Below.forEach((s) -> sb.append(s).append(','));
-            sb.append('}');
-        }
-        if (cvssV4Below != null && !cvssV4Below.isEmpty()) {
-            sb.append("cvssV4Below={");
-            cvssV4Below.forEach((s) -> sb.append(s).append(','));
-            sb.append('}');
-        }
-        sb.append('}');
-        return sb.toString();
+        return "SuppressionRule{" +
+                "filePath=" + filePath +
+                ", sha1=" + sha1 +
+                ", cpe=" + cpe +
+                ", cwe=" + cwe +
+                ", cve=" + cve +
+                ", vulnerabilityNames=" + vulnerabilityNames +
+                ", cvssBelow=" + cvssBelow +
+                ", cvssV2Below=" + cvssV2Below +
+                ", cvssV3Below=" + cvssV3Below +
+                ", cvssV4Below=" + cvssV4Below +
+                ", gav=" + gav +
+                ", packageUrl=" + packageUrl +
+                ", base=" + base +
+                ", matched=" + matched +
+                '}';
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
@@ -49,24 +49,18 @@ public class SuppressionRule {
     private List<Double> cvssV2Below = new ArrayList<>();
     private List<Double> cvssV3Below = new ArrayList<>();
     private List<Double> cvssV4Below = new ArrayList<>();
-    private List<String> cwe = new ArrayList<>();
-    private List<String> cve = new ArrayList<>();
+    private List<PropertyType> cwe = new ArrayList<>();
     private final List<PropertyType> vulnerabilityNames = new ArrayList<>();
     private PropertyType gav;
     private PropertyType packageUrl;
     private String notes;
     private boolean base;
     private Calendar until;
-    private boolean matched = false;
-
     // Suppression entry tracking
     private final Set<SuppressionEntry> allEntries = ConcurrentHashMap.newKeySet();
 
     // ----------------- getters/setters -----------------
-
-    public boolean isMatched() { return matched; }
-    public void setMatched(boolean matched) { this.matched = matched; }
-
+    
     public Calendar getUntil() { return until; }
     public void setUntil(Calendar until) { this.until = until; }
 
@@ -100,10 +94,11 @@ public class SuppressionRule {
         track(SuppressionEntry.Type.VULNERABILITY_NAME, name);
     }
 
-    public void addCwe(String cwe) {
-        this.cwe.add(cwe);
-        track(SuppressionEntry.Type.CWE, new PropertyType(cwe));
-    }
+public void addCwe(String cwe) {
+    PropertyType pt = new PropertyType(cwe);
+    this.cwe.add(pt);
+    track(SuppressionEntry.Type.CWE, pt);
+}
 
     public void addCve(String cve) {
         this.cve.add(cve);
@@ -146,20 +141,24 @@ public class SuppressionRule {
         if (hasGav() && !matchIdentifier(dependency, gav)) return;
         if (hasPackageUrl() && !matchPurl(dependency, packageUrl)) return;
 
-        // ---- CPE suppression ----
-        if (hasCpe()) {
-            Set<Identifier> removalList = new HashSet<>();
-            for (Identifier i : dependency.getVulnerableSoftwareIdentifiers()) {
-                for (PropertyType c : cpe) {
-                    if (identifierMatches(c, i)) {
-                        suppressIdentifier(dependency, i);
-                        removalList.add(i);
-                        break;
-                    }
-                }
+// ---- CPE suppression ----
+if (hasCpe()) {
+    List<Identifier> identifiersToRemove = new ArrayList<>();
+
+    for (Identifier i : new ArrayList<>(dependency.getVulnerableSoftwareIdentifiers())) {
+        for (PropertyType c : cpe) {
+            if (identifierMatches(c, i)) {
+                suppressByCpeMatch(dependency, i);
+                identifiersToRemove.add(i);
+                break;
             }
-            removalList.forEach(dependency::removeVulnerableSoftwareIdentifier);
         }
+    }
+
+    for (Identifier i : identifiersToRemove) {
+        dependency.removeVulnerableSoftwareIdentifier(i);
+    }
+}
 
         // ---- Vulnerability suppression ----
         Set<Vulnerability> removeVulns = new HashSet<>();
@@ -178,40 +177,43 @@ public class SuppressionRule {
 
         removeVulns.forEach(dependency::removeVulnerability);
     }
-
-    private void suppressIdentifier(Dependency dep, Identifier id) {
-        if (!isBase()) {
-            matched = true;
-            if (notes != null) id.setNotes(notes);
-            dep.addSuppressedIdentifier(id);
-        }
+private void suppressIdentifier(Dependency dep, Identifier id) {
+    if (!isBase()) {
+        if (notes != null) id.setNotes(notes);
+        dep.addSuppressedIdentifier(id);
     }
-
+    
+}
     private void suppressVulnerability(Dependency dep, Vulnerability v) {
-        if (!isBase()) {
-            matched = true;
-            if (notes != null) v.setNotes(notes);
-            dep.addSuppressedVulnerability(v);
-        }
+    if (!isBase()) {
+        if (notes != null) v.setNotes(notes);
+        dep.addSuppressedVulnerability(v);
     }
+}
 
     // ----------------- match helpers -----------------
 
-    private boolean matchesCve(Vulnerability v) {
-        for (String entry : cve) {
-            if (entry.equalsIgnoreCase(v.getName())) return true;
+private boolean matchesCve(Vulnerability v) {
+    for (String entry : cve) {
+        if (entry.equalsIgnoreCase(v.getName())) {
+            return true;
         }
-        return false;
     }
+    return false;
+}
 
-    private boolean matchesCwe(Vulnerability v) {
-        if (v.getCwes() == null) return false;
-        for (String entry : cwe) {
-            String target = "CWE-" + entry;
-            if (v.getCwes().stream().anyMatch(c -> c.startsWith(target))) return true;
+private boolean matchesCwe(Vulnerability v) {
+    if (v.getCwes() == null) return false;
+
+    for (PropertyType rule : cwe) {
+        for (String vulnCwe : v.getCwes()) {
+            if (rule.matches(vulnCwe)) {
+                return true;
+            }
         }
-        return false;
     }
+    return false;
+}
 
     private boolean matchesVulnerabilityName(Vulnerability v) {
         if (v.getName() == null) return false;
@@ -310,7 +312,6 @@ public class SuppressionRule {
                 ", gav=" + gav +
                 ", packageUrl=" + packageUrl +
                 ", base=" + base +
-                ", matched=" + matched +
                 '}';
     }
 }


### PR DESCRIPTION
This PR fixes an issue where vulnerabilities matched via CPE suppression were not being removed from the dependency, and improves CWE matching by using PropertyType consistently.

I agree that the suppression system has broader design limitations (tests, thread-safety, rule tracking, etc.). My goal here was to address the immediate functional bugs with minimal scope.

I’d be happy to help work on a larger redesign or test coverage in a follow-up PR if that would be useful.