### PR TITLE
fix(fp): suppress false positives from grpc-netty-shaded

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1737,6 +1737,14 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
+    FP per issue #7981. GRPC intention is to not match Netty, and to have any CVEs reported against grpc-java itself
+    per https://github.com/grpc/grpc-java/issues/11135#issuecomment-2088568147
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.grpc/grpc-netty-shaded@.*$</packageUrl>
+    <cpe>cpe:/a:netty:netty</cpe>
+</suppress>
+<suppress base="true">
+    <notes><![CDATA[
     FP per issue #7734
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/edu\.washington\.cs\.knowitall/opennlp-postag-models@.*$</packageUrl>


### PR DESCRIPTION
## Description of Change

Rather than approving the FP, raising the fix for #7981 for discussion.

The short version is:
- `grpc-netty-shaded` IS netty, i.e `cpe:/a:netty:netty` so the match is not entirely "bad" from ODC.
- since most features of Netty are NOT used by GRPC, almost all CVEs actually don't affect GRPC.
- the intention of the team appears to be to avoid scanners doing such matching and manage CVEs themselves; i.e have any that actually affect GRPC reported against `cpe:2.3:a:grpc:grpc:*:*:*:*:*:java:*:*`, not solely the Netty CPEs.
  - note the comment at https://github.com/grpc/grpc-java/issues/11135#issuecomment-2088568147 where they deliberately removed identifiers etc to reduce the chance of this happening
  - a maintainer specifically says
  > I don't see any CPEs in [the CVE](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) that match against grpc-java 1.63.0

Since the Google/GRPC team are mature, and their own CNA - I think this is good enough to expect any issues caused by netty to be reviewed and reported against their own CPE; so will show up in ODC anyway, and the current fuzzy name matching is just causing unnecessary FPs/noise.

## Related issues

- fixes #7981

## Have test cases been added to cover the new functionality?

N/A