### PR TITLE
fix(reports): Correct XML report attribute denoting matched status for a suppressed vulnerability

### DIFF
--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -617,7 +617,7 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
                     </references>
                     <vulnerableSoftware>
 #foreach($vs in $vuln.getVulnerableSoftware(true))
-                        <software#if($vs == $vuln.matchedVulnerableSoftware) matched="true"#end
+                        <software#if($vs == $vuln.matchedVulnerableSoftware) vulnerabilityIdMatched="true"#end
                             #if($vs.versionStartIncluding) versionStartIncluding="$enc.xml($vs.versionStartIncluding)"#end
                             #if($vs.versionStartExcluding) versionStartExcluding="$enc.xml($vs.versionStartExcluding)"#end
                             #if($vs.versionEndIncluding) versionEndIncluding="$enc.xml($vs.versionEndIncluding)"#end


### PR DESCRIPTION
## Description of Change

This is incorrect with respect to the schema. It's correct for non-suppressed vulnerabilities.

https://github.com/dependency-check/DependencyCheck/blob/706a2bf981c573bc47b3ad5195bd7ad66b2e6fe7/core/src/main/resources/schema/dependency-check.4.1.xsd#L184-L195

## Related issues

None

## Have test cases been added to cover the new functionality?

N/A