### PR TITLE
fix(fp): suppress Jetty toolchain.setuid FPs while consolidating side-project suppressions

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1036,9 +1036,13 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
-    FP per issue #6666, #6798, #6812
+    FP per issue #796, https://github.com/dependency-check/dependency-check-gradle/issues/61, #1515, #2554, #4442,
+    #6666, #6798, #6812, #8483
+    Jetty toolchain, orbit and alpn are not the same or part of the actual jetty server and versioned independently.
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/.*@.*$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.(toolchain|alpn|orbit).*$</packageUrl>
+    <cpe>cpe:/a:mortbay_jetty:jetty</cpe>
+    <cpe>cpe:/a:mortbay:jetty</cpe>
     <cpe>cpe:/a:jetty:jetty</cpe>
     <cpe>cpe:/a:eclipse:jetty</cpe>
 </suppress>


### PR DESCRIPTION
## Description of Change

Consolidates the swathes of rules from base suppressions into hosted suppressions for the known Jetty "side projects" underneath the main `org.eclipse.jetty` group.

This includes these groups, which are all independent of the Jetty server:
- https://mvnrepository.com/artifact/org.eclipse.jetty.toolchain
- https://mvnrepository.com/artifact/org.eclipse.jetty.toolchain.setuid
- https://mvnrepository.com/artifact/org.eclipse.jetty.alpn
- https://mvnrepository.com/artifact/org.eclipse.jetty.orbit

There are probably, more, but this makes them easier to manage as there are dozens of artifacts under these groups.

## Related issues

- fixes #8483

## Have test cases been added to cover the new functionality?

N/A