### PR TITLE
test: fix expectations for RetireJS against AngularJS integration test

### DIFF
--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzerIT.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/RetireJsAnalyzerIT.java
@@ -151,7 +151,6 @@ class RetireJsAnalyzerIT extends BaseDBTestCase {
                         "CVE-2022-25869",
                         "CVE-2024-8373",
                         "CVE-2025-0716",
-                        "CVE-2025-2336",
                         "DOS in $sanitize",
                         "GHSA-28hp-fgcr-2r4h",
                         "GHSA-5cp4-xmrw-59wf",


### PR DESCRIPTION
## Description of Change

Integration tests are currently failing on `master` as some bounds matching/generation was fixed upstream in RetireJS via https://github.com/RetireJS/retire.js/pull/571, which removed a false positive in our expectations. (now that CVE only correctly matches for Angular `1.3.1`+, our test mocks Angular `1.2.27`)

## Related issues

N/A

## Have test cases been added to cover the new functionality?

yes