### PR TITLE
fix(fp): correct `validator:validator` and `pkg:maven/co.elastic.apm/.*` hosted suppressions

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1600,7 +1600,7 @@
     FP per issue #4260
     ]]></notes>
     <packageUrl regex="true">^pkg:nuget/Microsoft\.AspNet\.TelemetryCorrelation@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:microsoft:asp.net(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:microsoft:asp\.net(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1805,7 +1805,7 @@
     FP per issue #7661
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.core/org\.eclipse\.core\.expressions@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:eclipse:org.eclipse.core.runtime(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:eclipse:org\.eclipse\.core\.runtime(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1841,7 +1841,7 @@
     FP per issue #8051
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.spdx/spdx-java-model-2_X@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:x.org:x.org(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:x\.org:x\.org(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[

--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1796,7 +1796,7 @@
     <notes><![CDATA[
     FP per issues #3876, #7998
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/co\.elastic\.apm/(:.*)?$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/co\.elastic\.apm/.*</packageUrl>
     <cpe regex="true">cpe:/a:elastic:elastic_agent(:.*)?$</cpe>
     <cve>CVE-2019-7617</cve>
 </suppress>
@@ -1912,7 +1912,7 @@
     <notes><![CDATA[
     FP per issue #8243, #8244, #8247, #8249
     ]]></notes>
-    <packageUrl regex="true">^pkg:(?!maven/nu\.validator/validator@|npm/vnu-jar)(:.*)?$</packageUrl>
+    <packageUrl regex="true">^pkg:(?!maven/nu\.validator/validator@|npm/vnu-jar).*</packageUrl>
     <cpe regex="true">cpe:/a:validator:validator(:.*)?$</cpe>
 </suppress>
 <suppress base="true">


### PR DESCRIPTION
## Description of Change

Another minor regression due to #8522. I was sure I had sanity checked the diff hunks to make sure only `<cpe>` lines were changed when converting to regex. Obviously messed something up.

This reverts the package URL matchers to how they were before being accidentally changed; and corrects a few regex `.`-escaping nitpicks.

## Related issues

- relates to #8522

## Have test cases been added to cover the new functionality?

This time I have `git diff`ed to before all these changes to double-check only intended `<cpe>` rules have a delta with before.