### PR TITLE
docs: correct Core Engine menu display

### DIFF
--- a/src/site/markdown/components.md
+++ b/src/site/markdown/components.md
@@ -20,7 +20,7 @@ Extending dependency-check
 A [dependency-check-plugin maven archetype](dependency-check-plugin/index.html)
 has been created to assist with creating your own analyzers.
 
-Core Engine
+Engine
 --------------------------
 Information about the core engine and the utilities used can be found:
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -104,10 +104,8 @@ Copyright (c) 2013 Jeremy Long. All Rights Reserved.
                 </item>
                 <item name="Jenkins Plugin" href="./dependency-check-jenkins/index.html"/>
                 <item name="Maven Plugin Archetype" href="./dependency-check-plugin/index.html"/>
-                <item collapse="true" name="Core Engine">
-                    <item name="Core" href="./dependency-check-core/index.html"/>
-                    <item name="Utils" href="./dependency-check-utils/index.html"/>
-                </item>
+                <item name="Engine: Core" href="./dependency-check-core/index.html"/>
+                <item name="Engine: Utils" href="./dependency-check-utils/index.html"/>
             </item>
             <item collapse="true" name="Analyzers" href="./analyzers/index.html">
                 <item name="Archive" href="./analyzers/archive-analyzer.html"/>


### PR DESCRIPTION
## Description of Change

Currently the display is collapsed by default, which doesn't work properly since there is no aggregating/index page for the two independent Maven sites so you cannot expand the menu by clicking it:

<img width="249" height="215" alt="image" src="https://github.com/user-attachments/assets/5f9800a7-8997-46be-a745-aa597ad81855" />

Since we can't collapse the items, may as well flatten the display to save screen real estate:

<img width="245" height="246" alt="image" src="https://github.com/user-attachments/assets/7438c661-24f7-4e93-aa97-0d6b9480fa76" />


## Related issues

N/A

## Have test cases been added to cover the new functionality?
N/A