### PR TITLE
fix(fp): ensure reactor-netty suppression matches the generic artifact

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1752,9 +1752,9 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
-    FP per issue #7761
+    FP per issue #7761, #8348
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.projectreactor\.netty/reactor-netty-.*@.*$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/io\.projectreactor\.netty/reactor-netty.*@.*$</packageUrl>
     <cpe>cpe:/a:netty:netty</cpe>
 </suppress>
 <suppress base="true">


### PR DESCRIPTION
## Description of Change

They actually publish an empty JAR file for the `reactor-netty` POM/BOM artifact for some reason, which probably confuses tools, and for which the current generic suppression is not working.

## Related issues

- fixes #8348

## Have test cases been added to cover the new functionality?

N/A