### PR TITLE
fix(fp): convert hosted/generated suppressions to conservative regex prefix matchers

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -3,330 +3,330 @@
     FP per issue #4806
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.vaadin\.addon/easyuploads@.*$</packageUrl>
-    <cpe>cpe:/a:vaadin:vaadin:</cpe>
+    <cpe regex="true">cpe:/a:vaadin:vaadin(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4790
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback-classic@.*$</packageUrl>
-    <cpe>cpe:/a:qos:slf4j:</cpe>
+    <cpe regex="true">cpe:/a:qos:slf4j(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4781
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.microprofile\.config/microprofile-config-api@.*$</packageUrl>
-    <cpe>cpe:/a:payara:payara:</cpe>
+    <cpe regex="true">cpe:/a:payara:payara(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4777
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.james/apache-mime4j@.*$</packageUrl>
-    <cpe>cpe:/a:apache:james:</cpe>
+    <cpe regex="true">cpe:/a:apache:james(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4755
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.postgresql/r2dbc-postgresql@.*$</packageUrl>
-    <cpe>cpe:/a:postgresql:postgresql:</cpe>
+    <cpe regex="true">cpe:/a:postgresql:postgresql(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4754
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.mockito/mockito-junit-jupiter@.*$</packageUrl>
-    <cpe>cpe:/a:junit:junit4:</cpe>
+    <cpe regex="true">cpe:/a:junit:junit4(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4735
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.robolectric/junit@.*$</packageUrl>
-    <cpe>cpe:/a:junit:junit4:</cpe>
+    <cpe regex="true">cpe:/a:junit:junit4(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4729
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.openhtmltopdf/openhtmltopdf-jsoup-dom-converter@.*$</packageUrl>
-    <cpe>cpe:/a:jsoup:jsoup:</cpe>
+    <cpe regex="true">cpe:/a:jsoup:jsoup(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4728
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.vladsch\.flexmark/flexmark-ext-xwiki-macros@.*$</packageUrl>
-    <cpe>cpe:/a:xwiki:xwiki:</cpe>
+    <cpe regex="true">cpe:/a:xwiki:xwiki(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4727
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.vladsch\.flexmark/flexmark-ext-macros@.*$</packageUrl>
-    <cpe>cpe:/a:processing:processing:</cpe>
+    <cpe regex="true">cpe:/a:processing:processing(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4726
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jfrog\.artifactory\.client/artifactory-java-client-api@.*$</packageUrl>
-    <cpe>cpe:/a:jfrog:artifactory:</cpe>
+    <cpe regex="true">cpe:/a:jfrog:artifactory(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4897
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-annotation-processing-gradle@.*$</packageUrl>
-    <cpe>cpe:/a:processing:processing:</cpe>
+    <cpe regex="true">cpe:/a:processing:processing(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4900
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.testcontainers/mysql@.*$</packageUrl>
-    <cpe>cpe:/a:mysql:mysql:</cpe>
+    <cpe regex="true">cpe:/a:mysql:mysql(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4899
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.mariadb/r2dbc-mariadb@.*$</packageUrl>
-    <cpe>cpe:/a:mariadb:mariadb:</cpe>
+    <cpe regex="true">cpe:/a:mariadb:mariadb(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4898
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.testcontainers/mariadb@.*$</packageUrl>
-    <cpe>cpe:/a:mariadb:mariadb:</cpe>
+    <cpe regex="true">cpe:/a:mariadb:mariadb(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4721
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.camel/camel-activemq@.*$</packageUrl>
-    <cpe>cpe:/a:apache:activemq:</cpe>
+    <cpe regex="true">cpe:/a:apache:activemq(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4652
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jruby\.rack/jruby-rack@.*$</packageUrl>
-    <cpe>cpe:/a:jruby:jruby:</cpe>
+    <cpe regex="true">cpe:/a:jruby:jruby(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4647
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jruby/dirgra@.*$</packageUrl>
-    <cpe>cpe:/a:jruby:jruby:</cpe>
+    <cpe regex="true">cpe:/a:jruby:jruby(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4932
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.datasketches/datasketches-java@.*$</packageUrl>
-    <cpe>cpe:/a:sketch:sketch:</cpe>
+    <cpe regex="true">cpe:/a:sketch:sketch(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5038
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.locationtech\.spatial4j/spatial4j@.*$</packageUrl>
-    <cpe>cpe:/a:pro_search:pro_search:</cpe>
+    <cpe regex="true">cpe:/a:pro_search:pro_search(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5037
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.ko-sys\.av/airac@.*$</packageUrl>
-    <cpe>cpe:/a:keybase:keybase:</cpe>
+    <cpe regex="true">cpe:/a:keybase:keybase(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5027
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/software\.aws\.rds/aws-mysql-jdbc@.*$</packageUrl>
-    <cpe>cpe:/a:mysql:mysql:</cpe>
+    <cpe regex="true">cpe:/a:mysql:mysql(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5024
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/net\.openhft/chronicle-wire@.*$</packageUrl>
-    <cpe>cpe:/a:wire:wire:</cpe>
+    <cpe regex="true">cpe:/a:wire:wire(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5022
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.zendesk/mysql-binlog-connector-java@.*$</packageUrl>
-    <cpe>cpe:/a:mysql:mysql:</cpe>
+    <cpe regex="true">cpe:/a:mysql:mysql(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5021
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.debezium/debezium-connector-mysql@.*$</packageUrl>
-    <cpe>cpe:/a:mysql:mysql:</cpe>
+    <cpe regex="true">cpe:/a:mysql:mysql(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4944
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase-zookeeper@.*$</packageUrl>
-    <cpe>cpe:/a:apache:zookeeper:</cpe>
+    <cpe regex="true">cpe:/a:apache:zookeeper(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5014
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.ejbca\.cvc/cert-cvc@.*$</packageUrl>
-    <cpe>cpe:/a:primekey:ejbca:</cpe>
+    <cpe regex="true">cpe:/a:primekey:ejbca(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4952
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.twill/twill-zookeeper@.*$</packageUrl>
-    <cpe>cpe:/a:apache:zookeeper:</cpe>
+    <cpe regex="true">cpe:/a:apache:zookeeper(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4947
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.pf4j/pf4j@.*$</packageUrl>
-    <cpe>cpe:/a:sonatype:nexus:</cpe>
+    <cpe regex="true">cpe:/a:sonatype:nexus(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4946
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.iceberg/iceberg-hive-metastore@.*$</packageUrl>
-    <cpe>cpe:/a:apache:hive:</cpe>
+    <cpe regex="true">cpe:/a:apache:hive(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4942
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase-hadoop-compat@.*$</packageUrl>
-    <cpe>cpe:/a:apache:hadoop:</cpe>
+    <cpe regex="true">cpe:/a:apache:hadoop(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4941
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.flink/flink-rpc-akka-loader@.*$</packageUrl>
-    <cpe>cpe:/a:akka:akka:</cpe>
+    <cpe regex="true">cpe:/a:akka:akka(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4940
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.flink/flink-hadoop-fs@.*$</packageUrl>
-    <cpe>cpe:/a:apache:hadoop:</cpe>
+    <cpe regex="true">cpe:/a:apache:hadoop(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4931
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.azure\.resourcemanager/azure-resourcemanager-appplatform@.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:platform_sdk:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:platform_sdk(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4720
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.clojure/data\.priority-map@.*$</packageUrl>
-    <cpe>cpe:/a:priority-software:priority:</cpe>
+    <cpe regex="true">cpe:/a:priority-software:priority(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4651
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.hibernate/hibernate-commons-annotations@.*$</packageUrl>
-    <cpe>cpe:/a:hibernate:hibernate_orm:</cpe>
+    <cpe regex="true">cpe:/a:hibernate:hibernate_orm(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5097
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/software\.aws\.rds/aws-mysql-jdbc@.*$</packageUrl>
-    <cpe>cpe:/a:mariadb:mariadb:</cpe>
-    <cpe>cpe:/a:mysql:mysql:</cpe>
+    <cpe regex="true">cpe:/a:mariadb:mariadb(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:mysql:mysql(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5108
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jfrog\.artifactory\.client/artifactory-java-client-httpClient@.*$</packageUrl>
-    <cpe>cpe:/a:jfrog:artifactory:</cpe>
+    <cpe regex="true">cpe:/a:jfrog:artifactory(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5107
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentracing\.contrib/opentracing-apache-httpclient@.*$</packageUrl>
-    <cpe>cpe:/a:apache:httpclient:</cpe>
+    <cpe regex="true">cpe:/a:apache:httpclient(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4621
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson-xc@.*$</packageUrl>
-    <cpe>cpe:/a:fasterxml:jackson-databind:</cpe>
+    <cpe regex="true">cpe:/a:fasterxml:jackson-databind(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per #5118
     ]]></notes>
     <sha1>5b8f86fea035328fc9e8c660773037a3401ce25f</sha1>
-    <cpe regex="true">.*</cpe>
+    <cpe regex="true">(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4575
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.wildfly\.wildfly-http-client/wildfly-http-ejb-client@.*$</packageUrl>
-    <cpe>cpe:/a:redhat:jboss-ejb-client:</cpe>
+    <cpe regex="true">cpe:/a:redhat:jboss-ejb-client(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5162
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jgroups\.kubernetes/jgroups-kubernetes@.*$</packageUrl>
-    <cpe>cpe:/a:redhat:jgroups:</cpe>
+    <cpe regex="true">cpe:/a:redhat:jgroups(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5171
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.james/queue-activemq-guice@.*$</packageUrl>
-    <cpe>cpe:/a:apache:activemq:</cpe>
+    <cpe regex="true">cpe:/a:apache:activemq(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5172
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.projectreactor\.rabbitmq/reactor-rabbitmq@.*$</packageUrl>
-    <cpe>cpe:/a:vmware:rabbitmq:</cpe>
+    <cpe regex="true">cpe:/a:vmware:rabbitmq(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5170
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.james/james-server-queue-activemq@.*$</packageUrl>
-    <cpe>cpe:/a:apache:activemq:</cpe>
+    <cpe regex="true">cpe:/a:apache:activemq(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5168
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.james/apache-jsieve-core@.*$</packageUrl>
-    <cpe>cpe:/a:apache:james:</cpe>
+    <cpe regex="true">cpe:/a:apache:james(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -340,217 +340,224 @@
     FP per issue #5169
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.google\.crypto\.tink/apps-webpush@.*$</packageUrl>
-    <cpe>cpe:/a:google:google_apps:</cpe>
+    <cpe regex="true">cpe:/a:google:google_apps(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5276
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop\.thirdparty/hadoop-shaded-guava@.*$</packageUrl>
-    <cpe>cpe:/a:apache:hadoop:</cpe>
+    <cpe regex="true">cpe:/a:apache:hadoop(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5278
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.datastax\.oss/native-protocol@.*$</packageUrl>
-    <cpe>cpe:/a:apache:cassandra:</cpe>
+    <cpe regex="true">cpe:/a:apache:cassandra(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5336
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.openrewrite\.recipe/rewrite-jhipster@.*$</packageUrl>
-    <cpe>cpe:/a:jhipster:jhipster:</cpe>
+    <cpe regex="true">cpe:/a:jhipster:jhipster(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5361
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/jakarta\.resource/jakarta\.resource-api@.*$</packageUrl>
-    <cpe>cpe:/a:payara:payara:</cpe>
+    <cpe regex="true">cpe:/a:payara:payara(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5375
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.microprofile\.jwt/microprofile-jwt-auth-api@.*$</packageUrl>
-    <cpe>cpe:/a:payara:payara:</cpe>
+    <cpe regex="true">cpe:/a:payara:payara(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5368
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop\.thirdparty/hadoop-shaded-protobuf_3_7@.*$</packageUrl>
-    <cpe>cpe:/a:apache:hadoop:</cpe>
+    <cpe regex="true">cpe:/a:apache:hadoop(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5436
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.codehaus\.woodstox/stax2-api@.*$</packageUrl>
-    <cpe>cpe:/a:fasterxml:woodstox:</cpe>
+    <cpe regex="true">cpe:/a:fasterxml:woodstox(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5459
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.oracle\.database\.nls/orai18n@.*$</packageUrl>
-    <cpe>cpe:/a:oracle:database:</cpe>
+    <cpe regex="true">cpe:/a:oracle:database(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5460
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.oracle\.database\.nls/orai18n@.*$</packageUrl>
-    <cpe>cpe:/a:oracle:oracle_database:</cpe>
+    <cpe regex="true">cpe:/a:oracle:oracle_database(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5500
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.iceberg/iceberg-orc@.*$</packageUrl>
-    <cpe>cpe:/a:apache:orc:</cpe>
+    <cpe regex="true">cpe:/a:apache:orc(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5499
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.iceberg/iceberg-flink-1\.15@.*$</packageUrl>
-    <cpe>cpe:/a:apache:flink:</cpe>
+    <cpe regex="true">cpe:/a:apache:flink(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5498
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.googlecode\.javaewah/JavaEWAH@.*$</packageUrl>
-    <cpe>cpe:/a:google:google_search:</cpe>
+    <cpe regex="true">cpe:/a:google:google_search(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5496
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.flink/flink-s3-fs-hadoop@.*$</packageUrl>
-    <cpe>cpe:/a:apache:hadoop:</cpe>
+    <cpe regex="true">cpe:/a:apache:hadoop(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5492
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.microsoft\.azure/azure-cosmosdb-direct@.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:platform_sdk:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:platform_sdk(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5471
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.spark/spark-token-provider-kafka-0-10_2\.12@.*$</packageUrl>
-    <cpe>cpe:/a:apache:kafka:</cpe>
+    <cpe regex="true">cpe:/a:apache:kafka(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5461
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.github\.luben/zstd-jni@.*$</packageUrl>
-    <cpe>cpe:/a:freebsd:freebsd:</cpe>
+    <cpe regex="true">cpe:/a:freebsd:freebsd(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5529
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.github\.dasniko/testcontainers-keycloak@.*$</packageUrl>
-    <cpe>cpe:/a:keycloak:keycloak:</cpe>
+    <cpe regex="true">cpe:/a:keycloak:keycloak(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5540
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.kerby/zookeeper-backend@.*$</packageUrl>
-    <cpe>cpe:/a:apache:zookeeper:</cpe>
+    <cpe regex="true">cpe:/a:apache:zookeeper(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5592
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/javax\.resource/connector@.*$</packageUrl>
-    <cpe>cpe:/a:sun:j2ee:</cpe>
+    <cpe regex="true">cpe:/a:sun:j2ee(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5615
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.cloud/spring-cloud-sleuth-autoconfigure@.*$</packageUrl>
-    <cpe>cpe:/a:vmware:spring_cloud_config:</cpe>
+    <cpe regex="true">cpe:/a:vmware:spring_cloud_config(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5618
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jfrog\.artifactory\.client/artifactory-java-client-services@.*$</packageUrl>
-    <cpe>cpe:/a:jfrog:artifactory:</cpe>
+    <cpe regex="true">cpe:/a:jfrog:artifactory(:.*)?$</cpe>
+</suppress>
+<suppress base="true">
+    <notes><![CDATA[
+    FP per issue #5629
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.integration/spring-integration-ftp@.*$</packageUrl>
+    <cpe regex="true">cpe:/a:vmware:spring_integration(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5700
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy\.microprofile/microprofile-config@.*$</packageUrl>
-    <cpe>cpe:/a:redhat:resteasy:</cpe>
+    <cpe regex="true">cpe:/a:redhat:resteasy(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5684
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.ignite/ignite-log4j2@.*$</packageUrl>
-    <cpe>cpe:/a:apache:log4j:</cpe>
+    <cpe regex="true">cpe:/a:apache:log4j(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5704
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.api/api-ldap-net-mina@.*$</packageUrl>
-    <cpe>cpe:/a:apache:mina:</cpe>
+    <cpe regex="true">cpe:/a:apache:mina(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5727
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.quarkiverse\.openapi\.generator/quarkus-openapi-generator@.*$</packageUrl>
-    <cpe>cpe:/a:openapi-generator:openapi_generator:</cpe>
+    <cpe regex="true">cpe:/a:openapi-generator:openapi_generator(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5736
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/FluentFTP@.*$</packageUrl>
-    <cpe>cpe:/a:ftp:ftp:</cpe>
+    <cpe regex="true">cpe:/a:ftp:ftp(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5734
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/KubernetesClient@.*$</packageUrl>
-    <cpe>cpe:/a:kubernetes:kubernetes:</cpe>
+    <cpe regex="true">cpe:/a:kubernetes:kubernetes(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5742
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.sling/org\.apache\.sling\.commons\.johnzon@.*$</packageUrl>
-    <cpe>cpe:/a:apache:sling_commons_json:</cpe>
+    <cpe regex="true">cpe:/a:apache:sling_commons_json(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5749
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/AspNetCoreRateLimit\.Redis@.*$</packageUrl>
-    <cpe>cpe:/a:asp-project:asp-project:</cpe>
+    <cpe regex="true">cpe:/a:asp-project:asp-project(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5762
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jruby/jzlib@.*$</packageUrl>
-    <cpe>cpe:/a:jruby:jruby:</cpe>
+    <cpe regex="true">cpe:/a:jruby:jruby(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -559,88 +566,88 @@
     suppressions
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy\.microprofile/.*$</packageUrl>
-    <cpe>cpe:/a:redhat:resteasy:</cpe>
+    <cpe regex="true">cpe:/a:redhat:resteasy(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5772
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy\.microprofile/microprofile-rest-client@.*$</packageUrl>
-    <cpe>cpe:/a:redhat:resteasy:</cpe>
+    <cpe regex="true">cpe:/a:redhat:resteasy(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5774
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.sling/org\.apache\.sling\.commons\.osgi@.*$</packageUrl>
-    <cpe>cpe:/a:apache:sling:</cpe>
+    <cpe regex="true">cpe:/a:apache:sling(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5788
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/Minio\.AspNetCore@.*$</packageUrl>
-    <cpe>cpe:/a:minio:minio:</cpe>
+    <cpe regex="true">cpe:/a:minio:minio(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5781
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
-    <cpe>cpe:/a:apache:thrift:</cpe>
+    <cpe regex="true">cpe:/a:apache:thrift(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5543
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.cxf/cxf-rt-bindings-soap@.*$</packageUrl>
-    <cpe>cpe:/a:apache:soap:</cpe>
+    <cpe regex="true">cpe:/a:apache:soap(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5802
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.itextpdf\.licensing/licensing-base@.*$</packageUrl>
-    <cpe>cpe:/a:itextpdf:itext:</cpe>
+    <cpe regex="true">cpe:/a:itextpdf:itext(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5803
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.itextpdf\.licensing/licensing-remote@.*$</packageUrl>
-    <cpe>cpe:/a:itextpdf:itext:</cpe>
+    <cpe regex="true">cpe:/a:itextpdf:itext(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5830
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.github\.detekt\.sarif4k/sarif4k-jvm@.*$</packageUrl>
-    <cpe>cpe:/a:detekt:detekt:</cpe>
+    <cpe regex="true">cpe:/a:detekt:detekt(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
-    <notes><![CDATA[
+<notes><![CDATA[
     FP per issue #5854
     akka-grpc libraries are not part of the akka actor system
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.lightbend\.akka\.grpc/.*$</packageUrl>
-    <cpe>cpe:/a:akka:akka:</cpe>
-    <cpe>cpe:/a:lightbend:akka:</cpe>
+    <cpe regex="true">cpe:/a:akka:akka(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:lightbend:akka(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5855;  akka-persistence-r2dbc is not part of the akka actor system projects
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.lightbend\.akka/akka-persistence-r2dbc.*$</packageUrl>
-    <cpe>cpe:/a:akka:akka:</cpe>
-    <cpe>cpe:/a:lightbend:akka:</cpe>
+    <cpe regex="true">cpe:/a:akka:akka(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:lightbend:akka(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issues #5857, #5856; akka-projection projects are not part of the akka actor system projects
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.lightbend\.akka/akka-projection-.*$</packageUrl>
-    <cpe>cpe:/a:akka:akka:</cpe>
-    <cpe>cpe:/a:lightbend:akka:</cpe>
+    <cpe regex="true">cpe:/a:akka:akka(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:lightbend:akka(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -649,91 +656,91 @@
     can be discarded when bringing the suppressions into the package suppressions file.
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.jackrabbit/oak-.*$</packageUrl>
-    <cpe>cpe:/a:apache:jackrabbit:</cpe>
+    <cpe regex="true">cpe:/a:apache:jackrabbit(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5859
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.jackrabbit/oak-core@.*$</packageUrl>
-    <cpe>cpe:/a:apache:jackrabbit:</cpe>
+    <cpe regex="true">cpe:/a:apache:jackrabbit(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5860
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.vaadin/vaadin-swing-kit-flow@.*$</packageUrl>
-    <cpe>cpe:/a:vaadin:flow:</cpe>
+    <cpe regex="true">cpe:/a:vaadin:flow(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5864
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.sling/org\.apache\.sling\.commons\.johnzon@.*$</packageUrl>
-    <cpe>cpe:/a:apache:sling:</cpe>
+    <cpe regex="true">cpe:/a:apache:sling(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5883
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.geronimo\.specs/geronimo-saaj_1\.3_spec@.*$</packageUrl>
-    <cpe>cpe:/a:apache:soap:</cpe>
+    <cpe regex="true">cpe:/a:apache:soap(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5880
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.ops4j\.pax\.logging/pax-logging-log4j2@.*$</packageUrl>
-    <cpe>cpe:/a:apache:log4j:</cpe>
+    <cpe regex="true">cpe:/a:apache:log4j(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5888
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/software\.amazon\.awssdk\.crt/aws-crt@.*$</packageUrl>
-    <cpe>cpe:/a:amazon:aws-sdk-java:</cpe>
+    <cpe regex="true">cpe:/a:amazon:aws-sdk-java(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5904
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.adobe\.cq/core\.wcm\.components\.core@.*$</packageUrl>
-    <cpe>cpe:/a:adobe:download_manager:</cpe>
+    <cpe regex="true">cpe:/a:adobe:download_manager(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5905
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.adobe\.cq/core\.wcm\.components\.core@.*$</packageUrl>
-    <cpe>cpe:/a:adobe:experience_manager:</cpe>
+    <cpe regex="true">cpe:/a:adobe:experience_manager(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5906
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.adobe\.cq/core\.wcm\.components\.core@.*$</packageUrl>
-    <cpe>cpe:/a:adobe:experience_manager_forms:</cpe>
+    <cpe regex="true">cpe:/a:adobe:experience_manager_forms(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5908
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.adobe\.cq/core\.wcm\.components\.core@.*$</packageUrl>
-    <cpe>cpe:/a:adobe:form_client:</cpe>
+    <cpe regex="true">cpe:/a:adobe:form_client(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5909
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.adobe\.cq/core\.wcm\.components\.core@.*$</packageUrl>
-    <cpe>cpe:/a:list_site_pro:list_site_pro:</cpe>
+    <cpe regex="true">cpe:/a:list_site_pro:list_site_pro(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5916
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring-plugin-core@.*$</packageUrl>
-    <cpe>cpe:/a:vmware:spring:</cpe>
+    <cpe regex="true">cpe:/a:vmware:spring(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -747,203 +754,203 @@
     FP per issue #5932
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.logback-extensions/logback-ext-spring@.*$</packageUrl>
-    <cpe>cpe:/a:qos:logback:</cpe>
+    <cpe regex="true">cpe:/a:qos:logback(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5948
     ]]></notes>
     <packageUrl regex="true">^pkg:npm/mysql@.*$</packageUrl>
-    <cpe>cpe:/a:mysql:mysql:</cpe>
+    <cpe regex="true">cpe:/a:mysql:mysql(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5958
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/net\.rossillo\.mvc\.cache/spring-mvc-cache-control@.*$</packageUrl>
-    <cpe>cpe:/a:spring:spring:</cpe>
+    <cpe regex="true">cpe:/a:spring:spring(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5961
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/ch\.qos\.logback\.contrib/logback-json-core@.*$</packageUrl>
-    <cpe>cpe:/a:json-c:json-c:</cpe>
+    <cpe regex="true">cpe:/a:json-c:json-c(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5966
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/ch\.qos\.logback\.contrib/logback-json-classic@.*$</packageUrl>
-    <cpe>cpe:/a:json-c:json-c:</cpe>
+    <cpe regex="true">cpe:/a:json-c:json-c(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5953
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.asyncer/r2dbc-mysql@.*$</packageUrl>
-    <cpe>cpe:/a:mysql:mysql:</cpe>
+    <cpe regex="true">cpe:/a:mysql:mysql(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5967
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.netty\.incubator/netty-incubator-codec-native-quic@.*$</packageUrl>
-    <cpe>cpe:/a:chromium:chromium:</cpe>
+    <cpe regex="true">cpe:/a:chromium:chromium(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5939
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/xalan/xalan@.*$</packageUrl>
-    <cpe>cpe:/a:apache:commons_bcel:</cpe>
+    <cpe regex="true">cpe:/a:apache:commons_bcel(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6088
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/CommandLineParser@.*$</packageUrl>
-    <cpe>cpe:/a:line:line:</cpe>
+    <cpe regex="true">cpe:/a:line:line(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6041
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.flywaydb/flyway-database-postgresql@.*$</packageUrl>
-    <cpe>cpe:/a:postgresql:postgresql:</cpe>
+    <cpe regex="true">cpe:/a:postgresql:postgresql(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6038
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/net\.lbruun\.springboot/preliquibase-spring-boot-starter@.*$</packageUrl>
-    <cpe>cpe:/a:liquibase:liquibase:</cpe>
+    <cpe regex="true">cpe:/a:liquibase:liquibase(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6138 and #6139
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/rubygems/.*@.*$</packageUrl>
-    <cpe>cpe:/a:rubygems:rubygems:</cpe>
+    <cpe regex="true">cpe:/a:rubygems:rubygems(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6170
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.parquet/parquet-avro@.*$</packageUrl>
-    <cpe>cpe:/a:apache:avro:</cpe>
+    <cpe regex="true">cpe:/a:apache:avro(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6313
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.camel/camel-reactive-executor-tomcat@.*$</packageUrl>
-    <cpe>cpe:/a:apache_tomcat:apache_tomcat:</cpe>
+    <cpe regex="true">cpe:/a:apache_tomcat:apache_tomcat(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6286
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/info\.picocli/picocli@.*$</packageUrl>
-    <cpe>cpe:/a:line:line:</cpe>
+    <cpe regex="true">cpe:/a:line:line(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6199
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.r2dbc/r2dbc-mssql@.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:sql_server:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:sql_server(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6031
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.thymeleaf\.extras/thymeleaf-extras-java8time@.*$</packageUrl>
-    <cpe>cpe:/a:thymeleaf:thymeleaf:</cpe>
+    <cpe regex="true">cpe:/a:thymeleaf:thymeleaf(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6367
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.keycloak/keycloak-model-infinispan@.*$</packageUrl>
-    <cpe>cpe:/a:infinispan:infinispan:</cpe>
+    <cpe regex="true">cpe:/a:infinispan:infinispan(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6368
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jgroups\.azure/jgroups-azure@.*$</packageUrl>
-    <cpe>cpe:/a:redhat:jgroups:</cpe>
+    <cpe regex="true">cpe:/a:redhat:jgroups(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6459
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.bornium/oauth2-openid@.*$</packageUrl>
-    <cpe>cpe:/a:openid:openid:</cpe>
+    <cpe regex="true">cpe:/a:openid:openid(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6460
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.hsqldb/hsqldb@.*$</packageUrl>
-    <cpe>cpe:/a:hyper:hyper:</cpe>
+    <cpe regex="true">cpe:/a:hyper:hyper(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6408
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jboss\.activemq\.artemis\.integration/artemis-wildfly-integration@.*$</packageUrl>
-    <cpe>cpe:/a:redhat:wildfly:</cpe>
+    <cpe regex="true">cpe:/a:redhat:wildfly(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6482
     ]]></notes>
     <packageUrl regex="true">^pkg:npm/bare-os@.*$</packageUrl>
-    <cpe>cpe:/a:bareos:bareos:</cpe>
+    <cpe regex="true">cpe:/a:bareos:bareos(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6538
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.camel\.quarkus/camel-quarkus-core@.*$</packageUrl>
-    <cpe>cpe:/a:apache:camel:</cpe>
+    <cpe regex="true">cpe:/a:apache:camel(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6388
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.rat/apache-rat@.*$</packageUrl>
-    <cpe>cpe:/a:line:line:</cpe>
+    <cpe regex="true">cpe:/a:line:line(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6385
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/MagicFileEncoding@.*$</packageUrl>
-    <cpe>cpe:/a:file:file:</cpe>
+    <cpe regex="true">cpe:/a:file:file(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6376
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/MongoDB\.Bson@.*$</packageUrl>
-    <cpe>cpe:/a:mongodb:mongodb:</cpe>
+    <cpe regex="true">cpe:/a:mongodb:mongodb(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6613
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.batch\.extensions/spring-batch-excel@.*$</packageUrl>
-    <cpe>cpe:/a:pivotal_software:spring_batch:</cpe>
+    <cpe regex="true">cpe:/a:pivotal_software:spring_batch(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     hand-curated better suppression for FP per issues #6626, #7015, #7019, #7020, #7021, #7022
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.glassfish(?!\.main).*$</packageUrl>
-    <cpe>cpe:/a:eclipse:glassfish:</cpe>
+    <cpe regex="true">cpe:/a:eclipse:glassfish(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -969,29 +976,29 @@
     only pkg:maven/org.clojure:clojure@.* is the CPE cpe:/a:clojure:clojure
     ]]></notes>
     <packageUrl regex="true">^pkg:(?!maven/org\.clojure/clojure@).*$</packageUrl>
-    <cpe>cpe:/a:clojure:clojure:</cpe>
+    <cpe regex="true">cpe:/a:clojure:clojure(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6415, #6631, #6632, #6886
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.pivotal\.cfenv/.*@.*$</packageUrl>
-    <cpe>cpe:/a:vmware:spring_framework:</cpe>
-    <cpe>cpe:/a:vmware:spring_boot:</cpe>
+    <cpe regex="true">cpe:/a:vmware:spring_framework(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:vmware:spring_boot(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6640
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.togglz/togglz-mongodb@.*$</packageUrl>
-    <cpe>cpe:/a:mongodb:mongodb:</cpe>
+    <cpe regex="true">cpe:/a:mongodb:mongodb(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6662
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/dbup-postgresql@.*$</packageUrl>
-    <cpe>cpe:/a:postgresql:postgresql:</cpe>
+    <cpe regex="true">cpe:/a:postgresql:postgresql(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1000,52 +1007,52 @@
     Jetty toolchain, orbit and alpn are not the same or part of the actual jetty server and versioned independently.
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.(toolchain|alpn|orbit).*$</packageUrl>
-    <cpe>cpe:/a:mortbay_jetty:jetty:</cpe>
-    <cpe>cpe:/a:mortbay:jetty:</cpe>
-    <cpe>cpe:/a:jetty:jetty:</cpe>
-    <cpe>cpe:/a:eclipse:jetty:</cpe>
+    <cpe regex="true">cpe:/a:mortbay_jetty:jetty(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:mortbay:jetty(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:jetty:jetty(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:eclipse:jetty(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6257
     ]]></notes>
     <packageUrl regex="true">^pkg:generic/Mono.Cecil@.*$</packageUrl>
-    <cpe>cpe:/a:cecil:cecil:</cpe>
+    <cpe regex="true">cpe:/a:cecil:cecil(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6711
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.google\.http-client/google-http-client-protobuf@.*$</packageUrl>
-    <cpe>cpe:/a:google:protobuf-java:</cpe>
+    <cpe regex="true">cpe:/a:google:protobuf-java(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6701
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.zipkin\.contrib\.brave-propagation-w3c/brave-propagation-tracecontext@.*$</packageUrl>
-    <cpe>cpe:/a:brave:brave:</cpe>
+    <cpe regex="true">cpe:/a:brave:brave(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6700
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.micrometer/micrometer-tracing-bridge-brave@.*$</packageUrl>
-    <cpe>cpe:/a:brave:brave:</cpe>
+    <cpe regex="true">cpe:/a:brave:brave(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6743
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.junit\..*/junit-.*@.*$</packageUrl>
-    <cpe>cpe:/a:1e:platform:</cpe>
+    <cpe regex="true">cpe:/a:1e:platform(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6725
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring-boot-jarmode-tools@.*$</packageUrl>
-    <cpe>cpe:/a:vmware:tools:</cpe>
+    <cpe regex="true">cpe:/a:vmware:tools(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1053,8 +1060,8 @@
     NOTE: the additional colon in the CPE is required to not match on prefix
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.sandesha2/sandesha2.*$</packageUrl>
-    <cpe>cpe:/a:apache:axis2:</cpe>
-    <cpe>cpe:/a:apache:axis:</cpe>
+    <cpe regex="true">cpe:/a:apache:axis2(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:apache:axis(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1062,134 +1069,134 @@
     NOTE: the additional colon in the CPE is required to not match on prefix
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.axis2.*$</packageUrl>
-    <cpe>cpe:/a:apache:axis:</cpe>
+    <cpe regex="true">cpe:/a:apache:axis(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6829
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty-openid@.*$</packageUrl>
-    <cpe>cpe:/a:openid:openid:</cpe>
+    <cpe regex="true">cpe:/a:openid:openid(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6858, #8392, #8396
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework.*@.*$</packageUrl>
-    <cpe>cpe:/a:vmware:server:</cpe>
-    <cpe>cpe:/a:vmware:vmware_server:</cpe>
+    <cpe regex="true">cpe:/a:vmware:server(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:vmware:vmware_server(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6901
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.yahoo\.datasketches/sketches-core@.*$</packageUrl>
-    <cpe>cpe:/a:sketch:sketch:</cpe>
+    <cpe regex="true">cpe:/a:sketch:sketch(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6838
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.azure/azure-core-http-netty@.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:azure_cli:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:azure_cli(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6837
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.azure/azure-core@.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:azure_cli:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:azure_cli(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6925
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.tukaani/xz@.*$</packageUrl>
-    <cpe>cpe:/a:tukaani:xz:</cpe>
+    <cpe regex="true">cpe:/a:tukaani:xz(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6926
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.bouncycastle/bc(pg)?-fips@.*$</packageUrl>
-    <cpe>cpe:/a:bouncycastle:legion-of-the-bouncy-castle:</cpe>
+    <cpe regex="true">cpe:/a:bouncycastle:legion-of-the-bouncy-castle(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6854
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.bouncycastle/bc(pg)?-fips@.*$</packageUrl>
-    <cpe>cpe:/a:bouncycastle:bouncy_castle_for_java:</cpe>
+    <cpe regex="true">cpe:/a:bouncycastle:bouncy_castle_for_java(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6839
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/commons-discovery/commons-discovery@.*$</packageUrl>
-    <cpe>cpe:/a:spirit-project:spirit:</cpe>
+    <cpe regex="true">cpe:/a:spirit-project:spirit(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6967
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jmdns/jmdns@.*$</packageUrl>
-    <cpe>cpe:/a:openhab:openhab:</cpe>
+    <cpe regex="true">cpe:/a:openhab:openhab(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6992
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.azure/azure-identity@.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:azure_cli:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:azure_cli(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6991
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.apollographql\.federation/federation-graphql-java-support@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:apollo(_project)?:apollo.*</cpe>
+    <cpe regex="true">cpe:/a:apollo(_project)?:apollo(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7018
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/fi\.solita\.clamav/clamav-client@.*$</packageUrl>
-    <cpe>cpe:/a:clamav:clamav:</cpe>
+    <cpe regex="true">cpe:/a:clamav:clamav(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7034
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/jakarta\.json/jakarta\.json-api@.*$</packageUrl>
-    <cpe>cpe:/a:eclipse:glassfish:</cpe>
+    <cpe regex="true">cpe:/a:eclipse:glassfish(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7028
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.glassfish\.jaxb/jaxb-runtime@.*$</packageUrl>
-    <cpe>cpe:/a:eclipse:glassfish:</cpe>
+    <cpe regex="true">cpe:/a:eclipse:glassfish(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7026
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.ftpserver/ftplet-api@.*$</packageUrl>
-    <cpe>cpe:/a:apache:apache_http_server:</cpe>
+    <cpe regex="true">cpe:/a:apache:apache_http_server(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7035
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.ftpserver/ftpserver-core@.*$</packageUrl>
-    <cpe>cpe:/a:apache:apache_http_server:</cpe>
+    <cpe regex="true">cpe:/a:apache:apache_http_server(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7043
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.ftpserver/ftplet-api@.*$</packageUrl>
-    <cpe regex="true">^cpe:/a:apache:mina:.*</cpe>
+    <cpe regex="true">cpe:/a:apache:mina:(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1198,15 +1205,15 @@
     NOTE: the additional colon in the CPE is required to not match on prefix with cpe:/a:mysql:mysql_connector_j etc
     ]]></notes>
     <gav regex="true">^(mysql:mysql-connector-java|com\.mysql:mysql-connector-j|org\.drizzle\.jdbc:drizzle-jdbc):.*$</gav>
-    <cpe>cpe:/a:mysql:mysql:</cpe>
-    <cpe>cpe:/a:oracle:mysql:</cpe>
+    <cpe regex="true">cpe:/a:mysql:mysql(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:oracle:mysql(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6435
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/IronPython@.*$</packageUrl>
-    <cpe>cpe:/a:python:python:</cpe>
+    <cpe regex="true">cpe:/a:python:python(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1216,93 +1223,93 @@
     artifacts independently versioned and released.
     ]]></notes>
     <packageUrl regex="true">^pkg:(?!maven/com\.graphql-java/graphql-java@).*$</packageUrl>
-    <cpe regex="true">cpe:/a:graphql-java(_project)?:graphql-java:.*</cpe>
+    <cpe regex="true">cpe:/a:graphql-java(_project)?:graphql-java:(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7066
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.azure/azure-json@.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:azure_cli:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:azure_cli(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7073
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.agrona/agrona@.*$</packageUrl>
-    <cpe>cpe:/a:protonmail:protonmail:</cpe>
+    <cpe regex="true">cpe:/a:protonmail:protonmail(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7047
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache-el@.*$</packageUrl>
-    <cpe>cpe:/a:eclipse:jetty:</cpe>
+    <cpe regex="true">cpe:/a:eclipse:jetty(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6431
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.maciejwalkowiak\.spring/wiremock-spring-boot@.*$</packageUrl>
-    <cpe>cpe:/a:wiremock:wiremock:</cpe>
-    <cpe>cpe:/a:wire:wire:</cpe>
+    <cpe regex="true">cpe:/a:wiremock:wiremock(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:wire:wire(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7124
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.azure/azure-core-amqp@.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:azure_cli:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:azure_cli(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6981 and #7123
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.etcd/jetcd-.*@.*$</packageUrl>
-    <cpe>cpe:/a:redhat:etcd:</cpe>
-    <cpe>cpe:/a:etcd:etcd:</cpe>
+    <cpe regex="true">cpe:/a:redhat:etcd(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:etcd:etcd(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7110
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.azure/azure-core-management@.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:azure_cli:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:azure_cli(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7132
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws-java-sdk-opensearch@.*$</packageUrl>
-    <cpe>cpe:/a:amazon:opensearch:</cpe>
+    <cpe regex="true">cpe:/a:amazon:opensearch(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7209
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.webjars\.npm/url-parse@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:parse-url(_project)?:parse-url.*</cpe>
+    <cpe regex="true">cpe:/a:parse-url(_project)?:parse-url(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7207
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.datomic/memcache-asg-java-client@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:memcache(_project)?:memcache.*</cpe>
+    <cpe regex="true">cpe:/a:memcache(_project)?:memcache(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7214
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws-java-sdk-marketplacedeployment@.*$</packageUrl>
-    <cpe>cpe:/a:amazon:aws_deployment_framework:</cpe>
+    <cpe regex="true">cpe:/a:amazon:aws_deployment_framework(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7229
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/cd\.go\.plugin\.base/gocd-plugin-base@.*$</packageUrl>
-    <cpe>cpe:/a:thoughtworks:gocd:</cpe>
+    <cpe regex="true">cpe:/a:thoughtworks:gocd(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1310,49 +1317,49 @@
       NPM node-windows sudowin sudo.exe binary is not Linux sudo project, but https://github.com/akutz/sudowin
       ]]></notes>
     <filePath regex="true">.*/node-windows/bin/sudowin/sudo.exe</filePath>
-    <cpe regex="true">cpe:/a:sudo(_project)?:sudo.*</cpe>
+    <cpe regex="true">cpe:/a:sudo(_project)?:sudo(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7225
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.datomic/memcache-asg-java-client@.*$</packageUrl>
-    <cpe>cpe:/a:memcached:memcached:</cpe>
+    <cpe regex="true">cpe:/a:memcached:memcached(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7188
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/fish\.payara\.security\.connectors/security-connectors-api@.*$</packageUrl>
-    <cpe>cpe:/a:payara:payara:</cpe>
+    <cpe regex="true">cpe:/a:payara:payara(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7238
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.microsoft\.azure/msal4j-persistence-extension@.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:authentication_library:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:authentication_library(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6679
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.google\.cloud\.tools/jib-build-plan@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:jib(_project)?:jib.*</cpe>
+    <cpe regex="true">cpe:/a:jib(_project)?:jib(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6491
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.azure/azure-identity-extensions@.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:azure_cli:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:azure_cli(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7247
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.google\.cloud\.opentelemetry/detector-resources-support@.*$</packageUrl>
-    <cpe>cpe:/a:opentelemetry:opentelemetry:</cpe>
+    <cpe regex="true">cpe:/a:opentelemetry:opentelemetry(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1360,7 +1367,7 @@
       as suggested in #7250. If it's not in the io.grpc groupId it's not gRPC itself
       ]]></notes>
     <packageUrl regex="true">^pkg:maven/(?!io\.grpc/).*$</packageUrl>
-    <cpe>cpe:/a:grpc:grpc:</cpe>
+    <cpe regex="true">cpe:/a:grpc:grpc(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1390,294 +1397,294 @@
     The sms:sms (Linux SMS package) is not a Java library so it will never appear on the Maven repository
     ]]></notes>
     <packageUrl regex="true">^pkg:maven\/.*$</packageUrl>
-    <cpe>cpe:/a:sms:sms:</cpe>
+    <cpe regex="true">cpe:/a:sms:sms(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #6416
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.sap\.cloud\.db\.jdbc/ngdbc@.*$</packageUrl>
-    <cpe>cpe:/a:sap:hana:</cpe>
+    <cpe regex="true">cpe:/a:sap:hana(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7265
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.google\.cloud\.opentelemetry/shared-resourcemapping@.*$</packageUrl>
-    <cpe>cpe:/a:opentelemetry:opentelemetry:</cpe>
+    <cpe regex="true">cpe:/a:opentelemetry:opentelemetry(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7264
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.google\.cloud\.opentelemetry/exporter-metrics@.*$</packageUrl>
-    <cpe>cpe:/a:opentelemetry:opentelemetry:</cpe>
+    <cpe regex="true">cpe:/a:opentelemetry:opentelemetry(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5571
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/dev\.zio/zio-akka-cluster_2\.13@.*$</packageUrl>
-    <cpe>cpe:/a:akka:akka:</cpe>
+    <cpe regex="true">cpe:/a:akka:akka(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7271
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring-boot-starter-data-rest@.*$</packageUrl>
-    <cpe>cpe:/a:vmware:spring_data_rest:</cpe>
+    <cpe regex="true">cpe:/a:vmware:spring_data_rest(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7308
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/Npgsql\.EntityFrameworkCore\.PostgreSQL@.*$</packageUrl>
-    <cpe>cpe:/a:postgresql:postgresql:</cpe>
+    <cpe regex="true">cpe:/a:postgresql:postgresql(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7317
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/System\.Threading\.Tasks\.Extensions@.*$</packageUrl>
-    <cpe>cpe:/a:tasks:tasks:</cpe>
+    <cpe regex="true">cpe:/a:tasks:tasks(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7339
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.splunk\.logging/splunk-library-javalogging@.*$</packageUrl>
-    <cpe>cpe:/a:splunk:splunk:</cpe>
+    <cpe regex="true">cpe:/a:splunk:splunk(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7348
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/System\.ServiceModel\.NetTcp@.*$</packageUrl>
-    <cpe>cpe:/a:tcp:tcp:</cpe>
+    <cpe regex="true">cpe:/a:tcp:tcp(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7359
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.ai/spring-ai-spring-boot-autoconfigure@.*$</packageUrl>
-    <cpe>cpe:/a:vmware:spring_boot:</cpe>
+    <cpe regex="true">cpe:/a:vmware:spring_boot(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7392
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/Serilog\.Sinks\.Graylog@.*$</packageUrl>
-    <cpe>cpe:/a:graylog:graylog:</cpe>
+    <cpe regex="true">cpe:/a:graylog:graylog(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7403
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.hazelcast\.marketing/hazelcast-license-extractor@.*$</packageUrl>
-    <cpe>cpe:/a:hazelcast:hazelcast:</cpe>
+    <cpe regex="true">cpe:/a:hazelcast:hazelcast(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7423, #7424, #7425
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.google\.devtools\.ksp/.*@.*$</packageUrl>
-    <cpe>cpe:/a:processing:processing:</cpe>
+    <cpe regex="true">cpe:/a:processing:processing(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7216, #7215, #7280, #7428
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.azure\.resourcemanager/.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:azure_cli:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:azure_cli(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5527
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.sling/org\.apache\.sling\.javax\.activation@.*$</packageUrl>
-    <cpe>cpe:/a:apache:sling:</cpe>
+    <cpe regex="true">cpe:/a:apache:sling(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5882
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.platform/org\.eclipse\.osgi@.*$</packageUrl>
-    <cpe>cpe:/a:eclipse:platform:</cpe>
+    <cpe regex="true">cpe:/a:eclipse:platform(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5881
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.platform/org\.eclipse\.osgi@.*$</packageUrl>
-    <cpe>cpe:/a:eclipse:equinox:</cpe>
+    <cpe regex="true">cpe:/a:eclipse:equinox(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7448
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.nlopez\.compose\.rules/detekt@.*$</packageUrl>
-    <cpe>cpe:/a:detekt:detekt:</cpe>
+    <cpe regex="true">cpe:/a:detekt:detekt(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7464
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.quarkiverse\.wiremock/quarkus-wiremock@.*$</packageUrl>
-    <cpe>cpe:/a:wiremock:wiremock:</cpe>
+    <cpe regex="true">cpe:/a:wiremock:wiremock(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7555
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.github\.jpmsilva\.jsystemd/jsystemd-core@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:systemd(_project)?:systemd.*</cpe>
+    <cpe regex="true">cpe:/a:systemd(_project)?:systemd(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7556
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.azure/azure-ai-openai@.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:azure_cli:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:azure_cli(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7553
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/Microsoft\.AspNetCore\.Authentication\.OpenIdConnect@.*$</packageUrl>
-    <cpe>cpe:/a:openid:openid_connect:</cpe>
+    <cpe regex="true">cpe:/a:openid:openid_connect(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7581
     ]]></notes>
     <packageUrl regex="true">^pkg:composer/phpunit/php-invoker@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:phpunit(_project)?:phpunit.*</cpe>
+    <cpe regex="true">cpe:/a:phpunit(_project)?:phpunit(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7582
     ]]></notes>
     <packageUrl regex="true">^pkg:composer/phpunit/php-text-template@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:phpunit(_project)?:phpunit.*</cpe>
+    <cpe regex="true">cpe:/a:phpunit(_project)?:phpunit(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7602
     ]]></notes>
     <packageUrl regex="true">^pkg:composer/spatie/laravel-.*$</packageUrl>
-    <cpe>cpe:/a:laravel:laravel:</cpe>
+    <cpe regex="true">cpe:/a:laravel:laravel(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7644
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.opensearch\.plugin/transport-netty4-client@.*$</packageUrl>
-    <cpe>cpe:/a:netty:netty:</cpe>
+    <cpe regex="true">cpe:/a:netty:netty(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4525
     ]]></notes>
     <packageUrl regex="true">^pkg:npm/opener@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:opener(_project)?:opener.*</cpe>
+    <cpe regex="true">cpe:/a:opener(_project)?:opener(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5651
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.oracle\.database\.nls/orai18n@.*$</packageUrl>
-    <cpe>cpe:/a:oracle:text:</cpe>
+    <cpe regex="true">cpe:/a:oracle:text(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #4260
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/Microsoft\.AspNet\.TelemetryCorrelation@.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:asp.net:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:asp.net(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #5836
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/Akka\.Cluster\.Hosting@.*$</packageUrl>
-    <cpe>cpe:/a:akka:akka:</cpe>
+    <cpe regex="true">cpe:/a:akka:akka(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7650
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.core/org\.eclipse\.core\.jobs@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:jobs-plugin(_project)?:jobs-plugin.*</cpe>
+    <cpe regex="true">cpe:/a:jobs-plugin(_project)?:jobs-plugin(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7649
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.core/org\.eclipse\.core\.commands@.*$</packageUrl>
-    <cpe>cpe:/a:eclipse:equinox:</cpe>
+    <cpe regex="true">cpe:/a:eclipse:equinox(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7703
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/edu\.washington\.cs\.knowitall/opennlp-chunk-models@.*$</packageUrl>
-    <cpe>cpe:/a:apache:opennlp:</cpe>
+    <cpe regex="true">cpe:/a:apache:opennlp(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7700
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.microsoft\.azure/azure-eventhubs.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:azure_cli:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:azure_cli(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7708
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.nokogiri/nekodtd@.*$</packageUrl>
-    <cpe>cpe:/a:nokogiri:nokogiri:</cpe>
+    <cpe regex="true">cpe:/a:nokogiri:nokogiri(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7715
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/opensymphony/oscache@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:tag(_project)?:tag.*</cpe>
+    <cpe regex="true">cpe:/a:tag(_project)?:tag(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7716
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.api/api-i18n@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:i18n(_project)?:i18n.*</cpe>
+    <cpe regex="true">cpe:/a:i18n(_project)?:i18n(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7688
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.github\.x-stream/mxparser@.*$</packageUrl>
-    <cpe>cpe:/a:x-stream:xstream:</cpe>
+    <cpe regex="true">cpe:/a:x-stream:xstream(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7724
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.xmlgraphics/batik-i18n@.*$</packageUrl>
-    <cpe>cpe:/a:apache:xml_graphics_batik:</cpe>
+    <cpe regex="true">cpe:/a:apache:xml_graphics_batik(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7732
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.openrewrite\.recipe/rewrite-jenkins@.*$</packageUrl>
-    <cpe>cpe:/a:jenkins:github:</cpe>
+    <cpe regex="true">cpe:/a:jenkins:github(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7660
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.grpc/grpc-netty@.*$</packageUrl>
-    <cpe>cpe:/a:netty:netty:</cpe>
+    <cpe regex="true">cpe:/a:netty:netty(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1685,112 +1692,112 @@
     per https://github.com/grpc/grpc-java/issues/11135#issuecomment-2088568147
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.grpc/grpc-netty-shaded@.*$</packageUrl>
-    <cpe>cpe:/a:netty:netty:</cpe>
+    <cpe regex="true">cpe:/a:netty:netty(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7734
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/edu\.washington\.cs\.knowitall/opennlp-postag-models@.*$</packageUrl>
-    <cpe>cpe:/a:apache:opennlp:</cpe>
+    <cpe regex="true">cpe:/a:apache:opennlp(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7761, #8348
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.projectreactor\.netty/reactor-netty.*@.*$</packageUrl>
-    <cpe>cpe:/a:netty:netty:</cpe>
+    <cpe regex="true">cpe:/a:netty:netty(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7756
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.ccil\.cowan\.tagsoup/tagsoup@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:tag(_project)?:tag.*</cpe>
+    <cpe regex="true">cpe:/a:tag(_project)?:tag(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7752
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.groovy/groovy-json@.*$</packageUrl>
-    <cpe>cpe:/a:apache:groovy:</cpe>
+    <cpe regex="true">cpe:/a:apache:groovy(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7806
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/javax\.resource/connector-api@.*$</packageUrl>
-    <cpe>cpe:/a:sun:j2ee:</cpe>
+    <cpe regex="true">cpe:/a:sun:j2ee(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7798
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.quarkus/quarkus-hibernate-validator@.*$</packageUrl>
-    <cpe>cpe:/a:hibernate:hibernate-validator:</cpe>
+    <cpe regex="true">cpe:/a:hibernate:hibernate-validator(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7804
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache-jsp@.*$</packageUrl>
-    <cpe>cpe:/a:apache:tomcat:</cpe>
+    <cpe regex="true">cpe:/a:apache:tomcat(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7842
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.almworks\.sqlite4java/sqlite4java@.*$</packageUrl>
-    <cpe>cpe:/a:sqlite:sqlite:</cpe>
+    <cpe regex="true">cpe:/a:sqlite:sqlite(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7841
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.quarkiverse\.wiremock/quarkus-wiremock@.*$</packageUrl>
-    <cpe>cpe:/a:wire:wire:</cpe>
+    <cpe regex="true">cpe:/a:wire:wire(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7892
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jooq.*/jooq-meta-extensions-liquibase@.*$</packageUrl>
-    <cpe>cpe:/a:liquibase:liquibase:</cpe>
+    <cpe regex="true">cpe:/a:liquibase:liquibase(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7917
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.xmlunit/xmlunit-core@.*$</packageUrl>
-    <cpe>cpe:/a:ada:ada:</cpe>
+    <cpe regex="true">cpe:/a:ada:ada(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7916
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.debezium/mysql-binlog-connector-java@.*$</packageUrl>
-    <cpe>cpe:/a:mysql:mysql:</cpe>
+    <cpe regex="true">cpe:/a:mysql:mysql(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7735
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/edu\.washington\.cs\.knowitall/opennlp-tokenize-models@.*$</packageUrl>
-    <cpe>cpe:/a:apache:opennlp:</cpe>
+    <cpe regex="true">cpe:/a:apache:opennlp(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7831
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/Microsoft\.AspNetCore\.Authentication\.OpenIdConnect@.*$</packageUrl>
-    <cpe>cpe:/a:openid:openid:</cpe>
+    <cpe regex="true">cpe:/a:openid:openid(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issues #3876, #7998
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/co\.elastic\.apm/.*</packageUrl>
-    <cpe>cpe:/a:elastic:elastic_agent:</cpe>
+    <packageUrl regex="true">^pkg:maven/co\.elastic\.apm/(:.*)?$</packageUrl>
+    <cpe regex="true">cpe:/a:elastic:elastic_agent(:.*)?$</cpe>
     <cve>CVE-2019-7617</cve>
 </suppress>
 <suppress base="true">
@@ -1798,28 +1805,28 @@
     FP per issue #7661
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.core/org\.eclipse\.core\.expressions@.*$</packageUrl>
-    <cpe>cpe:/a:eclipse:org.eclipse.core.runtime:</cpe>
+    <cpe regex="true">cpe:/a:eclipse:org.eclipse.core.runtime(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7663
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.platform/org\.eclipse\.equinox\.supplement@.*$</packageUrl>
-    <cpe>cpe:/a:eclipse:platform:</cpe>
+    <cpe regex="true">cpe:/a:eclipse:platform(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8018
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast-eureka-two@.*$</packageUrl>
-    <cpe>cpe:/a:hazelcast:hazelcast:</cpe>
+    <cpe regex="true">cpe:/a:hazelcast:hazelcast(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8040
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.pinterest\.ktlint/ktlint-cli-reporter-checkstyle@.*$</packageUrl>
-    <cpe>cpe:/a:checkstyle:checkstyle:</cpe>
+    <cpe regex="true">cpe:/a:checkstyle:checkstyle(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1827,156 +1834,156 @@
     pypi package here. Not suppressed for other ecosystems as Sentry Server is still available open-source elsewhere.
     ]]></notes>
     <packageUrl regex="true">^pkg:pypi/(?!sentry@).*$</packageUrl>
-    <cpe>cpe:/a:sentry:sentry:</cpe>
+    <cpe regex="true">cpe:/a:sentry:sentry:(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
   <notes><![CDATA[
     FP per issue #8051
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.spdx/spdx-java-model-2_X@.*$</packageUrl>
-    <cpe>cpe:/a:x.org:x.org:</cpe>
+    <cpe regex="true">cpe:/a:x.org:x.org(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8130, #8441
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.angus/angus-activation@.*$</packageUrl>
-    <cpe>cpe:/a:eclipse:angus_mail:</cpe>
-    <cpe>cpe:/a:eclipse:jakarta_mail:</cpe>
+    <cpe regex="true">cpe:/a:eclipse:angus_mail(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:eclipse:jakarta_mail(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8139
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.azure\.resourcemanager/azure-resourcemanager-msi@.*$</packageUrl>
-    <cpe>cpe:/a:microsoft:azure_identity_sdk:</cpe>
+    <cpe regex="true">cpe:/a:microsoft:azure_identity_sdk(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8164, #8165
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/.*@.*$</packageUrl>
-    <cpe>cpe:/a:liquibase:liquibase:</cpe>
+    <cpe regex="true">cpe:/a:liquibase:liquibase(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8168, #8169
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.micronaut\.jsonschema/micronaut-json-schema-utils@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:utils(_project)?:utils.*</cpe>
-    <cpe regex="true">cpe:/a:cron-utils(_project)?:cron-utils.*</cpe>
+    <cpe regex="true">cpe:/a:utils(_project)?:utils(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:cron-utils(_project)?:cron-utils(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8176
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/jakarta\.enterprise/jakarta\.enterprise\.lang-model@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:model(_project)?:model.*</cpe>
+    <cpe regex="true">cpe:/a:model(_project)?:model(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8183
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.exposed/exposed-kotlin-datetime@.*$</packageUrl>
-    <cpe>cpe:/a:jetbrains:kotlin:</cpe>
+    <cpe regex="true">cpe:/a:jetbrains:kotlin(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #7869
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.solace/solace-messaging-client@.*$</packageUrl>
-    <cpe>cpe:/a:solace:pubsub\+:</cpe>
+    <cpe regex="true">cpe:/a:solace:pubsub\+(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
-    FP per issue #7906, #8208, #8209, #8210
+    FP per issue #8210
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework.*@.*$</packageUrl>
-    <cpe>cpe:/a:mongodb:mongodb:</cpe>
+    <cpe regex="true">cpe:/a:mongodb:mongodb(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8223
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop\.thirdparty/hadoop-shaded-protobuf_3_25@.*$</packageUrl>
-    <cpe>cpe:/a:apache:hadoop:</cpe>
+    <cpe regex="true">cpe:/a:apache:hadoop(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8243, #8244, #8247, #8249
     ]]></notes>
-    <packageUrl regex="true">^pkg:(?!maven/nu\.validator/validator@|npm/vnu-jar).*</packageUrl>
-    <cpe>cpe:/a:validator:validator:</cpe>
+    <packageUrl regex="true">^pkg:(?!maven/nu\.validator/validator@|npm/vnu-jar)(:.*)?$</packageUrl>
+    <cpe regex="true">cpe:/a:validator:validator(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8257
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/net\.java\.dev\.jna/jna-jpms@.*$</packageUrl>
-    <cpe>cpe:/a:oracle:java_se:</cpe>
+    <cpe regex="true">cpe:/a:oracle:java_se(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8260
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.felix/org\.apache\.felix\.framework@.*$</packageUrl>
-    <cpe>cpe:/a:sun:sun_ftp:</cpe>
+    <cpe regex="true">cpe:/a:sun:sun_ftp(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8299
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/DotNumerics@.*$</packageUrl>
-    <cpe>cpe:/a:lapack_project:lapack:</cpe>
+    <cpe regex="true">cpe:/a:lapack_project:lapack(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8309
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/DotNumerics@.*$</packageUrl>
-    <cpe>cpe:/a:singular:singular:</cpe>
+    <cpe regex="true">cpe:/a:singular:singular(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8333
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.testcontainers/testcontainers-postgresql@.*$</packageUrl>
-    <cpe>cpe:/a:postgresql:postgresql:</cpe>
+    <cpe regex="true">cpe:/a:postgresql:postgresql(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8339
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.cxf\.karaf/cxf-karaf-commands@.*$</packageUrl>
-    <cpe>cpe:/a:apache:karaf:</cpe>
+    <cpe regex="true">cpe:/a:apache:karaf(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8361
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring-boot-batch@.*$</packageUrl>
-    <cpe>cpe:/a:pivotal_software:spring_batch:</cpe>
+    <cpe regex="true">cpe:/a:pivotal_software:spring_batch(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8374
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.sun\.xml\.bind/jaxb-impl@.*$</packageUrl>
-    <cpe>cpe:/a:eclipse:glassfish:</cpe>
+    <cpe regex="true">cpe:/a:eclipse:glassfish(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8395
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.grpc/spring-grpc-spring-boot-starter@.*$</packageUrl>
-    <cpe>cpe:/a:netty:netty:</cpe>
+    <cpe regex="true">cpe:/a:netty:netty(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8397
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/dev\.detekt/detekt-report-checkstyle@.*$</packageUrl>
-    <cpe>cpe:/a:checkstyle:checkstyle:</cpe>
+    <cpe regex="true">cpe:/a:checkstyle:checkstyle(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1985,21 +1992,21 @@
     very generic name, likely to mistakenly match many other artifacts.
     ]]></notes>
     <packageUrl regex="true">^pkg:(?!golang/).*$</packageUrl>
-    <cpe regex="true">cpe:/a:distribution(_project)?:distribution:.*</cpe>
+    <cpe regex="true">cpe:/a:distribution(_project)?:distribution:(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8439
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.platform/org\.eclipse\.equinox\.cm@.*$</packageUrl>
-    <cpe>cpe:/a:eclipse:platform:</cpe>
+    <cpe regex="true">cpe:/a:eclipse:platform(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8446
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.github\.oshi/oshi-common@.*$</packageUrl>
-    <cpe>cpe:/a:ada:ada:</cpe>
+    <cpe regex="true">cpe:/a:ada:ada(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -2033,33 +2040,26 @@
     - https://nvd.nist.gov/vuln/search#/nvd/home?cpeFilterMode=applicability&cpeName=cpe:2.3:a:prometheus:prometheus:*:*:*:*:*:*:*:*&resultType=records
     ]]></notes>
     <packageUrl regex="true">^pkg:(?!golang/github\.com/prometheus/prometheus).*$</packageUrl>
-    <cpe>cpe:/a:prometheus:prometheus:</cpe>
+    <cpe regex="true">cpe:/a:prometheus:prometheus:(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8508
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/net\.sf\.saxon/Saxon-HE@.*$</packageUrl>
-    <cpe>cpe:/a:kay_framework_project:kay_framework:</cpe>
+    <cpe regex="true">cpe:/a:kay_framework_project:kay_framework(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8518
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel@.*$</packageUrl>
-    <cpe>cpe:/a:opentelemetry:opentelemetry:</cpe>
+    <cpe regex="true">cpe:/a:opentelemetry:opentelemetry(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8520
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.testcontainers/testcontainers-mysql@.*$</packageUrl>
-    <cpe>cpe:/a:mysql:mysql:</cpe>
-</suppress>
-<suppress base="true">
-    <notes><![CDATA[
-    FP per issue #8521
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/msv/isorelax@.*$</packageUrl>
-    <cpe>cpe:/a:validator:validator:</cpe>
+    <cpe regex="true">cpe:/a:mysql:mysql(:.*)?$</cpe>
 </suppress>


### PR DESCRIPTION
## Description of Change

As discovered myself in https://github.com/dependency-check/DependencyCheck/issues/8521#issuecomment-4494622767 unfortunately my change in #8510 caused some unintentional regression of suppression applicability for hosted suppressions, since the trailing bits of the CPE are removed for vulnerabilities without versions in them (typically ones with startsWith/endsWith ranges at NVD such as https://nvd.nist.gov/vuln/detail/CVE-2025-15104) 
 
<img width="797" height="131" alt="image" src="https://github.com/user-attachments/assets/2e5a574f-8996-4199-a14a-900c4635558c" />
 
The existing code does not normalise the suppression rule CPE URI from the suppressions before comparing the string representation prefix. This means vulns with affected versions like `cpe:2.3:a:validator:validator:*:*:*:*:*:*` will no longer match as they are correctly normalized by the code to `cpe:/a:validator:validator` without a trailing `:` before matching to the prefix rule. I'd forgotten about this CPE 2.2 vs 2.3 difference :-(

This change converts them to regexes - so it's possible to express the matching across ODC versions. An alternative would be to just revert things and leave the false negative possibilities.
- It's probably not great (complexity, readability, performance) to have to do regex matching everywhere here, however since hosted suppressions are supported across older versions, the alternative would leave us stuck without consistent conservative matching, as requires code change to fix.
- Happy to take feedback though - WDYT @jeremylong @marcelstoer?
- I'll follow up with a "fix" of some sort on master as well once we've agreed approach; to improve the non-regex matching; and/or to improve the regex matching speed.

## Related issues

- caused #8521
- caused by #8510 

## Have test cases been added to cover the new functionality?

no