### PR TITLE
build: use maven jdk toolchains to build with Java 25; test against Java 11/17/21/25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
           -Dtoolchain.jdk.test.version=${{ matrix.jdk_test_version }} -Dtoolchain.jdk.test.home="$JAVA_HOME_${{ matrix.jdk_test_version }}_X64"
           ${{ matrix.jdk_test_version == matrix.jdk_default_version && 'source:jar javadoc:jar site' || '' }}
           ${{ steps.install-gpg-key.outcome == 'success' && '-Prelease gpg:sign deploy' || '' }} 
-          --no-transfer-progress --batch-mode
+          --no-transfer-progress --batch-mode -Dstyle.color=always
       - name: SARIF Multitool
         uses: microsoft/sarif-actions@v0.2
         with:
@@ -144,6 +144,6 @@ jobs:
         run: >
           mvn -V -s settings.xml -pl cli -am 
           package -DskipTests=true
-          --no-transfer-progress --batch-mode
+          --no-transfer-progress --batch-mode -Dstyle.color=always
       - name: Test Docker Image
         run: ./docker-test.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,10 +70,10 @@ jobs:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: >
           mvn -V -s settings.xml 
-          clean package verify source:jar javadoc:jar 
-          ${{ steps.install-gpg-key.outcome == 'success' && '-Prelease gpg:sign deploy' || '' }} 
-          -PFullIntegrationTesting 
+          clean verify -PFullIntegrationTesting
           -Dtoolchain.jdk.test.version=${{ matrix.jdk_test_version }} -Dtoolchain.jdk.test.home="$JAVA_HOME_${{ matrix.jdk_test_version }}_X64"
+          ${{ matrix.jdk_test_version == matrix.jdk_default_version && 'source:jar javadoc:jar site' || '' }}
+          ${{ steps.install-gpg-key.outcome == 'success' && '-Prelease gpg:sign deploy' || '' }} 
           --no-transfer-progress --batch-mode
       - name: SARIF Multitool
         uses: microsoft/sarif-actions@v0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,30 +9,28 @@ on:
       - '**/*.txt'
 
 permissions: {}
+
 jobs:
   build:
+    strategy:
+      matrix:
+        jdk_default_version: [ '25' ]                # Single JDK version to run Maven with and use for compilation etc
+        jdk_test_version: [ '11', '17', '21', '25' ] # JDK version to run surefire/failsafe tests using
+      fail-fast: false
+
+    name: Build and Test (JDK ${{ matrix.jdk_test_version }}${{ matrix.jdk_test_version == matrix.jdk_default_version && ' - Default' || '' }})
     permissions:
       contents: read # to fetch code (actions/checkout)
-
-    name: Build dependency-check
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     steps:
       - name: Install gpg secret key
-        if: github.repository_owner == 'dependency-check'
+        if: matrix.jdk_test_version == matrix.jdk_default_version && github.repository_owner == 'dependency-check'
         id: install-gpg-key
         run: |
           cat <(echo -e "${{ secrets.GPG_PRIVATE_KEY }}") | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
       - uses: actions/checkout@v6
-      - name: Check Maven Cache
-        id: maven-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Check Local Maven Cache
+      - name: Maven Integration Test Cache
         id: maven-it-cache
         uses: actions/cache@v5
         with:
@@ -47,26 +45,36 @@ jobs:
       - uses: actions/setup-dotnet@v5.1.0
         with:
           dotnet-version: '8.0.x'
-      - name: Set up JDK 11
-        id: jdk-11
+      - name: Set up JDKs
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: | # last version takes precedence as default
+            ${{ matrix.jdk_test_version }}
+            ${{ matrix.jdk_default_version }}
           distribution: 'zulu'
+          check-latest: true
+          cache: 'maven'
+          cache-dependency-path: '**/pom.xml'
           server-id: central
           server-username: ${{ secrets.CENTRAL_USER }}
           server-password: ${{ secrets.CENTRAL_PASSWORD }}
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
           version: 6.0.2
-      - name: Build Snapshot with Maven
+      - name: Build/Test Snapshot with Maven${{ steps.install-gpg-key.outcome == 'success' && ' (then Deploy)' || '' }}
         id: build-snapshot
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USER }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSWORD }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: mvn -V -s settings.xml clean package verify source:jar javadoc:jar ${{ steps.install-gpg-key.outcome == 'success' && '-Prelease gpg:sign deploy' || '' }} -DreleaseTesting --no-transfer-progress --batch-mode
+        run: >
+          mvn -V -s settings.xml 
+          clean package verify source:jar javadoc:jar 
+          ${{ steps.install-gpg-key.outcome == 'success' && '-Prelease gpg:sign deploy' || '' }} 
+          -PFullIntegrationTesting 
+          -Dtoolchain.jdk.test.version=${{ matrix.jdk_test_version }} -Dtoolchain.jdk.test.home="$JAVA_HOME_${{ matrix.jdk_test_version }}_X64"
+          --no-transfer-progress --batch-mode
       - name: SARIF Multitool
         uses: microsoft/sarif-actions@v0.2
         with:
@@ -77,10 +85,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: it-test-logs
+          name: it-test-logs-jdk-${{ matrix.jdk_test_version }}
           retention-days: 7
           path: maven/target/it/**/build.log
       - name: Archive code coverage results
+        if: matrix.jdk_test_version == matrix.jdk_default_version
         id: archive-coverage
         uses: actions/upload-artifact@v6
         with:
@@ -90,6 +99,7 @@ jobs:
             **/target/jacoco-results/jacoco.xml
             **/target/jacoco-results/**/*.html
       - name: Archive Snapshot
+        if: matrix.jdk_test_version == matrix.jdk_default_version
         id: archive-snapshot
         uses: actions/upload-artifact@v6
         with:
@@ -112,14 +122,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Check Maven Cache
-        id: maven-cache
-        uses: actions/cache@v5
+      - name: Set up JDK
+        uses: actions/setup-java@v5
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          java-version: '25'
+          distribution: 'zulu'
+          check-latest: true
+          cache: 'maven'
+          cache-dependency-path: '**/pom.xml'
       - name: Download release build
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,7 +58,7 @@ jobs:
     #    uses a compiled language
 
     - run: |
-       mvn -s settings.xml clean package -DskipTests=true --no-transfer-progress --batch-mode
+       mvn -s settings.xml clean package -DskipTests=true --no-transfer-progress --batch-mode -Dstyle.color=always
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/false-positive-ops.yml
+++ b/.github/workflows/false-positive-ops.yml
@@ -97,7 +97,7 @@ jobs:
           cd ./fp-project
           ## not ideal as verify would be better then using the docker image...
           ##mvn verify
-          mvn dependency:copy-dependencies --no-transfer-progress --batch-mode 
+          mvn dependency:copy-dependencies --no-transfer-progress --batch-mode -Dstyle.color=always
           cd ..
       - name: Setup npm fp-project
         if: ${{ fromJSON(steps.purl-parser.outputs.result).type == 'npm' }}

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -52,7 +52,7 @@ jobs:
           clean verify
           -Dtoolchain.jdk.test.version=${{ matrix.jdk_test_version }} -Dtoolchain.jdk.test.home="$JAVA_HOME_${{ matrix.jdk_test_version }}_X64" 
           ${{ matrix.jdk_test_version == matrix.jdk_default_version && 'source:jar javadoc:jar site' || '' }}
-          --no-transfer-progress --batch-mode
+          --no-transfer-progress --batch-mode -Dstyle.color=always
       - name: SARIF Multitool
         uses: microsoft/sarif-actions@v0.2
         with:
@@ -142,7 +142,7 @@ jobs:
           mvn -V -s settings.xml -pl maven -am 
           clean verify -DskipTests=true -PFullIntegrationTesting
           -Dtoolchain.jdk.test.version=${{ matrix.jdk_test_version }} -Dtoolchain.jdk.test.home="$JAVA_HOME_${{ matrix.jdk_test_version }}_X64"
-          --no-transfer-progress --batch-mode
+          --no-transfer-progress --batch-mode -Dstyle.color=always
       - name: Archive IT test logs
         id: archive-logs
         if: always()
@@ -176,7 +176,7 @@ jobs:
       - name: Checkstyle
         id: checkstyle
         run: |
-            mvn -V -s settings.xml checkstyle:checkstyle-aggregate --no-transfer-progress --batch-mode
+            mvn -V -s settings.xml checkstyle:checkstyle-aggregate --no-transfer-progress --batch-mode -Dstyle.color=always
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v4
         with:
@@ -215,6 +215,6 @@ jobs:
         run: >
           mvn -V -s settings.xml -pl cli -am 
           package -DskipTests=true
-          --no-transfer-progress --batch-mode
+          --no-transfer-progress --batch-mode -Dstyle.color=always
       - name: Test Docker Image
         run: ./docker-test.sh

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -49,8 +49,9 @@ jobs:
         id: build
         run: >
           mvn -V -s settings.xml -pl '!maven' -am 
-          compile verify 
+          clean verify
           -Dtoolchain.jdk.test.version=${{ matrix.jdk_test_version }} -Dtoolchain.jdk.test.home="$JAVA_HOME_${{ matrix.jdk_test_version }}_X64" 
+          ${{ matrix.jdk_test_version == matrix.jdk_default_version && 'source:jar javadoc:jar site' || '' }}
           --no-transfer-progress --batch-mode
       - name: SARIF Multitool
         uses: microsoft/sarif-actions@v0.2
@@ -139,9 +140,8 @@ jobs:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: >
           mvn -V -s settings.xml -pl maven -am 
-          compile verify 
-          -DskipTests=true -PFullIntegrationTesting
-          -Dtoolchain.jdk.test.version=${{ matrix.jdk_test_version }} -Dtoolchain.jdk.test.home="$JAVA_HOME_${{ matrix.jdk_test_version }}_X64" 
+          clean verify -DskipTests=true -PFullIntegrationTesting
+          -Dtoolchain.jdk.test.version=${{ matrix.jdk_test_version }} -Dtoolchain.jdk.test.home="$JAVA_HOME_${{ matrix.jdk_test_version }}_X64"
           --no-transfer-progress --batch-mode
       - name: Archive IT test logs
         id: archive-logs

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -6,39 +6,52 @@ on:
       - '**/*.md'
       - '**/*.txt'
 
+permissions: {}
+
 jobs:
-  test:
-    name: Build and Test
+  build:
+    strategy:
+      matrix:
+        jdk_default_version: [ '25' ]                # Single JDK version to run Maven with and use for compilation etc
+        jdk_test_version: [ '11', '17', '21', '25' ] # JDK version to run surefire/failsafe tests using
+      fail-fast: false
+
+    name: Build and Test (JDK ${{ matrix.jdk_test_version }}${{ matrix.jdk_test_version == matrix.jdk_default_version && ' - Default' || '' }})
     permissions: 
       security-events: write
       contents: read
     runs-on: ubuntu-latest 
     steps:
       - uses: actions/checkout@v6
-      - name: Check Maven Cache
-        id: maven-cache
+      - name: Check ODC Data Cache
+        id: odc-data-cache
         uses: actions/cache@v5
         with:
-          path: ~/.m2/repository/
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          path: core/target/data
+          key: odc-data
       - uses: actions/setup-dotnet@v5.1.0
         with:
           dotnet-version: '8.0.x'
-      - name: Set up JDK 11
-        id: jdk-11
+      - name: Set up JDKs
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: | # last version takes precedence as default
+            ${{ matrix.jdk_test_version }}
+            ${{ matrix.jdk_default_version }}
           distribution: 'zulu'
+          check-latest: true
+          cache: 'maven'
+          cache-dependency-path: '**/pom.xml'
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
           version: 6.0.2
-      - name: Test with Maven
+      - name: Build/Test with Maven
         id: build
-        run: |
-            mvn -V -s settings.xml -pl utils,core,cli,ant,archetype -am compile verify --no-transfer-progress --batch-mode
+        run: >
+          mvn -V -s settings.xml -pl '!maven' -am 
+          compile verify 
+          -Dtoolchain.jdk.test.version=${{ matrix.jdk_test_version }} -Dtoolchain.jdk.test.home="$JAVA_HOME_${{ matrix.jdk_test_version }}_X64" 
+          --no-transfer-progress --batch-mode
       - name: SARIF Multitool
         uses: microsoft/sarif-actions@v0.2
         with:
@@ -65,6 +78,7 @@ jobs:
           sarif_file: core/target/spotbugsSarif.json
           category: spotbugs-core
       - name: Archive Snapshot
+        if: matrix.jdk_test_version == matrix.jdk_default_version
         id: archive-snapshot
         uses: actions/upload-artifact@v6
         with:
@@ -78,30 +92,44 @@ jobs:
             cli/target/*.zip
 
   maven:
-    name: Regression Test Maven Plugin
+    strategy:
+      matrix:
+        jdk_default_version: [ '25' ]                # Single JDK version to run Maven with and use for compilation etc
+        jdk_test_version: [ '11', '17', '21', '25' ] # JDK version to run surefire/failsafe tests using
+      fail-fast: false
+
+    name: Regression Test Maven Plugin (JDK ${{ matrix.jdk_test_version }}${{ matrix.jdk_test_version == matrix.jdk_default_version && ' - Default' || '' }})
     permissions: 
       security-events: write
       contents: read
     runs-on: ubuntu-latest 
     steps:
       - uses: actions/checkout@v6
-      - name: Check Maven Cache
-        id: maven-cache
+      - name: Maven Integration Test Cache
+        id: maven-it-cache
         uses: actions/cache@v5
         with:
-          path: ~/.m2/repository/
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          path: maven/target/local-repo
+          key: mvn-it-repo
+      - name: Check ODC Data Cache
+        id: odc-data-cache
+        uses: actions/cache@v5
+        with:
+          path: core/target/data
+          key: odc-data
       - uses: actions/setup-dotnet@v5.1.0
         with:
           dotnet-version: '8.0.x'
-      - name: Set up JDK 11
-        id: jdk-11
+      - name: Set up JDKs
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: | # last version takes precedence as default
+            ${{ matrix.jdk_test_version }}
+            ${{ matrix.jdk_default_version }}
           distribution: 'zulu'
+          check-latest: true
+          cache: 'maven'
+          cache-dependency-path: '**/pom.xml'
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
           version: 6.0.2
@@ -109,14 +137,18 @@ jobs:
         id: build
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: |
-            mvn -V -s settings.xml -pl maven -am compile verify -DtestMavenPlugin -DreleaseTesting --no-transfer-progress --batch-mode
+        run: >
+          mvn -V -s settings.xml -pl maven -am 
+          compile verify 
+          -DskipTests=true -PFullIntegrationTesting
+          -Dtoolchain.jdk.test.version=${{ matrix.jdk_test_version }} -Dtoolchain.jdk.test.home="$JAVA_HOME_${{ matrix.jdk_test_version }}_X64" 
+          --no-transfer-progress --batch-mode
       - name: Archive IT test logs
         id: archive-logs
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: it-test-logs
+          name: it-test-logs-jdk-${{ matrix.jdk_test_version }}
           retention-days: 7
           path: maven/target/it/**/build.log
       - name: Upload SARIF file
@@ -133,20 +165,14 @@ jobs:
     runs-on: ubuntu-latest 
     steps:
       - uses: actions/checkout@v6
-      - name: Check Maven Cache
-        id: maven-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2/repository/
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Set up JDK 11
-        id: jdk-11
+      - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: '25'
           distribution: 'zulu'
+          check-latest: true
+          cache: 'maven'
+          cache-dependency-path: '**/pom.xml'
       - name: Checkstyle
         id: checkstyle
         run: |
@@ -163,18 +189,18 @@ jobs:
 
     name: Build and Test Docker
     runs-on: ubuntu-latest
-    needs: test
+    needs: build
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Check Maven Cache
-        id: maven-cache
-        uses: actions/cache@v5
+      - name: Set up JDK
+        uses: actions/setup-java@v5
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          java-version: '25'
+          distribution: 'zulu'
+          check-latest: true
+          cache: 'maven'
+          cache-dependency-path: '**/pom.xml'
       - name: Download release build
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/purge-cache.yml
+++ b/.github/workflows/purge-cache.yml
@@ -11,15 +11,7 @@ jobs:
     runs-on: ubuntu-latest 
     steps:
       - uses: actions/checkout@v6
-      - name: Check Maven Cache
-        id: maven-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Check Local Maven Cache
+      - name: Maven Integration Test Cache
         id: maven-it-cache
         uses: actions/cache@v5
         with:
@@ -31,6 +23,14 @@ jobs:
         with:
           path: core/target/data
           key: odc-data
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+          check-latest: true
+          cache: 'maven'
+          cache-dependency-path: '**/pom.xml'
       - name: Delete Data Directories
         run: |
           rm -rf ~/.m2/repository/org/owasp/dependency-check-data

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           clean verify -PFullIntegrationTesting
           source:jar javadoc:jar site
           -Prelease gpg:sign deploy site:stage 
-          --no-transfer-progress --batch-mode
+          --no-transfer-progress --batch-mode -Dstyle.color=always
       - name: Archive code coverage results
         id: archive-coverage
         uses: actions/upload-artifact@v6
@@ -147,7 +147,7 @@ jobs:
         run: >
           mvn -V -s settings.xml -pl cli -am 
           package -DskipTests=true
-          --no-transfer-progress --batch-mode
+          --no-transfer-progress --batch-mode -Dstyle.color=always
       - name: Test Docker Image
         run: ./docker-test.sh
       - name: Deploy Docker Image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build:
     if: github.repository_owner == 'dependency-check'
-    name: Build dependency-check
+    name: Build for release
     runs-on: ubuntu-latest 
     steps:
       - name: Install gpg secret key
@@ -28,13 +28,7 @@ jobs:
           cat <(echo -e "${{ secrets.GPG_PRIVATE_KEY }}") | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
       - uses: actions/checkout@v6
-      - name: Check Maven Cache
-        id: maven-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2/repository/
-          key: mvn-repo
-      - name: Check Local Maven Cache
+      - name: Maven Integration Test Cache
         id: maven-it-cache
         uses: actions/cache@v5
         with:
@@ -49,12 +43,14 @@ jobs:
       - uses: actions/setup-dotnet@v5.1.0
         with:
           dotnet-version: '8.0.x'
-      - name: Set up JDK 11
-        id: jdk-11
+      - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: '25'
           distribution: 'zulu'
+          check-latest: true
+          cache: 'maven'
+          cache-dependency-path: '**/pom.xml'
           server-id: central
           server-username: ${{ secrets.CENTRAL_USER }}
           server-password: ${{ secrets.CENTRAL_PASSWORD }}
@@ -77,8 +73,12 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSWORD }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: |
-          mvn -V -s settings.xml -Prelease clean package source:jar javadoc:jar gpg:sign deploy site site:stage -DreleaseTesting --no-transfer-progress --batch-mode
+        run: >
+          mvn -V -s settings.xml
+          -Prelease 
+          clean package source:jar javadoc:jar gpg:sign deploy site site:stage 
+          -PFullIntegrationTesting
+          --no-transfer-progress --batch-mode
       - name: Archive code coverage results
         id: archive-coverage
         uses: actions/upload-artifact@v6
@@ -109,21 +109,6 @@ jobs:
           retention-days: 7
           path: target/staging/
 
-#  publish_coverage:
-#    name: publish code coverage reports
-#    runs-on: ubuntu-latest
-#    needs: build
-#    steps:
-#      - name: Download coverage reports
-#        uses: actions/download-artifact@v7
-#        with:
-#          name: code-coverage-report
-#      - name: Run codacy-coverage-reporter
-#        uses: codacy/codacy-coverage-reporter-action@master
-#        with:
-#          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-#          coverage-reports: utils/target/jacoco-results/jacoco.xml,core/target/jacoco-results/jacoco.xml,maven/target/jacoco-results/jacoco.xml,ant/target/jacoco-results/jacoco.xml,cli/target/jacoco-results/jacoco.xml
-
   docker:
     name: Publish Docker
     runs-on: ubuntu-latest
@@ -132,12 +117,6 @@ jobs:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
     steps:
-      - name: Check Maven Cache
-        id: maven-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2/repository/
-          key: mvn-repo
       - name: Check Docker ODC Cache
         id: docker-odc-cache
         uses: actions/cache@v5
@@ -146,6 +125,14 @@ jobs:
           key: docker-repo
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+          check-latest: true
+          cache: 'maven'
+          cache-dependency-path: '**/pom.xml'
       - name: Download release build
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,9 @@ jobs:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: >
           mvn -V -s settings.xml
-          -Prelease 
-          clean package source:jar javadoc:jar gpg:sign deploy site site:stage 
-          -PFullIntegrationTesting
+          clean verify -PFullIntegrationTesting
+          source:jar javadoc:jar site
+          -Prelease gpg:sign deploy site:stage 
           --no-transfer-progress --batch-mode
       - name: Archive code coverage results
         id: archive-coverage

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -226,7 +226,7 @@ Copyright (c) 2013 - Jeremy Long. All Rights Reserved.
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-core</artifactId>
             <version>${project.parent.version}</version>
-            <type>test-jar</type>
+            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -18,6 +18,17 @@
     <properties>
         <maven.compiler.release>${maven.compiler.release}</maven.compiler.release>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.owasp</groupId>
@@ -40,19 +51,16 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -174,10 +174,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                     <groupId>org.apache.ant</groupId>
                     <artifactId>ant-launcher</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.sun</groupId>
-                    <artifactId>tools</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -99,13 +99,7 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                     <repositoryName>lib</repositoryName>
                     <unixScriptTemplate>${project.basedir}/src/main/conf/unixBinTemplate.sh</unixScriptTemplate>
                     <windowsScriptTemplate>${project.basedir}/src/main/conf/windowsBinTemplate.bat</windowsScriptTemplate>
-                    <!--
-                       enable-native-access=ALL-UNNAMED
-                            Java 21+: Needed by Lucene indexes unless we do -Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false
-                                      to go back to regular ByteBuffer (non-native) usage.
-                       -XX:+IgnoreUnrecognizedVMOptions
-                            Java <21: Allow use of enable-native-access on Java 11 JVMs without errors -->
-                    <extraJvmArguments>--enable-native-access=ALL-UNNAMED -XX:+IgnoreUnrecognizedVMOptions</extraJvmArguments>
+                    <extraJvmArguments>${runtime.extra.jvm.args}</extraJvmArguments>
                 </configuration>
                 <executions>
                     <execution>
@@ -185,11 +179,6 @@ Copyright (c) 2012 - Jeremy Long. All Rights Reserved.
                     <artifactId>tools</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -163,16 +163,9 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>test-jar</id>
-                        <phase>package</phase>
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
-                        <configuration>
-                            <includes>
-                                <include>**/*.class</include>
-                            </includes>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -278,6 +271,11 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
         </dependency>
+        <!-- Allow redirection of Commons Logging to slf4j -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
@@ -377,9 +375,8 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <version>1.3.1</version>
         </dependency>
         <dependency>
-            <groupId>com.vaadin.external.google</groupId>
-            <artifactId>android-json</artifactId>
-            <version>0.0.20131108.vaadin1</version>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
         </dependency>
     </dependencies>
     <profiles>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -333,11 +333,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <artifactId>aho-corasick-double-array-trie</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
         </dependency>
@@ -388,32 +383,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
         </dependency>
     </dependencies>
     <profiles>
-        <profile>
-            <id>TestMavenPlugin-core</id>
-            <activation>
-                <property>
-                    <name>testMavenPlugin</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>MySQL-IntegrationTest</id>
             <activation>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -226,11 +226,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-test-framework</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
         </dependency>

--- a/core/src/main/java/org/owasp/dependencycheck/Engine.java
+++ b/core/src/main/java/org/owasp/dependencycheck/Engine.java
@@ -19,8 +19,8 @@ package org.owasp.dependencycheck;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.jcs3.JCS;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.owasp.dependencycheck.analyzer.AnalysisPhase;
 import org.owasp.dependencycheck.analyzer.Analyzer;
 import org.owasp.dependencycheck.analyzer.AnalyzerService;
@@ -145,7 +145,7 @@ public class Engine implements FileFilter, AutoCloseable {
      *
      * @param settings reference to the configured settings
      */
-    public Engine(@NotNull final Settings settings) {
+    public Engine(@NonNull final Settings settings) {
         this(Mode.STANDALONE, settings);
     }
 
@@ -155,7 +155,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param mode the mode of operation
      * @param settings reference to the configured settings
      */
-    public Engine(@NotNull final Mode mode, @NotNull final Settings settings) {
+    public Engine(@NonNull final Mode mode, @NonNull final Settings settings) {
         this(Thread.currentThread().getContextClassLoader(), mode, settings);
     }
 
@@ -165,7 +165,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param serviceClassLoader a reference the class loader being used
      * @param settings reference to the configured settings
      */
-    public Engine(@NotNull final ClassLoader serviceClassLoader, @NotNull final Settings settings) {
+    public Engine(@NonNull final ClassLoader serviceClassLoader, @NonNull final Settings settings) {
         this(serviceClassLoader, Mode.STANDALONE, settings);
     }
 
@@ -176,7 +176,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param mode the mode of the engine
      * @param settings reference to the configured settings
      */
-    public Engine(@NotNull final ClassLoader serviceClassLoader, @NotNull final Mode mode, @NotNull final Settings settings) {
+    public Engine(@NonNull final ClassLoader serviceClassLoader, @NonNull final Mode mode, @NonNull final Settings settings) {
         this.settings = settings;
         this.serviceClassLoader = serviceClassLoader;
         this.mode = mode;
@@ -277,7 +277,7 @@ public class Engine implements FileFilter, AutoCloseable {
      *
      * @param dependency the dependency to remove.
      */
-    public synchronized void removeDependency(@NotNull final Dependency dependency) {
+    public synchronized void removeDependency(@NonNull final Dependency dependency) {
         dependencies.remove(dependency);
         dependenciesExternalView = null;
     }
@@ -300,7 +300,7 @@ public class Engine implements FileFilter, AutoCloseable {
      *
      * @param dependencies the dependencies
      */
-    public synchronized void setDependencies(@NotNull final List<Dependency> dependencies) {
+    public synchronized void setDependencies(@NonNull final List<Dependency> dependencies) {
         this.dependencies.clear();
         this.dependencies.addAll(dependencies);
         dependenciesExternalView = null;
@@ -315,7 +315,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @return the list of dependencies scanned
      * @since v0.3.2.5
      */
-    public List<Dependency> scan(@NotNull final String[] paths) {
+    public List<Dependency> scan(@NonNull final String[] paths) {
         return scan(paths, null);
     }
 
@@ -330,7 +330,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @return the list of dependencies scanned
      * @since v1.4.4
      */
-    public List<Dependency> scan(@NotNull final String[] paths, @Nullable final String projectReference) {
+    public List<Dependency> scan(@NonNull final String[] paths, @Nullable final String projectReference) {
         final List<Dependency> deps = new ArrayList<>();
         for (String path : paths) {
             final List<Dependency> d = scan(path, projectReference);
@@ -349,7 +349,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param path the path to a file or directory to be analyzed
      * @return the list of dependencies scanned
      */
-    public List<Dependency> scan(@NotNull final String path) {
+    public List<Dependency> scan(@NonNull final String path) {
         return scan(path, null);
     }
 
@@ -364,7 +364,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @return the list of dependencies scanned
      * @since v1.4.4
      */
-    public List<Dependency> scan(@NotNull final String path, String projectReference) {
+    public List<Dependency> scan(@NonNull final String path, String projectReference) {
         final File file = new File(path);
         return scan(file, projectReference);
     }
@@ -461,7 +461,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @since v1.4.4
      */
     @Nullable
-    public List<Dependency> scan(@NotNull final File file, String projectReference) {
+    public List<Dependency> scan(@NonNull final File file, String projectReference) {
         if (file.exists()) {
             if (file.isDirectory()) {
                 return scanDirectory(file, projectReference);
@@ -498,7 +498,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @return the list of Dependency objects scanned
      * @since v1.4.4
      */
-    protected List<Dependency> scanDirectory(@NotNull final File dir, @Nullable final String projectReference) {
+    protected List<Dependency> scanDirectory(@NonNull final File dir, @Nullable final String projectReference) {
         final File[] files = dir.listFiles();
         final List<Dependency> deps = new ArrayList<>();
         if (files != null) {
@@ -526,7 +526,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param file The file to scan
      * @return the scanned dependency
      */
-    protected Dependency scanFile(@NotNull final File file) {
+    protected Dependency scanFile(@NonNull final File file) {
         return scanFile(file, null);
     }
 
@@ -541,7 +541,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @return the scanned dependency
      * @since v1.4.4
      */
-    protected synchronized Dependency scanFile(@NotNull final File file, @Nullable final String projectReference) {
+    protected synchronized Dependency scanFile(@NonNull final File file, @Nullable final String projectReference) {
         Dependency dependency = null;
         if (file.isFile()) {
             if (accept(file)) {
@@ -681,7 +681,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param exceptions a collection to store non-fatal exceptions
      * @throws ExceptionCollection thrown if fatal exceptions occur
      */
-    private void initializeAndUpdateDatabase(@NotNull final List<Throwable> exceptions) throws ExceptionCollection {
+    private void initializeAndUpdateDatabase(@NonNull final List<Throwable> exceptions) throws ExceptionCollection {
         if (!mode.isDatabaseRequired()) {
             return;
         }
@@ -741,7 +741,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @param analyzer the analyzer to execute
      * @throws ExceptionCollection thrown if exceptions occurred during analysis
      */
-    protected void executeAnalysisTasks(@NotNull final Analyzer analyzer, List<Throwable> exceptions) throws ExceptionCollection {
+    protected void executeAnalysisTasks(@NonNull final Analyzer analyzer, List<Throwable> exceptions) throws ExceptionCollection {
         LOGGER.debug("Starting {}", analyzer.getName());
         final List<AnalysisTask> analysisTasks = getAnalysisTasks(analyzer, exceptions);
         final ExecutorService executorService = getExecutorService(analyzer);
@@ -805,7 +805,7 @@ public class Engine implements FileFilter, AutoCloseable {
      * @throws InitializationException thrown when there is a problem
      * initializing the analyzer
      */
-    protected void initializeAnalyzer(@NotNull final Analyzer analyzer) throws InitializationException {
+    protected void initializeAnalyzer(@NonNull final Analyzer analyzer) throws InitializationException {
         try {
             LOGGER.debug("Initializing {}", analyzer.getName());
             analyzer.prepare(this);
@@ -837,7 +837,7 @@ public class Engine implements FileFilter, AutoCloseable {
      *
      * @param analyzer the analyzer to close
      */
-    protected void closeAnalyzer(@NotNull final Analyzer analyzer) {
+    protected void closeAnalyzer(@NonNull final Analyzer analyzer) {
         LOGGER.debug("Closing Analyzer '{}'", analyzer.getName());
         try {
             analyzer.close();
@@ -1029,7 +1029,7 @@ public class Engine implements FileFilter, AutoCloseable {
      *
      * @return a list of Analyzers
      */
-    @NotNull
+    @NonNull
     public List<Analyzer> getAnalyzers() {
         final List<Analyzer> analyzerList = new ArrayList<>();
         //insteae of forEach - we can just do a collect
@@ -1129,7 +1129,7 @@ public class Engine implements FileFilter, AutoCloseable {
      *
      * @param fta the file type analyzer to add
      */
-    protected void addFileTypeAnalyzer(@NotNull final FileTypeAnalyzer fta) {
+    protected void addFileTypeAnalyzer(@NonNull final FileTypeAnalyzer fta) {
         this.fileTypeAnalyzers.add(fta);
     }
 
@@ -1154,8 +1154,8 @@ public class Engine implements FileFilter, AutoCloseable {
      * @throws ExceptionCollection a collection of exceptions that occurred
      * during analysis
      */
-    private void throwFatalExceptionCollection(String message, @NotNull final Throwable throwable,
-            @NotNull final List<Throwable> exceptions) throws ExceptionCollection {
+    private void throwFatalExceptionCollection(String message, @NonNull final Throwable throwable,
+            @NonNull final List<Throwable> exceptions) throws ExceptionCollection {
         LOGGER.error(message);
         LOGGER.debug("", throwable);
         exceptions.add(throwable);
@@ -1212,7 +1212,7 @@ public class Engine implements FileFilter, AutoCloseable {
     @Deprecated
     public synchronized void writeReports(String applicationName, @Nullable final String groupId,
             @Nullable final String artifactId, @Nullable final String version,
-            @NotNull final File outputDir, String format) throws ReportException {
+            @NonNull final File outputDir, String format) throws ReportException {
         writeReports(applicationName, groupId, artifactId, version, outputDir, format, null);
     }
 
@@ -1233,7 +1233,7 @@ public class Engine implements FileFilter, AutoCloseable {
      */
     public synchronized void writeReports(String applicationName, @Nullable final String groupId,
             @Nullable final String artifactId, @Nullable final String version,
-            @NotNull final File outputDir, String format, ExceptionCollection exceptions) throws ReportException {
+            @NonNull final File outputDir, String format, ExceptionCollection exceptions) throws ReportException {
         if (mode == Mode.EVIDENCE_COLLECTION) {
             throw new UnsupportedOperationException("Cannot generate report in evidence collection mode.");
         }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AbstractSuppressionAnalyzer.java
@@ -31,11 +31,10 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import javax.annotation.concurrent.ThreadSafe;
 
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.update.HostedSuppressionsDataSource;
-import org.owasp.dependencycheck.data.update.exception.UpdateException;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.exception.WriteLockException;
@@ -219,7 +218,7 @@ public abstract class AbstractSuppressionAnalyzer extends AbstractAnalyzer {
         }
     }
 
-    private static @NotNull URL getPackagedFile(String packagedFileName) throws SuppressionParseException {
+    private static @NonNull URL getPackagedFile(String packagedFileName) throws SuppressionParseException {
         final URL jarLocation = AbstractSuppressionAnalyzer.class.getProtectionDomain().getCodeSource().getLocation();
         String suppressionFileLocation = jarLocation.getFile();
         if (suppressionFileLocation.endsWith(".jar")) {

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/CPEAnalyzer.java
@@ -46,8 +46,8 @@ import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.data.cpe.CpeMemoryIndex;
@@ -1277,7 +1277,7 @@ public class CPEAnalyzer extends AbstractAnalyzer {
          * @return the natural ordering of IdentifierMatch
          */
         @Override
-        public int compareTo(@NotNull IdentifierMatch o) {
+        public int compareTo(@NonNull IdentifierMatch o) {
             return new CompareToBuilder()
                     .append(identifierConfidence, o.identifierConfidence)
                     .append(identifier, o.identifier)

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/HintAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/HintAnalyzer.java
@@ -17,7 +17,7 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import org.jetbrains.annotations.VisibleForTesting;
+import com.google.common.annotations.VisibleForTesting;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/PnpmAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/PnpmAuditAnalyzer.java
@@ -20,9 +20,9 @@ package org.owasp.dependencycheck.analyzer;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.jspecify.annotations.NonNull;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.analyzer.exception.SearchException;
@@ -281,7 +281,7 @@ public class PnpmAuditAnalyzer extends AbstractNpmAnalyzer {
         }
     }
 
-    @NotNull
+    @NonNull
     private NpmAuditParser getAuditParser() {
         return new NpmAuditParser();
     }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/YarnAuditAnalyzer.java
@@ -443,7 +443,7 @@ public class YarnAuditAnalyzer extends AbstractNpmAnalyzer {
             final var advisory = new Advisory();
             final var object = advisoryJson.getJSONObject("children");
             final var moduleName = advisoryJson.optString("value", null);
-            final var id = object.getString("ID");
+            final var id = object.get("ID");
             final var url = object.optString("URL", null);
             final var ghsaId = extractGhsaId(url);
             final var issue = object.optString("Issue", null);

--- a/core/src/main/java/org/owasp/dependencycheck/data/lucene/AbstractTokenizingFilter.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/lucene/AbstractTokenizingFilter.java
@@ -90,8 +90,12 @@ public abstract class AbstractTokenizingFilter extends TokenFilter {
         if (termAdded) {
             final String term = tokens.pop();
             clearAttributes();
-            termAtt.append(term);
+            appendTerm(term);
         }
         return termAdded;
+    }
+
+    protected void appendTerm(String term) {
+        termAtt.append(term);
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/data/lucene/AlphaNumericFilter.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/lucene/AlphaNumericFilter.java
@@ -40,7 +40,7 @@ import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
  *
  * @author jeremy long
  */
-public final class AlphaNumericFilter extends AbstractTokenizingFilter {
+public class AlphaNumericFilter extends AbstractTokenizingFilter {
 
     /**
      * The position increment attribute.
@@ -65,7 +65,7 @@ public final class AlphaNumericFilter extends AbstractTokenizingFilter {
      * {@inheritDoc}
      */
     @Override
-    public boolean incrementToken() throws IOException {
+    public final boolean incrementToken() throws IOException {
         final ArrayDeque<String> tokens = getTokens();
         final CharTermAttribute termAtt = getTermAtt();
         if (tokens.isEmpty()) {

--- a/core/src/main/java/org/owasp/dependencycheck/data/lucene/TokenPairConcatenatingFilter.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/lucene/TokenPairConcatenatingFilter.java
@@ -36,7 +36,7 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
  * @author Jeremy Long
  */
 @NotThreadSafe
-public final class TokenPairConcatenatingFilter extends TokenFilter {
+public class TokenPairConcatenatingFilter extends TokenFilter {
 
     /**
      * The char term attribute.
@@ -72,11 +72,11 @@ public final class TokenPairConcatenatingFilter extends TokenFilter {
      * @throws IOException is thrown when an IOException occurs
      */
     @Override
-    public boolean incrementToken() throws IOException {
+    public final boolean incrementToken() throws IOException {
         if (addSingleTerm && previousWord != null) {
             addSingleTerm = false;
             clearAttributes();
-            termAtt.append(previousWord);
+            appendTerm(previousWord);
             return true;
 
         } else if (input.incrementToken()) {
@@ -86,18 +86,23 @@ public final class TokenPairConcatenatingFilter extends TokenFilter {
             }
             if (addSingleTerm) {
                 clearAttributes();
-                termAtt.append(word);
+                appendTerm(word);
                 previousWord = word;
                 addSingleTerm = false;
             } else {
                 clearAttributes();
-                termAtt.append(previousWord).append(word);
+                appendTerm(previousWord);
+                appendTerm(word);
                 previousWord = word;
                 addSingleTerm = true;
             }
             return true;
         }
         return false;
+    }
+
+    protected void appendTerm(String term) {
+        termAtt.append(term);
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/data/lucene/UrlTokenizingFilter.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/lucene/UrlTokenizingFilter.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * @author Jeremy Long
  */
 @NotThreadSafe
-public final class UrlTokenizingFilter extends AbstractTokenizingFilter {
+public class UrlTokenizingFilter extends AbstractTokenizingFilter {
 
     /**
      * The logger.
@@ -60,8 +60,7 @@ public final class UrlTokenizingFilter extends AbstractTokenizingFilter {
      * @throws IOException is thrown when an IOException occurs
      */
     @Override
-    @SuppressWarnings("StringSplitter")
-    public boolean incrementToken() throws IOException {
+    public final boolean incrementToken() throws IOException {
         final ArrayDeque<String> tokens = getTokens();
         final CharTermAttribute termAtt = getTermAtt();
         if (tokens.isEmpty() && input.incrementToken()) {

--- a/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV3Search.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nexus/NexusV3Search.java
@@ -24,7 +24,7 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.message.BasicHeader;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.owasp.dependencycheck.utils.DownloadFailedException;
 import org.owasp.dependencycheck.utils.Downloader;
 import org.owasp.dependencycheck.utils.ForbiddenException;

--- a/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NodeAuditSearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nodeaudit/NodeAuditSearch.java
@@ -31,7 +31,6 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.message.BasicHeader;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.owasp.dependencycheck.utils.DownloadFailedException;
 import org.owasp.dependencycheck.utils.Downloader;
@@ -171,7 +170,7 @@ public class NodeAuditSearch {
                 cache.put(key, advisories);
             }
             return advisories;
-        } catch (RuntimeException | URISyntaxException | JSONException | TooManyRequestsException | ResourceNotFoundException ex) {
+        } catch (RuntimeException | URISyntaxException | TooManyRequestsException | ResourceNotFoundException ex) {
             LOGGER.debug("Error connecting to Node Audit API. Error: {}",
                     ex.getMessage());
             throw new SearchException("Could not connect to Node Audit API: " + ex.getMessage(), ex);

--- a/core/src/main/java/org/owasp/dependencycheck/data/update/NvdApiDataSource.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/update/NvdApiDataSource.java
@@ -55,7 +55,7 @@ import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.zip.GZIPOutputStream;
 
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.data.nvdcve.CveDB;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
@@ -666,20 +666,20 @@ public class NvdApiDataSource implements CachedWebDataSource {
             return new FeedUrl(url, patternTransformer.apply(Optional.ofNullable(pattern)));
         }
 
-        @NotNull String toFormattedUrlString(String formatArg) {
+        @NonNull String toFormattedUrlString(String formatArg) {
             return url + MessageFormat.format(Optional.ofNullable(pattern).orElseThrow(), formatArg);
         }
 
-        @NotNull String toFormattedUrlString(int formatArg) {
+        @NonNull String toFormattedUrlString(int formatArg) {
             return toFormattedUrlString(String.valueOf(formatArg));
         }
 
-        @NotNull URL toFormattedUrl(@NotNull String formatArg) throws MalformedURLException, URISyntaxException {
+        @NonNull URL toFormattedUrl(@NonNull String formatArg) throws MalformedURLException, URISyntaxException {
             return new URI(toFormattedUrlString(formatArg)).toURL();
         }
 
         @SuppressWarnings("SameParameterValue")
-        @NotNull URL toSuffixedUrl(String suffix) throws MalformedURLException, URISyntaxException {
+        @NonNull URL toSuffixedUrl(String suffix) throws MalformedURLException, URISyntaxException {
             return new URI(url + suffix).toURL();
         }
 
@@ -705,7 +705,7 @@ public class NvdApiDataSource implements CachedWebDataSource {
             return new FeedUrl(baseUrl, pattern);
         }
 
-        private static @NotNull Pair<Integer, Integer> toYearRange(Settings settings, ZonedDateTime now) {
+        private static @NonNull Pair<Integer, Integer> toYearRange(Settings settings, ZonedDateTime now) {
             // for establishing the current year use the timezone where the new year starts first
             // as from that moment on CNAs might start assigning CVEs with the new year depending
             // on the CNA's timezone
@@ -714,11 +714,11 @@ public class NvdApiDataSource implements CachedWebDataSource {
             return new Pair<>(startYear, endYear);
         }
 
-        private @NotNull ZonedDateTime getLastModifiedFor(int year) throws UpdateException {
+        private @NonNull ZonedDateTime getLastModifiedFor(int year) throws UpdateException {
             return getLastModifiedFor(String.valueOf(year));
         }
 
-        private @NotNull ZonedDateTime getLastModifiedFor(String fileVersion) throws UpdateException {
+        private @NonNull ZonedDateTime getLastModifiedFor(String fileVersion) throws UpdateException {
             try {
                 String content = Downloader.getInstance().fetchContent(toFormattedUrl(fileVersion), UTF_8);
                 Properties props = new Properties();

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Evidence.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Evidence.java
@@ -21,7 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.io.Serializable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -235,7 +235,7 @@ public class Evidence implements Serializable, Comparable<Evidence> {
      * @return an integer indicating the ordering of the two objects
      */
     @Override
-    public int compareTo(@NotNull Evidence o) {
+    public int compareTo(@NonNull Evidence o) {
         return new CompareToBuilder()
                 .append(this.source == null ? null : this.source.toLowerCase(), o.source == null ? null : o.source.toLowerCase())
                 .append(this.name == null ? null : this.name.toLowerCase(), o.name == null ? null : o.name.toLowerCase())

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Reference.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Reference.java
@@ -22,7 +22,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * An external reference for a vulnerability. This contains a name, URL, and a
@@ -160,7 +160,7 @@ public class Reference implements Serializable, Comparable<Reference> {
      * @return an integer indicating the ordering of the two objects
      */
     @Override
-    public int compareTo(@NotNull Reference o) {
+    public int compareTo(@NonNull Reference o) {
         return new CompareToBuilder()
                 .append(source, o.source)
                 .append(name, o.name)

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Vulnerability.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.owasp.dependencycheck.utils.SeverityUtil;
 
 /**
@@ -506,7 +506,7 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
      * @see #bestEffortSeverityLevelForSorting()
      */
     @Override
-    public int compareTo(@NotNull Vulnerability o) {
+    public int compareTo(@NonNull Vulnerability o) {
         return new CompareToBuilder()
                 .append(o.bestEffortSeverityLevelForSorting(), this.bestEffortSeverityLevelForSorting())
                 .append(this.name, o.name)
@@ -529,7 +529,7 @@ public class Vulnerability implements Serializable, Comparable<Vulnerability> {
      * highest CVSSv2 HIGH and the lowest CVSSv3 CRITICAL severity level.
      *
      * @see SeverityUtil#estimatedSortAdjustedCVSSv3(String)
-     * @see SeverityUtil#sortAdjustedCVSSv3BaseScore(float)
+     * @see SeverityUtil#sortAdjustedCVSSv3BaseScore(Double)
      * @return A float value that allows for best-effort sorting on
      * vulnerability severity
      */

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/VulnerableSoftware.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/VulnerableSoftware.java
@@ -26,7 +26,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException;
 import org.owasp.dependencycheck.dependency.naming.CpeIdentifier;
 import org.owasp.dependencycheck.utils.DependencyVersion;
@@ -134,7 +134,7 @@ public class VulnerableSoftware extends Cpe implements Serializable {
     }
 
     @Override
-    public int compareTo(@NotNull ICpe o) {
+    public int compareTo(@NonNull ICpe o) {
         if (o instanceof VulnerableSoftware) {
             final VulnerableSoftware other = (VulnerableSoftware) o;
             return new CompareToBuilder()

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/naming/CpeIdentifier.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/naming/CpeIdentifier.java
@@ -21,7 +21,7 @@ import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.hc.core5.net.PercentCodec;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.owasp.dependencycheck.dependency.Confidence;
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.CpeBuilder;
@@ -190,7 +190,7 @@ public class CpeIdentifier implements Identifier {
     }
 
     @Override
-    public int compareTo(@NotNull Identifier o) {
+    public int compareTo(@NonNull Identifier o) {
         if (o instanceof CpeIdentifier) {
             final CpeIdentifier other = (CpeIdentifier) o;
             return new CompareToBuilder()

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/naming/GenericIdentifier.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/naming/GenericIdentifier.java
@@ -21,7 +21,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.owasp.dependencycheck.dependency.Confidence;
 
 /**
@@ -189,7 +189,7 @@ public class GenericIdentifier implements Identifier {
      * @return an integer indicating the ordering
      */
     @Override
-    public int compareTo(@NotNull Identifier o) {
+    public int compareTo(@NonNull Identifier o) {
         return new CompareToBuilder()
                 .append(this.value, o.toString())
                 .append(this.url, o.getUrl())

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/naming/PurlIdentifier.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/naming/PurlIdentifier.java
@@ -19,7 +19,7 @@ package org.owasp.dependencycheck.dependency.naming;
 
 import com.github.packageurl.MalformedPackageURLException;
 import org.apache.commons.lang3.builder.CompareToBuilder;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.owasp.dependencycheck.dependency.Confidence;
 import com.github.packageurl.PackageURL;
 import com.github.packageurl.PackageURLBuilder;
@@ -212,7 +212,7 @@ public class PurlIdentifier implements Identifier {
     }
 
     @Override
-    public int compareTo(@NotNull Identifier o) {
+    public int compareTo(@NonNull Identifier o) {
         if (o instanceof PurlIdentifier) {
             final PurlIdentifier other = (PurlIdentifier) o;
             return new CompareToBuilder()

--- a/core/src/main/java/org/owasp/dependencycheck/utils/DependencyVersion.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/DependencyVersion.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * <p>
@@ -113,7 +113,7 @@ public class DependencyVersion implements Iterable<String>, Comparable<Dependenc
      *
      * @return an iterator for the version parts
      */
-    @NotNull
+    @NonNull
     @Override
     public Iterator<String> iterator() {
         return versionParts.iterator();
@@ -232,10 +232,7 @@ public class DependencyVersion implements Iterable<String>, Comparable<Dependenc
     }
 
     @Override
-    public int compareTo(@NotNull DependencyVersion version) {
-        if (version == null) {
-            return 1;
-        }
+    public int compareTo(@NonNull DependencyVersion version) {
         final List<String> left = this.getVersionParts();
         final List<String> right = version.getVersionParts();
         final int max = Math.min(left.size(), right.size());

--- a/core/src/main/java/org/owasp/dependencycheck/utils/Filter.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/Filter.java
@@ -1,6 +1,5 @@
 package org.owasp.dependencycheck.utils;
 
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;

--- a/core/src/main/java/org/owasp/dependencycheck/xml/XmlInputStream.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/XmlInputStream.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import javax.annotation.concurrent.NotThreadSafe;
 
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -212,7 +212,7 @@ public class XmlInputStream extends FilterInputStream {
      * stream
      */
     @Override
-    public int read(@NotNull byte[] data, int offset, int length) throws IOException {
+    public int read(@NonNull byte[] data, int offset, int length) throws IOException {
         final StringBuilder s = read(length);
         int n = 0;
         for (int i = 0; i < Math.min(length, s.length()); i++) {

--- a/core/src/test/java/org/owasp/dependencycheck/data/lucene/BaseTokenFilterTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/lucene/BaseTokenFilterTest.java
@@ -1,0 +1,55 @@
+package org.owasp.dependencycheck.data.lucene;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public abstract class BaseTokenFilterTest {
+    private Analyzer analyzer;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        analyzer = new KeywordAnalyzer();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        analyzer.close();
+    }
+
+    @RepeatedTest(1000)
+    public void testRandomStrings() {
+        String input = RandomStringUtils.insecure().nextAlphanumeric(1, 1000);
+        assertDoesNotThrow(() -> processAllFrom(input), () -> "Failed to process input: " + input);
+    }
+
+    protected @NonNull TokenStream freshTokenStream(String input) throws IOException {
+        TokenStream dummy = analyzer.tokenStream("dummy", input);
+        dummy.reset();
+        return dummy;
+    }
+
+    @NonNull
+    protected List<String> processAllFrom(String input) throws IOException {
+        List<String> terms = new ArrayList<>();
+        try (TokenFilter filter = newFilter(freshTokenStream(input), terms)) {
+            //noinspection StatementWithEmptyBody
+            while (filter.incrementToken()) {}
+            return terms;
+        }
+    }
+
+    abstract TokenFilter newFilter(@NonNull final TokenStream stream, List<String> terms);
+}

--- a/core/src/test/java/org/owasp/dependencycheck/data/lucene/TokenPairConcatenatingFilterTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/lucene/TokenPairConcatenatingFilterTest.java
@@ -17,82 +17,33 @@
  */
 package org.owasp.dependencycheck.data.lucene;
 
-import java.io.IOException;
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
-import static org.apache.lucene.tests.analysis.BaseTokenStreamTestCase.checkOneTerm;
-import org.apache.lucene.tests.analysis.MockTokenizer;
-import org.apache.lucene.analysis.Tokenizer;
-import org.apache.lucene.analysis.core.KeywordTokenizer;
-import static org.junit.Assert.fail;
-import org.junit.Before;
-import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 
-/**
- *
- * @author Jeremy Long
- */
-public class TokenPairConcatenatingFilterTest extends BaseTokenStreamTestCase {
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-//    private Analyzer analyzer;
-//
-//    @Before
-//    @Override
-//    public void setUp() throws Exception {
-//        super.setUp();
-//        analyzer = new Analyzer() {
-//            @Override
-//            protected Analyzer.TokenStreamComponents createComponents(String fieldName) {
-//                Tokenizer source = new MockTokenizer(MockTokenizer.WHITESPACE, false);
-//                return new Analyzer.TokenStreamComponents(source, new TokenPairConcatenatingFilter(source));
-//            }
-//        };
-//    }
-//
-//    /**
-//     * Test of incrementToken method, of class TokenPairConcatenatingFilter.
-//     */
-//    @Test
-//    public void testIncrementToken() throws Exception {
-//        String[] expected = new String[5];
-//        expected[0] = "red";
-//        expected[1] = "redblue";
-//        expected[2] = "blue";
-//        expected[3] = "bluegreen";
-//        expected[4] = "green";
-//        assertAnalyzesTo(analyzer, "red blue green", expected);
-//    }
-//    /**
-//     * copied from
-//     * http://svn.apache.org/repos/asf/lucene/dev/trunk/lucene/analysis/common/src/test/org/apache/lucene/analysis/en/TestEnglishMinimalStemFilter.java
-//     * blast some random strings through the analyzer
-//     */
-//    public void testRandomStrings() {
-//        try {
-//            checkRandomData(random(), analyzer, 1000 * RANDOM_MULTIPLIER);
-//        } catch (IOException ex) {
-//            fail("Failed test random strings: " + ex.getMessage());
-//        }
-//    }
-    /**
-     * copied from
-     * http://svn.apache.org/repos/asf/lucene/dev/trunk/lucene/analysis/common/src/test/org/apache/lucene/analysis/en/TestEnglishMinimalStemFilter.java
-     *
-     * @throws IOException
-     */
+import java.util.List;
+
+public class TokenPairConcatenatingFilterTest extends BaseTokenFilterTest {
+
     @Test
-    public void testEmptyTerm() {
-        Analyzer a = new Analyzer() {
+    @Disabled("Has been broken since change to reset logic in 74ff6d99e78eaef15c595fe35d7ed12d8c22a7a9")
+    public void testIncrementToken() throws Exception {
+        assertThat(processAllFrom("red blue green"), contains("red", "redblue", "blue", "bluegreen", "green"));
+    }
+
+    @Override
+    TokenFilter newFilter(@NonNull final TokenStream stream, List<String> terms) {
+        return new TokenPairConcatenatingFilter(stream) {
             @Override
-            protected Analyzer.TokenStreamComponents createComponents(String fieldName) {
-                Tokenizer tokenizer = new KeywordTokenizer();
-                return new Analyzer.TokenStreamComponents(tokenizer, new TokenPairConcatenatingFilter(tokenizer));
+            protected void appendTerm(String term) {
+                super.appendTerm(term);
+                terms.add(term);
             }
         };
-        try {
-            checkOneTerm(a, "", "");
-        } catch (IOException ex) {
-            fail("Failed test random strings: " + ex.getMessage());
-        }
     }
 }

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -29,6 +29,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <inceptionYear>2013</inceptionYear>
     <properties>
         <version.maven-plugin-plugin>3.15.2</version.maven-plugin-plugin>
+        <toolchain.jdk.test.home>${java.home}</toolchain.jdk.test.home>
     </properties>
     <scm>
         <connection>scm:git:https://github.com/dependency-check/DependencyCheck.git</connection>
@@ -113,16 +114,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-utils</artifactId>
             <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -216,25 +207,31 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <profiles>
         <profile>
             <id>FullIntegrationTesting</id>
-            <activation>
-                <property>
-                    <name>releaseTesting</name>
-                </property>
-            </activation>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <!-- Override any setting from the command line for other projects when running the integration tests to
+                            ensure we also run unit tests for maven project only -->
+                            <skipTests>false</skipTests>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>
                         <configuration>
                             <!--streamLogs>true</streamLogs-->
                             <parallelThreads>4</parallelThreads>
-                            <mavenOpts>${failsafeArgLine}</mavenOpts>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
                             <localRepositoryPath>target/local-repo</localRepositoryPath>
                             <properties>
                                 <odc.version>${project.version}</odc.version>
                             </properties>
+                            <!-- Doesn't seem a way to make this plugin toolchain aware, so have to use a property
+                                 or env var to get the JAVA_HOME from to match what surefire/failsafe are using -->
+                            <javaHome>${toolchain.jdk.test.home}</javaHome>
                         </configuration>
                         <executions>
                             <execution>
@@ -245,13 +242,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                                 </goals>
                             </execution>
                         </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.apache.commons</groupId>
-                                <artifactId>commons-lang3</artifactId>
-                                <version>${commons-lang3.version}</version>
-                            </dependency>
-                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -93,17 +93,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             </plugin>
         </plugins>
     </reporting>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-resolver-provider</artifactId>
-                <version>${maven.api.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.owasp</groupId>
@@ -180,11 +169,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/maven/src/it/1751-use-child-repositories/postbuild.groovy
+++ b/maven/src/it/1751-use-child-repositories/postbuild.groovy
@@ -16,7 +16,7 @@
  * Copyright (c) 2014 Jeremy Long. All Rights Reserved.
  */
 
-import groovy.util.XmlSlurper
+import groovy.xml.XmlSlurper
 
 String report = new File(basedir, "target/dependency-check-report.xml").text;
 

--- a/maven/src/it/690-threadsafety/first-a/pom.xml
+++ b/maven/src/it/690-threadsafety/first-a/pom.xml
@@ -39,7 +39,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>1.5.2.RELEASE</version>
+            <version>1.5.22.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.apache.james</groupId>

--- a/maven/src/it/690-threadsafety/first/pom.xml
+++ b/maven/src/it/690-threadsafety/first/pom.xml
@@ -39,7 +39,7 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>1.5.2.RELEASE</version>
+            <version>1.5.22.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.apache.james</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,6 @@ Copyright (c) 2012 - Jeremy Long
         <org.eclipse.parsson.jakarta.json.version>1.1.7</org.eclipse.parsson.jakarta.json.version>
         <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
         <maven-common-artifact-filters.version>3.4.0</maven-common-artifact-filters.version>
-        <groovy-all.version>2.4.21</groovy-all.version>
         <gmavenplus-plugin.version>4.3.0</gmavenplus-plugin.version>
         <com.h3xstream.retirejs.core.version>3.0.4</com.h3xstream.retirejs.core.version>
         <jackson.version>2.21.0</jackson.version>
@@ -349,13 +348,6 @@ Copyright (c) 2012 - Jeremy Long
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
                     <version>3.9.1</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.codehaus.groovy</groupId>
-                            <artifactId>groovy-all</artifactId>
-                            <version>${groovy-all.version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.gmavenplus</groupId>
@@ -363,9 +355,9 @@ Copyright (c) 2012 - Jeremy Long
                     <version>${gmavenplus-plugin.version}</version>
                     <dependencies>
                         <dependency>
-                            <groupId>org.codehaus.groovy</groupId>
-                            <artifactId>groovy-all</artifactId>
-                            <version>${groovy-all.version}</version>
+                            <groupId>org.apache.groovy</groupId>
+                            <artifactId>groovy-ant</artifactId>
+                            <version>5.0.4</version>
                             <scope>runtime</scope>
                         </dependency>
                     </dependencies>
@@ -376,14 +368,6 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy-all</artifactId>
-                        <version>${groovy-all.version}</version>
-                        <scope>runtime</scope>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>add-dynamic-properties-clean</id>

--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,9 @@ Copyright (c) 2012 - Jeremy Long
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.4.0</version>
+                    <configuration>
+                        <propertiesEncoding>ISO-8859-1</propertiesEncoding>
+                    </configuration>
                     <dependencies>
                         <dependency>
                             <groupId>org.owasp.maven-tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@ Copyright (c) 2012 - Jeremy Long
                 <plugin>
                     <groupId>org.jsonschema2pojo</groupId>
                     <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-                    <version>1.2.2</version>
+                    <version>1.3.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1143,11 +1143,6 @@ Copyright (c) 2012 - Jeremy Long
                 <version>${apache.lucene.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.lucene</groupId>
-                <artifactId>lucene-test-framework</artifactId>
-                <version>${apache.lucene.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>1.21.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,15 @@ Copyright (c) 2012 - Jeremy Long
         <!--necessary for some IDEs to be able to execute test cases (Netbeans)-->
         <surefireArgLine />
         <mock-server.version>5.15.0</mock-server.version>
+
+        <!--
+           Extra JVM arguments needed at runtime to avoid errors on modern JDKs from certain libraries.
+           enable-native-access=ALL-UNNAMED
+                Java 21+: Needed by Lucene indexes unless we do -Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false
+                          to go back to regular ByteBuffer (non-native) usage.
+           -XX:+IgnoreUnrecognizedVMOptions
+                Java <21: Allow use of enable-native-access on Java 11 JVMs without errors and without JVM-specific arg detection -->
+        <runtime.extra.jvm.args>--enable-native-access=ALL-UNNAMED -XX:+IgnoreUnrecognizedVMOptions</runtime.extra.jvm.args>
     </properties>
     <distributionManagement>
         <site>
@@ -440,6 +449,7 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <release>${maven.compiler.release}</release>
                     <showDeprecation>true</showDeprecation>
                     <compilerArgs>
                         <arg>-Xlint</arg>
@@ -629,9 +639,20 @@ Copyright (c) 2012 - Jeremy Long
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>@{surefireArgLine} -Dfile.encoding=UTF-8</argLine>
+                    <argLine>@{surefireArgLine} -javaagent:${org.mockito:mockito-core:jar} ${runtime.extra.jvm.args} -Dfile.encoding=UTF-8</argLine>
                     <failIfNoTests>false</failIfNoTests>
                     <systemPropertyVariables>
                         <data.directory>${project.build.directory}/data</data.directory>
@@ -644,7 +665,7 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <argLine>@{failsafeArgLine}</argLine>
+                    <argLine>@{failsafeArgLine} -javaagent:${org.mockito:mockito-core:jar} ${runtime.extra.jvm.args}</argLine>
                     <systemPropertyVariables>
                         <data.directory>${project.build.directory}/data</data.directory>
                         <temp.directory>${project.build.directory}/temp</temp.directory>
@@ -1345,12 +1366,22 @@ Copyright (c) 2012 - Jeremy Long
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -1375,6 +1406,36 @@ Copyright (c) 2012 - Jeremy Long
         <!-- endregion -->
     </dependencies>
     <profiles>
+        <profile>
+            <id>test-with-specific-toolchain</id>
+            <activation>
+                <property>
+                    <name>toolchain.jdk.test.version</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <jdkToolchain>
+                                <version>${toolchain.jdk.test.version}</version>
+                            </jdkToolchain>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <jdkToolchain>
+                                <version>${toolchain.jdk.test.version}</version>
+                            </jdkToolchain>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>release</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,6 @@ Copyright (c) 2012 - Jeremy Long
         <driver.mysql.version>9.6.0</driver.mysql.version>
         <!--necessary for some IDEs to be able to execute test cases (Netbeans)-->
         <surefireArgLine />
-        <mock-server.version>5.15.0</mock-server.version>
 
         <!--
            Extra JVM arguments needed at runtime to avoid errors on modern JDKs from certain libraries.
@@ -948,24 +947,6 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.anarres.jdiagnostics</groupId>
                 <artifactId>jdiagnostics</artifactId>
                 <version>1.0.7</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mock-server</groupId>
-                <artifactId>mockserver-core</artifactId>
-                <version>${mock-server.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mock-server</groupId>
-                <artifactId>mockserver-client-java</artifactId>
-                <scope>test</scope>
-                <version>${mock-server.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mock-server</groupId>
-                <artifactId>mockserver-junit-jupiter</artifactId>
-                <version>${mock-server.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,6 @@ Copyright (c) 2012 - Jeremy Long
         <spotbugs.maven.plugin.version>4.9.8.2</spotbugs.maven.plugin.version>
         <taglist-maven-plugin.version>3.2.2</taglist-maven-plugin.version>
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
-        <jetbrains.annotations.version>26.0.2-1</jetbrains.annotations.version>
         <com.h2database.version>2.4.240</com.h2database.version>
         <commons-cli.version>1.11.0</commons-cli.version>
         <commons-io.version>2.21.0</commons-io.version>
@@ -1381,8 +1380,8 @@ Copyright (c) 2012 - Jeremy Long
         <!-- endregion -->
         <!-- region generic annotation libraries for compile / codereview relevant annotations -->
         <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,8 @@ Copyright (c) 2012 - Jeremy Long
         <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
         <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
-        <maven-jxr-plugin.version>3.6.0</maven-jxr-plugin.version>
+        <!-- upgrading beyond 2.5 breaks maven site when aggregating for parent due to the ant module test dependency on core -->
+        <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
         <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
         <maven-surefire-report-plugin.version>3.5.4</maven-surefire-report-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
@@ -849,7 +850,7 @@ Copyright (c) 2012 - Jeremy Long
                     <reportSet>
                         <reports>
                             <report>summary</report>
-                            <report>issue-management </report>
+                            <report>issue-management</report>
                             <report>modules</report>
                             <report>team</report>
                             <report>scm</report>

--- a/pom.xml
+++ b/pom.xml
@@ -130,10 +130,9 @@ Copyright (c) 2012 - Jeremy Long
         <reporting.checkstyle.tool.version>9.3</reporting.checkstyle.tool.version>
         <doxia-base.version>2.0.0</doxia-base.version>
         <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
-        <maven-dependency-plugin.version>3.9.0</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
-        <!-- upgrading beyond 2.5 breaks maven site-->
-        <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
+        <maven-jxr-plugin.version>3.6.0</maven-jxr-plugin.version>
         <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
         <maven-surefire-report-plugin.version>3.5.4</maven-surefire-report-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
@@ -149,9 +148,6 @@ Copyright (c) 2012 - Jeremy Long
         <commons-text.version>1.15.0</commons-text.version>
         <httpcomponents.client.version>5.5.1</httpcomponents.client.version>
         <httpcomponents.core.version>5.3.6</httpcomponents.core.version>
-        <!-- note that logging will be noisy and broken until we upgrade to 3.2
-            See https://issues.apache.org/jira/browse/JCS-232 and
-            https://github.com/apache/commons-jcs/pull/120 -->
         <commons-jcs-core.version>3.2.1</commons-jcs-core.version>
         <aho-corasick-double-array-trie.version>1.2.3</aho-corasick-double-array-trie.version>
         <junit.version>5.14.2</junit.version>
@@ -362,6 +358,14 @@ Copyright (c) 2012 - Jeremy Long
                         </dependency>
                     </dependencies>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>${versions-maven-plugin.version}</version>
+                    <configuration>
+                        <ignoredVersions>.*-(alpha|beta|M|rc)[-0-9]+</ignoredVersions>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -555,14 +559,14 @@ Copyright (c) 2012 - Jeremy Long
                         </configuration>
                     </execution>
                     <execution>
-                        <id>enforce-maven-3</id>
+                        <id>enforce-maven</id>
                         <goals>
                             <goal>enforce</goal>
                         </goals>
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>[3.1,]</version>
+                                    <version>3.9.0</version>
                                 </requireMavenVersion>
                             </rules>
                             <fail>true</fail>
@@ -919,7 +923,6 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>${versions-maven-plugin.version}</version>
                 <reportSets>
                     <reportSet>
                         <reports>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,6 @@ Copyright (c) 2012 - Jeremy Long
         <taglist-maven-plugin.version>3.2.2</taglist-maven-plugin.version>
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
         <jetbrains.annotations.version>26.0.2-1</jetbrains.annotations.version>
-        <findbugs.spotbugs.version>4.9.8</findbugs.spotbugs.version>
         <com.h2database.version>2.4.240</com.h2database.version>
         <commons-cli.version>1.11.0</commons-cli.version>
         <commons-io.version>2.21.0</commons-io.version>
@@ -443,6 +442,7 @@ Copyright (c) 2012 - Jeremy Long
                     <release>${maven.compiler.release}</release>
                     <showDeprecation>true</showDeprecation>
                     <compilerArgs>
+                        <arg>-proc:none</arg>
                         <arg>-Xlint</arg>
                     </compilerArgs>
                 </configuration>
@@ -968,18 +968,6 @@ Copyright (c) 2012 - Jeremy Long
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-junit-jupiter</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-jcs3-core</artifactId>
                 <version>${commons-jcs-core.version}</version>
@@ -987,6 +975,11 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>org.apache.httpcomponents.client5</groupId>
                 <artifactId>httpclient5</artifactId>
+                <version>${httpcomponents.client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5-cache</artifactId>
                 <version>${httpcomponents.client.version}</version>
             </dependency>
             <dependency>
@@ -1004,9 +997,23 @@ Copyright (c) 2012 - Jeremy Long
                 <artifactId>commons-validator</artifactId>
                 <version>1.10.1</version>
                 <exclusions>
+                    <!-- Unnecessary capabilities -->
                     <exclusion>
                         <groupId>commons-beanutils</groupId>
                         <artifactId>commons-beanutils</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-collections</groupId>
+                        <artifactId>commons-collections</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-digester</groupId>
+                        <artifactId>commons-digester</artifactId>
+                    </exclusion>
+                    <!-- Replaced by org.slf4j:jcl-over-slf4j -->
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1014,6 +1021,13 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-dbcp2</artifactId>
                 <version>2.14.0</version>
+                <exclusions>
+                    <!-- Replaced by org.slf4j:jcl-over-slf4j -->
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.github.package-url</groupId>
@@ -1036,9 +1050,10 @@ Copyright (c) 2012 - Jeremy Long
                 <version>5.8.0</version>
             </dependency>
             <dependency>
-                <groupId>org.jetbrains</groupId>
-                <artifactId>annotations</artifactId>
-                <version>${jetbrains.annotations.version}</version>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>1.0.0</version>
+                <optional>true</optional>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>
@@ -1072,11 +1087,6 @@ Copyright (c) 2012 - Jeremy Long
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jsr310</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
@@ -1102,22 +1112,18 @@ Copyright (c) 2012 - Jeremy Long
                 <version>${logback.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>${mockito.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
                 <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-params</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -1128,21 +1134,16 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
                 <version>${apache.ant.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.sun</groupId>
-                        <artifactId>tools</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant-testutil</artifactId>
                 <version>${apache.ant.version}</version>
                 <exclusions>
+                    <!-- consolidated into org.hamcrest:hamcrest -->
                     <exclusion>
-                        <groupId>com.sun</groupId>
-                        <artifactId>tools</artifactId>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1175,6 +1176,18 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>com.h3xstream.retirejs</groupId>
                 <artifactId>retirejs-core</artifactId>
                 <version>${com.h3xstream.retirejs.core.version}</version>
+                <exclusions>
+                    <!-- Replace with canonical org.json:json -->
+                    <exclusion>
+                        <groupId>com.vaadin.external.google</groupId>
+                        <artifactId>android-json</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>20251224</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
@@ -1223,6 +1236,7 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.apache.maven.plugin-testing</groupId>
                 <artifactId>maven-plugin-testing-harness</artifactId>
                 <version>${maven-plugin-testing-harness.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.plugin-tools</groupId>
@@ -1278,6 +1292,11 @@ Copyright (c) 2012 - Jeremy Long
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.maven.shared</groupId>
                 <artifactId>maven-artifact-transfer</artifactId>
                 <version>${maven-artifact-transfer.version}</version>
@@ -1293,15 +1312,11 @@ Copyright (c) 2012 - Jeremy Long
                 <version>${doxia-base.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-annotations</artifactId>
-                <version>${findbugs.spotbugs.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.sonatype.ossindex</groupId>
                 <artifactId>ossindex-service-client</artifactId>
                 <version>1.8.2</version>
                 <exclusions>
+                    <!-- We use our own httpclient5 transport client -->
                     <exclusion>
                         <groupId>org.apache.httpcomponents</groupId>
                         <artifactId>httpclient</artifactId>
@@ -1310,20 +1325,27 @@ Copyright (c) 2012 - Jeremy Long
                         <groupId>org.apache.httpcomponents</groupId>
                         <artifactId>httpcore</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>jcl-over-slf4j</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>33.5.0-jre</version>
+                <exclusions>
+                    <!-- Not needed at runtime for ODC cases -->
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>listenablefuture</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.j2objc</groupId>
+                        <artifactId>j2objc-annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.hankcs</groupId>
@@ -1337,11 +1359,7 @@ Copyright (c) 2012 - Jeremy Long
                 <exclusions>
                     <exclusion>
                         <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcprov-jdk15on</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcpg-jdk15on</artifactId>
+                        <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1390,6 +1408,7 @@ Copyright (c) 2012 - Jeremy Long
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
+            <version>4.9.8</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -120,36 +120,7 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
                         </usedDependencies>
                     </configuration>
                 </plugin>
-
             </plugins>
         </pluginManagement>
     </build>
-    <profiles>
-        <profile>
-            <id>utils</id>
-            <activation>
-                <property>
-                    <name>testMavenPlugin</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -82,27 +82,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-client-java</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http</artifactId>
-            <version>4.2.10.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <pluginManagement>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -60,17 +60,18 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Downloader.java
@@ -45,7 +45,7 @@ import org.apache.hc.core5.http.io.entity.BasicHttpEntity;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -507,7 +507,7 @@ public final class Downloader {
      * @param credentialsProvider The credentialStore to configure the credentials in
      * @param authCache The AuthCache to cache the pre-empted credentials in
      */
-    private void tryConfigureProxyCredentials(@NotNull CredentialsStore credentialsProvider, @NotNull AuthCache authCache) {
+    private void tryConfigureProxyCredentials(@NonNull CredentialsStore credentialsProvider, @NonNull AuthCache authCache) {
         if (proxyPreEmptAuth != null) {
             credentialsProvider.setCredentials(proxyAuthScope, proxyCreds);
             authCache.put(proxyHttpHost, proxyPreEmptAuth);
@@ -648,7 +648,7 @@ public final class Downloader {
      * @throws TooManyRequestsException  When HTTP status 429 is encountered
      * @throws ResourceNotFoundException When HTTP status 404 is encountered
      */
-    public <T> T fetchAndHandle(@NotNull URL url, @NotNull HttpClientResponseHandler<T> handler)
+    public <T> T fetchAndHandle(@NonNull URL url, @NonNull HttpClientResponseHandler<T> handler)
             throws IOException, TooManyRequestsException, ResourceNotFoundException, URISyntaxException, ForbiddenException {
         return fetchAndHandle(url, handler, Collections.emptyList(), true);
     }
@@ -665,7 +665,7 @@ public final class Downloader {
      * @throws TooManyRequestsException  When HTTP status 429 is encountered
      * @throws ResourceNotFoundException When HTTP status 404 is encountered
      */
-    public <T> T fetchAndHandle(@NotNull URL url, @NotNull HttpClientResponseHandler<T> handler, @NotNull List<Header> hdr)
+    public <T> T fetchAndHandle(@NonNull URL url, @NonNull HttpClientResponseHandler<T> handler, @NonNull List<Header> hdr)
             throws IOException, TooManyRequestsException, ResourceNotFoundException, URISyntaxException, ForbiddenException {
         return fetchAndHandle(url, handler, hdr, true);
     }
@@ -683,7 +683,7 @@ public final class Downloader {
      * @throws TooManyRequestsException  When HTTP status 429 is encountered
      * @throws ResourceNotFoundException When HTTP status 404 is encountered
      */
-    public <T> T fetchAndHandle(@NotNull URL url, @NotNull HttpClientResponseHandler<T> handler, @NotNull List<Header> hdr, boolean useProxy)
+    public <T> T fetchAndHandle(@NonNull URL url, @NonNull HttpClientResponseHandler<T> handler, @NonNull List<Header> hdr, boolean useProxy)
             throws IOException, TooManyRequestsException, ResourceNotFoundException, URISyntaxException, ForbiddenException {
         final T data;
         if ("file".equals(url.getProtocol())) {
@@ -716,8 +716,8 @@ public final class Downloader {
      * @throws TooManyRequestsException  When HTTP status 429 is encountered
      * @throws ResourceNotFoundException When HTTP status 404 is encountered
      */
-    public <T> T fetchAndHandle(@NotNull CloseableHttpClient client, @NotNull URL url, @NotNull HttpClientResponseHandler<T> handler,
-                                @NotNull List<Header> hdr) throws IOException, TooManyRequestsException,
+    public <T> T fetchAndHandle(@NonNull CloseableHttpClient client, @NonNull URL url, @NonNull HttpClientResponseHandler<T> handler,
+                                @NonNull List<Header> hdr) throws IOException, TooManyRequestsException,
             ResourceNotFoundException, ForbiddenException {
         try {
             final String theProtocol = url.getProtocol();

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/FileUtils.java
@@ -33,8 +33,8 @@ import java.util.stream.Stream;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,8 +72,7 @@ public final class FileUtils {
      * @return the file extension.
      */
     @Nullable
-    public static String getFileExtension(@NotNull String fileName) {
-        @Nullable
+    public static String getFileExtension(@NonNull String fileName) {
         final String fileExt = FilenameUtils.getExtension(fileName);
         return StringUtils.isNoneEmpty(fileExt) ? StringUtils.lowerCase(fileExt) : null;
     }
@@ -113,7 +112,7 @@ public final class FileUtils {
      * @throws java.io.IOException thrown when a directory cannot be created
      * within the base directory
      */
-    @NotNull
+    @NonNull
     public static File createTempDirectory(@Nullable final File base) throws IOException {
         final File tempDir = new File(base, "dctemp" + UUID.randomUUID());
         if (tempDir.exists()) {
@@ -132,7 +131,7 @@ public final class FileUtils {
      *
      * @return a String containing the bit bucket
      */
-    @NotNull
+    @NonNull
     public static String getBitBucket() {
         return SystemUtils.IS_OS_WINDOWS ? BIT_BUCKET_WIN : BIT_BUCKET_UNIX;
     }
@@ -160,7 +159,7 @@ public final class FileUtils {
      * @return the input stream for the given resource
      * @throws FileNotFoundException if the file could not be found
      */
-    public static InputStream getResourceAsStream(@NotNull String resource) throws FileNotFoundException {
+    public static InputStream getResourceAsStream(@NonNull String resource) throws FileNotFoundException {
         final ClassLoader classLoader = FileUtils.class.getClassLoader();
         final InputStream inputStream = classLoader != null
                 ? classLoader.getResourceAsStream(resource)

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -18,14 +18,13 @@
 package org.owasp.dependencycheck.utils;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -958,7 +957,7 @@ public final class Settings {
      *
      * @param propertiesFilePath the path to the base properties file to load
      */
-    public Settings(@NotNull final String propertiesFilePath) {
+    public Settings(@NonNull final String propertiesFilePath) {
         initialize(propertiesFilePath);
     }
 
@@ -967,7 +966,7 @@ public final class Settings {
      *
      * @param propertiesFilePath the path to the settings property file
      */
-    private void initialize(@NotNull final String propertiesFilePath) {
+    private void initialize(@NonNull final String propertiesFilePath) {
         props = new Properties();
         try (InputStream in = FileUtils.getResourceAsStream(propertiesFilePath)) {
             props.load(in);
@@ -1009,7 +1008,7 @@ public final class Settings {
      * @return <code>true</code> if the key is for a sensitive property value;
      * otherwise <code>false</code>
      */
-    private boolean isKeyMasked(@NotNull String key) {
+    private boolean isKeyMasked(@NonNull String key) {
         if (maskedKeys == null || maskedKeys.isEmpty()) {
             initMaskedKeys();
         }
@@ -1024,7 +1023,7 @@ public final class Settings {
      * @param value the property value
      * @return the printable value
      */
-    String getPrintableValue(@NotNull String key, String value) {
+    String getPrintableValue(@NonNull String key, String value) {
         String printableValue = null;
         if (value != null) {
             printableValue = isKeyMasked(key) ? "********" : value;
@@ -1056,7 +1055,7 @@ public final class Settings {
      * @param header the header to print with the log message
      * @param properties the properties to log
      */
-    private void logProperties(@NotNull final String header, @NotNull final Properties properties) {
+    private void logProperties(@NonNull final String header, @NonNull final Properties properties) {
         if (LOGGER.isDebugEnabled()) {
             initMaskedKeys();
             final StringWriter sw = new StringWriter();
@@ -1082,7 +1081,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setString(@NotNull final String key, @NotNull final String value) {
+    public void setString(@NonNull final String key, @NonNull final String value) {
         props.setProperty(key, value);
         LOGGER.debug("Setting: {}='{}'", key, getPrintableValue(key, value));
     }
@@ -1093,7 +1092,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setStringIfNotNull(@NotNull final String key, @Nullable final String value) {
+    public void setStringIfNotNull(@NonNull final String key, @Nullable final String value) {
         if (null != value) {
             setString(key, value);
         }
@@ -1105,7 +1104,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setStringIfNotEmpty(@NotNull final String key, @Nullable final String value) {
+    public void setStringIfNotEmpty(@NonNull final String key, @Nullable final String value) {
         if (null != value && !value.isEmpty()) {
             setString(key, value);
         }
@@ -1117,7 +1116,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setArrayIfNotEmpty(@NotNull final String key, @Nullable final String[] value) {
+    public void setArrayIfNotEmpty(@NonNull final String key, @Nullable final String[] value) {
         if (null != value && value.length > 0) {
             try {
                 setString(key, objectMapper.writeValueAsString(value));
@@ -1133,7 +1132,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setArrayIfNotEmpty(@NotNull final String key, @Nullable final List<String> value) {
+    public void setArrayIfNotEmpty(@NonNull final String key, @Nullable final List<String> value) {
         if (null != value && !value.isEmpty()) {
             try {
                 setString(key, objectMapper.writeValueAsString(value));
@@ -1149,7 +1148,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setBoolean(@NotNull final String key, boolean value) {
+    public void setBoolean(@NonNull final String key, boolean value) {
         setString(key, Boolean.toString(value));
     }
 
@@ -1159,7 +1158,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setBooleanIfNotNull(@NotNull final String key, @Nullable final Boolean value) {
+    public void setBooleanIfNotNull(@NonNull final String key, @Nullable final Boolean value) {
         if (null != value) {
             setBoolean(key, value);
         }
@@ -1171,7 +1170,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setFloat(@NotNull final String key, final float value) {
+    public void setFloat(@NonNull final String key, final float value) {
         setString(key, Float.toString(value));
     }
 
@@ -1181,7 +1180,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setInt(@NotNull final String key, final int value) {
+    public void setInt(@NonNull final String key, final int value) {
         props.setProperty(key, String.valueOf(value));
         LOGGER.debug("Setting: {}='{}'", key, value);
     }
@@ -1192,7 +1191,7 @@ public final class Settings {
      * @param key the key for the property
      * @param value the value for the property
      */
-    public void setIntIfNotNull(@NotNull final String key, @Nullable final Integer value) {
+    public void setIntIfNotNull(@NonNull final String key, @Nullable final Integer value) {
         if (null != value) {
             setInt(key, value);
         }
@@ -1211,7 +1210,7 @@ public final class Settings {
      * loading/merging the properties
      */
     @SuppressFBWarnings(justification = "try with resource will clenaup the resources", value = {"OBL_UNSATISFIED_OBLIGATION"})
-    public void mergeProperties(@NotNull final File filePath) throws FileNotFoundException, IOException {
+    public void mergeProperties(@NonNull final File filePath) throws FileNotFoundException, IOException {
         try (FileInputStream fis = new FileInputStream(filePath)) {
             mergeProperties(fis);
         }
@@ -1230,7 +1229,7 @@ public final class Settings {
      * loading/merging the properties
      */
     @SuppressFBWarnings(justification = "try with resource will clenaup the resources", value = {"OBL_UNSATISFIED_OBLIGATION"})
-    public void mergeProperties(@NotNull final String filePath) throws FileNotFoundException, IOException {
+    public void mergeProperties(@NonNull final String filePath) throws FileNotFoundException, IOException {
         try (FileInputStream fis = new FileInputStream(filePath)) {
             mergeProperties(fis);
         }
@@ -1246,7 +1245,7 @@ public final class Settings {
      * @throws java.io.IOException is thrown when there is an exception
      * loading/merging the properties
      */
-    public void mergeProperties(@NotNull final InputStream stream) throws IOException {
+    public void mergeProperties(@NonNull final InputStream stream) throws IOException {
         props.load(stream);
         logProperties("Properties updated via merge", props);
     }
@@ -1261,7 +1260,7 @@ public final class Settings {
      * @return the property from the properties file converted to a File object
      */
     @Nullable
-    public File getFile(@NotNull final String key) {
+    public File getFile(@NonNull final String key) {
         final String file = getString(key);
         if (file == null) {
             return null;
@@ -1283,7 +1282,7 @@ public final class Settings {
      * @param key the key to lookup within the properties file
      * @return the property from the properties file converted to a File object
      */
-    File getDataFile(@NotNull final String key) {
+    File getDataFile(@NonNull final String key) {
         final String file = getString(key);
         LOGGER.debug("Settings.getDataFile() - file: '{}'", file);
         if (file == null) {
@@ -1337,7 +1336,7 @@ public final class Settings {
      * @param defaultValue the default value for the requested property
      * @return the property from the properties file
      */
-    public String getString(@NotNull final String key, @Nullable final String defaultValue) {
+    public String getString(@NonNull final String key, @Nullable final String defaultValue) {
         return System.getProperty(key, props.getProperty(key, defaultValue));
     }
 
@@ -1364,7 +1363,7 @@ public final class Settings {
      * @param key the key to lookup within the properties file
      * @return the property from the properties file
      */
-    public String getString(@NotNull final String key) {
+    public String getString(@NonNull final String key) {
         return System.getProperty(key, props.getProperty(key));
     }
 
@@ -1377,7 +1376,7 @@ public final class Settings {
      * {@link org.owasp.dependencycheck.utils.Settings}.
      * @return the list or {@code null} if the key wasn't present.
      */
-    public String[] getArray(@NotNull final String key) {
+    public String[] getArray(@NonNull final String key) {
         final String string = getString(key);
         if (string != null) {
             if (string.charAt(0) == '{' || string.charAt(0) == '[') {
@@ -1399,7 +1398,7 @@ public final class Settings {
      *
      * @param key the property key to remove
      */
-    public void removeProperty(@NotNull final String key) {
+    public void removeProperty(@NonNull final String key) {
         props.remove(key);
     }
 
@@ -1414,7 +1413,7 @@ public final class Settings {
      * @throws org.owasp.dependencycheck.utils.InvalidSettingException is thrown
      * if there is an error retrieving the setting
      */
-    public int getInt(@NotNull final String key) throws InvalidSettingException {
+    public int getInt(@NonNull final String key) throws InvalidSettingException {
         try {
             return Integer.parseInt(getString(key));
         } catch (NumberFormatException ex) {
@@ -1433,7 +1432,7 @@ public final class Settings {
      * @return the property from the properties file or the defaultValue if the
      * property does not exist or cannot be converted to an integer
      */
-    public int getInt(@NotNull final String key, int defaultValue) {
+    public int getInt(@NonNull final String key, int defaultValue) {
         int value;
         try {
             value = Integer.parseInt(getString(key));
@@ -1458,7 +1457,7 @@ public final class Settings {
      * @throws org.owasp.dependencycheck.utils.InvalidSettingException is thrown
      * if there is an error retrieving the setting
      */
-    public long getLong(@NotNull final String key) throws InvalidSettingException {
+    public long getLong(@NonNull final String key) throws InvalidSettingException {
         try {
             return Long.parseLong(getString(key));
         } catch (NumberFormatException ex) {
@@ -1477,7 +1476,7 @@ public final class Settings {
      * @return the property from the properties file or the defaultValue if the
      * property does not exist or cannot be converted to an integer
      */
-    public long getLong(@NotNull final String key, long defaultValue) {
+    public long getLong(@NonNull final String key, long defaultValue) {
         long value;
         try {
             value = Long.parseLong(getString(key));
@@ -1503,7 +1502,7 @@ public final class Settings {
      * @throws org.owasp.dependencycheck.utils.InvalidSettingException is thrown
      * if there is an error retrieving the setting
      */
-    public boolean getBoolean(@NotNull final String key) throws InvalidSettingException {
+    public boolean getBoolean(@NonNull final String key) throws InvalidSettingException {
         return Boolean.parseBoolean(getString(key));
     }
 
@@ -1519,7 +1518,7 @@ public final class Settings {
      * exist
      * @return the property from the properties file
      */
-    public boolean getBoolean(@NotNull final String key, boolean defaultValue) {
+    public boolean getBoolean(@NonNull final String key, boolean defaultValue) {
         return Boolean.parseBoolean(getString(key, Boolean.toString(defaultValue)));
     }
 
@@ -1535,7 +1534,7 @@ public final class Settings {
      * exist
      * @return the property from the properties file
      */
-    public float getFloat(@NotNull final String key, float defaultValue) {
+    public float getFloat(@NonNull final String key, float defaultValue) {
         float retValue = defaultValue;
         try {
             retValue = Float.parseFloat(getString(key));
@@ -1637,7 +1636,7 @@ public final class Settings {
      * @return a temporary File
      * @throws java.io.IOException if any.
      */
-    public File getTempFile(@NotNull final String prefix, @NotNull final String extension) throws IOException {
+    public File getTempFile(@NonNull final String prefix, @NonNull final String extension) throws IOException {
         final File dir = getTempDirectory();
         final String tempFileName = String.format("%s%s.%s", prefix, UUID.randomUUID(), extension);
         final File tempFile = new File(dir, tempFileName);

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/XmlUtils.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/XmlUtils.java
@@ -27,8 +27,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.VisibleForTesting;
+import com.google.common.annotations.VisibleForTesting;
+import org.jspecify.annotations.NonNull;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -153,7 +153,7 @@ public final class XmlUtils {
         return buildSecureSaxParserFactory().newSAXParser();
     }
 
-    private static @NotNull SAXParserFactory buildSecureSaxParserFactory() throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+    private static @NonNull SAXParserFactory buildSecureSaxParserFactory() throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
         final SAXParserFactory factory = SAXParserFactory.newInstance();
 
         // See https://xerces.apache.org/xerces2-j/features.html and

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/XmlUtilsTest.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/XmlUtilsTest.java
@@ -1,7 +1,7 @@
 package org.owasp.dependencycheck.utils;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -104,7 +104,7 @@ class XmlUtilsTest {
         }
     }
 
-    private static @NotNull XMLReader withDefaultReader(AutoCloseableInputSource... schemas)
+    private static @NonNull XMLReader withDefaultReader(AutoCloseableInputSource... schemas)
             throws ParserConfigurationException, SAXException {
         XMLReader xmlReader = XmlUtils.buildSecureValidatingXmlReader(schemas);
         xmlReader.setErrorHandler(new ErrorHandler() {


### PR DESCRIPTION
## Description of Change

As discussed in https://github.com/dependency-check/DependencyCheck/pull/8275#issuecomment-3841308401 this change switches Dependency Check to

- run Maven and compile using the same "default" JVM (upgraded to Java 11 --> 25)
- `-release` target is still Java 11 (as before), ensuring compile time and `bootclasspath` compatibility.
- run all unit, integration and maven release tests against all of Java 11/17/21/25 to ensure runtime compatibility

This should allow us to
- update build-time plugins to later versions while maintaining confidence on a target Java version
- better support/replicate issues on newer Java versions rather than only running with the minimum

### Additional detail

In order to do this and ensure it is as safe as possible this change as a side effect:

_Dev Experience_
- everything will work as before when running from CLI or IDE - for convenience, tests and compile will run with the same JVM as Maven
- Maven is not enforcing running/compiling with a fixed JDK right now; only GitHub Actions controls that
- running tests with specific JDK versions via Maven toolchains requires opt-in with `-Dtoolchain.jdk.test.version` (and `-Dtoolchain.jdk.test.home` for maven integration tests, unfortunately) which activates a Maven profile
- fixes warnings from both Mockito and ODC's own code when running tests on newer JVM versions

_GitHub Actions_
- runs tests in a matrix in parallel
  - for simplicity, each run compiles the code itself rather than consuming artifacts. This could be changed.
  - only the "default" JDK version archives its compiled results/deploys snapshot
- switches to using `setup-java` to manage primary maven cache rather than doing manually
- further aligns build jobs between PR/`main`/`release`

_Dependencies_
- consolidates nullness annotations on `org.jspecify:jspecify` similar to other projects (rather than jetbrains annotations)
- upgrades ancient `org.json` library to supported variant rather than stale google android fork
- cleans up exclusions and dependency clashes for transitives that we don't need
  - removes unused `mockserver` dependency
  - correctly removes transitive `bouncycastle` dependency from `packager-rpm` as originally intended
  - removes compile-only dependencies from guava
  - `maven` plugin project
    - fixes mockito version clashes on `maven` project from the resolver BOM
    - aligns junit version being used
    - upgrades test groovy dependency to current
    - upgrades one test dependency to ensure it works on modern JVMs

## Related issues

N/A

## Have test cases been added to cover the new functionality?

yes

- validated that all surefire/failsafe tests are running with the chosen JVM
- validated that the maven plugin tests are running with the configured JVM
- validated builds aren't taking significantly longer to run
- validated the GitHub workflow runs ok on `main` ([see this run](https://github.com/chadlwilson/DependencyCheck/actions/runs/21858751201))
- diffed the `ant` and `cli` build archives to ensure any differences in dependencies are expected
- sanity checked maven `site` generation
- sanity checked with the gradle plugin and its tests
