### PR TITLE
test: Make tests locale independent

### DIFF
--- a/core/src/test/java/org/owasp/dependencycheck/xml/hints/HintParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/hints/HintParserTest.java
@@ -85,7 +85,9 @@ class HintParserTest extends BaseTest {
         File file = BaseTest.getResourceAsFile(this, "hints_invalid.xml");
         HintParser instance = new HintParser();
         Exception exception = assertThrows(org.owasp.dependencycheck.xml.hints.HintParseException.class, () -> instance.parseHints(file));
-        assertThat(exception.getMessage(), containsString("Line=10, Column=133: cvc-enumeration-valid: Value 'version' is not facet-valid with respect to enumeration '[vendor, product]'. It must be a value from the enumeration."));
+        assertThat(exception.getMessage(), containsString("Line=10, Column=133: cvc-enumeration-valid"));
+        assertThat(exception.getMessage(), containsString("'version'"));
+        assertThat(exception.getMessage(), containsString("'[vendor, product]'"));
     }
 
     /**

--- a/core/src/test/java/org/owasp/dependencycheck/xml/hints/HintParserTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/hints/HintParserTest.java
@@ -73,7 +73,7 @@ class HintParserTest extends BaseTest {
      * Test the application of the correct XSD by the parser by using a
      * hints-file with namespace
      * {@code https://jeremylong.github.io/DependencyCheck/dependency-hint.1.1.xsd}
-     * that is using the version evidence for {@code<given>} that was introduced
+     * that is using the version evidence for {@code <given>} that was introduced
      * with namespace
      * {@code https://jeremylong.github.io/DependencyCheck/dependency-hint.1.2.xsd}.
      * This should yield a specific SAXParseException that gets wrapped into a


### PR DESCRIPTION
## Description of Change

This change proposes to improve assertions to make them locale independent. The updated tests are failing on a French locale system.

## Related issues

None

## Have test cases been added to cover the new functionality?

*no* new test as no functionality is added