### PR TITLE
chore: fix Maven scm tags after 12.2.1-SNAPSHOT bump

### DIFF
--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -32,7 +32,7 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/dependency-check/DependencyCheck.git</connection>
         <url>https://github.com/dependency-check/DependencyCheck/tree/main/ant</url>
         <developerConnection>scm:git:git@github.com/dependency-check/DependencyCheck.git</developerConnection>
-        <tag>v6.4.1</tag>
+        <tag>HEAD</tag>
     </scm>
     <build>
         <resources>

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -33,8 +33,8 @@ Copyright (c) 2017 Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/dependency-check/DependencyCheck.git</connection>
         <url>https://github.com/dependency-check/DependencyCheck/tree/main/archetype</url>
         <developerConnection>scm:git:git@github.com/dependency-check/DependencyCheck.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
     <build>
         <plugins>
             <plugin>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -32,7 +32,7 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/dependency-check/DependencyCheck.git</connection>
         <url>https://github.com/dependency-check/DependencyCheck/tree/main/cli</url>
         <developerConnection>scm:git:git@github.com/dependency-check/DependencyCheck.git</developerConnection>
-        <tag>v6.4.1</tag>
+        <tag>HEAD</tag>
     </scm>
     <build>
         <finalName>dependency-check-${project.version}</finalName>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -32,7 +32,7 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/dependency-check/DependencyCheck.git</connection>
         <url>https://github.com/dependency-check/DependencyCheck/tree/main/core</url>
         <developerConnection>scm:git:git@github.com/dependency-check/DependencyCheck.git</developerConnection>
-        <tag>v6.4.1</tag>
+        <tag>HEAD</tag>
     </scm>
     <build>
         <resources>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -34,7 +34,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/dependency-check/DependencyCheck.git</connection>
         <url>https://github.com/dependency-check/DependencyCheck/tree/master/maven</url>
         <developerConnection>scm:git:git@github.com/dependency-check/DependencyCheck.git</developerConnection>
-        <tag>v6.4.1</tag>
+        <tag>HEAD</tag>
     </scm>
     <prerequisites>
         <maven>3.6.3</maven>

--- a/maven/src/test/resources/maven_project_base_dir/pom.xml
+++ b/maven/src/test/resources/maven_project_base_dir/pom.xml
@@ -27,7 +27,9 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <executions>
                     <execution>
-                        <goals>check</goals>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@ Copyright (c) 2012 - Jeremy Long
         <connection>scm:git:https://github.com/dependency-check/DependencyCheck.git</connection>
         <url>https://github.com/dependency-check/DependencyCheck</url>
         <developerConnection>scm:git:https://github.com/dependency-check/DependencyCheck.git</developerConnection>
-        <tag>v6.4.1</tag>
+        <tag>HEAD</tag>
     </scm>
     <issueManagement>
         <system>github</system>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -30,7 +30,7 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
         <connection>scm:git:https://github.com/dependency-check/DependencyCheck.git</connection>
         <url>https://github.com/dependency-check/DependencyCheck/tree/main/utils</url>
         <developerConnection>scm:git:git@github.com/dependency-check/DependencyCheck.git</developerConnection>
-        <tag>v6.4.1</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <spotbugs.onlyAnalyze>org.owasp.dependencycheck.utils.*</spotbugs.onlyAnalyze>


### PR DESCRIPTION
## Description of Change

Something went awry during [the last bump](https://github.com/dependency-check/DependencyCheck/commit/6f46091d567b6ecd2368235c9ff58ec0e9983899) - not sure if there is some automation/script issue to resolve.

Also fixes a minor validation issue which IDEs tend to complain about.

## Have test cases been added to cover the new functionality?

N/A