### PR TITLE
fix: bump open-vulnerability-clients to resolve NVD timestamp parsing errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -912,7 +912,7 @@ Copyright (c) 2012 - Jeremy Long
             <dependency>
                 <groupId>io.github.jeremylong</groupId>
                 <artifactId>open-vulnerability-clients</artifactId>
-                <version>9.0.4</version>
+                <version>9.0.5</version>
             </dependency>
             <dependency>
                 <groupId>org.anarres.jdiagnostics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@ Copyright (c) 2012 - Jeremy Long
 
         <!-- upgrading slf4j and logback can cause issues ;) https://github.com/dependency-check/DependencyCheck/issues/4846 -->
         <slf4j.version>2.0.17</slf4j.version>
-        <logback.version>1.5.25</logback.version>
+        <logback.version>1.5.32</logback.version>
 
         <apache.lucene.version>9.12.3</apache.lucene.version>
         <!-- Driver versions as properties for ease of extraction for reuse in Docker builds -->


### PR DESCRIPTION
## Description of Change

Bumps clients to include fix for https://github.com/jeremylong/open-vulnerability-clients/issues/106 / https://github.com/jeremylong/open-vulnerability-clients/issues/107

Also bumps logback. We must have a dependabot ignore rule that needs resetting.

## Related issues
- fixes #8424

## Have test cases been added to cover the new functionality?

Yes