### PR TITLE
feat: Allow Central Search to use JSON responses

### DIFF
--- a/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
+++ b/ant/src/main/java/org/owasp/dependencycheck/taskdefs/Check.java
@@ -139,6 +139,10 @@ public class Check extends Update {
      */
     private Boolean centralAnalyzerUseCache;
     /**
+     * Whether or not the Central Analyzer should use JSON responses.
+     */
+    private Boolean centralAnalyzerUseJson;
+    /**
      * Whether or not the nexus analyzer is enabled.
      */
     private Boolean nexusAnalyzerEnabled;
@@ -1109,6 +1113,15 @@ public class Check extends Update {
     }
 
     /**
+     * Set the value of centralAnalyzerUseJson.
+     *
+     * @param centralAnalyzerUseJson new value of centralAnalyzerUseJson
+     */
+    public void setCentralAnalyzerUseJson(Boolean centralAnalyzerUseJson) {
+        this.centralAnalyzerUseJson = centralAnalyzerUseJson;
+    }
+
+    /**
      * Set the value of nexusAnalyzerEnabled.
      *
      * @param nexusAnalyzerEnabled new value of nexusAnalyzerEnabled
@@ -1599,6 +1612,7 @@ public class Check extends Update {
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_LIBMAN_ENABLED, libmanAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_CENTRAL_ENABLED, centralAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_CENTRAL_USE_CACHE, centralAnalyzerUseCache);
+        getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_CENTRAL_JSON, centralAnalyzerUseJson);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_NEXUS_ENABLED, nexusAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_ARCHIVE_ENABLED, archiveAnalyzerEnabled);
         getSettings().setBooleanIfNotNull(Settings.KEYS.ANALYZER_ASSEMBLY_ENABLED, assemblyAnalyzerEnabled);

--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -652,6 +652,8 @@ public class App {
                 !cli.isDisabled(CliParser.ARGUMENT.DISABLE_CENTRAL, Settings.KEYS.ANALYZER_CENTRAL_ENABLED));
         settings.setBoolean(Settings.KEYS.ANALYZER_CENTRAL_USE_CACHE,
                 !cli.isDisabled(CliParser.ARGUMENT.DISABLE_CENTRAL_CACHE, Settings.KEYS.ANALYZER_CENTRAL_USE_CACHE));
+        settings.setBoolean(Settings.KEYS.ANALYZER_CENTRAL_JSON,
+                !cli.isDisabled(CliParser.ARGUMENT.ANALYZER_CENTRAL_JSON, Settings.KEYS.ANALYZER_CENTRAL_JSON));
         settings.setBoolean(Settings.KEYS.ANALYZER_OSSINDEX_ENABLED,
                 !cli.isDisabled(CliParser.ARGUMENT.DISABLE_OSSINDEX, Settings.KEYS.ANALYZER_OSSINDEX_ENABLED));
         settings.setBoolean(Settings.KEYS.ANALYZER_OSSINDEX_USE_CACHE,

--- a/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
@@ -1427,6 +1427,10 @@ public final class CliParser {
          */
         public static final String DISABLE_CENTRAL_CACHE = "disableCentralCache";
         /**
+         * Use JSON response type when querying Maven central.
+         */
+        public static final String ANALYZER_CENTRAL_JSON = "centralJson";
+        /**
          * The alternative URL for Maven Central Search.
          */
         public static final String CENTRAL_URL = "centralUrl";

--- a/core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/central/CentralSearch.java
@@ -17,7 +17,6 @@
  */
 package org.owasp.dependencycheck.data.central;
 
-import org.apache.hc.client5.http.impl.classic.AbstractHttpClientResponseHandler;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.owasp.dependencycheck.utils.DownloadFailedException;
 import org.owasp.dependencycheck.utils.Downloader;
@@ -42,6 +41,9 @@ import org.owasp.dependencycheck.data.cache.DataCacheFactory;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.utils.Settings;
 import org.owasp.dependencycheck.utils.ToXMLDocumentResponseHandler;
+import org.owasp.dependencycheck.utils.json.CentralSearchResponse;
+import org.owasp.dependencycheck.utils.json.ResponseDocument;
+import org.owasp.dependencycheck.utils.json.ToJsonResponseHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -71,6 +73,11 @@ public class CentralSearch {
     private final boolean useProxy;
 
     /**
+     * Whether to use JSON response or the default XML response.
+     */
+    private final boolean useJson;
+
+    /**
      * Used for logging.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(CentralSearch.class);
@@ -98,7 +105,13 @@ public class CentralSearch {
             throw new MalformedURLException(String.format("The configured central analyzer URL is invalid: %s", searchUrl));
         }
         this.rootURL = searchUrl;
-        final String queryStr = settings.getString(Settings.KEYS.ANALYZER_CENTRAL_QUERY);
+
+        this.useJson = settings.getBoolean(Settings.KEYS.ANALYZER_CENTRAL_JSON, false);
+        if (this.useJson) {
+            LOGGER.debug("Using json response format");
+        }
+
+        final String queryStr = settings.getString(this.useJson ? Settings.KEYS.ANALYZER_CENTRAL_QUERY_JSON : Settings.KEYS.ANALYZER_CENTRAL_QUERY);
         LOGGER.debug("Central Search Query: {}", queryStr);
         if (!queryStr.matches("^%s.*%s.*$")) {
             final String msg = String.format("The configured central analyzer query parameter is invalid (it must have two %%s): %s", queryStr);
@@ -155,13 +168,23 @@ public class CentralSearch {
 
         LOGGER.trace("Searching Central url {}", url);
 
-        // JSON would be more elegant, but there's not currently a dependency
-        // on JSON, so don't want to add one just for this
-        final BasicHeader acceptHeader = new BasicHeader("Accept", "application/xml");
-        final AbstractHttpClientResponseHandler<Document> handler = new ToXMLDocumentResponseHandler();
+        final BasicHeader acceptHeader;
+        if (useJson) {
+            acceptHeader = new BasicHeader("Accept", "application/json");
+        } else {
+            acceptHeader = new BasicHeader("Accept", "application/xml");
+        }
         try {
-            final Document doc = Downloader.getInstance().fetchAndHandle(url, handler, List.of(acceptHeader), useProxy);
-            final boolean missing = addMavenArtifacts(doc, result);
+            final boolean missing;
+            if (useJson) {
+                final CentralSearchResponse json = Downloader.getInstance()
+                        .fetchAndHandle(url, new ToJsonResponseHandler(), List.of(acceptHeader), useProxy);
+                missing = addMavenArtifacts(json, result);
+            } else {
+                final Document doc = Downloader.getInstance()
+                        .fetchAndHandle(url, new ToXMLDocumentResponseHandler(), List.of(acceptHeader), useProxy);
+                missing = addMavenArtifacts(doc, result);
+            }
 
             if (missing) {
                 if (cache != null) {
@@ -189,6 +212,33 @@ public class CentralSearch {
             cache.put(sha1, result);
         }
         return result;
+    }
+
+    /**
+     * Collect the artifacts from a MavenCentral search result and add them to the list.
+     *
+     * @param response The JSON response received in response to the SHA1 search-request
+     * @param result   The list of MavenArtifacts to which found artifacts will be added
+     * @return Whether the given document holds no search results
+     */
+    private boolean addMavenArtifacts(CentralSearchResponse response, List<MavenArtifact> result) throws XPathExpressionException {
+        boolean missing = false;
+        final CentralSearchResponse.CentralSearchResponseContent body = response.getBody();
+        final int numFound = body.getNumFound();
+        if (numFound == 0) {
+            missing = true;
+        } else {
+            final List<ResponseDocument> docs = body.getDocs();
+            for (ResponseDocument doc : docs) {
+                LOGGER.trace("GroupId: {}", doc.getGroupId());
+                LOGGER.trace("ArtifactId: {}", doc.getArtifactId());
+                final List<String> attributes = doc.getAttributes();
+                boolean pomAvailable = attributes.stream().anyMatch(".pom"::equals);
+                boolean jarAvailable = attributes.stream().anyMatch(".jar"::equals);
+                result.add(toMavenArtifact(doc.getGroupId(), doc.getArtifactId(), doc.getVersion(), pomAvailable, jarAvailable));
+            }
+        }
+        return missing;
     }
 
     /**
@@ -222,23 +272,27 @@ public class CentralSearch {
                         jarAvailable = true;
                     }
                 }
-                final String centralContentUrl = settings.getString(Settings.KEYS.CENTRAL_CONTENT_URL);
-                String artifactUrl = null;
-                String pomUrl = null;
-                if (jarAvailable) {
-                    //org/springframework/spring-core/3.2.0.RELEASE/spring-core-3.2.0.RELEASE.pom
-                    artifactUrl = centralContentUrl + g.replace('.', '/') + '/' + a + '/'
-                            + v + '/' + a + '-' + v + ".jar";
-                }
-                if (pomAvailable) {
-                    //org/springframework/spring-core/3.2.0.RELEASE/spring-core-3.2.0.RELEASE.pom
-                    pomUrl = centralContentUrl + g.replace('.', '/') + '/' + a + '/'
-                            + v + '/' + a + '-' + v + ".pom";
-                }
-                result.add(new MavenArtifact(g, a, v, artifactUrl, pomUrl));
+                result.add(toMavenArtifact(g, a, v, pomAvailable, jarAvailable));
             }
         }
         return missing;
+    }
+
+    private MavenArtifact toMavenArtifact(String groupId, String artifactId, String version, boolean pomAvailable, boolean jarAvailable) {
+        final String centralContentUrl = settings.getString(Settings.KEYS.CENTRAL_CONTENT_URL);
+        String artifactUrl = null;
+        String pomUrl = null;
+        if (jarAvailable) {
+            //org/springframework/spring-core/3.2.0.RELEASE/spring-core-3.2.0.RELEASE.pom
+            artifactUrl = centralContentUrl + groupId.replace('.', '/') + '/' + artifactId + '/'
+                    + version + '/' + artifactId + '-' + version + ".jar";
+        }
+        if (pomAvailable) {
+            //org/springframework/spring-core/3.2.0.RELEASE/spring-core-3.2.0.RELEASE.pom
+            pomUrl = centralContentUrl + groupId.replace('.', '/') + '/' + artifactId + '/'
+                    + version + '/' + artifactId + '-' + version + ".pom";
+        }
+        return new MavenArtifact(groupId, artifactId, version, artifactUrl, pomUrl);
     }
 
     /**

--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -79,6 +79,7 @@ analyzer.central.url=https://search.maven.org/solrsearch/select
 # Note - the central query is used in a String.format(query, url, sha1)).analyzer.jar.enabled
 # As such, it must have two %s and any other % must be escapped by doubling it
 analyzer.central.query=%s?q=1:%s&wt=xml
+analyzer.central.query.json=%s?q=1:%s&wt=json
 analyzer.central.retry.count=3
 analyzer.central.parallel.analysis=false
 analyzer.central.use.cache=true

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/Settings.java
@@ -740,9 +740,17 @@ public final class Settings {
          */
         public static final String ANALYZER_CENTRAL_QUERY = "analyzer.central.query";
         /**
+         * The properties key for the Central search query when using JSON.
+         */
+        public static final String ANALYZER_CENTRAL_QUERY_JSON = "analyzer.central.query.json";
+        /**
          * The properties key for whether Central search results will be cached.
          */
         public static final String ANALYZER_CENTRAL_USE_CACHE = "analyzer.central.use.cache";
+        /**
+         * The properties key for whether Central search results will be cached.
+         */
+        public static final String ANALYZER_CENTRAL_JSON = "analyzer.central.json";
         /**
          * The path to dotnet core, if available.
          */

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/json/CentralSearchResponse.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/json/CentralSearchResponse.java
@@ -1,0 +1,32 @@
+package org.owasp.dependencycheck.utils.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CentralSearchResponse {
+    @JsonProperty("response")
+    private CentralSearchResponseContent body;
+
+    public CentralSearchResponseContent getBody() {
+        return body;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CentralSearchResponseContent {
+        @JsonProperty
+        private int numFound;
+        @JsonProperty
+        private List<ResponseDocument> docs;
+
+        public int getNumFound() {
+            return numFound;
+        }
+
+        public List<ResponseDocument> getDocs() {
+            return docs;
+        }
+    }
+}

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/json/HeaderParams.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/json/HeaderParams.java
@@ -1,0 +1,21 @@
+package org.owasp.dependencycheck.utils.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class HeaderParams {
+    @JsonProperty("q")
+    private String query;
+    private String core;
+    private boolean indent;
+    @JsonProperty("fl")
+    private String queriedFieldsList;
+    private String start;
+    private String sort;
+    private int rows;
+    private String responseType;
+    private String version;
+
+    public void setIndent(String value) {
+        this.indent = "on".equals(value);
+    }
+}

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/json/ResponseDocument.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/json/ResponseDocument.java
@@ -1,0 +1,45 @@
+package org.owasp.dependencycheck.utils.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Encapsulates an individual response document from Central search when using JSON responses.
+ * <br/>
+ * NOTE: The actual document format has more properties than are enumerated here, but the central analyzer does not use them.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ResponseDocument {
+    @JsonProperty
+    private String id;
+    @JsonProperty("g")
+    private String groupId;
+    @JsonProperty("a")
+    private String artifactId;
+    @JsonProperty("v")
+    private String version;
+    @JsonProperty("ec")
+    private List<String> attributes;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public List<String> getAttributes() {
+        return attributes;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/utils/src/main/java/org/owasp/dependencycheck/utils/json/ToJsonResponseHandler.java
+++ b/utils/src/main/java/org/owasp/dependencycheck/utils/json/ToJsonResponseHandler.java
@@ -1,0 +1,23 @@
+package org.owasp.dependencycheck.utils.json;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hc.client5.http.impl.classic.AbstractHttpClientResponseHandler;
+import org.apache.hc.core5.http.HttpEntity;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class ToJsonResponseHandler extends AbstractHttpClientResponseHandler<CentralSearchResponse> {
+    private static final ObjectMapper MAPPER = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
+
+    @Override
+    public CentralSearchResponse handleEntity(HttpEntity entity) throws IOException {
+        try (InputStream in = entity.getContent()) {
+            return MAPPER.readValue(in, CentralSearchResponse.class);
+        } catch (IOException e) {
+            final String errorMessage = "Failed to parse JSON Response: " + e.getMessage();
+            throw new IOException(errorMessage, e);
+        }
+    }
+}


### PR DESCRIPTION
## Description of Change

Maven central search supports JSON responses alongside the currently-used XML responses, which is also the preferred way of interacting with central.sonatype.com (the eventual/planned successor to the "legacy" central search). This is therefore also a prerequisite to eventually moving to that endpoint (while XML is also supported there, the schema is basically "JSON, but make it XML", i.e. the JSON properties are just converted to XML tags and that's it).

Unfortunately, the schema is currently undocumented, so the implementation is based on sample responses from the JSON endpoint.

So far, I have implemented the actual parsing and the necessary switches/settings for `core`, `cli`, and `ant`. I am marking this PR as draft for now as I have to add the new parameter to the Maven plugin as well.

## Related issues

- relates to #7889 

## Have test cases been added to cover the new functionality?

*no*

I wasn't entirely sure whether this is required, as I have found no tests relating to the XML format either. I'll be happy to add some JSON tests however!