### PR TITLE
fix(fp): suppress FPs for log4j-core and log4j-layout-template-json

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -2121,3 +2121,25 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
     <packageUrl regex="true">^pkg:maven/com\.github\.oshi/oshi-common@.*$</packageUrl>
     <cpe>cpe:/a:ada:ada</cpe>
 </suppress>
+<suppress base="true">
+    <notes><![CDATA[
+    only log4j-core is vulnerable; FP per earlier issues and issues #8456, #8457. By review of
+    https://nvd.nist.gov/vuln/search#/nvd/home?cpeFilterMode=applicability&cpeName=cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*&resultType=records
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/(?!log4j-core@).*$</packageUrl>
+    <cve>CVE-2021-44228</cve>
+    <cve>CVE-2021-44832</cve>
+    <cve>CVE-2021-45046</cve>
+    <cve>CVE-2021-45105</cve>
+    <cve>CVE-2025-68161</cve>
+    <cve>CVE-2026-34478</cve>
+    <cve>CVE-2026-34480</cve>
+</suppress>
+<suppress base="true">
+    <notes><![CDATA[
+    only log4j-layout-template-json is vulnerable; FP per issue #8458. By review of
+    https://nvd.nist.gov/vuln/search#/nvd/home?cpeFilterMode=applicability&cpeName=cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*&resultType=records
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/(?!log4j-layout-template-json@).*$</packageUrl>
+    <cve>CVE-2026-34481</cve>
+</suppress>


### PR DESCRIPTION
## Description of Change

Migrates and consolidates the CVE-by-CVE suppressions from below into `generatedSuppressions` for ease of maintenance.

I guess due to the prevalence of log4j we do maintain some CVE-by-CVE suppressions here, but probably not going to be scalable longer term I suppose.

https://github.com/dependency-check/DependencyCheck/blob/7829ad707d3641f8e6f06bdcf3e99a31ca2d6068/core/src/main/resources/dependencycheck-base-suppression.xml#L84-L93

Suppress some marked CVEs against all log4j pkgs other than `log4j-core` (and `log4j-layout-template-json` for one of them)

[NVD search](https://nvd.nist.gov/vuln/search#/nvd/home?cpeFilterMode=applicability&cpeName=cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*&resultType=records)

I'll remove from base suppressions after this, since it will become duplicated.

## Related issues

- fixes #8456
- fixes #8457
- fixes #8458

## Have test cases been added to cover the new functionality?

N/A