### PR TITLE
docs: define schema locations in XML examples

### DIFF
--- a/.github/workflows/false-positive-approvals.yml
+++ b/.github/workflows/false-positive-approvals.yml
@@ -118,7 +118,16 @@ jobs:
               if (!fs.existsSync('./suppressions')){
                   fs.mkdirSync('./suppressions');
               }
-              fs.appendFileSync('suppressions/publishedSuppressions.xml', '<?xml version="1.0" encoding="UTF-8"?>\n<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">' + generatedSuppressions + '\n' + suppression.trim() + '\n</suppressions>', function (err) {
+              fs.appendFileSync('suppressions/publishedSuppressions.xml',
+              `<?xml version="1.0" encoding="UTF-8"?>
+              <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd
+                                                https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+              ${generatedSuppressions}
+              ${suppression.trim()}
+              </suppressions>`,
+              function (err) {
                 if (err) throw err;
                 console.log('publishedSuppressions.xml created');
               });

--- a/.github/workflows/false-positive-ops.yml
+++ b/.github/workflows/false-positive-ops.yml
@@ -182,14 +182,14 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Maven Coordinates\n\n```xml\n<dependency>\n   <groupId>' + process.env.GROUPID + '</groupId>\n   <artifactId>' + process.env.ARTIFACTID + '</artifactId>\n   <version>' + process.env.VERSION + '</version>\n</dependency>\n```\n\n' +
+              body: 'Maven Coordinates\n\n```xml\n<dependency>\n  <groupId>' + process.env.GROUPID + '</groupId>\n  <artifactId>' + process.env.ARTIFACTID + '</artifactId>\n  <version>' + process.env.VERSION + '</version>\n</dependency>\n```\n\n' +
                     'Suppression rule:\n```xml\n' +
                     '<suppress base="true">\n' +
-                    '   <notes><![CDATA[\n' +
-                    '   FP per issue #' + context.issue.number + '\n' +
-                    '   ]]></notes>\n' +
-                    '   <packageUrl regex="true">' + purl + '</packageUrl>\n' +
-                    '   <cpe>' + matchcpe + '</cpe>\n' +
+                    '    <notes><![CDATA[\n' +
+                    '    FP per issue #' + context.issue.number + '\n' +
+                    '    ]]></notes>\n' +
+                    '    <packageUrl regex="true">' + purl + '</packageUrl>\n' +
+                    '    <cpe>' + matchcpe + '</cpe>\n' +
                     '</suppress>\n```\n\n' +
                     'Link to test results: ' + context.serverUrl + '/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + context.runId
             })
@@ -232,11 +232,11 @@ jobs:
               body: 'Npm Coordinates\n\n```shell\nnpm -i ' + process.env.NAME + '@' + process.env.VERSION + '\n```\n\n' +
                     'Suppression rule:\n```xml\n' +
                     '<suppress base="true">\n' +
-                    '   <notes><![CDATA[\n' +
-                    '   FP per issue #' + context.issue.number + '\n' +
-                    '   ]]></notes>\n' +
-                    '   <packageUrl regex="true">' + purl + '</packageUrl>\n' +
-                    '   <cpe>' + matchcpe + '</cpe>\n' +
+                    '    <notes><![CDATA[\n' +
+                    '    FP per issue #' + context.issue.number + '\n' +
+                    '    ]]></notes>\n' +
+                    '    <packageUrl regex="true">' + purl + '</packageUrl>\n' +
+                    '    <cpe>' + matchcpe + '</cpe>\n' +
                     '</suppress>\n```\n\n' +
                     'Link to test results: ' + context.serverUrl + '/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + context.runId
             })
@@ -278,11 +278,11 @@ jobs:
               body: 'Nuget Coordinates\n\n```shell\ndotnet add package ' + process.env.NAME + ' --version ' + process.env.VERSION + '\n```\n\n' +
                     'Suppression rule:\n```xml\n' +
                     '<suppress base="true">\n' +
-                    '   <notes><![CDATA[\n' +
-                    '   FP per issue #' + context.issue.number + '\n' +
-                    '   ]]></notes>\n' +
-                    '   <packageUrl regex="true">' + purl + '</packageUrl>\n' +
-                    '   <cpe>' + matchcpe + '</cpe>\n' +
+                    '    <notes><![CDATA[\n' +
+                    '    FP per issue #' + context.issue.number + '\n' +
+                    '    ]]></notes>\n' +
+                    '    <packageUrl regex="true">' + purl + '</packageUrl>\n' +
+                    '    <cpe>' + matchcpe + '</cpe>\n' +
                     '</suppress>\n```\n\n' +
                     'Link to test results: ' + context.serverUrl + '/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + context.runId
             })

--- a/.github/workflows/publish-suppressions.yml
+++ b/.github/workflows/publish-suppressions.yml
@@ -27,7 +27,15 @@ jobs:
             if (!fs.existsSync('./suppressions')){
                 fs.mkdirSync('./suppressions');
             }
-            fs.appendFileSync('suppressions/publishedSuppressions.xml', '<?xml version="1.0" encoding="UTF-8"?>\n<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">' + generatedSuppressions + '\n</suppressions>', function (err) {
+            fs.appendFileSync('suppressions/publishedSuppressions.xml',
+            `<?xml version="1.0" encoding="UTF-8"?>
+            <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd
+                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd
+                                              https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+            ${generatedSuppressions}
+            </suppressions>`,
+            function (err) {
               if (err) throw err;
               console.log('publishedSuppressions.xml created');
             });

--- a/ant/src/test/resources/test-suppression.xml
+++ b/ant/src/test/resources/test-suppression.xml
@@ -16,7 +16,10 @@ limitations under the License.
 
 Copyright (c) 2017 The OWASP Foundation. All Rights Reserved.
 -->
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
     <suppress>
         <notes><![CDATA[
             file name: axis-1.4.jar

--- a/ant/src/test/resources/test-suppression1.xml
+++ b/ant/src/test/resources/test-suppression1.xml
@@ -16,7 +16,10 @@ limitations under the License.
 
 Copyright (c) 2017 The OWASP Foundation. All Rights Reserved.
 -->
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
     <suppress>
         <notes><![CDATA[
             file name: axis-1.4.jar

--- a/ant/src/test/resources/test-suppression2.xml
+++ b/ant/src/test/resources/test-suppression2.xml
@@ -16,7 +16,10 @@ limitations under the License.
 
 Copyright (c) 2017 The OWASP Foundation. All Rights Reserved.
 -->
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
     <suppress>
         <notes><![CDATA[
             file name: org.mortbay.jetty.jar

--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.3.xsd">
+<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.4.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.4.xsd
+                           https://dependency-check.github.io/DependencyCheck/dependency-hint.1.4.xsd">
     <hint>
         <given><!-- NOTE: these are OR conditions -->
             <evidence type="product" source="Manifest" name="Implementation-Title" value="Spring Framework" confidence="HIGH"/>

--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
     <suppress base="true">
         <notes><![CDATA[
         obvious fp - currently not returning any CVEs

--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -110,9 +110,13 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                     }
                 });
                 $('#modal-add-header').click(function () {
-                    xml = '<?xml version="1.0" encoding="UTF-8"?>\n<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">\n   ';
-                    xml += $("#modal-text").text().replace(/\n/g,'\n   ');
-                    xml += '\n</suppressions>';
+                    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+    ${$("#modal-text").text().replace(/\n/g,'\n    ')}
+</suppressions>`;
                     $('#modal-add-header').toggleClass('active');
                     $('#modal-text').text(xml).focus().select();
                 });
@@ -158,26 +162,26 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             }
             function setCopyText(name, matchType, matchValue, suppressType, suppressVal) {
                 var xml =  '<suppress>\n';
-                xml += '   <notes><!'+'[CDATA[\n   file name: ' + name + '\n   ]]'+'></notes>\n';
+                xml += '    <notes><![CDATA[\n    file name: ' + name + '\n    ]]></notes>\n';
                 if (matchType=='packageUrl') {
                     var v = matchValue.match(/^[^@]+/);
                     if (v && v[0]) {
-                        xml += '   <'+matchType+' regex="true">^' + escapeRegExp(v[0]) + '@.*$</'+matchType+'>\n';
+                        xml += '    <'+matchType+' regex="true">^' + escapeRegExp(v[0]) + '@.*$</'+matchType+'>\n';
                     } else {
-                        xml += '   <'+matchType+'>' + matchValue + '</'+matchType+'>\n';
+                        xml += '    <'+matchType+'>' + matchValue + '</'+matchType+'>\n';
                     }
                 } else {
-                    xml += '   <'+matchType+'>' + matchValue + '</'+matchType+'>\n';
+                    xml += '    <'+matchType+'>' + matchValue + '</'+matchType+'>\n';
                 }
                 if (suppressType=='cpe') {
                     v = suppressVal.match(/^cpe:\/a:[^:]+:[^:]+/);
                     if (v && v[0]) {
-                        xml += '   <'+suppressType+'>' + v[0] + '</'+suppressType+'>\n';
+                        xml += '    <'+suppressType+'>' + v[0] + '</'+suppressType+'>\n';
                     } else {
-                        xml += '   <'+suppressType+'>' + suppressVal + '</'+suppressType+'>\n';
+                        xml += '    <'+suppressType+'>' + suppressVal + '</'+suppressType+'>\n';
                     }
                 } else {
-                    xml += '   <'+suppressType+'>' + suppressVal + '</'+suppressType+'>\n';
+                    xml += '    <'+suppressType+'>' + suppressVal + '</'+suppressType+'>\n';
                 }
                 xml += '</suppress>';
                 $('#modal-text').text(xml);
@@ -284,7 +288,8 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             }
             #modal-text {
                 border: 0;
-                overflow: hidden
+                overflow: auto;
+                white-space: pre;
             }
             #modal-text:focus {
                 outline: none;
@@ -671,8 +676,8 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <div id="modal-background"></div>
         <div id="modal-content">
             <div>Press CTR-C to copy XML&nbsp;<a href="https://dependency-check.github.io/DependencyCheck/general/suppression.html" class="infolink" target="_blank" title="Help with suppressing false positives">[help]</a></div>
-                <button id="modal-suppress-change-to-packageUrl" class="modal-button suppresstype" title="Supress by Maven Group Artifact Version">Suppress By GAV</button>
-                <button id="modal-suppress-change-to-sha1" class="modal-button suppresstype" title="Supress by SHA1 hash">Suppress By SHA1</button><br/>
+                <button id="modal-suppress-change-to-packageUrl" class="modal-button suppresstype" title="Supress by Maven Group Artifact Version">Suppress by Package URL</button>
+                <button id="modal-suppress-change-to-sha1" class="modal-button suppresstype" title="Supress by SHA1 hash">Suppress by SHA1</button><br/>
                 <input type="hidden" id="suppress-name"/>
                 <input type="hidden" id="suppress-type"/><input type="hidden" id="suppress-val"/>
                 <input type="hidden" id="suppress-sha1"/><input type="hidden" id="suppress-packageUrl"/>

--- a/core/src/main/resources/templates/jenkinsReport.vsl
+++ b/core/src/main/resources/templates/jenkinsReport.vsl
@@ -29,54 +29,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <link rel="shortcut icon" href="data:;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAVLSURBVFhHvZdvbFRFEMB3913v9Vr+FKUNRdtrewg1lQgRE0gMYkJSowYMwcSPkGDwg8ZigMR+UYzGaIuAEj+R+IfE+EUlRL+QYAwhGBMqkFQDpO1xd/YPBaSU9u767r0dZ5a513vtXVsq8Zcsb3bu9c3szuzsIMU8iEaj5fhYJlzRYCkZ7Utd+wbnQL+Nd0TeoyeAPLFgf/oiyTNxXw6g4WUhTz4JEtaiNXLCEE8l3seHJjlzsOJHfLxMsgHE4cje9B6eTUPxc0ZoxbFHG1qVFq9rCRsKjc+KFG3oFGQ6Kw6xJsCsDqDxNZYWbWSYVUFAJFkyaA2XWAxiHIlcGPukYg1rDCVDQKsOadmqBaxllY8CuKHBuqOlHlNKufFk/GdUmxxoeqTpMbBg1dGXRlZtqHc2R8rgedIXgk4eqNyXMblS1AE2vhWNP84qAxl2hewno6wyFHOAZOLAc6PRbU+kd2OyrmbVPTg3pjlQzDgazGmh40rKMY3LZrVBCi/Tl0z+gqJxYGV9fWNOWC0kF3Jm1/C2pZWwk6cG2olpOcDb7hsHgLQGcUWAGs0bV1K7EuSQFbbOLKmuPkOvkZ64mkzG8bXz5BirDBuP1fzQP6I+5yl9eAS9vxjYAVz9esx0P2a0ck+73VKGPFaR8Vtpx7k0ODiYZlVJmpcvfzirwi1SyUWsMiF5ZXX6A1zJzsq9mRO+A7T1lO2BIyZVN/6bJZFWnQO4Wl1dnerq6sqRbq401TWtw9qxjGT6zhfbs3+0Hrw+THPfgVhdA8Xdz3j84RpIdZOngrY1kUgMOR3lG1kVREkHhBp3smJ4wdLmf+TuoJOxuroW3NI6zN6L9B1W33MAV1+FW99mNIgUclBaYtCPObjx3lTqT5KxqJyk52y4nv5u4f7stzzNY+Hww0ncS0JXBIoDWryRN07JVlVTc9Xo74OQpV7F6ndk5CO7iVVEwDihVqxYYVtKrOc5bckIgHJIpnhl3MxfpWIuJZyWAMdo0Io1AOXMJFI0hm3VzrOiYG2BmsLEAz0Zd9DWzZmyHd/tLt+bOUmDthuzun3C8dryjqCDdzF5tqcPRr40f1AElcvl6lgmJkC5d1kWYS8bZ3HOVL0z0TcKiz70tBjAML4opVgsoeB2nIJyXfeKJfRxGo52j4ds+xwWmN9t1/7t8sDALX7vvqjdd31cChgi40YhZdXUSyiPGkAjPalUL43+/v6/e3p6btC4PHB5XsZ9sMqxZJAWbGIxwJz6gfkAWl5jcUYUbU1+3D60uIp0PPwiNR/wZAW3HERRh5Sy4C3LEhdoiAn368b6xhdoxKLRVn5nXmDpfZZFg7J00f5QgRYJlkV5GWyJVnk2yRpUKBaLFZ6QOYMFaAdW0x08xcXDr5E9E8V3wAmFD7NseO3pMf8uh1xuJYuzQuGjMJreT4rJc4/XrvZk6aZ0yZ47WPkm47M55mxnET23IrW1tRU8DUBFBlf2faYzcptGuefETRix9+NXDNhLHJmpPTenAON1xMyQRbZevaV5ooanwrbsdSz6kPF8kaEz7o9CqOEAvPO59yuFccBR4a/MjGnfNDp5M2IzgQnpd8QB41NBoxRvarWyVrgRe77Ad4vhHzX6H41S8l2eitO9ZR+/+dNDZ3lqbsW+VN/52x12YxlY04xbZd5IqUSbCd8BSiLby13AlTWwSnx6tvKNY10LzCmhm7E3kTiFYqAp/a/4lZCSUYIX6Frffmb86K6nxqJknDoZVD1Q48S0ajc1FBTXU8mFzVs/G77OmgdK0XLLZ7nNnGHuXvmn/w9yYrwzUvIefzAI8S83C2sS1J4rmAAAAABJRU5ErkJggg==" />
         <!--suppress CssUnknownProperty, CssUnusedSymbol, HtmlDeprecatedAttribute, CssRedundantUnit, CssReplaceWithShorthandSafely -->
         <style type="text/css">
-            #modal-background {
-                display: none;
-                position: fixed;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
-                background-color: white;
-                opacity: .50;
-                -webkit-opacity: .5;
-                -moz-opacity: .5;
-                filter: alpha(opacity=50);
-                z-index: 1000;
-            }
-
-            #modal-content {
-                background-color: white;
-                border-radius: 10px;
-                -webkit-border-radius: 10px;
-                -moz-border-radius: 10px;
-                box-shadow: 0 0 20px 0 #222;
-                -webkit-box-shadow: 0 0 20px 0 #222;
-                -moz-box-shadow: 0 0 20px 0 #222;
-                display: none;
-                height: 240px;
-                left: 50%;
-                margin: -120px 0 0 -160px;
-                padding: 10px;
-                position: fixed;
-                top: 50%;
-                z-index: 1000;
-            }
-            #modal-add-header {
-                display: none;
-            }
-            #modal-add-header.active {
-                display: block;
-            }
-            #modal-background.active, #modal-content.active {
-                display: block;
-            }
-            #modal-text {
-                border: 0;
-                overflow: hidden
-            }
-            #modal-text:focus {
-                outline: none;
-            }
             .suppresstype {
                 display: none;
             }
@@ -113,58 +65,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                 background-color: #dddddd;
                 border: 1px solid #444444;
                 color:#444444;
-                text-decoration:none;
-                -moz-border-radius: 3px;
-                -webkit-border-radius: 3px;
-                -khtml-border-radius: 3px;
-                -o-border-radius: 3px;
-                border-radius: 3px;
-            }
-            .modal-button {
-                padding:1px;
-                float:left;
-                background-color: #eeeeee;
-                border: 1px solid #555555;
-                color:#555555;
-                text-decoration:none;
-                -moz-border-radius: 3px;
-                -webkit-border-radius: 3px;
-                -khtml-border-radius: 3px;
-                -o-border-radius: 3px;
-                border-radius: 3px;
-            }
-            .modal-button:hover {
-                padding:1px;
-                float:left;
-                background-color: #dddddd;
-                border: 1px solid #333333;
-                color:#333333;
-                text-decoration:none;
-                -moz-border-radius: 3px;
-                -webkit-border-radius: 3px;
-                -khtml-border-radius: 3px;
-                -o-border-radius: 3px;
-                border-radius: 3px;
-            }
-            .modal-button-right {
-                padding:1px;
-                float:right;
-                background-color: #eeeeee;
-                border: 1px solid #555555;
-                color:#555555;
-                text-decoration:none;
-                -moz-border-radius: 3px;
-                -webkit-border-radius: 3px;
-                -khtml-border-radius: 3px;
-                -o-border-radius: 3px;
-                border-radius: 3px;
-            }
-            .modal-button-right:hover {
-                padding:1px;
-                float:right;
-                background-color: #dddddd;
-                border: 1px solid #333333;
-                color:#333333;
                 text-decoration:none;
                 -moz-border-radius: 3px;
                 -webkit-border-radius: 3px;

--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -19,7 +19,10 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
 @version 2.0
 
 *#<?xml version="1.0"?>
-<analysis xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.4.1.xsd">
+<analysis xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.4.1.xsd"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-check.4.1.xsd
+                              https://dependency-check.github.io/DependencyCheck/dependency-check.4.1.xsd">
     <scanInfo>
         <engineVersion>$version</engineVersion>
 #foreach($prop in $properties.getMetaData().entrySet())

--- a/core/src/test/java/org/owasp/dependencycheck/xml/hints/HintParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/hints/HintParserTest.java
@@ -24,6 +24,8 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -83,8 +85,7 @@ class HintParserTest extends BaseTest {
         File file = BaseTest.getResourceAsFile(this, "hints_invalid.xml");
         HintParser instance = new HintParser();
         Exception exception = assertThrows(org.owasp.dependencycheck.xml.hints.HintParseException.class, () -> instance.parseHints(file));
-        assertTrue(exception.getMessage().contains("Line=7, Column=133: cvc-enumeration-valid: Value 'version' is not facet-valid with respect to enumeration '[vendor, product]'. It must be a value from the enumeration."));
-
+        assertThat(exception.getMessage(), containsString("Line=10, Column=133: cvc-enumeration-valid: Value 'version' is not facet-valid with respect to enumeration '[vendor, product]'. It must be a value from the enumeration."));
     }
 
     /**

--- a/core/src/test/resources/commons-fileupload-1.2.1.suppression.xml
+++ b/core/src/test/resources/commons-fileupload-1.2.1.suppression.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
     <suppress>
         <notes><![CDATA[
         file name: commons-fileupload-1.2.1.jar

--- a/core/src/test/resources/hints.xml
+++ b/core/src/test/resources/hints.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.1.xsd">
+<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.4.xsd"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.4.xsd
+                           https://dependency-check.github.io/DependencyCheck/dependency-hint.1.4.xsd">
 	<hint>
 		<given>
 			<evidence type="product" source="product source" name="given product name" value="value" confidence="HIGH"/>

--- a/core/src/test/resources/hints_12.xml
+++ b/core/src/test/resources/hints_12.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.2.xsd">
+<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.2.xsd
+                           https://dependency-check.github.io/DependencyCheck/dependency-hint.1.2.xsd">
     <hint>
         <given><!-- NOTE: These are OR conditions -->
             <evidence type="product" source="product source" name="given product name" value="value" confidence="HIGH"/>

--- a/core/src/test/resources/hints_13.xml
+++ b/core/src/test/resources/hints_13.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.3.xsd">
+<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.3.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.3.xsd
+                           https://dependency-check.github.io/DependencyCheck/dependency-hint.1.3.xsd">
     <hint>
         <given><!-- NOTE: These are OR conditions -->
             <evidence type="product" source="product source" name="given product name" value="value" regex="true" confidence="HIGH"/>

--- a/core/src/test/resources/hints_invalid.xml
+++ b/core/src/test/resources/hints_invalid.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.1.xsd">
+<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.1.xsd"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.1.xsd
+                           https://dependency-check.github.io/DependencyCheck/dependency-hint.1.1.xsd">
 	<hint>
 		<given>
 			<evidence type="product" source="product source" name="given product name" value="value" confidence="HIGH"/>

--- a/core/src/test/resources/incorrectSuppressions.xml
+++ b/core/src/test/resources/incorrectSuppressions.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
    <suppress>
       <notes><![CDATA[
       Invalid suppression of CPE - just testing the notes.

--- a/core/src/test/resources/other-suppressions.xml
+++ b/core/src/test/resources/other-suppressions.xml
@@ -16,7 +16,10 @@ limitations under the License.
 
 Copyright (c) 2017 The OWASP Foundation. All Rights Reserved.
 -->
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
     <suppress>
         <notes><![CDATA[
    file name: jackson-dataformat-xml-2.4.5.jar

--- a/core/src/test/resources/suppressions_1_1.xml
+++ b/core/src/test/resources/suppressions_1_1.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions
-    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-    xmlns='https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd'
-    xsi:schemaLocation='https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.1.xsd'>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
     <suppress>
         <notes><![CDATA[
         This suppresses cpe:/a:csv:csv:1.0 for some.jar in the "c:\path\to" directory.

--- a/core/src/test/resources/suppressions_1_2.xml
+++ b/core/src/test/resources/suppressions_1_2.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions
-    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-    xmlns='https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd'
-    xsi:schemaLocation='https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.2.xsd'>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
     <suppress>
         <notes><![CDATA[
         This suppresses cpe:/a:csv:csv:1.0 for some.jar in the "c:\path\to" directory.

--- a/core/src/test/resources/suppressions_1_3.xml
+++ b/core/src/test/resources/suppressions_1_3.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes><![CDATA[
         This suppresses cpe:/a:csv:csv:1.0 for some.jar in the "c:\path\to" directory.

--- a/core/src/test/resources/suppressions_1_4.xml
+++ b/core/src/test/resources/suppressions_1_4.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
 
     <!-- Suppressions can be provided individually. -->
     <suppress base="true">

--- a/core/src/test/resources/suppressions_1_4_no_groups.xml
+++ b/core/src/test/resources/suppressions_1_4_no_groups.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
     <!-- Contentwise same as suppression_1_3.xml. Still valid according to schema 1.4 -->
     <suppress>
         <notes><![CDATA[

--- a/maven/src/it/730-multiple-suppression-files-configs/test-suppression1.xml
+++ b/maven/src/it/730-multiple-suppression-files-configs/test-suppression1.xml
@@ -16,7 +16,10 @@ limitations under the License.
 
 Copyright (c) 2017 The OWASP Foundation. All Rights Reserved.
 -->
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
     <suppress>
         <notes><![CDATA[
    file name: android-json-0.0.20131108.vaadin1.jar

--- a/maven/src/it/730-multiple-suppression-files-configs/test-suppression2.xml
+++ b/maven/src/it/730-multiple-suppression-files-configs/test-suppression2.xml
@@ -16,7 +16,10 @@ limitations under the License.
 
 Copyright (c) 2017 The OWASP Foundation. All Rights Reserved.
 -->
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
     <suppress>
         <notes><![CDATA[
    file name: jackson-dataformat-xml-2.4.5.jar

--- a/maven/src/it/815-broken-suppression-aggregate/broken-suppression.xml
+++ b/maven/src/it/815-broken-suppression-aggregate/broken-suppression.xml
@@ -16,7 +16,10 @@ limitations under the License.
 
 Copyright (c) 2017 The OWASP Foundation. All Rights Reserved.
 -->
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
     <suppress>
         <notes><![CDATA[
    file name: android-json-0.0.20131108.vaadin1.jar

--- a/src/site/markdown/general/hints.md
+++ b/src/site/markdown/general/hints.md
@@ -10,7 +10,10 @@ A sample hints file that add a product name and possible vendors for Spring fram
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.1.xsd">
+<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-hint.1.4.xsd">
     <hint>
         <given>
             <evidence type="product" source="Manifest" name="Implementation-Title" value="Spring Framework" confidence="HIGH"/>
@@ -33,7 +36,10 @@ The following shows some other ways to add evidence
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.1.xsd">
+<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.4.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.4.xsd
+                           https://dependency-check.github.io/DependencyCheck/dependency-hint.1.4.xsd">
    <hint>
         <given>
             <evidence type="product" source="jar" name="package name" value="springframework" confidence="LOW"/>

--- a/src/site/markdown/general/suppression.md
+++ b/src/site/markdown/general/suppression.md
@@ -6,7 +6,10 @@ A sample suppression file would look like:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
    <suppress>
       <notes><![CDATA[
       file name: some.jar
@@ -26,7 +29,10 @@ HTML version of the report. The other common scenario would be to ignore all CVE
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
     <suppress>
         <notes><![CDATA[
         This suppresses a CVE identified by OSS Index using the vulnerability name and packageUrl.
@@ -98,7 +104,10 @@ It is also possible to set an expiration date for a suppression rule:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
     <suppress until="2020-01-01Z">
         <notes><![CDATA[
         Suppresses a given CVE for a dependency with the given sha1 until the current date is 1 Jan 2020 or beyond.
@@ -113,7 +122,10 @@ Suppressions can also be configured based on CVSS scores.  The element cvssScore
 a score threshold.  Vulnerabilities that have any score below this threshold will be suppressed.
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
     <suppress until="2020-01-01Z">
         <notes><![CDATA[
         Suppress any vulnerability with a score below 7
@@ -130,7 +142,10 @@ version the threshold not be applied to the suppression decision.  If you specif
 element and cvssVnScore elements, the later will be ignored.
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
     <suppress until="2020-01-01Z">
         <notes><![CDATA[
         Suppress any vulnerability with different threshold per CVSS version

--- a/src/site/resources/general/SampleReport.html
+++ b/src/site/resources/general/SampleReport.html
@@ -60,11 +60,15 @@
                     setTimeout('$("#modal-content,#modal-background").toggleClass("active");',100);
                 });
                 $('#modal-add-header').click(function () {
-                    xml = '<?xml version="1.0" encoding="UTF-8"?>\n<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">\n   ';
-                    xml += $("#modal-text").text().replace(/\n/g,'\n   ');
-                    xml += '\n</suppressions>';
-                    $('#modal-text').text(xml).focus().select();
+                    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+                                  https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+    ${$("#modal-text").text().replace(/\n/g,'\n    ')}
+</suppressions>`;
                     $('#modal-add-header').toggleClass('active');
+                    $('#modal-text').text(xml).focus().select();
                 });
             });
             function suppressSwitchTo(switchTo) {
@@ -101,27 +105,27 @@
                 }
             }
             function setCopyText(name, matchType, matchValue, suppressType, suppressVal) {
-                xml =  '<suppress>\n';
-                xml += '   <notes><!'+'[CDATA[\n   file name: ' + name + '\n   ]]'+'></notes>\n';
+                var xml =  '<suppress>\n';
+                xml += '    <notes><![CDATA[\n    file name: ' + name + '\n    ]]></notes>\n';
                 if (matchType=='gav') {
                     v = matchValue.match(/^[^:]+:[^:]+:/);
                     if (v && v[0]) {
-                        xml += '   <'+matchType+' regex="true">^' + v[0].replace(/\./g,'\\.') + '.*$</'+matchType+'>\n';
+                        xml += '    <'+matchType+' regex="true">^' + v[0].replace(/\./g,'\\.') + '.*$</'+matchType+'>\n';
                     } else {
-                        xml += '   <'+matchType+'>' + matchValue + '</'+matchType+'>\n';
+                        xml += '    <'+matchType+'>' + matchValue + '</'+matchType+'>\n';
                     }
                 } else {
-                    xml += '   <'+matchType+'>' + matchValue + '</'+matchType+'>\n';
+                    xml += '    <'+matchType+'>' + matchValue + '</'+matchType+'>\n';
                 }
                 if (suppressType=='cpe') {
                     v = suppressVal.match(/^cpe:\/a:[^:]+:[^:]+/);
                     if (v && v[0]) {
-                        xml += '   <'+suppressType+'>' + v[0] + '</'+suppressType+'>\n';
+                        xml += '    <'+suppressType+'>' + v[0] + '</'+suppressType+'>\n';
                     } else {
-                        xml += '   <'+suppressType+'>' + suppressVal + '</'+suppressType+'>\n';
+                        xml += '    <'+suppressType+'>' + suppressVal + '</'+suppressType+'>\n';
                     }
                 } else {
-                    xml += '   <'+suppressType+'>' + suppressVal + '</'+suppressType+'>\n';
+                    xml += '    <'+suppressType+'>' + suppressVal + '</'+suppressType+'>\n';
                 }
                 xml += '</suppress>';
                 $('#modal-text').text(xml);
@@ -178,7 +182,8 @@
             }
             #modal-text {
                 border: 0;
-                overflow: hidden
+                overflow: auto;
+                white-space: pre;
             }
             #modal-text:focus {
                 outline: none;
@@ -559,10 +564,9 @@ the reporting provided constitutes acceptance for use in an AS IS condition, and
 implied or otherwise, with regard to the analysis or its use. Any use of the tool and the reporting provided
 is at the user’s risk. In no event shall the copyright holder or OWASP be held liable for any damages whatsoever
 arising out of or in connection with the use of this tool, the analysis performed, or the resulting report.</p>
-<h3><a href="https://dependency-check.github.io/DependencyCheck/general/thereport.html" target="_bank">How&nbsp;to&nbsp;read&nbsp;the&nbsp;report</a> |
-<a href="https://dependency-check.github.io/DependencyCheck/general/suppression.html" target="_bank">Suppressing false positives</a> |
-Getting Help: <a href="https://groups.google.com/forum/#!forum/dependency-check" target="_blank">google group</a> | 
-<a href="https://github.com/dependency-check/DependencyCheck/issues" target="_blank">github issues</a></h3>
+<h3><a href="https://dependency-check.github.io/DependencyCheck/general/thereport.html" target="_blank">How&nbsp;to&nbsp;read&nbsp;the&nbsp;report</a> |
+<a href="https://dependency-check.github.io/DependencyCheck/general/suppression.html" target="_blank">Suppressing false positives</a> |
+Getting Help: <a href="https://github.com/dependency-check/DependencyCheck/issues" target="_blank">github issues</a></h3>
 
             <h2 class="">Project:&nbsp;DependencyCheck</h2>
             <div class="">

--- a/src/site/resources/js/purl.js
+++ b/src/site/resources/js/purl.js
@@ -9,9 +9,9 @@ function convert() {
 
             $('#coord').text(
                     '<dependency>\n' +
-                    '   <groupId>' + pobj.namespace + '</groupId>\n' +
-                    '   <artifactId>' + pobj.name + '</artifactId>\n' +
-                    '   <version>' + pobj.version + '</version>\n' +
+                    '  <groupId>' + pobj.namespace + '</groupId>\n' +
+                    '  <artifactId>' + pobj.name + '</artifactId>\n' +
+                    '  <version>' + pobj.version + '</version>\n' +
                     '</dependency>\n'
                     );
             copyToClipboard();


### PR DESCRIPTION
## Description of Change

As discussed in #7627 and others; currently the namespaces of schemas include the old jeremylong.github.io namespace which confuses people. When ODC is not on the classpath in IDEs, this can confuse editors about where to retrieve the schema for the given namespace/IRI from. If we consistently define schema locations this may go some way to resolving this.

We can also subsequently add new versions which declare a new target namespace (the namespaces are versioned anyway), but that can be separate to this.

Smaller side changes
- aligns indentation of the generated/suggested suppressions to 4 spaces, not 3 similar to the base suppressions to satisfy my OCD and editors.
- fix minor typo in HTML report (Suppress by GAV -> Package URL)
- fix wrapping of XML in suppression modal in HTML report (now wider due to the XML headers for full doc)
- removed unused modal CSS cruft from jenkinsReport I came across at the same time
- change some minor stuff in the website SampleReport, but it really needs fully regenerating probably.

## Related issues

- fixes #7627
- fixes #1940

## Have test cases been added to cover the new functionality?

yes - existing tests cover