### PR TITLE
build(deps): base docker image off latest Alpine with updated DB driver versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ FROM azul/zulu-openjdk-alpine:25 AS jlink
 
 RUN "$JAVA_HOME/bin/jlink" --compress=zip-6 --module-path /opt/java/openjdk/jmods --add-modules java.base,java.compiler,java.datatransfer,jdk.crypto.ec,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.scripting,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.unsupported --output /jlinked
 
-FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine3.22
+FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine
 
 ARG VERSION
-ARG POSTGRES_DRIVER_VERSION=42.7.8
-ARG MYSQL_DRIVER_VERSION=9.5.0
+ARG POSTGRES_DRIVER_VERSION=42.7.9
+ARG MYSQL_DRIVER_VERSION=9.6.0
 ARG UID=1000
 ARG GID=1000
 


### PR DESCRIPTION
## Description of Change

We use mutable tags for the golang and JVM layers which move Alpine versions over time, so we probably should be consistent with the main base image, which is a [dotnet runtime image](https://mcr.microsoft.com/en-us/artifact/mar/dotnet/runtime/tags). Right now we are using a golang and JVM built off Alpine 3.2e while running on Alpine 3.22.

While that should not generally be an issue; it might be, as I don't think Java is statically compiled; still dynamically linked to musl libc.verisins which can different across Alpine releases.

The alternative change here is to use specific Alpine versions and update them together - there are possibly ways to trick dependabot into being able to do this if we'd rather go use an Alpine-feature-mutating tag.

Also bumps the bundled driver versions to latest.

## Related issues

N/A

## Have test cases been added to cover the new functionality?

yes