### PR TITLE
fix(fp): suppress non-golang false positives for `distribution` project

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -2090,3 +2090,12 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
     <packageUrl regex="true">^pkg:maven/dev\.detekt/detekt-report-checkstyle@.*$</packageUrl>
     <cpe>cpe:/a:checkstyle:checkstyle</cpe>
 </suppress>
+<suppress base="true">
+    <notes><![CDATA[
+    FP per issue #8408
+    Consolidated suppression aginst any non-golang packages. The distribution project is a golang toolkit with a
+    very generic name, likely to mistakenly match many other artifacts.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:(?!golang/).*$</packageUrl>
+    <cpe regex="true">cpe:/a:distribution(_project)?:distribution:.*</cpe>
+</suppress>


### PR DESCRIPTION
## Description of Change

The distribution project: https://github.com/distribution/distribution is a golang toolkit with an extremely generic name likely to generate false positives in many different places.

This change proposes a generic suppression against anything that's not golang, as a workaround for lack of support for the extended attributes in CPEs (`:go:`) as denoted in NVD (surprisingly given I think it only has one language).

## Related issues

- fixes #8408

## Have test cases been added to cover the new functionality?
N/A