### PR TITLE
fix(fp): extend Sentry server CPE suppression to other ecosystems

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1823,11 +1823,13 @@
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
-    hand-curated better suppression for FP per issue #8057. The sentry server is/was only available on the specific
-    pypi package here. Not suppressed for other ecosystems as Sentry Server is still available open-source elsewhere.
+    hand-curated better suppression for FP per issues #8057, #8519. The Sentry Server is Python-based and was only
+    available on the specific pypi package here, or as an image. SDKs and other components of the server have their own CPEs.
+    For all vendor=sentry CVEs, can review the below:
+    https://nvd.nist.gov/vuln/search#/nvd/home?sortOrder=5&sortDirection=2&cpeFilterMode=applicability&cpeName=cpe:2.3:a:sentry:*:*:*:*:*:*:*:*:*&resultType=records
     ]]></notes>
-    <packageUrl regex="true">^pkg:pypi/(?!sentry@).*$</packageUrl>
-    <cpe>cpe:/a:sentry:sentry:</cpe>
+    <packageUrl regex="true">^pkg:(?!pypi/sentry@|docker|generic).*$</packageUrl>
+    <cpe regex="true">cpe:/a:sentry:sentry(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
   <notes><![CDATA[


### PR DESCRIPTION
## Description of Change

This is an extension of earlier PR #8058 to suppress for other ecosystems - excluding `docker`, `generic`.

There are hundreds of sentry packages across various ecossytems, from `maven` to `composer`, `cargo`, `npm`, `rubygems`, `go` and `swift`. The self-hosted server is Python (and typescript) based and used to be distributed on the previously excluded Python package, but is now distributed as docker images with pre-compiled Python: https://github.com/getsentry/sentry/blob/master/self-hosted/Dockerfile

This is all a bit of a minefield, but it should be relatively safe to extend the suppression as suggested here, while still matching for folks against the self-hosted instance (even though we don't support discovering docker dependencies right now).

## Related issues

- fixes #8519

## Have test cases been added to cover the new functionality?

*yes/no*