### PR TITLE
fix(cli): correct displayed application name and deprecations in help text

### DIFF
--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -130,11 +130,11 @@ public class App {
             cli.parse(args);
         } catch (FileNotFoundException ex) {
             System.err.println(ex.getMessage());
-            cli.printHelp();
+            cli.printHelp(System.out);
             return 1;
         } catch (ParseException ex) {
             System.err.println(ex.getMessage());
-            cli.printHelp();
+            cli.printHelp(System.out);
             return 2;
         }
         final String verboseLog = cli.getStringArgument(CliParser.ARGUMENT.VERBOSE_LOG);
@@ -234,7 +234,7 @@ public class App {
                 settings.cleanup();
             }
         } else {
-            cli.printHelp();
+            cli.printHelp(System.out);
         }
         return exitCode;
     }

--- a/cli/src/main/java/org/owasp/dependencycheck/App.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/App.java
@@ -24,6 +24,7 @@ import ch.qos.logback.classic.filter.ThresholdFilter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.FileAppender;
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.types.LogLevel;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
@@ -46,6 +47,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -95,6 +97,14 @@ public class App {
      */
     public App() {
         settings = new Settings();
+        settings.setString(Settings.KEYS.APPLICATION_NAME, determineName());
+    }
+
+    private static String determineName() {
+        return Optional.ofNullable(System.getenv("ODC_NAME"))
+                .filter(StringUtils::isNotBlank)
+                .map(n -> n.replace('/', '-').replace(' ', '_'))
+                .orElse("dependency-check-cli");
     }
 
     /**
@@ -456,12 +466,6 @@ public class App {
      * file is unable to be loaded.
      */
     protected void populateSettings(CliParser cli) throws InvalidSettingException {
-        String name = System.getenv("ODC_NAME") != null ? System.getenv("ODC_NAME") : "dependency-check-cli";
-        if (name.isBlank()) {
-            name = "dependency-check-cli";
-        }
-        name = name.replace("/", "-").replace(" ", "_");
-        settings.setString(Settings.KEYS.APPLICATION_NAME, name);
         final File propertiesFile = cli.getFileArgument(CliParser.ARGUMENT.PROP);
         if (propertiesFile != null) {
             try {

--- a/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
+++ b/cli/src/main/java/org/owasp/dependencycheck/CliParser.java
@@ -21,11 +21,12 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.help.HelpFormatter;
+import org.apache.commons.cli.help.TextHelpAppendable;
 import org.owasp.dependencycheck.reporting.ReportGenerator.Format;
 import org.owasp.dependencycheck.utils.InvalidSettingException;
 import org.owasp.dependencycheck.utils.Settings;
@@ -34,6 +35,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Comparator;
 
 /**
  * A utility to parse command line arguments for the DependencyCheck.
@@ -65,6 +69,12 @@ public final class CliParser {
      */
     private static final String SUPPORTED_FORMATS = "HTML, XML, CSV, JSON, JUNIT, SARIF, JENKINS, GITLAB or ALL";
 
+    private static final String HELP_MSG = String.format(
+            "Dependency-Check can be used to identify if there are any known CVE vulnerabilities in libraries " +
+                    "utilized by an application. Dependency-Check will automatically update required data from the " +
+                    "Internet, such as the CVE and CPE data files from nvd.nist.gov.%n"
+    );
+
     /**
      * Constructs a new CLI Parser object with the configured settings.
      *
@@ -82,7 +92,7 @@ public final class CliParser {
      * point to a file that exists.
      * @throws ParseException is thrown when a Parse Exception occurs.
      */
-    public void parse(String[] args) throws FileNotFoundException, ParseException {
+    public void parse(String... args) throws FileNotFoundException, ParseException {
         line = parseArgs(args);
 
         if (line != null) {
@@ -97,7 +107,7 @@ public final class CliParser {
      * @return the results of parsing the command line arguments
      * @throws ParseException if the arguments are invalid
      */
-    private CommandLine parseArgs(String[] args) throws ParseException {
+    private CommandLine parseArgs(String... args) throws ParseException {
         final CommandLineParser parser = new DefaultParser();
         final Options options = createCommandLineOptions();
         return parser.parse(options, args);
@@ -213,7 +223,7 @@ public final class CliParser {
      * @param argumentName the argument being validated (e.g. scan, out, etc.)
      * @return true, if path exists; false otherwise
      */
-    private boolean isValidFilePath(String path, String argumentName) {
+    private boolean isValidFilePath(String path, @SuppressWarnings("SameParameterValue") String argumentName) {
         try {
             validatePathExists(path, argumentName);
             return true;
@@ -232,7 +242,7 @@ public final class CliParser {
      * @throws FileNotFoundException is thrown if one of the paths being
      * validated does not exist.
      */
-    private void validatePathExists(String[] paths, String optType) throws FileNotFoundException {
+    private void validatePathExists(String[] paths, @SuppressWarnings("SameParameterValue") String optType) throws FileNotFoundException {
         for (String path : paths) {
             validatePathExists(path, optType);
         }
@@ -301,7 +311,6 @@ public final class CliParser {
      *
      * @return the command line options used for parsing the command line
      */
-    @SuppressWarnings("static-access")
     private Options createCommandLineOptions() {
         final Options options = new Options();
         addStandardOptions(options);
@@ -315,10 +324,8 @@ public final class CliParser {
      *
      * @param options a collection of command line arguments
      */
-    @SuppressWarnings("static-access")
     private void addStandardOptions(final Options options) {
-        //This is an option group because it can be specified more then once.
-
+        //This is an option group because it can be specified more than once.
         options.addOptionGroup(newOptionGroup(newOptionWithArg(ARGUMENT.SCAN_SHORT, ARGUMENT.SCAN, "path",
                         "The path to scan - this option can be specified multiple times. Ant style paths are supported (e.g. 'path/**/*.jar'); "
                                 + "if using Ant style paths it is highly recommended to quote the argument value.")))
@@ -357,7 +364,6 @@ public final class CliParser {
      *
      * @param options a collection of command line arguments
      */
-    @SuppressWarnings("static-access")
     private void addAdvancedOptions(final Options options) {
         options
                 .addOption(newOption(ARGUMENT.UPDATE_ONLY,
@@ -445,11 +451,11 @@ public final class CliParser {
                 .addOption(newOptionWithArg(ARGUMENT.RETIREJS_URL, "url",
                         "The Retire JS Repository URL"))
                 .addOption(newOptionWithArg(ARGUMENT.RETIREJS_URL_USER, "username",
-                        "The password to authenticate to Retire JS Repository URL"))
+                        "Credentials for basic auth towards the Retire JS Repository URL"))
                 .addOption(newOptionWithArg(ARGUMENT.RETIREJS_URL_PASSWORD, "password",
-                        "The password to authenticate to Retire JS Repository URL"))
+                        "Credentials for basic auth towards the Retire JS Repository URL"))
                 .addOption(newOptionWithArg(ARGUMENT.RETIREJS_URL_BEARER_TOKEN, "token",
-                        "The password to authenticate to Retire JS Repository URL"))
+                        "Token for bearer auth towards the Retire JS Repository URL"))
                 .addOption(newOption(ARGUMENT.RETIRE_JS_FILTER_NON_VULNERABLE, "Specifies that the Retire JS "
                         + "Analyzer should filter out non-vulnerable JS files from the report."))
                 .addOption(newOptionWithArg(ARGUMENT.ARTIFACTORY_PARALLEL_ANALYSIS, "true/false",
@@ -571,7 +577,6 @@ public final class CliParser {
      *
      * @param options a collection of command line arguments
      */
-    @SuppressWarnings({"static-access", "deprecation"})
     private void addDeprecatedOptions(final Options options) {
         //not a real option - but enables java debugging via the shell script
         options.addOption(newOption("debug",
@@ -784,26 +789,28 @@ public final class CliParser {
     }
 
     /**
-     * Displays the command line help message to the standard output.
+     * Appends the command line help message to the passed appendable
      */
-    public void printHelp() {
-        final HelpFormatter formatter = new HelpFormatter();
+    void printHelp(Appendable appendable) {
+        TextHelpAppendable helpAppendable = new TextHelpAppendable(appendable);
+        helpAppendable.setMaxWidth(100);
+        HelpFormatter formatter = HelpFormatter.builder()
+                .setShowSince(false)
+                .setComparator(Comparator.comparing(Option::getKey, String::compareToIgnoreCase))
+                .setHelpAppendable(helpAppendable)
+                .get();
+
         final Options options = new Options();
         addStandardOptions(options);
         if (line != null && line.hasOption(ARGUMENT.ADVANCED_HELP)) {
             addAdvancedOptions(options);
         }
-        final String helpMsg = String.format("%n%s"
-                        + " can be used to identify if there are any known CVE vulnerabilities in libraries utilized by an application. "
-                        + "%s will automatically update required data from the Internet, such as the CVE and CPE data files from nvd.nist.gov.%n%n",
-                settings.getString(Settings.KEYS.APPLICATION_NAME, "DependencyCheck"),
-                settings.getString(Settings.KEYS.APPLICATION_NAME, "DependencyCheck"));
 
-        formatter.printHelp(settings.getString(Settings.KEYS.APPLICATION_NAME, "DependencyCheck"),
-                helpMsg,
-                options,
-                "",
-                true);
+        try {
+            formatter.printHelp("dependency-check", HELP_MSG, formatter.sort(options), "", true);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     /**
@@ -1005,7 +1012,7 @@ public final class CliParser {
      * @return a new option
      */
     private Option newOption(String name, String description) {
-        return Option.builder().longOpt(name).desc(description).build();
+        return Option.builder().longOpt(name).desc(description).get();
     }
 
     /**
@@ -1017,7 +1024,7 @@ public final class CliParser {
      * @return a new option
      */
     private Option newOption(String shortName, String name, String description) {
-        return Option.builder(shortName).longOpt(name).desc(description).build();
+        return Option.builder(shortName).longOpt(name).desc(description).get();
     }
 
     /**
@@ -1029,7 +1036,7 @@ public final class CliParser {
      * @return a new option
      */
     private Option newOptionWithArg(String name, String arg, String description) {
-        return Option.builder().longOpt(name).argName(arg).hasArg().desc(description).build();
+        return Option.builder().longOpt(name).argName(arg).hasArg().desc(description).get();
     }
 
     /**
@@ -1042,7 +1049,7 @@ public final class CliParser {
      * @return a new option
      */
     private Option newOptionWithArg(String shortName, String name, String arg, String description) {
-        return Option.builder(shortName).longOpt(name).argName(arg).hasArg().desc(description).build();
+        return Option.builder(shortName).longOpt(name).argName(arg).hasArg().desc(description).get();
     }
 
     /**

--- a/cli/src/test/java/org/owasp/dependencycheck/CliParserTest.java
+++ b/cli/src/test/java/org/owasp/dependencycheck/CliParserTest.java
@@ -24,14 +24,21 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
+import java.io.StringWriter;
+import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInRelativeOrder;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
@@ -47,13 +54,8 @@ class CliParserTest extends BaseTest {
     @Test
     void testParse() throws Exception {
 
-        String[] args = {};
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(baos, true, UTF_8));
-
         CliParser instance = new CliParser(getSettings());
-        instance.parse(args);
+        instance.parse();
 
         assertFalse(instance.isGetVersion());
         assertFalse(instance.isGetHelp());
@@ -160,16 +162,9 @@ class CliParserTest extends BaseTest {
     @Test
     void testParse_unknown() {
 
-        String[] args = {"-unknown"};
-
-        ByteArrayOutputStream baos_out = new ByteArrayOutputStream();
-        ByteArrayOutputStream baos_err = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(baos_out, true, UTF_8));
-        System.setErr(new PrintStream(baos_err, true, UTF_8));
-
         CliParser instance = new CliParser(getSettings());
 
-        ParseException ex = assertThrows(ParseException.class, () -> instance.parse(args) ,
+        ParseException ex = assertThrows(ParseException.class, () -> instance.parse("-unknown"),
                 "Unrecognized option should have caused an exception");
         assertTrue(ex.getMessage().contains("Unrecognized option"));
 
@@ -243,7 +238,6 @@ class CliParserTest extends BaseTest {
      *
      */
     @Test
-    @SuppressWarnings("StringSplitter")
     void testParse_printVersionInfo() {
 
         PrintStream out = System.out;
@@ -253,11 +247,7 @@ class CliParserTest extends BaseTest {
         CliParser instance = new CliParser(getSettings());
         instance.printVersionInfo();
         try {
-            String text = baos.toString(UTF_8).toLowerCase();
-            String[] lines = text.split(System.lineSeparator());
-            assertTrue(lines.length >= 1);
-            assertTrue(text.contains("version"));
-            assertFalse(text.contains("unknown"));
+            assertThat(baos.toString(UTF_8), matchesPattern("(?mi)dependency-check.*version [0-9]+.*\n"));
         } finally {
             System.setOut(out);
         }
@@ -269,28 +259,32 @@ class CliParserTest extends BaseTest {
      * @throws Exception thrown when an exception occurs.
      */
     @Test
-    @SuppressWarnings("StringSplitter")
     void testParse_printHelp() throws Exception {
-
-        PrintStream out = System.out;
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(baos, true, UTF_8));
-
         CliParser instance = new CliParser(getSettings());
-        String[] args = {"-h"};
-        instance.parse(args);
-        instance.printHelp();
-        args[0] = "--advancedHelp";
-        instance.parse(args);
-        instance.printHelp();
-        try {
-            String text = (baos.toString(UTF_8));
-            String[] lines = text.split(System.lineSeparator());
-            assertTrue(lines[0].startsWith("usage: "));
-            assertTrue((lines.length > 2));
-        } finally {
-            System.setOut(out);
-        }
+        instance.parse("-h");
+        StringWriter text = new StringWriter();
+        instance.printHelp(text);
+
+        List<String> lines = text.toString().lines().collect(toList());
+        assertThat(lines, containsInRelativeOrder(startsWith(" usage:  dependency-check"), startsWith(" -v, --version")));
+        assertThat(lines.size(), greaterThan(10));
+    }
+
+    /**
+     * Test of printHelp, of class CliParser.
+     *
+     * @throws Exception thrown when an exception occurs.
+     */
+    @Test
+    void testParse_printHelpAdvanced() throws Exception {
+        CliParser instance = new CliParser(getSettings());
+        instance.parse("--advancedHelp");
+        StringWriter text = new StringWriter();
+        instance.printHelp(text);
+
+        List<String> lines = text.toString().lines().collect(toList());
+        assertThat(lines, containsInRelativeOrder(startsWith(" usage:  dependency-check"), startsWith(" -c, --connectiontimeout"), startsWith(" -v, --version")));
+        assertThat(lines.size(), greaterThan(60));
     }
 
     /**


### PR DESCRIPTION
## Description of Change

Currently the help text tends to display `usage: Dependency-Check Core` from the default `Settings.KEYS.APPLICATION_NAME` which is mildly confusing. Generally the actual entry point is `dependency-check` or `dependency-check.sh`.

The Application Name was overridden lateish in the process from env for telemetry purposes; but it is actually used earlier so moved the value setting earlier. In any case, the help/usage should probably indicate something approximating the script/executable name. I haven't gone so far as to detect the _actual_ name from shell script; nor to disambiguate between Homebrew variant without `.sh`, or running within Docker - so this is "better but not perfect".

Also migrated to the newer non-deprecated `HelpFormatter`. it looks basically the same as the old one:

```
$ cli/target/release/bin/dependency-check.sh
 usage:  dependency-check [--advancedHelp] [--disableVersionCheck] [--enableExperimental] [--exclude
 <pattern>] [-f <format>] [--failOnCVSS <score>] [-h] [--junitFailOnCVSS <score>] [-l <file>] [-n]
    [--nvdApiKey <apiKey>] [-o <path>] [--prettyPrint] [--project <name>] [-s <path>] [--suppression
    <file>] [-v]

 Dependency-Check can be used to identify if there are any known CVE vulnerabilities in libraries
    utilized by an application. Dependency-Check will automatically update required data from the
    Internet, such as the CVE and CPE data files from nvd.nist.gov.

          Options                                           Description
 --advancedHelp                Print the advanced help message.
 --disableVersionCheck         Disables the dependency-check version check
 --enableExperimental          Enables the experimental analyzers.
 --exclude <pattern>           Specify an exclusion pattern. This option can be specified multiple
                                times and it accepts Ant style exclusions.
 -f, --format <format>         The report format (HTML, XML, CSV, JSON, JUNIT, SARIF, JENKINS, GITLAB
                                or ALL). The default is HTML. Multiple format parameters can be
                                specified.
 --failOnCVSS <score>          Specifies if the build should be failed if a CVSS score above a
                                specified level is identified. The default is 11; since the CVSS
                                scores are 0-10, by default the build will never fail.
 -h, --help                    Print this message.
 --junitFailOnCVSS <score>     Specifies the CVSS score that is considered a failure when generating
                                the junit report. The default is 0.
 -l, --log <file>              The file path to write verbose logging information.
 -n, --noupdate                Disables the automatic updating of the NVD-CVE, hosted-suppressions
                                and RetireJS data.
 --nvdApiKey <apiKey>          The API Key to access the NVD API.
 -o, --out <path>              The folder to write reports to. This defaults to the current
                                directory. It is possible to set this to a specific file name if the
                                format argument is not set to ALL.
 --prettyPrint                 When specified the JSON and XML report formats will be pretty printed.
 --project <name>              The name of the project being scanned.
 -s, --scan <path>             The path to scan - this option can be specified multiple times. Ant
                                style paths are supported (e.g. 'path/**/*.jar'); if using Ant style
                                paths it is highly recommended to quote the argument value.
 --suppression <file>          The file path to the suppression XML file. This can be specified more
                                then once to utilize multiple suppression files
 -v, --version                 Print the version information.
 ```

## Related issues

N/A

## Have test cases been added to cover the new functionality?

yes