### PR TITLE
fix(fp): add consolidated suppression for Microsoft Kiota generated clients

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -2072,3 +2072,14 @@
     <packageUrl regex="true">^pkg:maven/com\.networknt/json-schema-validator@.*$</packageUrl>
     <cpe regex="true">cpe:/a:json-schema_project:json-schema(:.*)?$</cpe>
 </suppress>
+<suppress base="true">
+    <notes><![CDATA[
+    FP per issues #8534, #8535, #8536, #8537, #8538, #8539, #8540
+    Consolidated suppression for Microsoft Kiota. Kiota is a dotnet-written API-client generation CLI which is versioned
+    separately from its supporting SDK bundles in various languages. Only one group of packages under Microsoft.OpenAPI.Kiota
+    represent the generator product which is matched to the CPE; plus arguably its VSCode extension. Can verify CVEs via NVD:
+    https://nvd.nist.gov/vuln/search#/nvd/home?cpeFilterMode=applicability&cpeName=cpe:2.3:a:microsoft:kiota:*:*:*:*:*:*:*:*&resultType=records
+    ]]></notes>
+    <packageUrl regex="true">^pkg:(?!generic/|vscode-extension/|nuget/Microsoft\.OpenApi\.Kiota).*$</packageUrl>
+    <cpe regex="true">cpe:/a:microsoft:kiota(:.*)?$</cpe>
+</suppress>

--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -2076,7 +2076,7 @@
     <notes><![CDATA[
     FP per issues #8534, #8535, #8536, #8537, #8538, #8539, #8540
     Consolidated suppression for Microsoft Kiota. Kiota is a dotnet-written API-client generation CLI which is versioned
-    separately from its supporting SDK bundles in various languages. Only one group of packages under Microsoft.OpenAPI.Kiota
+    separately from its supporting SDK bundles in various languages. Only one group of packages under Microsoft.OpenApi.Kiota
     represent the generator product which is matched to the CPE; plus arguably its VSCode extension. Can verify CVEs via NVD:
     https://nvd.nist.gov/vuln/search#/nvd/home?cpeFilterMode=applicability&cpeName=cpe:2.3:a:microsoft:kiota:*:*:*:*:*:*:*:*&resultType=records
     ]]></notes>


### PR DESCRIPTION
## Description of Change

[Kiota](https://github.com/microsoft/kiota) is a dotnet-written API-client generation CLI and VSCode extension which is versioned separately from its supporting SDK bundles in various languages. Only one group of packages under Microsoft.OpenAPI.Kiota represent the generator product which is matched to the CPE.

The individual bundles for each language are versioned separately from the main (vulnerable) generator, and would need their own CPEs.

Can [verify CVEs via NVD](https://nvd.nist.gov/vuln/search#/nvd/home?cpeFilterMode=applicability&cpeName=cpe:2.3:a:microsoft:kiota:*:*:*:*:*:*:*:*&resultType=records) but right now there is only https://nvd.nist.gov/vuln/detail/CVE-2026-41134 

This suppression suppresses for all ecosystems except `generic`, and for all Nuget packages exception those under `Microsoft.OpenApi.Kiota.*` which represents the actual generator
- https://www.nuget.org/packages/Microsoft.OpenApi.Kiota
- https://www.nuget.org/packages/Microsoft.OpenApi.Kiota.Builder

Example bundled for generated clients (should be suppressed, essentially are SDK dependencies)
- https://www.nuget.org/packages/Microsoft.Kiota.Http.HttpClientLibrary
- https://mvnrepository.com/artifact/com.microsoft.kiota/microsoft-kiota-bundle/1.9.2/dependencies
- https://pkg.go.dev/github.com/microsoft/kiota-http-go@v1.5.6

## Related issues

- fixes #8534 
- dupes via #8535, #8536, #8537, #8538, #8539, #8540

## Have test cases been added to cover the new functionality?

no

✅ = would be suppressed
❌ - would not be suppressed

<img width="1261" height="534" alt="image" src="https://github.com/user-attachments/assets/f73dad03-64a3-4632-ad54-f7de21b10500" />

