### PR TITLE
fix(fp): suppress false positive for microsoft-kiota-abstractions (#8539)

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -5370,4 +5370,18 @@
         <packageUrl regex="true">^pkg:pypi/zabbix-utils@.*$</packageUrl>
         <cpe>cpe:/a:zabbix:zabbix:</cpe>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+        FP per issue #8539 - microsoft-kiota-abstractions primarily provides abstraction/interface contracts and
+        does not appear to contain the runtime/code-generation behavior associated with
+        CVE-2026-41134.
+        ]]></notes>
+
+        <packageUrl regex="true">
+            ^pkg:maven/com\.microsoft\.kiota/microsoft-kiota-abstractions@.*$
+        </packageUrl>
+
+        <cve>CVE-2026-41134</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
## Description of Change

Investigated and reproduced a false positive affecting:

`pkg:maven/com.microsoft.kiota/microsoft-kiota-abstractions@1.9.0`

Dependency-Check currently maps the artifact to:

`cpe:2.3:a:microsoft:kiota`

which results in `CVE-2026-41134` being reported.

From investigation of the package structure and advisory scope, the vulnerability appears related to runtime/code-generation behavior, while `microsoft-kiota-abstractions` primarily provides abstraction/interface contracts without the concrete runtime implementation associated with the vulnerable behavior.

This change adds a narrow suppression scoped specifically to:

* `pkg:maven/com.microsoft.kiota/microsoft-kiota-abstractions`
* `CVE-2026-41134`

to avoid broader suppression of other Kiota runtime artifacts.

## Related issues

* fixes #8539

## Have test cases been added to cover the new functionality?

No

The change is limited to a targeted false-positive suppression rule and existing project builds/tests complete successfully.
