### PR TITLE
fix: Correct published/hosted suppressions namespace header and indent

### DIFF
--- a/.github/workflows/false-positive-approvals.yml
+++ b/.github/workflows/false-positive-approvals.yml
@@ -119,14 +119,14 @@ jobs:
                   fs.mkdirSync('./suppressions');
               }
               fs.appendFileSync('suppressions/publishedSuppressions.xml',
-              `<?xml version="1.0" encoding="UTF-8"?>
-              <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd
-                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                            xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd
-                                                https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-              ${generatedSuppressions}
-              ${suppression.trim()}
-              </suppressions>`,
+            `<?xml version="1.0" encoding="UTF-8"?>
+            <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"
+                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd
+                                              https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+            ${generatedSuppressions}
+            ${suppression.trim()}
+            </suppressions>`,
               function (err) {
                 if (err) throw err;
                 console.log('publishedSuppressions.xml created');

--- a/.github/workflows/publish-suppressions.yml
+++ b/.github/workflows/publish-suppressions.yml
@@ -29,7 +29,7 @@ jobs:
             }
             fs.appendFileSync('suppressions/publishedSuppressions.xml',
             `<?xml version="1.0" encoding="UTF-8"?>
-            <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd
+            <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"
                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                           xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd
                                               https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.3.xsd">

--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -111,7 +111,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                 });
                 $('#modal-add-header').click(function () {
                     const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd
                                   https://dependency-check.github.io/DependencyCheck/dependency-suppression.1.4.xsd">


### PR DESCRIPTION
## Description of Change

URGENT: #8254 had a missing trailing quote in the syntax for creating the published suppressions so the current published file is not well formed XML and will be failing. Gulp.

I was deliberately testing it via #8257 (it's a real FP) to make sure it was OK, and noticed I'd broken it.

This PR should fix it (and tweak the indents slightly; as I hadn't noticed an `else` block in the `approvals` workflow)

See https://dependency-check.github.io/DependencyCheck/suppressions/publishedSuppressions.xml

<img width="1009" height="157" alt="image" src="https://github.com/user-attachments/assets/0ed05aec-3dfe-46c9-be97-4a0945dae20b" />


**Generated suppressions** - ✅ https://github.com/dependency-check/DependencyCheck/commit/8750da5b6005dae845863c8eb1aef105b88b1872
**Published suppressions** - ❌ https://github.com/dependency-check/DependencyCheck/commit/593b64765c83ce2e7d3497bf6da8fb0db2db8f08

## Related issues

- fixes #8259 

## Have test cases been added to cover the new functionality?

no