### PR TITLE
fix(fp): suppress FP from grpc-go; migrating grpc CVE-by-CVE suppressions to hosted suppressions

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1419,7 +1419,28 @@ only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
       as suggested in #7250. If it's not in the io.grpc groupId it's not gRPC itself
       ]]></notes>
     <packageUrl regex="true">^pkg:maven/(?!io\.grpc/).*$</packageUrl>
-    <cpe>cpe:/a:grpc:grpc</cpe>
+    <cpe>cpe:/a:grpc:grpc:</cpe>
+</suppress>
+<suppress base="true">
+    <notes><![CDATA[
+    FP per #3002 and #5890 - CVE are for GRPC C/ruby/python etc. Suppressing individual CVEs because ODC cannot understand the target SW
+    field. NVD search to review in future (not that some are marked incorrectly as affecting all languages)
+    --> https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=1&sortDirection=1&cpeFilterMode=applicability&cpeName=cpe:2.3:a:grpc:grpc:*:*:*:*:*:*:*:*&resultType=records
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.grpc/grpc\-.*$</packageUrl>
+    <cve>CVE-2017-7860</cve>
+    <cve>CVE-2017-7861</cve>
+    <cve>CVE-2017-8359</cve>
+    <cve>CVE-2017-9431</cve>
+    <cve>CVE-2020-7768</cve>
+    <cve>CVE-2023-1428</cve>
+    <cve>CVE-2023-32731</cve>
+    <cve>CVE-2023-32732</cve>
+    <cve>CVE-2023-33953</cve>
+    <cve>CVE-2023-4785</cve>
+    <cve>CVE-2024-11407</cve>
+    <cve>CVE-2024-7246</cve>
+    <cve>CVE-2026-33186</cve>
 </suppress>
 <suppress base="true">
 <notes><![CDATA[


### PR DESCRIPTION
## Description of Change

Migrates the GRPC CVE-by-CVE suppressions to hosted for easier maintenance; and suppresses additional vuln CVE-2026-33186 (another grpc-go CVE)

For reference:

https://github.com/dependency-check/DependencyCheck/blob/5b8a493b4d78c524005d907af72f774cacc3eda5/core/src/main/resources/dependencycheck-base-suppression.xml#L282-L301

## Related issues

- fixes #8503

## Have test cases been added to cover the new functionality?

N/A