### PR TITLE
chore: avoid use of parent pom and maven properties where unnecessary

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -468,7 +468,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
-                        <version>${maven-dependency-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>copy-test-dependencies</id>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -28,6 +28,8 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
     <description>dependency-check-maven is a Maven Plugin that uses dependency-check-core to detect publicly disclosed vulnerabilities associated with the project's dependencies. The plugin will generate a report listing the dependency, any identified Common Platform Enumeration (CPE) identifiers, and the associated Common Vulnerability and Exposure (CVE) entries.</description>
     <inceptionYear>2013</inceptionYear>
     <properties>
+        <maven.api.version>3.6.3</maven.api.version>
+
         <version.maven-plugin-plugin>3.15.2</version.maven-plugin-plugin>
         <toolchain.jdk.test.home>${java.home}</toolchain.jdk.test.home>
     </properties>
@@ -38,8 +40,102 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
         <tag>HEAD</tag>
     </scm>
     <prerequisites>
-        <maven>3.6.3</maven>
+        <maven>${maven.api.version}</maven>
     </prerequisites>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>${maven.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-shared-utils</artifactId>
+                <version>3.4.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-plugin-api</artifactId>
+                <version>${maven.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>file-management</artifactId>
+                <version>3.2.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-settings</artifactId>
+                <version>${maven.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-model</artifactId>
+                <version>${maven.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-artifact</artifactId>
+                <version>${maven.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-settings-builder</artifactId>
+                <version>${maven.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.plugin-tools</groupId>
+                <artifactId>maven-plugin-annotations</artifactId>
+                <version>3.15.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.reporting</groupId>
+                <artifactId>maven-reporting-api</artifactId>
+                <version>4.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.doxia</groupId>
+                <artifactId>doxia-sink-api</artifactId>
+                <version>2.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-dependency-tree</artifactId>
+                <version>3.3.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-artifact-transfer</artifactId>
+                <version>0.13.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-common-artifact-filters</artifactId>
+                <version>3.4.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>4.0.2</version>
+            </dependency>
+            <dependency>
+                <!--
+                    https://github.com/codehaus-plexus/plexus-utils/blob/master/README.md
+                    for Maven 3 compatibility plexus-xml should be at version 3.x
+                    -->
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-xml</artifactId>
+                <version>3.0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.plugin-testing</groupId>
+                <artifactId>maven-plugin-testing-harness</artifactId>
+                <version>3.5.1</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <resources>
             <resource>
@@ -84,15 +180,6 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             </plugin>
         </plugins>
     </build>
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-plugin-report-plugin</artifactId>
-                <version>${version.maven-plugin-plugin}</version>
-            </plugin>
-        </plugins>
-    </reporting>
     <dependencies>
         <dependency>
             <groupId>org.owasp</groupId>
@@ -120,46 +207,9 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.doxia</groupId>
-            <artifactId>doxia-sink-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>file-management</artifactId>
-        </dependency>
-        <dependency><!--upgrade transitive dependency due to reported vulns-->
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-xml</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.reporting</groupId>
-            <artifactId>maven-reporting-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-settings-builder</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-dependency-tree</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugin-testing</groupId>
-            <artifactId>maven-plugin-testing-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-artifact-transfer</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -170,6 +220,39 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings-builder</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.reporting</groupId>
+            <artifactId>maven-reporting-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-sink-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>file-management</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-xml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-artifact-transfer</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
@@ -187,7 +270,21 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
             <groupId>com.github.package-url</groupId>
             <artifactId>packageurl-java</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-testing</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-report-plugin</artifactId>
+                <version>${version.maven-plugin-plugin}</version>
+            </plugin>
+        </plugins>
+    </reporting>
     <profiles>
         <profile>
             <id>FullIntegrationTesting</id>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -50,19 +50,9 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                 <version>${maven.api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.maven.shared</groupId>
-                <artifactId>maven-shared-utils</artifactId>
-                <version>3.4.2</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
                 <version>${maven.api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.shared</groupId>
-                <artifactId>file-management</artifactId>
-                <version>3.2.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
@@ -113,6 +103,11 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                 <groupId>org.apache.maven.shared</groupId>
                 <artifactId>maven-common-artifact-filters</artifactId>
                 <version>3.4.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>file-management</artifactId>
+                <version>3.2.0</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -116,58 +116,31 @@ Copyright (c) 2012 - Jeremy Long
         <project.build.outputTimestamp>2026-01-09T12:38:08Z</project.build.outputTimestamp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <github.global.server>github</github.global.server>
 
-        <apache.lucene.version>9.12.3</apache.lucene.version>
-        <apache.ant.version>1.10.15</apache.ant.version>
+        <!-- Reporting plugins do not inherit from plugin management, so de-duplicate versions via properties -->
+        <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
+        <checkstyle.tool.version>9.3</checkstyle.tool.version>
+        <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+        <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
+        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
+        <spotbugs.maven.plugin.version>4.9.8.2</spotbugs.maven.plugin.version>
 
         <!-- upgrading slf4j and logback can cause issues ;) https://github.com/dependency-check/DependencyCheck/issues/4846 -->
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.25</logback.version>
 
-        <maven.api.version>3.6.3</maven.api.version>
-        <reporting.checkstyle-plugin.version>3.6.0</reporting.checkstyle-plugin.version>
-        <reporting.checkstyle.tool.version>9.3</reporting.checkstyle.tool.version>
-        <doxia-base.version>2.0.0</doxia-base.version>
-        <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
-        <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
-        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
-        <!-- upgrading beyond 2.5 breaks maven site when aggregating for parent due to the ant module test dependency on core -->
-        <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
-        <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
-        <maven-surefire-report-plugin.version>3.5.5</maven-surefire-report-plugin.version>
-        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
-        <spotbugs.maven.plugin.version>4.9.8.2</spotbugs.maven.plugin.version>
-        <taglist-maven-plugin.version>3.2.2</taglist-maven-plugin.version>
-        <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
-        <com.h2database.version>2.4.240</com.h2database.version>
-        <commons-cli.version>1.11.0</commons-cli.version>
-        <commons-io.version>2.21.0</commons-io.version>
-        <commons-lang3.version>3.20.0</commons-lang3.version>
-        <commons-text.version>1.15.0</commons-text.version>
-        <httpcomponents.client.version>5.5.1</httpcomponents.client.version>
-        <httpcomponents.core.version>5.3.6</httpcomponents.core.version>
-        <commons-jcs-core.version>3.2.1</commons-jcs-core.version>
-        <aho-corasick-double-array-trie.version>1.2.3</aho-corasick-double-array-trie.version>
-        <junit.version>5.14.3</junit.version>
-        <hamcrest.version>3.0</hamcrest.version>
-        <mockito.version>5.21.0</mockito.version>
-        <jsoup.version>1.22.1</jsoup.version>
-        <commons-compress.version>1.27.1</commons-compress.version>
-        <org.apache.maven.shared.file-management.version>3.2.0</org.apache.maven.shared.file-management.version>
-        <maven-plugin-testing-harness.version>3.5.1</maven-plugin-testing-harness.version>
-        <maven-plugin-annotations.version>3.15.2</maven-plugin-annotations.version>
-        <maven-reporting-api.version>4.0.0</maven-reporting-api.version>
-        <org.apache.velocity.version>2.4.1</org.apache.velocity.version>
-        <maven-dependency-tree.version>3.3.0</maven-dependency-tree.version>
-        <org.eclipse.parsson.jakarta.json.version>1.1.7</org.eclipse.parsson.jakarta.json.version>
-        <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
-        <maven-common-artifact-filters.version>3.4.0</maven-common-artifact-filters.version>
-        <gmavenplus-plugin.version>4.3.1</gmavenplus-plugin.version>
-        <com.h3xstream.retirejs.core.version>3.0.4</com.h3xstream.retirejs.core.version>
-        <jackson.version>2.21.1</jackson.version>
+        <apache.lucene.version>9.12.3</apache.lucene.version>
+        <!-- Driver versions as properties for ease of extraction for reuse in Docker builds -->
+        <driver.h2database.version>2.4.240</driver.h2database.version>
         <driver.postgresql.version>42.7.10</driver.postgresql.version>
         <driver.mysql.version>9.6.0</driver.mysql.version>
+
+        <apache.ant.version>1.10.15</apache.ant.version>
+        <httpcomponents.client.version>5.5.1</httpcomponents.client.version>
+        <httpcomponents.core.version>5.3.6</httpcomponents.core.version>
+        <junit.version>5.14.3</junit.version>
+
         <!--necessary for some IDEs to be able to execute test cases (Netbeans)-->
         <surefireArgLine />
 
@@ -299,7 +272,7 @@ Copyright (c) 2012 - Jeremy Long
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.4</version>
+                    <version>3.5.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -332,12 +305,12 @@ Copyright (c) 2012 - Jeremy Long
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>${reporting.checkstyle-plugin.version}</version>
+                    <version>${maven-checkstyle-plugin.version}</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>${reporting.checkstyle.tool.version}</version>
+                            <version>${checkstyle.tool.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -349,7 +322,7 @@ Copyright (c) 2012 - Jeremy Long
                 <plugin>
                     <groupId>org.codehaus.gmavenplus</groupId>
                     <artifactId>gmavenplus-plugin</artifactId>
-                    <version>${gmavenplus-plugin.version}</version>
+                    <version>4.3.1</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.groovy</groupId>
@@ -362,7 +335,7 @@ Copyright (c) 2012 - Jeremy Long
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>${versions-maven-plugin.version}</version>
+                    <version>2.21.0</version>
                     <configuration>
                         <ignoredVersions>.*-(alpha|beta|M|rc)[-0-9]+</ignoredVersions>
                     </configuration>
@@ -512,7 +485,6 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
                     <failOnError>false</failOnError>
                     <bottom>Copyright© 2012-21 Jeremy Long. All Rights Reserved.</bottom>
@@ -709,7 +681,6 @@ Copyright (c) 2012 - Jeremy Long
                 <inherited>false</inherited>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>${maven-antrun-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>copy-xsd</id>
@@ -754,7 +725,6 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${reporting.checkstyle-plugin.version}</version>
                 <executions>
                     <execution>
                         <inherited>false</inherited>
@@ -826,12 +796,13 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>${maven-jxr-plugin.version}</version>
+                <!-- upgrading beyond 2.5 breaks maven site when aggregating for parent due to the ant module test dependency on core -->
+                <version>2.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${reporting.checkstyle-plugin.version}</version>
+                <version>${maven-checkstyle-plugin.version}</version>
                 <configuration>
                     <enableRulesSummary>false</enableRulesSummary>
                     <enableFilesSummary>false</enableFilesSummary>
@@ -863,7 +834,7 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>${maven-surefire-report-plugin.version}</version>
+                <version>3.5.5</version>
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -901,7 +872,7 @@ Copyright (c) 2012 - Jeremy Long
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>taglist-maven-plugin</artifactId>
-                <version>${taglist-maven-plugin.version}</version>
+                <version>3.2.2</version>
                 <configuration>
                     <tagListOptions>
                         <tagClasses>
@@ -951,7 +922,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-jcs3-core</artifactId>
-                <version>${commons-jcs-core.version}</version>
+                <version>3.2.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents.client5</groupId>
@@ -1039,48 +1010,34 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>${com.h2database.version}</version>
+                <version>${driver.h2database.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
-                <version>${commons-cli.version}</version>
-            </dependency>
-            <dependency><!--upgrade transitive dependency due to reported vulns-->
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-utils</artifactId>
-                <version>4.0.2</version>
-            </dependency>
-            <dependency>
-                <!--
-                    https://github.com/codehaus-plexus/plexus-utils/blob/master/README.md
-                    for Maven 3 compatibility plexus-xml should be at version 3.x
-                    -->
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-xml</artifactId>
-                <version>3.0.1</version>
+                <version>1.11.0</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
+                <version>2.21.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>${commons-io.version}</version>
+                <version>2.21.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.version}</version>
+                <version>3.20.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>${commons-text.version}</version>
+                <version>1.15.0</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
@@ -1095,7 +1052,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-bom</artifactId>
-                <version>${mockito.version}</version>
+                <version>5.21.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -1109,7 +1066,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>${commons-compress.version}</version>
+                <version>1.27.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.ant</groupId>
@@ -1151,7 +1108,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>com.h3xstream.retirejs</groupId>
                 <artifactId>retirejs-core</artifactId>
-                <version>${com.h3xstream.retirejs.core.version}</version>
+                <version>3.0.4</version>
                 <exclusions>
                     <!-- Replace with canonical org.json:json -->
                     <exclusion>
@@ -1166,66 +1123,6 @@ Copyright (c) 2012 - Jeremy Long
                 <version>20251224</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-core</artifactId>
-                <version>${maven.api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.shared</groupId>
-                <artifactId>maven-shared-utils</artifactId>
-                <version>3.4.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-plugin-api</artifactId>
-                <version>${maven.api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.shared</groupId>
-                <artifactId>file-management</artifactId>
-                <version>${org.apache.maven.shared.file-management.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-settings</artifactId>
-                <version>${maven.api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-model</artifactId>
-                <version>${maven.api.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-artifact</artifactId>
-                <version>${maven.api.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-settings-builder</artifactId>
-                <version>${maven.api.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.plugin-testing</groupId>
-                <artifactId>maven-plugin-testing-harness</artifactId>
-                <version>${maven-plugin-testing-harness.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.plugin-tools</groupId>
-                <artifactId>maven-plugin-annotations</artifactId>
-                <version>${maven-plugin-annotations.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.reporting</groupId>
-                <artifactId>maven-reporting-api</artifactId>
-                <version>${maven-reporting-api.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-collections4</artifactId>
                 <version>4.5.0</version>
@@ -1233,29 +1130,23 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>org.apache.velocity</groupId>
                 <artifactId>velocity-engine-core</artifactId>
-                <version>${org.apache.velocity.version}</version>
-            </dependency>
-            <!-- upgrading beyond 2.2 requires reworking the dependency resolution -->
-            <dependency>
-                <groupId>org.apache.maven.shared</groupId>
-                <artifactId>maven-dependency-tree</artifactId>
-                <version>${maven-dependency-tree.version}</version>
+                <version>2.4.1</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.parsson</groupId>
                 <artifactId>jakarta.json</artifactId>
-                <version>${org.eclipse.parsson.jakarta.json.version}</version>
+                <version>1.1.7</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>
-                <version>${hamcrest.version}</version>
+                <version>3.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>${jsoup.version}</version>
+                <version>1.22.1</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -1271,21 +1162,6 @@ Copyright (c) 2012 - Jeremy Long
                 <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
                 <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.shared</groupId>
-                <artifactId>maven-artifact-transfer</artifactId>
-                <version>${maven-artifact-transfer.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.shared</groupId>
-                <artifactId>maven-common-artifact-filters</artifactId>
-                <version>${maven-common-artifact-filters.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.doxia</groupId>
-                <artifactId>doxia-sink-api</artifactId>
-                <version>${doxia-base.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.sonatype.ossindex</groupId>
@@ -1326,7 +1202,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>com.hankcs</groupId>
                 <artifactId>aho-corasick-double-array-trie</artifactId>
-                <version>${aho-corasick-double-array-trie.version}</version>
+                <version>1.2.3</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.packager</groupId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -90,7 +90,6 @@ Copyright (c) 2014 - Jeremy Long. All Rights Reserved.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>${maven-dependency-plugin.version}</version>
                     <configuration>
                         <usedDependencies combine.children="append">
                             <!-- logback is our logging implementation during test and is test-scoped due to a lack of a


### PR DESCRIPTION
## Description of Change

IMHO our current way of using properties 
- adds unnecessarily confusing indirection to dependencies when tracking dependency clashes down
- sometimes for plugins separates versions from the configuration that may be specific to that version you might want to see when reviewing a dependabot PR
- tends to cause merge conflicts across dependabot PRs (minor nitpick)

Parent POM `pluginManagement`/`dependencyManagement` already serves this purpose for the most part, so I suggest should we reserve use of properties for cases where we really need to de-duplicate versions (even though dependabot can help us with updating such duplicates anyway) or add clarity for coupled versions via the properties.

Additionally, it is clearer to manage the special dependencies for the maven plugin in its own `dependencyManagement` since this has no effect on the rest of ODC, doesn't need the parent POM to reference; and has its own considerations to consider in isolation.

Appreciate this is a bit irritating to review, but can rest assured that if I accidentally downgraded anything that dependabot will re-upgrade it :-)

## Related issues

N/A

## Have test cases been added to cover the new functionality?

yes