### PR TITLE
fix: raw type warning in ProcessReader

### DIFF
--- a/utils/src/main/java/org/owasp/dependencycheck/utils/processing/ProcessReader.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/processing/ProcessReader.java
@@ -127,7 +127,7 @@ public class ProcessReader implements AutoCloseable {
      *
      * @param p a reference to the processor to start.
      */
-    private void startProcessor(Processor p) {
+    private void startProcessor(Processor<InputStream> p) {
         if (p != null) {
             final Thread t = new Thread(p);
             threads.add(t);


### PR DESCRIPTION
Adds explicit generic type parameter to the `Processor` argument in the `startProcessor` method. Raw types bypass compile-time type checking and can generate unchecked warnings. The method was already using `Processor<InputStream>` semantically, so making this explicit improves type safety.

Fixes #8323