### PR TITLE
ci: automatically publish suppressions after merged PRs

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -2,6 +2,10 @@ name: "Lint PR"
 
 on:
   pull_request_target:
+    # BE CAREFUL - this event runs in the context of the default branch (`main`) workflow definition in the target
+    #    repository (MOT the fork's context), so it has potentially sensitive access.
+    #    It is critical that this only runs on very limited events and/or access to the repo
+    # Read https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target
     types:
       - opened
       - edited

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -3,7 +3,7 @@ name: "Lint PR"
 on:
   pull_request_target:
     # BE CAREFUL - this event runs in the context of the default branch (`main`) workflow definition in the target
-    #    repository (MOT the fork's context), so it has potentially sensitive access.
+    #    repository (NOT the fork's context), so it has potentially sensitive access.
     #    It is critical that this only runs on very limited events and/or access to the repo
     # Read https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target
     types:

--- a/.github/workflows/publish-suppressions.yml
+++ b/.github/workflows/publish-suppressions.yml
@@ -2,13 +2,21 @@ name: Publish Suppressions
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - generatedSuppressions
+  pull_request_target:
+    # BE CAREFUL - this event runs in the context of the default branch (`main`) workflow definition in the target
+    #    repository (MOT the fork's context), so it has potentially sensitive access.
+    #    It is critical that this only runs on very limited events and/or access to the repo
+    # Read https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target
+    types: [ closed ]
+    branches: [ generatedSuppressions ]
+    paths: [ generatedSuppressions.xml ]
+
 
 permissions: {}
 jobs:
   update_suppression:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+
     permissions:
       contents: write # to push changes in repo (jamesives/github-pages-deploy-action)
 

--- a/.github/workflows/publish-suppressions.yml
+++ b/.github/workflows/publish-suppressions.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request_target:
     # BE CAREFUL - this event runs in the context of the default branch (`main`) workflow definition in the target
-    #    repository (MOT the fork's context), so it has potentially sensitive access.
+    #    repository (NOT the fork's context), so it has potentially sensitive access.
     #    It is critical that this only runs on very limited events and/or access to the repo
     # Read https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target
     types: [ closed ]


### PR DESCRIPTION
## Description of Change

Alternate implementation of #8516 which triggers off merged pull requests targetting the branch.

As noted in https://github.com/dependency-check/DependencyCheck/pull/8516#issuecomment-4497837632 the `on.branch` or normal `on.pull_request` triggers won't work, as they operate in the context of the relevant branch; however https://github.com/dependency-check/DependencyCheck/tree/generatedSuppressions is a bare tree/orphaned branch which does not contain the workflow definitions - so there is nothing to trigger. You can simulate a similar warning if you try and use workflow dispatch off this branch, which it wont let you:

<img width="328" height="341" alt="image" src="https://github.com/user-attachments/assets/c9db96ca-93e0-4140-9b8d-ca802e8c0ce7" />

The alternative is to use the (_somewhat risky_) `pull_request_target` event; which operates in the context of the `default` branch's workflow (`main`), in the PR target repository. This means it always uses the workflow definition off `main`, which in our case is what we want - albeit with some downsides.

This event type is pretty notorious recently for repos getting script-injected and tokens stolen due to "untrusted PR code" being used when misconfigured; so we have to be careful here, similar to the "Lint PR" workflow too. To mitigate all this, this only runs on post-review PR merges (which unfortunately GHA does not have a dedicated event for), and only those targeting the `generatedSuppressions` branch (and file `paths` to be extra paranoid). 

IMO risk should be OK given it always checks out code from hard-coded `generatedSuppressions` branch, and does not inject/interpolate any variables from the PR context. We probably need some GHA workflow static analysis tooling though, to prevent regression.

Testing off my fork: https://github.com/chadlwilson/DependencyCheck/actions/workflows/publish-suppressions.yml
- Direct pushes to the branch don't/won't trigger
  - e.g https://github.com/chadlwilson/DependencyCheck/commit/f4b246cf3a7df4f7378f69ccaa01a3d845fc2781 
  - so there is some fat-finger protection for maintainers there, even without branch protection enabled
- closed (unmerged) PR doesn't trigger
  - e.g https://github.com/chadlwilson/DependencyCheck/actions/runs/26163791276
- merged PR triggers and publishes
  - https://github.com/chadlwilson/DependencyCheck/pull/13
  - https://github.com/chadlwilson/DependencyCheck/actions/runs/26163820362/job/76962374868  
- workflow_dispatch still triggers
  - https://github.com/chadlwilson/DependencyCheck/actions/runs/26163588509

## Related issues

- fixes #8512 

## Have test cases been added to cover the new functionality?

N/A