### PR TITLE
fix(fp): correct hosted suppression CPE matching for regexes which previously had trailing colons

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1196,7 +1196,7 @@
     FP per issue #7043
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.ftpserver/ftplet-api@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:apache:mina:(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:apache:mina(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1223,7 +1223,7 @@
     artifacts independently versioned and released.
     ]]></notes>
     <packageUrl regex="true">^pkg:(?!maven/com\.graphql-java/graphql-java@).*$</packageUrl>
-    <cpe regex="true">cpe:/a:graphql-java(_project)?:graphql-java:(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:graphql-java(_project)?:graphql-java(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1834,7 +1834,7 @@
     pypi package here. Not suppressed for other ecosystems as Sentry Server is still available open-source elsewhere.
     ]]></notes>
     <packageUrl regex="true">^pkg:pypi/(?!sentry@).*$</packageUrl>
-    <cpe regex="true">cpe:/a:sentry:sentry:(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:sentry:sentry(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
   <notes><![CDATA[
@@ -1988,11 +1988,11 @@
 <suppress base="true">
     <notes><![CDATA[
     FP per issue #8408
-    Consolidated suppression aginst any non-golang packages. The distribution project is a golang toolkit with a
+    Consolidated suppression against any non-golang packages. The distribution project is a golang toolkit with a
     very generic name, likely to mistakenly match many other artifacts.
     ]]></notes>
     <packageUrl regex="true">^pkg:(?!golang/).*$</packageUrl>
-    <cpe regex="true">cpe:/a:distribution(_project)?:distribution:(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:distribution(_project)?:distribution(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -2040,7 +2040,7 @@
     - https://nvd.nist.gov/vuln/search#/nvd/home?cpeFilterMode=applicability&cpeName=cpe:2.3:a:prometheus:prometheus:*:*:*:*:*:*:*:*&resultType=records
     ]]></notes>
     <packageUrl regex="true">^pkg:(?!golang/github\.com/prometheus/prometheus).*$</packageUrl>
-    <cpe regex="true">cpe:/a:prometheus:prometheus:(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:prometheus:prometheus(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[


### PR DESCRIPTION
## Description of Change

Fixes yet another regression from #8522 after the regex conversion - regexes which already had a trailing `:` in their rule were failing to match some CPE rules from NVD because the new optional suffix was added regardless; requiring it to end in `::.*` to match (two colons), which would no longer match anything.

Sorry @nhumblot 😅

## Related issues

- relates to #8522
- relates to #8497

## Have test cases been added to cover the new functionality?

no