### PR TITLE
fix: de-duplicate and sort both `includedBy` and `projectReferences` in reports

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -104,9 +104,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
     private final SortedSet<Dependency> relatedDependencies = new TreeSet<>(Dependency.NAME_COMPARATOR);
     /**
      * The set of dependencies that included this dependency (i.e., this is a
-     * transitive dependency because it was included by X). This is a pair where
-     * the left element is the includedBy and the right element is the type
-     * (e.g. buildEnv, plugins).
+     * transitive dependency because it was included by X).
      */
     private final Set<IncludedByReference> includedBy = new HashSet<>();
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -19,6 +19,7 @@ package org.owasp.dependencycheck.dependency;
 
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
+import com.google.common.collect.ImmutableSortedSet;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
@@ -796,7 +797,17 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * @return the unmodifiable set of includedBy
      */
     public synchronized Set<IncludedByReference> getIncludedBy() {
-        return Collections.unmodifiableSet(new HashSet<>(includedBy));
+        return Set.copyOf(includedBy);
+    }
+
+    /**
+     * Get the unmodifiable set of includedBy (the list of parents of this
+     * transitive dependency), sorted by natural comparator.
+     *
+     * @return the unmodifiable set of includedBy, sorted
+     */
+    public synchronized SortedSet<IncludedByReference> getIncludedBySorted() {
+        return ImmutableSortedSet.copyOf(includedBy);
     }
 
     /**
@@ -835,7 +846,16 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * @return the unmodifiable set of projectReferences
      */
     public synchronized Set<String> getProjectReferences() {
-        return Collections.unmodifiableSet(new HashSet<>(projectReferences));
+        return Set.copyOf(projectReferences);
+    }
+
+    /**
+     * Get the unmodifiable set of projectReferences, sorted by natural comparator.
+     *
+     * @return the unmodifiable set of projectReferences, sorted
+     */
+    public synchronized SortedSet<String> getProjectReferencesSorted() {
+        return ImmutableSortedSet.copyOf(projectReferences);
     }
 
     /**
@@ -895,7 +915,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * @return the value of availableVersions
      */
     public synchronized List<String> getAvailableVersions() {
-        return Collections.unmodifiableList(new ArrayList<>(availableVersions));
+        return List.copyOf(availableVersions);
     }
 
     /**

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/Dependency.java
@@ -22,6 +22,8 @@ import com.github.packageurl.PackageURL;
 import com.google.common.collect.ImmutableSortedSet;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.owasp.dependencycheck.data.nexus.MavenArtifact;
 import org.owasp.dependencycheck.utils.Checksum;
 import org.slf4j.Logger;
@@ -816,7 +818,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      *
      * @param includedBy a project reference
      */
-    public synchronized void addIncludedBy(String includedBy) {
+    public synchronized void addIncludedBy(@NonNull String includedBy) {
         this.includedBy.add(new IncludedByReference(includedBy, null));
     }
 
@@ -827,7 +829,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      * @param includedBy a project reference
      * @param type the type of project reference (i.e. 'plugins', 'buildEnv')
      */
-    public synchronized void addIncludedBy(String includedBy, String type) {
+    public synchronized void addIncludedBy(@NonNull String includedBy, @Nullable String type) {
         this.includedBy.add(new IncludedByReference(includedBy, type));
     }
 
@@ -836,7 +838,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      *
      * @param includedBy a set of project references
      */
-    public synchronized void addAllIncludedBy(Set<IncludedByReference> includedBy) {
+    public synchronized void addAllIncludedBy(@NonNull Set<IncludedByReference> includedBy) {
         this.includedBy.addAll(includedBy);
     }
 
@@ -863,7 +865,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      *
      * @param projectReference a project reference
      */
-    public synchronized void addProjectReference(String projectReference) {
+    public synchronized void addProjectReference(@NonNull String projectReference) {
         this.projectReferences.add(projectReference);
     }
 
@@ -872,7 +874,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      *
      * @param projectReferences a set of project references
      */
-    public synchronized void addAllProjectReferences(Set<String> projectReferences) {
+    public synchronized void addAllProjectReferences(@NonNull Set<String> projectReferences) {
         this.projectReferences.addAll(projectReferences);
     }
 
@@ -923,7 +925,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      *
      * @param version the version to add to the list
      */
-    public synchronized void addAvailableVersion(String version) {
+    public synchronized void addAvailableVersion(@NonNull String version) {
         this.availableVersions.add(version);
     }
 
@@ -945,7 +947,7 @@ public class Dependency extends EvidenceCollection implements Serializable {
      */
     @Override
     public boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof Dependency)) {
+        if (!(obj instanceof Dependency)) {
             return false;
         }
         if (this == obj) {

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/IncludedByReference.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/IncludedByReference.java
@@ -18,6 +18,7 @@
 package org.owasp.dependencycheck.dependency;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * POJO to store a reference to the "included by" node in a dependency tree;
@@ -70,4 +71,15 @@ public class IncludedByReference implements Serializable {
         return type;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof IncludedByReference)) return false;
+        IncludedByReference that = (IncludedByReference) o;
+        return Objects.equals(reference, that.reference) && Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(reference, type);
+    }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/dependency/IncludedByReference.java
+++ b/core/src/main/java/org/owasp/dependencycheck/dependency/IncludedByReference.java
@@ -17,6 +17,9 @@
  */
 package org.owasp.dependencycheck.dependency;
 
+import org.apache.commons.lang3.builder.CompareToBuilder;
+import org.jspecify.annotations.NonNull;
+
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -26,7 +29,7 @@ import java.util.Objects;
  *
  * @author Jeremy Long
  */
-public class IncludedByReference implements Serializable {
+public class IncludedByReference implements Serializable, Comparable<IncludedByReference> {
 
     /**
      * The serial version UID for serialization.
@@ -75,11 +78,24 @@ public class IncludedByReference implements Serializable {
     public boolean equals(Object o) {
         if (!(o instanceof IncludedByReference)) return false;
         IncludedByReference that = (IncludedByReference) o;
-        return Objects.equals(reference, that.reference) && Objects.equals(type, that.type);
+        return Objects.equals(type, that.type) && Objects.equals(reference, that.reference);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(reference, type);
+        return Objects.hash(type, reference);
+    }
+
+    @Override
+    public int compareTo(@NonNull IncludedByReference o) {
+        return new CompareToBuilder()
+                .append(type, o.type) // Group by type (nulls-first)
+                .append(reference, o.reference) // then the actual reference
+                .toComparison();
+    }
+
+    @Override
+    public String toString() {
+        return "IncludedByReference{reference='" + reference + "', type='" + type + "'}";
     }
 }

--- a/core/src/main/resources/templates/gitlabReport.vsl
+++ b/core/src/main/resources/templates/gitlabReport.vsl
@@ -87,7 +87,7 @@
                                 ## "direct": false, --> not implemented
                                 ## we don't have a good way of assigning iids, so this won't work
                                 ##"dependency_path": [
-                                ##    #foreach( $inc in $dependency.includedBy )
+                                ##    #foreach( $inc in $dependency.includedBySorted )
                                 ##        {
                                 ##            "iid":
                                 ##        }

--- a/core/src/main/resources/templates/htmlReport.vsl
+++ b/core/src/main/resources/templates/htmlReport.vsl
@@ -887,23 +887,24 @@ Getting Help: <a href="https://github.com/dependency-check/DependencyCheck/issue
                             <b>SHA1:</b>&nbsp;$enc.html($dependency.Sha1sum)<br/>
                             <b>SHA256:</b>$enc.html($dependency.Sha256sum)
                             #end
-                            #if ($dependency.projectReferences.size()==1)
-                                <br/><b>Referenced In Project/Scope:</b> $enc.html($dependency.projectReferences.iterator().next())
+                            #set($projectReferences = $dependency.projectReferencesSorted)
+                            #if ($projectReferences.size()==1)
+                                <br/><b>Referenced In Project/Scope:</b> $enc.html($projectReferences.first())
                             #end
-                            #if ($dependency.projectReferences.size()>1)
+                            #if ($projectReferences.size()>1)
                                 <br/><b>Referenced In Projects/Scopes:</b><ul>
-                                #foreach($ref in $dependency.projectReferences)
+                                #foreach($ref in $projectReferences)
                                     <li>$enc.html($ref)</li>
                                 #end
                                 </ul>
                             #end
-                            #if ($dependency.includedBy.size()==1)
-                                #set($incBy=$dependency.includedBy.iterator().next())
-                                <br/><span class="tooltip"><span class="tooltiptext">$enc.html($dependency.DisplayFileName) is in the transitive dependency tree of the listed items.</span><b>Included by:</b></span> $enc.html($incBy.getReference())#if($incBy.getType()) ($enc.html($incBy.getType()))#end
+                            #set($includedBy = $dependency.includedBySorted)
+                            #if ($includedBy.size()==1)
+                                <br/><span class="tooltip"><span class="tooltiptext">$enc.html($dependency.DisplayFileName) is in the transitive dependency tree of the listed items.</span><b>Included by:</b></span> $enc.html($includedBy.first().getReference())#if($includedBy.first().getType()) ($enc.html($includedBy.first().getType()))#end
                             #end
-                            #if ($dependency.includedBy.size()>1)
+                            #if ($includedBy.size()>1)
                                 <br/><span class="tooltip"><span class="tooltiptext">$enc.html($dependency.DisplayFileName) is in the transitive dependency tree of the listed items.</span><b>Included by:</b></span><ul>
-                                #foreach($parent in $dependency.includedBy)
+                                #foreach($parent in $includedBy)
                                     <li>$enc.html($parent.getReference())#if($parent.getType()) ($enc.html($parent.getType()))#end</li>
                                 #end
                                 </ul>
@@ -1124,23 +1125,24 @@ Getting Help: <a href="https://github.com/dependency-check/DependencyCheck/issue
                                     <b>SHA1:</b>&nbsp;$enc.html($dependency.Sha1sum)<br/>
                                     <b>SHA256:</b>&nbsp;$enc.html($dependency.Sha256sum)
                                 #end
-                                #if ($dependency.projectReferences.size()==1)
-                                    <br/><b>Referenced In Project/Scope:</b> $enc.html($dependency.projectReferences.iterator().next())
+                                #set($projectReferences = $dependency.projectReferencesSorted)
+                                #if ($projectReferences.size()==1)
+                                    <br/><b>Referenced In Project/Scope:</b> $enc.html($projectReferences.first())
                                 #end
-                                #if ($dependency.projectReferences.size()>1)
+                                #if ($projectReferences.size()>1)
                                     <br/><b>Referenced In Projects/Scopes:</b><ul>
-                                    #foreach($ref in $dependency.projectReferences)
+                                    #foreach($ref in $projectReferences)
                                         <li>$enc.html($ref)</li>
                                     #end
                                     </ul>
                                 #end
-                                #if ($dependency.includedBy.size()==1)
-                                    #set($incBy=$dependency.includedBy.iterator().next())
-                                    <br/><span class="tooltip"><span class="tooltiptext">$enc.html($dependency.DisplayFileName) is in the transitive dependency tree of the listed items.</span><b>Included by:</b></span> $enc.html($incBy.getReference())#if($incBy.getType()) ($enc.html($incBy.getType()))#end
+                                #set($includedBy = $dependency.includedBySorted)
+                                #if ($includedBy.size()==1)
+                                    <br/><span class="tooltip"><span class="tooltiptext">$enc.html($dependency.DisplayFileName) is in the transitive dependency tree of the listed items.</span><b>Included by:</b></span> $enc.html($includedBy.first().getReference())#if($includedBy.first().getType()) ($enc.html($includedBy.first().getType()))#end
                                 #end
-                                #if ($dependency.includedBy.size()>1)
+                                #if ($includedBy.size()>1)
                                     <br/><b>Included by:</b><ul>
-                                    #foreach($parent in $dependency.includedBy)
+                                    #foreach($parent in $includedBy)
                                         <li>$enc.html($parent.getReference())#if($parent.getType()) ($enc.html($parent.getType()))#end</li>
                                     #end
                                     </ul>

--- a/core/src/main/resources/templates/jenkinsReport.vsl
+++ b/core/src/main/resources/templates/jenkinsReport.vsl
@@ -521,23 +521,24 @@ Getting Help: <a href="https://github.com/dependency-check/DependencyCheck/issue
                             <b>SHA1:</b>&nbsp;$enc.html($dependency.Sha1sum)<br/>
                             <b>SHA256:</b>$enc.html($dependency.Sha256sum)
                             #end
-                            #if ($dependency.projectReferences.size()==1)
-                                <br/><b>Referenced In Project/Scope:</b> $enc.html($dependency.projectReferences.iterator().next())
+                            #set($projectReferences = $dependency.projectReferencesSorted)
+                            #if ($projectReferences.size()==1)
+                                <br/><b>Referenced In Project/Scope:</b> $enc.html($projectReferences.first())
                             #end
-                            #if ($dependency.projectReferences.size()>1)
+                            #if ($projectReferences.size()>1)
                                 <br/><b>Referenced In Projects/Scopes:</b><ul>
-                                #foreach($ref in $dependency.projectReferences)
+                                #foreach($ref in $projectReferences)
                                     <li>$enc.html($ref)</li>
                                 #end
                                 </ul>
                             #end
-                            #if ($dependency.includedBy && $dependency.includedBy.size()==1)
-                                #set($incBy=$dependency.includedBy.iterator().next())
-                                <br/><span class="tooltip"><span class="tooltiptext">$enc.html($dependency.DisplayFileName) is in the transitive dependency tree of the listed items.</span><b>Included by:</b></span> $enc.html($incBy.getReference())#if($incBy.getType()) ($enc.html($incBy.getType()))#end
+                            #set($includedBy = $dependency.includedBySorted)
+                            #if ($includedBy.size()==1)
+                                <br/><span class="tooltip"><span class="tooltiptext">$enc.html($dependency.DisplayFileName) is in the transitive dependency tree of the listed items.</span><b>Included by:</b></span> $enc.html($includedBy.first().getReference())#if($includedBy.first().getType()) ($enc.html($includedBy.first().getType()))#end
                             #end
-                            #if ($dependency.includedBy && $dependency.includedBy.size()>1)
+                            #if ($includedBy.size()>1)
                                 <br/><span class="tooltip"><span class="tooltiptext">$enc.html($dependency.DisplayFileName) is in the transitive dependency tree of the listed items.</span><b>Included by:</b></span><ul>
-                                #foreach($parent in $dependency.includedBy)
+                                #foreach($parent in $includedBy)
                                     <li>$enc.html($parent.getReference())#if($parent.getType()) ($enc.html($parent.getType()))#end</li>
                                 #end
                                 </ul>

--- a/core/src/main/resources/templates/jsonReport.vsl
+++ b/core/src/main/resources/templates/jsonReport.vsl
@@ -65,17 +65,19 @@
             "sha256": "$enc.json($dependency.Sha256sum)"#end
             #if($dependency.description),"description": "$enc.json($dependency.description)"#end
             #if($dependency.license),"license": "$enc.json($dependency.license)"#end
-            #if ($dependency.projectReferences.size()>0)
+            #set($projectReferences = $dependency.projectReferencesSorted)
+            #if ($projectReferences.size()>0)
             ,"projectReferences": [
-            #foreach($ref in $dependency.projectReferences)
+            #foreach($ref in $projectReferences)
                 #if($foreach.count > 1),#end
                 "$enc.json($ref)"
             #end
             ]
             #end
-            #if ($dependency.includedBy.size()>0)
+            #set($includedBy = $dependency.includedBySorted)
+            #if ($includedBy.size()>0)
             ,"includedBy": [
-            #foreach($ref in $dependency.includedBy)
+            #foreach($ref in $includedBy)
                 #if($foreach.count > 1),#end
                 { "reference":"$enc.json($ref.getReference())"#if($ref.getType()),"type":"$enc.json($ref.getType())"#end }
             #end

--- a/core/src/main/resources/templates/junitReport.vsl
+++ b/core/src/main/resources/templates/junitReport.vsl
@@ -93,7 +93,7 @@
                 #end]]>#end</system-out>
             #set($referencedProjects="")
             #set($projectReferenced=false)
-            #foreach($ref in $dependency.projectReferences)
+            #foreach($ref in $dependency.projectReferencesSorted)
                 #if($projectReferenced)
                     #set($referencedProjects="$referencedProjects, $ref")
                 #else

--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -88,16 +88,18 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
 #if ($dependency.license)
             <license>$enc.xml($dependency.license)</license>
 #end
-#if ($dependency.projectReferences.size()>0)
+#set($projectReferences = $dependency.projectReferencesSorted)
+#if ($projectReferences.size()>0)
             <projectReferences>
-#foreach($ref in $dependency.projectReferences)
+#foreach($ref in $projectReferences)
                 <projectReference>$enc.xml($ref)</projectReference>
 #end
             </projectReferences>
 #end
-#if ($dependency.includedBy.size()>0)
+#set($includedBy = $dependency.includedBySorted)
+#if ($includedBy.size()>0)
             <includedBy>
-#foreach($ref in $dependency.includedBy)
+#foreach($ref in $includedBy)
                 <reference#if($ref.getType()) type="$enc.xml($ref.getType())"#end>$enc.xml($ref.getReference())</reference>
 #end
             </includedBy>

--- a/core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/dependency/DependencyTest.java
@@ -30,6 +30,8 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -287,5 +289,24 @@ class DependencyTest extends BaseTest {
         assertFalse(instance.getSoftwareIdentifiers().isEmpty());
 
         instance.getSoftwareIdentifiers().forEach((i) -> assertNotNull(i.getUrl()));
+    }
+
+    @Test
+    void sortsProjectReferences() {
+        Dependency instance = new Dependency();
+        instance.addAllProjectReferences(Set.of("c", "b", "a"));
+        assertThat(instance.getProjectReferencesSorted(), contains("a", "b", "c"));
+    }
+
+    @Test
+    void sortsIncludedByReferences() {
+        Dependency instance = new Dependency();
+        IncludedByReference ref1 = new IncludedByReference("ref1", null);
+        IncludedByReference ref1Typed = new IncludedByReference("ref1", "type1");
+        IncludedByReference ref2 = new IncludedByReference("ref2", null);
+        IncludedByReference ref2Typed = new IncludedByReference("ref2", "type1");
+        IncludedByReference ref1OtherType = new IncludedByReference("ref1", "type2");
+        instance.addAllIncludedBy(Set.of(ref1, ref1Typed, ref1OtherType, ref2, ref2Typed));
+        assertThat(instance.getIncludedBySorted(), contains(ref1, ref2, ref1Typed, ref2Typed, ref1OtherType));
     }
 }


### PR DESCRIPTION
## Description of Change

- Since https://github.com/dependency-check/DependencyCheck/pull/5001 these `includedBy` references have been accidentally duplicated, since they are put into `Sets` but the custom type doesn't have equals/hashCode like the previous `Pair` type did.
- sorted them since these can be very large for bigger projects; and sorting them makes it easier to scan through. Added new methods rather than changing semantics of the existing accessors on Dependency.

## Related issues
N/A

## Have test cases been added to cover the new functionality?

yes

Example HTML report: 
[dependency-check-report.html](https://github.com/user-attachments/files/26955992/dependency-check-report.html)
