### PR TITLE
fix: add corepack to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV user=dependencycheck
 ENV JAVA_HOME=/opt/jdk
 ENV JAVA_OPTS="-Danalyzer.assembly.dotnet.path=/usr/bin/dotnet -Danalyzer.bundle.audit.path=/usr/bin/bundle-audit -Danalyzer.golang.path=/usr/local/go/bin/go"
 ENV ODC_NAME=dependency-check-docker
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=false
 
 COPY --from=jlink /jlinked /opt/jdk/
 COPY --from=go /usr/local/go/ /usr/local/go/
@@ -28,10 +29,7 @@ RUN apk update                                                                  
     apk add --no-cache git ruby ruby-rdoc npm                                                        && \
     gem install bundler-audit                                                                        && \
     bundle audit update                                                                              && \
-    mkdir /opt/yarn                                                                                  && \
-    curl -Ls https://yarnpkg.com/latest.tar.gz | tar -xz --strip-components=1 --directory /opt/yarn  && \
-    ln -s /opt/yarn/bin/yarn /usr/bin/yarn                                                           && \
-    npm install -g pnpm                                                                              && \
+    npm install -g corepack                                                                          && \
     unzip dependency-check-${VERSION}-release.zip -d /usr/share/                                     && \
     rm dependency-check-${VERSION}-release.zip                                                       && \
     cd /usr/share/dependency-check/plugins                                                           && \
@@ -49,6 +47,11 @@ RUN apk update                                                                  
 ### remove any suid sgid - we don't need them
 RUN find / -path /proc -prune -perm +6000 -type f -exec chmod a-s {} \;
 USER ${UID}
+
+### preload pnpm and yarn
+RUN corepack enable                                                                                  && \
+    corepack prepare pnpm@latest --activate                                                          && \
+    corepack prepare yarn@1.22.22 --activate
 
 VOLUME ["/src", "/report"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,11 @@ COPY --from=go /usr/local/go/ /usr/local/go/
 
 ADD cli/target/dependency-check-${VERSION}-release.zip /
 
-RUN apk update                                                                                       && \
-    apk add --no-cache --virtual .build-deps curl tar                                                && \
-    apk add --no-cache git ruby ruby-rdoc npm                                                        && \
-    gem install bundler-audit                                                                        && \
-    bundle audit update                                                                              && \
-    npm install -g corepack                                                                          && \
+RUN apk upgrade --no-cache                                                                           && \
+    apk add --no-cache --virtual .build-deps curl                                                    && \
+    apk add --no-cache git ruby npm                                                                  && \
+    gem install --no-document bundler-audit                                                          && \
+    npm install --global --ignore-scripts corepack                                                   && \
     unzip dependency-check-${VERSION}-release.zip -d /usr/share/                                     && \
     rm dependency-check-${VERSION}-release.zip                                                       && \
     cd /usr/share/dependency-check/plugins                                                           && \
@@ -42,16 +41,18 @@ RUN apk update                                                                  
     mkdir /report                                                                                    && \
     chown -R ${user}:0 /report                                                                       && \
     chmod -R g=u /report                                                                             && \
-    apk del .build-deps
+    apk del .build-deps                                                                              && \
+    rm -rf /tmp/* /root/.cache /root/.npm
 
 ### remove any suid sgid - we don't need them
 RUN find / -path /proc -prune -perm +6000 -type f -exec chmod a-s {} \;
 USER ${UID}
 
-### preload pnpm and yarn
-RUN corepack enable                                                                                  && \
-    corepack prepare pnpm@latest --activate                                                          && \
-    corepack prepare yarn@1.22.22 --activate
+### Cache pieces needed for the specific run user
+RUN bundle audit update                                                                              && \
+    corepack prepare pnpm@latest yarn@latest yarn@1 --activate                                       && \
+    printf "enableTelemetry: false\nenableScripts: false\n" >> ${HOME}/.yarnrc.yml                   && \
+    rm -rf /tmp/*
 
 VOLUME ["/src", "/report"]
 


### PR DESCRIPTION
## Description of Change

This merge request adds Corepack to the base OWASP Dependency-Check Docker image.
The goal is to provide native support for package managers such as Yarn and pnpm without requiring downstream images or CI pipelines to manually install Corepack.

This change enables:
- Use of yarn install or pnpm install directly inside the owasp/dependency-check image
- Better compatibility for projects using modern Node.js tooling
- Reduced setup time in CI where Dependency-Check is executed alongside Node-based dependency workflows

No breaking changes are introduced:
If Node.js tooling is not needed, the image behaves exactly as before.
Corepack is now enabled and used as recommended by the pnpm and yarn projects.