### PR TITLE
fix: #8140 AssemblyAnalyzer version resolution issue

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
@@ -253,30 +253,23 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
                 }
             }
             if (dependency.getVersion() == null) {
-                if (data.getFileVersion() != null && data.getProductVersion() != null
-                        && data.getFileVersion().length() >= data.getProductVersion().length()) {
-                    if (fileVersion != null && fileVersion.toString().length() == data.getFileVersion().length()) {
+                if (fileVersion != null && productVersion != null) {
+                    if (fileVersion.toString().startsWith(productVersion.toString())) {
                         dependency.setVersion(fileVersion.toString());
-                    } else if (productVersion != null && productVersion.toString().length() == data.getProductVersion().length()) {
+                    } else if (productVersion.toString().startsWith(fileVersion.toString())) {
                         dependency.setVersion(productVersion.toString());
-                    }
-                } else {
-                    if (productVersion != null && productVersion.toString().length() == data.getProductVersion().length()) {
-                        dependency.setVersion(productVersion.toString());
-                    } else if (fileVersion != null && fileVersion.toString().length() == data.getFileVersion().length()) {
-                        dependency.setVersion(fileVersion.toString());
                     }
                 }
             }
         }
-        if (dependency.getVersion() == null && data.getFileVersion() != null) {
-            final DependencyVersion version = DependencyVersionUtil.parseVersion(data.getFileVersion(), true);
+        if (dependency.getVersion() == null && data.getProductVersion() != null) {
+            final DependencyVersion version = DependencyVersionUtil.parseVersion(data.getProductVersion(), true);
             if (version != null) {
                 dependency.setVersion(version.toString());
             }
         }
-        if (dependency.getVersion() == null && data.getProductVersion() != null) {
-            final DependencyVersion version = DependencyVersionUtil.parseVersion(data.getProductVersion(), true);
+        if (dependency.getVersion() == null && data.getFileVersion() != null) {
+            final DependencyVersion version = DependencyVersionUtil.parseVersion(data.getFileVersion(), true);
             if (version != null) {
                 dependency.setVersion(version.toString());
             }

--- a/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
+++ b/core/src/main/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzer.java
@@ -194,7 +194,7 @@ public class AssemblyAnalyzer extends AbstractFileTypeAnalyzer {
      * @param data the assembly data
      * @param dependency the dependency to update
      */
-    private void updateDependency(final AssemblyData data, Dependency dependency) {
+    void updateDependency(final AssemblyData data, Dependency dependency) {
         final StringBuilder sb = new StringBuilder();
         if (!StringUtils.isBlank(data.getFileDescription())) {
             sb.append(data.getFileDescription());

--- a/core/src/main/resources/dependencycheck-base-hint.xml
+++ b/core/src/main/resources/dependencycheck-base-hint.xml
@@ -479,5 +479,16 @@
         </remove>
     </hint>
 
+    <hint>
+        <given>
+            <evidence type="product" source="grokassembly" name="ProductName" value="Azure .NET SDK"
+                      confidence="HIGHEST" />
+            <evidence type="product" source="file" name="name" value="Azure.Identity" confidence="HIGH" />
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="azure_identity_library_for_.net"
+                      confidence="HIGHEST"/>
+        </add>
+    </hint>
 </hints>
 

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzerTest.java
@@ -17,6 +17,9 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,12 +30,15 @@ import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
 import org.owasp.dependencycheck.dependency.EvidenceType;
+import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
 import org.owasp.dependencycheck.exception.InitializationException;
 import org.owasp.dependencycheck.utils.Settings;
+import org.owasp.dependencycheck.xml.assembly.AssemblyData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -173,6 +179,117 @@ class AssemblyAnalyzerTest extends BaseTest {
                 System.setProperty(Settings.KEYS.ANALYZER_ASSEMBLY_DOTNET_PATH, oldValue);
             }
         }
+    }
+
+    @Test
+    void testAzureIdentity() throws MalformedPackageURLException {
+        // Given
+        var data = newAzureIdentityAssemblyData();
+        var dependency = newAzureIdentityDependency();
+
+        var expectedDescription = "Microsoft Azure.Identity Component\n\nThis is the implementation of the Azure SDK " +
+                "Client Library for Azure Identity";
+        var expectedVersionEvidences = expectedAzureIdentityVersionEvidences();
+        var expectedVersion = "1.700.22.46903";
+        var expectedProductEvidences = expectedAzureIdentityProductEvidences();
+        var expectedVendorEvidences = expectedAzureIdentityVendorEvidences();
+        var expectedName = "Azure.Identity";
+        var expectedIdentifiers = Set.of(new PurlIdentifier(new PackageURL("pkg:generic/Azure.Identity@1.700.22.46903"),
+                Confidence.MEDIUM));
+        var expectedEcosystem = "dotnet";
+
+        // When
+        analyzer.updateDependency(data, dependency);
+
+        // Then
+        assertEquals(expectedDescription, dependency.getDescription());
+        assertEquals(expectedVersionEvidences, dependency.getEvidence(EvidenceType.VERSION));
+        assertEquals(expectedVersion, dependency.getVersion());
+        assertEquals(expectedProductEvidences, dependency.getEvidence(EvidenceType.PRODUCT));
+        assertEquals(expectedVendorEvidences, dependency.getEvidence(EvidenceType.VENDOR));
+        assertEquals(expectedName, dependency.getName());
+        assertEquals(expectedIdentifiers, dependency.getSoftwareIdentifiers());
+        assertEquals(expectedEcosystem, dependency.getEcosystem());
+    }
+
+    private static @NonNull AssemblyData newAzureIdentityAssemblyData() {
+        var data = new AssemblyData();
+        data.setCompanyName("Microsoft Corporation");
+        data.setProductName("Azure .NET SDK");
+        data.setProductVersion("1.7.0+3627e3cbc75c628f659d033ed9270c9d02ab9038");
+        data.setComments("This is the implementation of the Azure SDK Client Library for Azure Identity");
+        data.setFileDescription("Microsoft Azure.Identity Component");
+        data.setFileName("/home/jdoe/ScanFolder/Azure.Identity.dll");
+        data.setFileVersion("1.700.22.46903");
+        data.setInternalName("Azure.Identity.dll");
+        data.setOriginalFilename("Azure.Identity.dll");
+        data.setFullName("Azure.Identity, Version=1.7.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8");
+
+        data.addNamespace("Microsoft.CodeAnalysis");
+        data.addNamespace("System.Runtime.CompilerServices");
+        data.addNamespace("Azure.Core");
+        data.addNamespace("Azure.Core.Pipeline");
+        data.addNamespace("Azure.Core.Diagnostics");
+        // The following duplication is on purpose, this use case has one
+        data.addNamespace("Azure.Identitiy");
+        data.addNamespace("Azure.Identitiy");
+        return data;
+    }
+
+    private static @NonNull Dependency newAzureIdentityDependency() {
+        var dependency = new Dependency();
+        dependency.setActualFilePath("/home/jdoe/ScanFolder/Azure.Identity.dll");
+        dependency.setFilePath("/home/jdoe/ScanFolder/Azure.Identity.dll");
+        dependency.setFileName("Azure.Identity.dll");
+        dependency.setPackagePath("/home/jdoe/ScanFolder/Azure.Identity.dll");
+        dependency.setMd5sum("19f72346b3952c135c121e30235d4064");
+        dependency.setSha1sum("1ac0e967367aa7679a89b2eb652a7996870d9043");
+        dependency.setSha256sum("666973af908cf82a495530b2ea23074004dead445e1bb46ef75a5e3c879a6321");
+
+        var nameEvidence = new Evidence("file", "name", "Azure.Identity", Confidence.HIGH);
+
+        dependency.addEvidence(EvidenceType.VENDOR, nameEvidence);
+        dependency.addEvidence(EvidenceType.PRODUCT, nameEvidence);
+
+        return dependency;
+    }
+
+    private static @NonNull Set<Evidence> expectedAzureIdentityVersionEvidences() {
+        var fileVersionEvidence = new Evidence("grokassembly", "FileVersion", "1.700.22.46903", Confidence.HIGH);
+        var productVersionEvidence = new Evidence("grokassembly", "ProductVersion", "1.7.0+3627e3cbc75c628f659d033ed9270c9d02ab9038", Confidence.HIGHEST);
+
+        return Set.of(fileVersionEvidence, productVersionEvidence);
+    }
+
+    private static @NonNull Set<Evidence> expectedAzureIdentityProductEvidences() {
+        var nameEvidence = new Evidence("file", "name", "Azure.Identity", Confidence.HIGH);
+        var companyNameLowEvidence = new Evidence("grokassembly", "CompanyName", "Microsoft Corporation", Confidence.LOW);
+        var fileDescriptionHighEvidence = new Evidence("grokassembly", "FileDescription",
+                "Microsoft Azure.Identity Component", Confidence.HIGH);
+        var internalNameMediumEvidence = new Evidence("grokassembly", "InternalName", "Azure.Identity.dll",
+                Confidence.MEDIUM);
+        var originalFilenameMediumEvidence = new Evidence("grokassembly", "OriginalFilename", "Azure.Identity.dll",
+                Confidence.MEDIUM);
+        var productNameHighestEvidence = new Evidence("grokassembly", "ProductName", "Azure .NET SDK", Confidence.HIGHEST);
+
+        return Set.of(nameEvidence, companyNameLowEvidence, fileDescriptionHighEvidence,
+                internalNameMediumEvidence, originalFilenameMediumEvidence, productNameHighestEvidence);
+    }
+
+    private static @NonNull Set<Evidence> expectedAzureIdentityVendorEvidences() {
+        var nameEvidence = new Evidence("file", "name", "Azure.Identity", Confidence.HIGH);
+        var companyNameHighestEvidence = new Evidence("grokassembly", "CompanyName", "Microsoft Corporation",
+                Confidence.HIGHEST);
+        var fileDescriptionLowEvidence = new Evidence("grokassembly", "FileDescription",
+                "Microsoft Azure.Identity Component", Confidence.LOW);
+        var internalNameLowEvidence = new Evidence("grokassembly", "InternalName", "Azure.Identity.dll",
+                Confidence.LOW);
+        var originalFilenameLowEvidence = new Evidence("grokassembly", "OriginalFilename", "Azure.Identity.dll",
+                Confidence.LOW);
+        var productNameMediumEvidence = new Evidence("grokassembly", "ProductName", "Azure .NET SDK",
+                Confidence.MEDIUM);
+        return Set.of(nameEvidence, companyNameHighestEvidence, fileDescriptionLowEvidence,
+                internalNameLowEvidence, originalFilenameLowEvidence, productNameMediumEvidence);
     }
 
     @AfterEach

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/AssemblyAnalyzerTest.java
@@ -190,11 +190,11 @@ class AssemblyAnalyzerTest extends BaseTest {
         var expectedDescription = "Microsoft Azure.Identity Component\n\nThis is the implementation of the Azure SDK " +
                 "Client Library for Azure Identity";
         var expectedVersionEvidences = expectedAzureIdentityVersionEvidences();
-        var expectedVersion = "1.700.22.46903";
+        var expectedVersion = "1.7.0";
         var expectedProductEvidences = expectedAzureIdentityProductEvidences();
         var expectedVendorEvidences = expectedAzureIdentityVendorEvidences();
         var expectedName = "Azure.Identity";
-        var expectedIdentifiers = Set.of(new PurlIdentifier(new PackageURL("pkg:generic/Azure.Identity@1.700.22.46903"),
+        var expectedIdentifiers = Set.of(new PurlIdentifier(new PackageURL("pkg:generic/Azure.Identity@1.7.0"),
                 Confidence.MEDIUM));
         var expectedEcosystem = "dotnet";
 


### PR DESCRIPTION
## Description of Change

### Witnessed behavior change

#### Commit **fix: #8140 fix version resolution** `1fb840ba7d94cc894f5a4fb92dfa8ed2f384adfd`

With the AssemblyAnalyzer version resolution commit, the shared dll in #8140 is now resolved as being in version `1.7.0` instead of `1.700.22.46903`.

<img width="1131" height="105" alt="Capture d’écran du 2026-03-06 13-31-46" src="https://github.com/user-attachments/assets/0728ef36-1eae-4be0-bab9-b24286833648" />

This commit allow to raise CVE-2023-36414

#### Commit **fix: #8140 hint azure_identity_library_for_.net** `9f58d2f2c4fcde3c8e3df36837efcee10f972234`

This additional hint make DependencyCheck report CVE-2024-29992 on the shared dll in #8140 

### Business logic

This PR proposes to fix the `AssemblyAnalyzer` version resolution at priority levels 2, 3 & 4.

Priority level 1 resolution remains unchanged. In case ProductVersion and FileVersion both match on the first 3 parts, the common pattern between both versions is used as the dependency version.

Priority level 2 adds a stronger filtering mechanism to prevent picking one of the ProductVersion or FileVersion as the dependency version in case the less specified version contradicts the longer one.

As an example: 
parsed `ProductVersion = 1.2` & parsed `FileVersion = 1.2.13.0` will resolves the dependency version to `1.2.13.0` as `1.2` is included in the longer one - not a change with the current implementation.
parsed `ProductVersion = 1.2.13.0` & parsed `FileVersion = 1.2` will resolves the dependency version to `1.2.13.0` as `1.2` is included in the longer one - not a change with the current implementation.
parsed `ProductVersion = 1.7.0` & parsed `FileVersion = 1.700.22.46903` will **not** resolve the dependency version as there is a contradiction at minor version level between `1.7` & `1.700` - **change with the current implementation which set the longer version.**

Priority level 3 will pick the `ProductVersion` if exists and can be parsed - **change with the current implementation which would pick the parsed `FileVersion`. This aligns with our current evidence confidence where ProductVersion has a higher confidence than FileVersion.**

Priority level 4 will pick parsed `FileVersion` if no `ProductVersion` could be parsed - **change with the current implementation which would pick the parsed `ProductVersion` at this priority level.**

Finally, if nothing before could help us set the dependency version, we do not set it and leave the evidences, which do not get filtered by the VersionFilterAnalyzer as now dependency version is set. - not a change with the current implementation

## Related issues

- fixes #8140

## Have test cases been added to cover the new functionality?

*yes*, the added test covers the `AssemblyAnalyzer` dependency version resolution, with its input strictly being exactly what was provided into the method during real execution in debug mode.

### Test snippet used to execute the CLI in e2e

In `AppTest`, with `my-secrets.properties`  containing my NVD API Key and OssIndex credentials:

```java
    @Test
    void should_app_reports_tpl_as_vulnerable() {
        // Given
        String[] args =
                new String[]{"--format", "HTML", "--format", "JSON", "--out", "ReportFileName",
                                "--scan", "/my/absolute/path/ScanFolder",
                                "--propertyfile", "my-secrets.properties", "--log", "cli.log"};

        // When
        App.main(args);

        // Then
    }
``` 

## Additional notes identified during the investigation

[Thanks to @chadwilson for a first investigation which already located the root of the issue](https://github.com/dependency-check/DependencyCheck/issues/8140#issuecomment-3551911969)

I identified additional room of improvements/analysis into the product, and would like to share to see if we agree to pursue some additional improvements.

### `AssenblyAnalyzer` dependency version resolution refactoring

The code holding the logic to decide to set a version could be refactored to improve clarify and reveal the business logic. I did not do it in this change on purpose as I want to emphasis the behavior change in this PR. If the approach of the change is approved, I am planning to come with an additional refactoring PR, looking for an easier to read logic.

### `VersionFilterAnalyzer` responsibility

As stated in this comment the `VersionFilterAnalyzer` removes version evidences if a version is set, unless evidence is a hint.

The JavaDoc shows the intention behind the version analyzer:

>  This analyzer attempts to filter out erroneous version numbers collected. **Initially, this will focus on JAR files that contain a POM version number that matches the file name - if identified all other version information will be removed.**

It is actually covering much more than that as it will inspect all dependencies. Is this JavaDoc still showing the true intention of this analyzer, in such case we have a bug, or is the doc obsolete and to be updated?

**I believe we could consider narrowing the scope of the VersionFilterAnalyzer to be specifically dedicated to jar files, as intended by the JavaDoc. This would increase the number of false positive, but reduce the risk of false negatives (and I believe with the purpose of DependencyCheck, it is better to have false positives than false negatives). Please note this was first considered as the fix in this PR, which has the same effect as the dependency version resolution, but I did not pick this route in fear of raising the amount of false positive while the assembly dependency version resolution logic was already looking broken, it may still improve some other scenarios**

### `CPEAnalyzer` integration issue with `VersionFilterAnalyzer` and owner of the decision to rely on the dependency version and evidences

In the `VersionFilterAnalyzer`, if a dependency version is set, then we remove all version evidences not coming from an hint.

Later in the analysis, we enter the `CPEAnalyzer` which has a method `considerDependencyVersion(Dependency dependency, String vendor, String product, Confidence confidence, final Set<IdentifierMatch> collected)` which decides to rely on version evidences in some cases even if a dependency version is set, while all the evidences got removed by the `VersionFilterAnalyzer`. It looks like we have 2 pieces of code at 2 different locations trying to have the same responsibility and they don't interact very well between each other :thinking:

### `CPEAnalyzer` decision to rely on the dependency version or evidences seems to have a case sensitivity bug

In `CPEAnalyzer`, the method `considerDependencyVersion(Dependency dependency, String vendor, String product, Confidence confidence, final Set<IdentifierMatch> collected)` has the following code snippet:

```java
for (String word : product.split("[^a-zA-Z0-9]")) {
                    useDependencyVersion &= name.contains(word) || stopWords.contains(word)
                            || wordMatchesEcosystem(dependency.getEcosystem(), word);
                }
```

While debugging in this snippet, for this specific case, a `"Azure".contains("azure")` ends up being made, which evaluates `useDependencyVersion` to `false`, which makes the `CPEAnalyzer` decides to not base itself on the dependency version but the version evidences (who were wiped out by the `VersionFilterAnalyzer`). I did not pursue a fix in this area as in this specific case, the analyzer still decides to rely on evidences for another reason afterwards. It might be interesting to consider an case insensitive comparison.