### PR TITLE
fix: evidence source in Retire JS analyzer

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzer.java
@@ -320,9 +320,9 @@ public class RetireJsAnalyzer extends AbstractFileTypeAnalyzer {
                         dependency.addSoftwareIdentifier(id);
                     }
 
-                    dependency.addEvidence(EvidenceType.VERSION, "file", "version", libraryResult.getDetectedVersion(), Confidence.HIGH);
-                    dependency.addEvidence(EvidenceType.PRODUCT, "file", "name", libraryResult.getLibrary().getName(), Confidence.HIGH);
-                    dependency.addEvidence(EvidenceType.VENDOR, "file", "name", libraryResult.getLibrary().getName(), Confidence.HIGH);
+                    dependency.addEvidence(EvidenceType.VERSION, "RetireJS", "version", libraryResult.getDetectedVersion(), Confidence.HIGH);
+                    dependency.addEvidence(EvidenceType.PRODUCT, "RetireJS", "name", libraryResult.getLibrary().getName(), Confidence.HIGH);
+                    dependency.addEvidence(EvidenceType.VENDOR, "RetireJS", "name", libraryResult.getLibrary().getName(), Confidence.HIGH);
 
                     final List<Vulnerability> vulns = new ArrayList<>();
                     final JsVulnerability jsVuln = libraryResult.getVuln();


### PR DESCRIPTION
## Description of Change

The Retire JS Analyzer reports evidence with source set to `file`, which is used by File Name Analyzer. I changed it to `RetireJS` which seems to be inline with the source of similar analyzers.

## Related issues

None that I'm aware of.

## Have test cases been added to cover the new functionality?

No.