### PR TITLE
chore: fix Charset warnings; preferring typed charsets

### DIFF
--- a/ant/src/test/java/org/owasp/dependencycheck/ant/logging/AntSlf4jServiceProviderTest.java
+++ b/ant/src/test/java/org/owasp/dependencycheck/ant/logging/AntSlf4jServiceProviderTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.spi.SLF4JServiceProvider;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -100,7 +101,7 @@ class AntSlf4jServiceProviderTest {
                     assertEquals(AntSlf4jServiceProvider.class.getName(), line.trim());
                 }
             } else {
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, UTF_8))) {
                     String line = reader.readLine();
                     assertNotNull(line);
                     assertEquals(AntSlf4jServiceProvider.class.getName(), line.trim());

--- a/cli/src/test/java/org/owasp/dependencycheck/CliParserTest.java
+++ b/cli/src/test/java/org/owasp/dependencycheck/CliParserTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.PrintStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -51,7 +50,7 @@ class CliParserTest extends BaseTest {
         String[] args = {};
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(baos));
+        System.setOut(new PrintStream(baos, true, UTF_8));
 
         CliParser instance = new CliParser(getSettings());
         instance.parse(args);
@@ -165,8 +164,8 @@ class CliParserTest extends BaseTest {
 
         ByteArrayOutputStream baos_out = new ByteArrayOutputStream();
         ByteArrayOutputStream baos_err = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(baos_out));
-        System.setErr(new PrintStream(baos_err));
+        System.setOut(new PrintStream(baos_out, true, UTF_8));
+        System.setErr(new PrintStream(baos_err, true, UTF_8));
 
         CliParser instance = new CliParser(getSettings());
 
@@ -249,20 +248,16 @@ class CliParserTest extends BaseTest {
 
         PrintStream out = System.out;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(baos));
+        System.setOut(new PrintStream(baos, true, UTF_8));
 
         CliParser instance = new CliParser(getSettings());
         instance.printVersionInfo();
         try {
-            baos.flush();
             String text = baos.toString(UTF_8).toLowerCase();
             String[] lines = text.split(System.lineSeparator());
             assertTrue(lines.length >= 1);
             assertTrue(text.contains("version"));
             assertFalse(text.contains("unknown"));
-        } catch (IOException ex) {
-            System.setOut(out);
-            fail("CliParser.printVersionInfo did not write anything to system.out.", ex);
         } finally {
             System.setOut(out);
         }
@@ -279,7 +274,7 @@ class CliParserTest extends BaseTest {
 
         PrintStream out = System.out;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(baos));
+        System.setOut(new PrintStream(baos, true, UTF_8));
 
         CliParser instance = new CliParser(getSettings());
         String[] args = {"-h"};
@@ -289,14 +284,10 @@ class CliParserTest extends BaseTest {
         instance.parse(args);
         instance.printHelp();
         try {
-            baos.flush();
             String text = (baos.toString(UTF_8));
             String[] lines = text.split(System.lineSeparator());
             assertTrue(lines[0].startsWith("usage: "));
             assertTrue((lines.length > 2));
-        } catch (IOException ex) {
-            System.setOut(out);
-            fail("CliParser.printVersionInfo did not write anything to system.out.");
         } finally {
             System.setOut(out);
         }

--- a/cli/src/test/java/org/owasp/dependencycheck/PluginLoaderTest.java
+++ b/cli/src/test/java/org/owasp/dependencycheck/PluginLoaderTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.mockito.ArgumentMatchers.assertArg;
@@ -52,11 +53,11 @@ class PluginLoaderTest {
     void shouldStopLoadingPluginsOnBadJarButSucceed() throws Exception {
         PrintStream originalErr = System.err;
         ByteArrayOutputStream errContent = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(errContent));
+        System.setErr(new PrintStream(errContent, true, UTF_8));
         try {
             createEmptyBadJar();
             PluginLoader.premain(tempDir.toString(), instrumentation);
-            assertThat(errContent.toString(), matchesPattern(Pattern.compile("\\[WARN\\] Failed to read plugin jar file at .*/dummy.*\\.jar\\. Jar will not be available on classpath.*zip file is empty.*", Pattern.DOTALL)));
+            assertThat(errContent.toString(), matchesPattern(Pattern.compile("\\[WARN] Failed to read plugin jar file at .*/dummy.*\\.jar\\. Jar will not be available on classpath.*zip file is empty.*", Pattern.DOTALL)));
         } finally {
             System.setErr(originalErr);
         }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -520,8 +519,6 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
             try (Reader reader = new InputStreamReader(jar.getInputStream(propEntry), StandardCharsets.UTF_8)) {
                 pomProperties.load(reader);
                 LOGGER.debug("Read pom.properties: {}", propPath);
-            } catch (UnsupportedEncodingException ex) {
-                LOGGER.trace("UTF-8 is not supported", ex);
             } catch (IOException ex) {
                 LOGGER.trace("Unable to read the POM properties", ex);
             }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/RubyBundleAuditAnalyzer.java
@@ -20,7 +20,6 @@ package org.owasp.dependencycheck.analyzer;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -208,7 +207,7 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
         if (engine != null) {
             this.cvedb = engine.getDatabase();
         }
-        String bundleAuditVersionDetails = null;
+        String bundleAuditVersionDetails;
         try {
             final List<String> bundleAuditArgs = Collections.singletonList("version");
             final Process process = launchBundleAudit(getSettings().getTempDirectory(), bundleAuditArgs);
@@ -232,10 +231,6 @@ public class RubyBundleAuditAnalyzer extends AbstractFileTypeAnalyzer {
             final String msg = String.format("Exception from bundle-audit process: %s. "
                     + "Disabling %s", ae.getCause(), ANALYZER_NAME);
             throw new InitializationException(msg, ae);
-        } catch (UnsupportedEncodingException ex) {
-            setEnabled(false);
-            throw new InitializationException("Unexpected bundle-audit encoding when "
-                    + "reading input stream.", ex);
         } catch (IOException ex) {
             setEnabled(false);
             throw new InitializationException("Unable to read bundle-audit output.", ex);

--- a/core/src/main/java/org/owasp/dependencycheck/data/cpe/IndexEntry.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/cpe/IndexEntry.java
@@ -18,7 +18,6 @@
 package org.owasp.dependencycheck.data.cpe;
 
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.concurrent.ThreadSafe;
@@ -143,16 +142,15 @@ public class IndexEntry implements Serializable {
      * version and revision) then you should use the `cpe-parser`.
      *
      * @param cpeName the CPE name
-     * @throws UnsupportedEncodingException should never be thrown...
      */
-    public void parseName(String cpeName) throws UnsupportedEncodingException {
+    public void parseName(String cpeName) {
         if (cpeName != null && cpeName.length() > 7) {
             final String cpeNameWithoutPrefix = cpeName.substring(7);
             final String[] data = StringUtils.split(cpeNameWithoutPrefix, ':');
             if (data.length >= 1) {
-                vendor = URLDecoder.decode(data[0].replace("+", "%2B"), StandardCharsets.UTF_8.name());
+                vendor = URLDecoder.decode(data[0].replace("+", "%2B"), StandardCharsets.UTF_8);
                 if (data.length >= 2) {
-                    product = URLDecoder.decode(data[1].replace("+", "%2B"), StandardCharsets.UTF_8.name());
+                    product = URLDecoder.decode(data[1].replace("+", "%2B"), StandardCharsets.UTF_8);
                 }
             }
         }

--- a/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
+++ b/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java
@@ -62,7 +62,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.ZonedDateTime;
@@ -463,8 +462,6 @@ public class ReportGenerator {
                 }
                 writer.flush();
             }
-        } catch (UnsupportedEncodingException ex) {
-            throw new ReportException("Unable to generate the report using UTF-8", ex);
         } catch (FileNotFoundException ex) {
             throw new ReportException("Unable to locate template file: " + templateName, ex);
         } catch (IOException ex) {
@@ -504,7 +501,7 @@ public class ReportGenerator {
             final TransformerFactory transformerFactory = SAXTransformerFactory.newInstance();
             transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             final Transformer transformer = transformerFactory.newTransformer();
-            transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+            transformer.setOutputProperty(OutputKeys.ENCODING, StandardCharsets.UTF_8.name());
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 

--- a/core/src/test/java/org/owasp/dependencycheck/data/elixir/MixAuditJsonParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/elixir/MixAuditJsonParserTest.java
@@ -2,49 +2,42 @@ package org.owasp.dependencycheck.data.elixir;
 
 import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
-import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
+import java.io.InputStreamReader;
+import java.io.Reader;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MixAuditJsonParserTest {
 
     @Test
-    void testEmptyResult() throws AnalysisException, FileNotFoundException {
-        MixAuditJsonParser parser;
+    void testEmptyResult() throws Exception {
+        try (Reader reader = new InputStreamReader(BaseTest.getResourceAsStream(this, "elixir/mix_audit/empty.json"), UTF_8)) {
+            MixAuditJsonParser parser = new MixAuditJsonParser(reader);
+            parser.process();
 
-        File jsonFixtureFile = BaseTest.getResourceAsFile(this, "elixir/mix_audit/empty.json");
-        FileReader fir = new FileReader(jsonFixtureFile);
-
-        parser = new MixAuditJsonParser(fir);
-        parser.process();
-
-        assertEquals(0, parser.getResults().size(), "results must be empty");
+            assertEquals(0, parser.getResults().size(), "results must be empty");
+        }
     }
 
     @Test
-    void testSingleResult() throws AnalysisException, FileNotFoundException {
-        MixAuditJsonParser parser;
+    void testSingleResult() throws Exception {
+        try (Reader reader = new InputStreamReader(BaseTest.getResourceAsStream(this, "elixir/mix_audit/plug.json"), UTF_8)) {
+            MixAuditJsonParser parser = new MixAuditJsonParser(reader);
+            parser.process();
 
-        File jsonFixtureFile = BaseTest.getResourceAsFile(this, "elixir/mix_audit/plug.json");
-        FileReader fir = new FileReader(jsonFixtureFile);
+            assertEquals(1, parser.getResults().size(), "must have 1 result");
 
-        parser = new MixAuditJsonParser(fir);
-        parser.process();
-
-        assertEquals(1, parser.getResults().size(), "must have 1 result");
-
-        MixAuditResult r = parser.getResults().get(0);
-        assertEquals("dc96aba4-4462-4d3b-b73f-28b9349133d8", r.getId());
-        assertEquals("2018-1000883", r.getCve());
-        assertEquals("Header Injection\n", r.getTitle());
-        assertEquals("Cookie headers were not validated\n", r.getDescription());
-        assertEquals("https://github.com/elixir-plug/plug/commit/8857f8ab4acf9b9c22e80480dae2636692f5f573", r.getUrl());
-        assertEquals("/DependencyCheck/core/src/test/resources/elixir/vulnerable/mix.lock", r.getDependencyLockfile());
-        assertEquals("plug", r.getDependencyPackage());
-        assertEquals("1.3.4", r.getDependencyVersion());
+            MixAuditResult r = parser.getResults().get(0);
+            assertEquals("dc96aba4-4462-4d3b-b73f-28b9349133d8", r.getId());
+            assertEquals("2018-1000883", r.getCve());
+            assertEquals("Header Injection\n", r.getTitle());
+            assertEquals("Cookie headers were not validated\n", r.getDescription());
+            assertEquals("https://github.com/elixir-plug/plug/commit/8857f8ab4acf9b9c22e80480dae2636692f5f573", r.getUrl());
+            assertEquals("/DependencyCheck/core/src/test/resources/elixir/vulnerable/mix.lock", r.getDependencyLockfile());
+            assertEquals("plug", r.getDependencyPackage());
+            assertEquals("1.3.4", r.getDependencyVersion());
+        }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/golang/GoModJsonParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/golang/GoModJsonParserTest.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -786,8 +787,7 @@ class GoModJsonParserTest {
      */
     @Test
     void testProcess() throws Exception {
-        InputStream inputStream = new ByteArrayInputStream(issue2891.getBytes());
-        List<GoModDependency> expResult = null;
+        InputStream inputStream = new ByteArrayInputStream(issue2891.getBytes(UTF_8));
         List<GoModDependency> result = GoModJsonParser.process(inputStream);
         assertEquals(96, result.size());
     }

--- a/core/src/test/java/org/owasp/dependencycheck/data/nuget/XPathNuspecParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/nuget/XPathNuspecParserTest.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -36,49 +37,42 @@ class XPathNuspecParserTest extends BaseTest {
 
     /**
      * Test all the valid components.
-     *
-     * @throws Exception if anything goes sideways.
      */
     @Test
     void testGoodDocument() throws Exception {
         XPathNuspecParser parser = new XPathNuspecParser();
-        //InputStream is = XPathNuspecParserTest.class.getClassLoader().getResourceAsStream("log4net.2.0.3.nuspec");
-        InputStream is = BaseTest.getResourceAsStream(this, "log4net.2.0.3.nuspec");
-        NugetPackage np = parser.parse(is);
-        assertEquals("log4net", np.getId());
-        assertEquals("2.0.3", np.getVersion());
-        assertEquals("log4net [1.2.13]", np.getTitle());
-        assertEquals("Apache Software Foundation", np.getAuthors());
-        assertEquals("Apache Software Foundation", np.getOwners());
-        assertEquals("http://logging.apache.org/log4net/license.html", np.getLicenseUrl());
+        try (InputStream is = BaseTest.getResourceAsStream(this, "log4net.2.0.3.nuspec")) {
+            NugetPackage np = parser.parse(is);
+            assertEquals("log4net", np.getId());
+            assertEquals("2.0.3", np.getVersion());
+            assertEquals("log4net [1.2.13]", np.getTitle());
+            assertEquals("Apache Software Foundation", np.getAuthors());
+            assertEquals("Apache Software Foundation", np.getOwners());
+            assertEquals("http://logging.apache.org/log4net/license.html", np.getLicenseUrl());
+        }
     }
 
     /**
      * Expect a NuspecParseException when what we pass isn't even XML.
-     *
-     * @throws Exception we expect this.
      */
     @Test
-    void testMissingDocument() {
+    void testMissingDocument() throws Exception {
         XPathNuspecParser parser = new XPathNuspecParser();
-        InputStream is = BaseTest.getResourceAsStream(this, "dependencycheck.properties");
-        final ByteArrayOutputStream myOut = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(myOut));
-        assertThrows(NuspecParseException.class, () ->
-
-            parser.parse(is));
+        try (InputStream is = BaseTest.getResourceAsStream(this, "dependencycheck.properties")) {
+            final ByteArrayOutputStream myOut = new ByteArrayOutputStream();
+            System.setErr(new PrintStream(myOut, true, UTF_8));
+            assertThrows(NuspecParseException.class, () -> parser.parse(is));
+        }
     }
 
     /**
      * Expect a NuspecParseException when it's valid XML, but not a Nuspec.
-     *
-     * @throws Exception we expect this.
      */
     @Test
-    void testNotNuspec() {
+    void testNotNuspec() throws Exception {
         XPathNuspecParser parser = new XPathNuspecParser();
-        InputStream is = BaseTest.getResourceAsStream(this, "suppressions.xml");
-        assertThrows(NuspecParseException.class, () ->
-            parser.parse(is));
+        try (InputStream is = BaseTest.getResourceAsStream(this, "suppressions.xml")) {
+            assertThrows(NuspecParseException.class, () -> parser.parse(is));
+        }
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/data/update/nvd/api/NvdApiProcessorTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/data/update/nvd/api/NvdApiProcessorTest.java
@@ -21,8 +21,7 @@ import org.owasp.dependencycheck.BaseTest;
 import org.owasp.dependencycheck.data.nvdcve.CveDB;
 
 import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -46,7 +45,7 @@ class NvdApiProcessorTest extends BaseTest {
     void unspecifiedFileName() throws Exception {
         try (CveDB cve = new CveDB(getSettings())) {
             File file = File.createTempFile("test", "test");
-            writeFileString(file, "");
+            Files.writeString(file.toPath(), "");
             NvdApiProcessor processor = new NvdApiProcessor(null, file);
             processor.call();
         }
@@ -57,7 +56,7 @@ class NvdApiProcessorTest extends BaseTest {
         try (CveDB cve = new CveDB(getSettings())) {
             File file = File.createTempFile("test", "test.json");
             // invalid content (broken array)
-            writeFileString(file, "[}");
+            Files.writeString(file.toPath(), "[}");
             NvdApiProcessor processor = new NvdApiProcessor(null, file);
             assertThrows(JsonParseException.class, processor::call);
         }
@@ -67,16 +66,10 @@ class NvdApiProcessorTest extends BaseTest {
     void processValidStructure() throws Exception {
         try (CveDB cve = new CveDB(getSettings())) {
             File file = File.createTempFile("test", "test.json");
-            writeFileString(file, "[]");
+            Files.writeString(file.toPath(), "[]");
             NvdApiProcessor processor = new NvdApiProcessor(null, file);
             processor.call();
         }
     }
 
-    static void writeFileString(File file, String content) throws IOException {
-        try (FileWriter writer = new FileWriter(file, false)) {
-            writer.write(content);
-            writer.flush();
-        }
-    }
 }

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/JsonArrayFixingInputStream.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/JsonArrayFixingInputStream.java
@@ -234,12 +234,9 @@ public class JsonArrayFixingInputStream extends InputStream {
 
     @Override
     public void close() throws IOException {
-        in.close();
-    }
-
-    @Override
-    public boolean markSupported() {
-        return false;
+        if (in != null) {
+            in.close();
+        }
     }
 
     /**

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.ProtectionDomain;
@@ -1306,19 +1305,12 @@ public final class Settings {
      * @return a File object
      */
     private File getJarPath() {
-        String decodedPath = ".";
         String jarPath = "";
         final ProtectionDomain domain = Settings.class.getProtectionDomain();
         if (domain != null && domain.getCodeSource() != null && domain.getCodeSource().getLocation() != null) {
             jarPath = Settings.class.getProtectionDomain().getCodeSource().getLocation().getPath();
         }
-        try {
-            decodedPath = URLDecoder.decode(jarPath, StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException ex) {
-            LOGGER.trace("", ex);
-        }
-
-        final File path = new File(decodedPath);
+        final File path = new File(URLDecoder.decode(jarPath, StandardCharsets.UTF_8));
         if (path.getName().toLowerCase().endsWith(".jar")) {
             return path.getParentFile();
         } else {

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/processing/ProcessReader.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/processing/ProcessReader.java
@@ -178,7 +178,7 @@ public class ProcessReader implements AutoCloseable {
         public void run() {
             try {
                 final InputStream inputStream = getInput();
-                text = IOUtils.toString(inputStream, StandardCharsets.UTF_8.name());
+                text = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
 
             } catch (IOException ex) {
                 exception = ex;

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/search/FileContentSearch.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/search/FileContentSearch.java
@@ -50,7 +50,7 @@ public final class FileContentSearch {
      * @throws java.io.IOException thrown if there is an error reading the file
      */
     public static boolean contains(File file, String pattern) throws IOException {
-        try (Scanner fileScanner = new Scanner(file, UTF_8.name())) {
+        try (Scanner fileScanner = new Scanner(file, UTF_8)) {
             final Pattern regex = Pattern.compile(pattern);
             if (fileScanner.findWithinHorizon(regex, 0) != null) {
                 return true;
@@ -73,7 +73,7 @@ public final class FileContentSearch {
         for (String pattern : patterns) {
             regexes.add(Pattern.compile(pattern));
         }
-        try (Scanner fileScanner = new Scanner(file, UTF_8.name())) {
+        try (Scanner fileScanner = new Scanner(file, UTF_8)) {
             return regexes.stream().anyMatch((regex) -> (fileScanner.findWithinHorizon(regex, 0) != null));
         }
     }

--- a/utils/src/test/java/org/owasp/dependencycheck/utils/JsonArrayFixingInputStreamTest.java
+++ b/utils/src/test/java/org/owasp/dependencycheck/utils/JsonArrayFixingInputStreamTest.java
@@ -112,8 +112,8 @@ class JsonArrayFixingInputStreamTest {
      */
     @Test
     void testRead_0args() throws Exception {
-        try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
-                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+        try (InputStream sample = new ByteArrayInputStream(sample1.getBytes(UTF_8));
+             JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             assertEquals('[', instance.read());
             assertEquals('{', instance.read());
             assertEquals('}', instance.read());
@@ -121,8 +121,8 @@ class JsonArrayFixingInputStreamTest {
             assertEquals(-1, instance.read());
         }
 
-        try (InputStream sample = new ByteArrayInputStream(sample2.getBytes());
-                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+        try (InputStream sample = new ByteArrayInputStream(sample2.getBytes(UTF_8));
+             JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             assertEquals('[', instance.read());
             assertEquals('{', instance.read());
             assertEquals('}', instance.read());
@@ -142,8 +142,8 @@ class JsonArrayFixingInputStreamTest {
     @Test
     void testRead_byteArr() throws Exception {
         byte[] b = new byte[9];
-        try (InputStream sample = new ByteArrayInputStream(sample2.getBytes());
-                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+        try (InputStream sample = new ByteArrayInputStream(sample2.getBytes(UTF_8));
+             JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             int read = instance.read(b);
             assertEquals(2, read);
             assertEquals('[', b[0]);
@@ -170,8 +170,8 @@ class JsonArrayFixingInputStreamTest {
 
     @Test
     void testRead_IOUtils() throws Exception {
-        try (InputStream sample = new ByteArrayInputStream(sample3.getBytes());
-                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+        try (InputStream sample = new ByteArrayInputStream(sample3.getBytes(UTF_8));
+             JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             String results = IOUtils.toString(instance, UTF_8);
             assertEquals("[{'key'='value'},{'key'='value'}]", results);
 
@@ -180,8 +180,8 @@ class JsonArrayFixingInputStreamTest {
 
     @Test
     void testRead_RealSample() throws Exception {
-        try (InputStream sample = new ByteArrayInputStream(sample4.getBytes());
-                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+        try (InputStream sample = new ByteArrayInputStream(sample4.getBytes(UTF_8));
+             JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             try (JsonReader reader = Json.createReader(instance)) {
                 final JsonArray modules = reader.readArray();
                 assertEquals(8, modules.size());
@@ -222,13 +222,12 @@ class JsonArrayFixingInputStreamTest {
     /**
      * Test of skip method, of class JsonArrayFixingInputStream.
      *
-     * @throws Exception because one might happen
      */
     @Test
     void testSkip() {
         assertThrows(UnsupportedOperationException.class, () -> {
-            try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
-                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+            try (InputStream sample = new ByteArrayInputStream(sample1.getBytes(UTF_8));
+                 JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
                 instance.skip(1);
             }
         });
@@ -241,16 +240,13 @@ class JsonArrayFixingInputStreamTest {
      */
     @Test
     void testAvailable() throws Exception {
-        try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
-                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+        try (InputStream sample = new ByteArrayInputStream(sample1.getBytes(UTF_8));
+             JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             int results = instance.available();
             assertTrue(results > 0);
-            String text = IOUtils.toString(instance, UTF_8);
+            IOUtils.toString(instance, UTF_8);
             int i = instance.read();
             assertEquals(-1, i);
-            //odd buffer is 0 and we've read to the end - but available on the underlying stream still says 3...
-            //results = instance.available();
-            //assertEquals(0, results);
         }
     }
 
@@ -261,8 +257,8 @@ class JsonArrayFixingInputStreamTest {
      */
     @Test
     void testClose() throws Exception {
-        try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
-                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+        try (InputStream sample = new ByteArrayInputStream(sample1.getBytes(UTF_8));
+             JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             int i = instance.read();
         }
     }
@@ -274,21 +270,22 @@ class JsonArrayFixingInputStreamTest {
      */
     @Test
     void testMarkSupported() throws Exception {
-        try (InputStream sample = new ByteArrayInputStream(sample1.getBytes());
-                JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
+        try (InputStream sample = new ByteArrayInputStream(sample1.getBytes(UTF_8));
+             JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(sample)) {
             boolean result = instance.markSupported();
             assertFalse(result);
         }
     }
 
     @Test
-    void testIsWhiteSpace() {
-        JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(null);
-        assertFalse(instance.isWhiteSpace((byte) 'a'));
-        assertTrue(instance.isWhiteSpace((byte) '\n'));
-        assertTrue(instance.isWhiteSpace((byte) '\t'));
-        assertTrue(instance.isWhiteSpace((byte) '\r'));
-        assertTrue(instance.isWhiteSpace((byte) ' '));
+    void testIsWhiteSpace() throws Exception {
+        try (JsonArrayFixingInputStream instance = new JsonArrayFixingInputStream(null)) {
+            assertFalse(instance.isWhiteSpace((byte) 'a'));
+            assertTrue(instance.isWhiteSpace((byte) '\n'));
+            assertTrue(instance.isWhiteSpace((byte) '\t'));
+            assertTrue(instance.isWhiteSpace((byte) '\r'));
+            assertTrue(instance.isWhiteSpace((byte) ' '));
+        }
     }
 
 }


### PR DESCRIPTION

## Description of Change

All Java 11+ impls must support UTF-8; so removed unnecessary exception handling.

## Related issues

N/A

## Have test cases been added to cover the new functionality?

yes