### PR TITLE
fix(fp): allow stricter matching of suppression CPE 2.2 URI prefixes to only whole parts

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/xml/hints/HintHandler.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/hints/HintHandler.java
@@ -17,15 +17,16 @@
  */
 package org.owasp.dependencycheck.xml.hints;
 
-import java.util.ArrayList;
-import java.util.List;
-import javax.annotation.concurrent.NotThreadSafe;
 import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.utils.XmlUtils;
 import org.owasp.dependencycheck.xml.suppression.PropertyType;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A handler to load hint rules.
@@ -268,19 +269,19 @@ public class HintHandler extends DefaultHandler {
                     }
                     break;
                 case FILE_NAME:
-                    final PropertyType pt = new PropertyType();
-                    pt.setValue(attr.getValue(CONTAINS));
+                    boolean isRegex = false;
+                    boolean isCaseSensitive = false;
                     if (attr.getLength() > 0) {
                         final String regex = attr.getValue(REGEX);
                         if (regex != null) {
-                            pt.setRegex(Boolean.parseBoolean(regex));
+                            isRegex = Boolean.parseBoolean(regex);
                         }
                         final String caseSensitive = attr.getValue(CASE_SENSITIVE);
                         if (caseSensitive != null) {
-                            pt.setCaseSensitive(Boolean.parseBoolean(caseSensitive));
+                            isCaseSensitive = Boolean.parseBoolean(caseSensitive);
                         }
                     }
-                    rule.addFilename(pt);
+                    rule.addFilename(new PropertyType(attr.getValue(CONTAINS), isRegex, isCaseSensitive));
                     break;
                 case VENDOR_DUPLICATING_RULE:
                     vendorDuplicatingHintRules.add(new VendorDuplicatingHintRule(attr.getValue(VALUE), attr.getValue(DUPLICATE)));

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/PropertyType.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/PropertyType.java
@@ -17,11 +17,13 @@
  */
 package org.owasp.dependencycheck.xml.suppression;
 
+import com.google.common.base.Suppliers;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import java.util.regex.Pattern;
 import javax.annotation.concurrent.ThreadSafe;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 /**
  * A simple PropertyType used to represent a string value that could be used as
@@ -37,15 +39,45 @@ public class PropertyType {
     /**
      * The value.
      */
-    private String value;
+    private final String value;
     /**
      * Whether or not the expression is a regex.
      */
-    private boolean regex = false;
+    private final boolean regex;
     /**
      * Indicates case sensitivity.
      */
-    private boolean caseSensitive = false;
+    private final boolean caseSensitive;
+
+    private final Supplier<Pattern> compiledRegex = Suppliers
+            .memoize(() -> isRegex() ? Pattern.compile(getValue(), isCaseSensitive() ? 0 : Pattern.CASE_INSENSITIVE) : null);
+
+    /**
+     * @param value the value of the value property
+     * @param regex whether the value is a regex
+     * @param caseSensitive whether the value is case-sensitive
+     */
+    public PropertyType(String value, boolean regex, boolean caseSensitive) {
+        this.value = value;
+        this.regex = regex;
+        this.caseSensitive = caseSensitive;
+    }
+
+    public static PropertyType of(String value) {
+        return new PropertyType(value, false, false);
+    }
+
+    public static PropertyType regex(String value) {
+        return new PropertyType(value, true, false);
+    }
+
+    public static PropertyType caseSensitive(String value) {
+        return new PropertyType(value, false, true);
+    }
+
+    public static PropertyType regexCaseSensitive(String value) {
+        return new PropertyType(value, true, true);
+    }
 
     /**
      * Gets the value of the value property.
@@ -54,15 +86,6 @@ public class PropertyType {
      */
     public String getValue() {
         return value;
-    }
-
-    /**
-     * Sets the value of the value property.
-     *
-     * @param value the value of the value property
-     */
-    public void setValue(String value) {
-        this.value = value;
     }
 
     /**
@@ -75,30 +98,12 @@ public class PropertyType {
     }
 
     /**
-     * Sets whether the value property is a regex.
-     *
-     * @param value true if the value is a regex, otherwise false
-     */
-    public void setRegex(boolean value) {
-        this.regex = value;
-    }
-
-    /**
      * Gets the value of the caseSensitive property.
      *
-     * @return true if the value is case sensitive
+     * @return true if the value is case-sensitive
      */
     public boolean isCaseSensitive() {
         return caseSensitive;
-    }
-
-    /**
-     * Sets the value of the caseSensitive property.
-     *
-     * @param value whether the value is case sensitive
-     */
-    public void setCaseSensitive(boolean value) {
-        this.caseSensitive = value;
     }
     //</editor-fold>
 
@@ -114,13 +119,7 @@ public class PropertyType {
             return false;
         }
         if (this.regex) {
-            final Pattern rx;
-            if (this.caseSensitive) {
-                rx = Pattern.compile(this.value);
-            } else {
-                rx = Pattern.compile(this.value, Pattern.CASE_INSENSITIVE);
-            }
-            return rx.matcher(text).matches();
+            return compiledRegex.get().matcher(text).matches();
         } else {
             if (this.caseSensitive) {
                 return value.equals(text);

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionHandler.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionHandler.java
@@ -17,11 +17,6 @@
  */
 package org.owasp.dependencycheck.xml.suppression;
 
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.List;
-import java.util.Optional;
-import javax.annotation.concurrent.NotThreadSafe;
 import org.owasp.dependencycheck.exception.ParseException;
 import org.owasp.dependencycheck.utils.DateUtil;
 import org.slf4j.Logger;
@@ -29,6 +24,12 @@ import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * A handler to load suppression rules. In the input xml a suppression rule can be part of a {@code suppressionGroup}. In that
@@ -282,18 +283,18 @@ public class SuppressionHandler extends DefaultHandler {
      * @return a PropertyType object
      */
     private PropertyType processPropertyType() {
-        final PropertyType pt = new PropertyType();
-        pt.setValue(currentText.toString().trim());
+        boolean isRegex = false;
+        boolean isCaseSensitive = false;
         if (currentAttributes != null && currentAttributes.getLength() > 0) {
             final String regex = currentAttributes.getValue("regex");
             if (regex != null) {
-                pt.setRegex(Boolean.parseBoolean(regex));
+                isRegex = Boolean.parseBoolean(regex);
             }
             final String caseSensitive = currentAttributes.getValue("caseSensitive");
             if (caseSensitive != null) {
-                pt.setCaseSensitive(Boolean.parseBoolean(caseSensitive));
+                isCaseSensitive = Boolean.parseBoolean(caseSensitive);
             }
         }
-        return pt;
+        return new PropertyType(currentText.toString().trim(), isRegex, isCaseSensitive);
     }
 }

--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
@@ -17,15 +17,9 @@
  */
 package org.owasp.dependencycheck.xml.suppression;
 
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import javax.annotation.concurrent.NotThreadSafe;
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.time.DateFormatUtils;
+import org.jspecify.annotations.NonNull;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Vulnerability;
 import org.owasp.dependencycheck.dependency.naming.CpeIdentifier;
@@ -35,6 +29,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.exceptions.CpeEncodingException;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  *
@@ -567,37 +569,17 @@ public class SuppressionRule {
         if (sha1 != null && !sha1.equalsIgnoreCase(dependency.getSha1sum())) {
             return;
         }
-        if (hasGav()) {
-            final Iterator<Identifier> itr = dependency.getSoftwareIdentifiers().iterator();
-            boolean found = false;
-            while (itr.hasNext()) {
-                final Identifier i = itr.next();
-                if (identifierMatches(this.gav, i)) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                return;
-            }
+        if (hasGav() && dependency.getSoftwareIdentifiers().stream()
+                .noneMatch(i -> identifierMatches(this.gav, i))) {
+            return;
         }
-        if (hasPackageUrl()) {
-            final Iterator<Identifier> itr = dependency.getSoftwareIdentifiers().iterator();
-            boolean found = false;
-            while (itr.hasNext()) {
-                final Identifier i = itr.next();
-                if (purlMatches(this.packageUrl, i)) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                return;
-            }
+        if (hasPackageUrl() && dependency.getSoftwareIdentifiers().stream()
+                .noneMatch(i -> purlMatches(this.packageUrl, i))) {
+            return;
         }
 
-        if (this.hasCpe()) {
-            final Set<Identifier> removalList = new HashSet<>();
+        if (hasCpe()) {
+            final Set<Identifier> removeIdentifiers = new HashSet<>();
             for (Identifier i : dependency.getVulnerableSoftwareIdentifiers()) {
                 for (PropertyType c : this.cpe) {
                     if (identifierMatches(c, i)) {
@@ -608,12 +590,12 @@ public class SuppressionRule {
                             }
                             dependency.addSuppressedIdentifier(i);
                         }
-                        removalList.add(i);
+                        removeIdentifiers.add(i);
                         break;
                     }
                 }
             }
-            removalList.forEach(dependency::removeVulnerableSoftwareIdentifier);
+            removeIdentifiers.forEach(dependency::removeVulnerableSoftwareIdentifier);
         }
         if (hasCve() || hasVulnerabilityName() || hasCwe() || hasCvssBelow() || hasCvssV2Below() || hasCvssV3Below() || hasCvssV4Below()) {
             final Set<Vulnerability> removeVulns = new HashSet<>();
@@ -702,36 +684,6 @@ public class SuppressionRule {
     }
 
     /**
-     * Identifies if the cpe specified by the cpe suppression rule does not
-     * specify a version.
-     *
-     * @param c a suppression rule identifier
-     * @return true if the property type does not specify a version; otherwise
-     * false
-     */
-    protected boolean cpeHasNoVersion(PropertyType c) {
-        return !c.isRegex() && countCharacter(c.getValue(), ':') <= 3;
-    }
-
-    /**
-     * Counts the number of occurrences of the character found within the
-     * string.
-     *
-     * @param str the string to check
-     * @param c the character to count
-     * @return the number of times the character is found in the string
-     */
-    private int countCharacter(String str, char c) {
-        int count = 0;
-        int pos = str.indexOf(c) + 1;
-        while (pos > 0) {
-            count += 1;
-            pos = str.indexOf(c, pos) + 1;
-        }
-        return count;
-    }
-
-    /**
      * Determines if the cpeEntry specified as a PropertyType matches the given
      * Identifier.
      *
@@ -760,33 +712,35 @@ public class SuppressionRule {
             final PurlIdentifier purl = (PurlIdentifier) identifier;
             return suppressionEntry.matches(purl.toGav());
         } else if (identifier instanceof CpeIdentifier) {
-            //TODO check for regex - not just type
-            final Cpe cpeId = ((CpeIdentifier) identifier).getCpe();
-            if (suppressionEntry.isRegex()) {
-                try {
-                    return suppressionEntry.matches(cpeId.toCpe22Uri());
-                } catch (CpeEncodingException ex) {
-                    LOGGER.debug("Unable to convert CPE to 22 URI?" + cpeId);
-                }
-            } else if (suppressionEntry.isCaseSensitive()) {
-                try {
-                    return cpeId.toCpe22Uri().startsWith(suppressionEntry.getValue());
-                } catch (CpeEncodingException ex) {
-                    LOGGER.debug("Unable to convert CPE to 22 URI?" + cpeId);
-                }
-            } else {
-                final String id;
-                try {
-                    id = cpeId.toCpe22Uri().toLowerCase();
-                } catch (CpeEncodingException ex) {
-                    LOGGER.debug("Unable to convert CPE to 22 URI?" + cpeId);
-                    return false;
-                }
-                final String check = suppressionEntry.getValue().toLowerCase();
-                return id.startsWith(check);
+            final Cpe cpe = ((CpeIdentifier) identifier).getCpe();
+            try {
+                // Override normal matching for non-regex CPE rules to be a prefix match rather than exact
+                String cpe22Uri = cpe.toCpe22Uri();
+                return suppressionEntry.isRegex() ? suppressionEntry.matches(cpe22Uri) : cpe22UriPrefixMatches(suppressionEntry, cpe22Uri);
+            } catch (CpeEncodingException ex) {
+                LOGGER.debug("Unable to convert CPE [{}] to 22 URI due to [{}], will try direct string match to rule.", cpe, ex.toString());
             }
         }
+        // Fallback and GenericIdentifier (?)
         return suppressionEntry.matches(identifier.getValue());
+    }
+
+    private static boolean cpe22UriPrefixMatches(PropertyType suppressionEntry, String cpe22Uri) {
+        String candidate = cpe22Uri + cpePartMatchingSuffixFor(suppressionEntry);
+        return (suppressionEntry.isCaseSensitive() ? Strings.CS : Strings.CI)
+                .startsWith(candidate, suppressionEntry.getValue());
+    }
+
+    /**
+     * Uses the passed rule to determine whether the match should be strict; i.e whether the match must be a prefix of
+     * the CPE 2.2 URI, but a whole part; rather than matching part way through.
+     * Prefix-matching rules ending with the CPE colon delimiter imply a strict match is necessary.
+     *
+     * @param rule A non-regex CPE prefix-matching rule
+     * @return A suffix for simple string matching of a CPE 2.2 URI
+     */
+    private static @NonNull String cpePartMatchingSuffixFor(PropertyType rule) {
+        return rule.getValue().endsWith(":") ? ":" : "";
     }
 
     /**

--- a/core/src/test/java/org/owasp/dependencycheck/analyzer/UnusedSuppressionRuleAnalyzerTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/analyzer/UnusedSuppressionRuleAnalyzerTest.java
@@ -13,6 +13,7 @@ import org.owasp.dependencycheck.xml.suppression.PropertyType;
 import org.owasp.dependencycheck.xml.suppression.SuppressionRule;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -21,9 +22,8 @@ import static org.owasp.dependencycheck.analyzer.AbstractSuppressionAnalyzer.SUP
 import static org.owasp.dependencycheck.analyzer.UnusedSuppressionRuleAnalyzer.EXCEPTION_MSG;
 
 class UnusedSuppressionRuleAnalyzerTest extends BaseTest {
-	private static final String NAME = "Unused Suppression Rule Analyzer";
-	private static final String PACKAGE_NAME = "CoolAsACucumber";
-	private static final String EXPECTED_EX = "should have thrown an AnalysisException";
+    private static final String NAME = "Unused Suppression Rule Analyzer";
+    private static final String PACKAGE_NAME = "CoolAsACucumber";
 
     @Test
     void testGetName() {
@@ -33,125 +33,113 @@ class UnusedSuppressionRuleAnalyzerTest extends BaseTest {
 
     @Test
     void testException() throws Exception {
-		boolean shouldFail = true;
-		Dependency dependency10 = getDependency("1.0");
-		Dependency dependency11 = getDependency("1.1");
+        boolean shouldFail = true;
+        Dependency dependency10 = getDependency("1.0");
+        Dependency dependency11 = getDependency("1.1");
 
-		UnusedSuppressionRuleAnalyzer analyzer = getAnalyzer(shouldFail);
-		Engine engine = getEngine(true, false, dependency10, dependency11);
-		try {
-			analyzer.analyzeDependency(dependency10, engine);
-			throw new Exception("should have thrown an AnalysisException");
-		} catch(AnalysisException ok){
-			assertEquals(String.format(EXCEPTION_MSG, 1), ok.getMessage());
-		}
+        UnusedSuppressionRuleAnalyzer analyzer = getAnalyzer(shouldFail);
+        Engine engine = getEngine(true, false, dependency10, dependency11);
+        try {
+            analyzer.analyzeDependency(dependency10, engine);
+            throw new Exception("should have thrown an AnalysisException");
+        } catch (AnalysisException ok) {
+            assertEquals(String.format(EXCEPTION_MSG, 1), ok.getMessage());
+        }
 
-		// no exception
-		shouldFail = false;
-		analyzer = getAnalyzer(shouldFail);
-		engine = getEngine(true, false, dependency10, dependency11);
-		analyzer.analyzeDependency(dependency10, engine);
-    	assertEquals(1, analyzer.getUnusedSuppressionRuleCount());
-	}
+        // no exception
+        shouldFail = false;
+        analyzer = getAnalyzer(shouldFail);
+        engine = getEngine(true, false, dependency10, dependency11);
+        analyzer.analyzeDependency(dependency10, engine);
+        assertEquals(1, analyzer.getUnusedSuppressionRuleCount());
+    }
 
     @Test
     void testCheckUnusedRules() throws Exception {
-		// flag unset
-		boolean shouldFail = false;
-		Dependency dependency10 = getDependency("1.0");
-		Dependency dependency11 = getDependency("1.1");
+        // flag unset
+        boolean shouldFail = false;
+        Dependency dependency10 = getDependency("1.0");
+        Dependency dependency11 = getDependency("1.1");
 
-		// a run without any suppression rule ➫ no unused suppression
-		checkUnusedRules(shouldFail, 0, false, false, dependency10);
+        // a run without any suppression rule ➫ no unused suppression
+        checkUnusedRules(shouldFail, 0, false, false, dependency10);
 
-		// a run without no matching rule ➫ one unused suppression
-		checkUnusedRules(shouldFail, 1, true, false, dependency10, dependency11);
+        // a run without no matching rule ➫ one unused suppression
+        checkUnusedRules(shouldFail, 1, true, false, dependency10, dependency11);
 
-		// a run with the vulnerable package ➫ no unused suppression
-		checkUnusedRules(shouldFail, 0, true, true, dependency10, dependency11);
+        // a run with the vulnerable package ➫ no unused suppression
+        checkUnusedRules(shouldFail, 0, true, true, dependency10, dependency11);
 
 
-		// set flag
-		shouldFail = true;
+        // set flag
+        shouldFail = true;
 
-		// a run without any suppression rule ➫ no unused suppression
-		checkUnusedRules(shouldFail, 0, false, false, dependency10);
+        // a run without any suppression rule ➫ no unused suppression
+        checkUnusedRules(shouldFail, 0, false, false, dependency10);
 
-		// a run without no matching rule ➫ one unused suppression
-		checkUnusedRules(shouldFail, 1, true, false, dependency10, dependency11);
+        // a run without no matching rule ➫ one unused suppression
+        checkUnusedRules(shouldFail, 1, true, false, dependency10, dependency11);
 
-		// a run with the vulnerable package ➫ no unused suppression
-		checkUnusedRules(shouldFail, 0, true, true, dependency10, dependency11);
+        // a run with the vulnerable package ➫ no unused suppression
+        checkUnusedRules(shouldFail, 0, true, true, dependency10, dependency11);
     }
 
-	private void checkUnusedRules(boolean shouldFail, int expectedCount,
-		boolean withSuppressionRules, boolean matching,
-		Dependency ... dependencies) {
+    private void checkUnusedRules(boolean shouldFail, int expectedCount,
+                                  boolean withSuppressionRules, boolean matching,
+                                  Dependency... dependencies) {
         UnusedSuppressionRuleAnalyzer analyzer = getAnalyzer(shouldFail);
-		assertNotNull(analyzer);
-		Engine engine = getEngine(withSuppressionRules, matching, dependencies);
-		analyzer.checkUnusedRules(engine);
-		assertEquals(expectedCount, analyzer.getUnusedSuppressionRuleCount());
-	}
+        assertNotNull(analyzer);
+        Engine engine = getEngine(withSuppressionRules, matching, dependencies);
+        analyzer.checkUnusedRules(engine);
+        assertEquals(expectedCount, analyzer.getUnusedSuppressionRuleCount());
+    }
 
 
-	private Dependency getDependency(String type, String namespace, String name, String version) throws Exception {
+    private Dependency getDependency(String type, String namespace, String name, String version) throws Exception {
         Dependency dependency = new Dependency();
-		Identifier id = new PurlIdentifier(type,namespace,name,version,Confidence.HIGHEST);
+        Identifier id = new PurlIdentifier(type, namespace, name, version, Confidence.HIGHEST);
         dependency.addSoftwareIdentifier(id);
-		return dependency;
-	}
+        return dependency;
+    }
 
-	private Dependency getDependency(String version) throws Exception {
-		return getDependency("maven", "test", PACKAGE_NAME, version);
-	}
+    private Dependency getDependency(String version) throws Exception {
+        return getDependency("maven", "test", PACKAGE_NAME, version);
+    }
 
-
-	private Engine getEngine(boolean hasSuppressionRules, boolean matching, Dependency ... dependencies) {
+    private Engine getEngine(boolean hasSuppressionRules, boolean matching, Dependency... dependencies) {
         Engine engine = new Engine(getSettings());
-		List<Dependency> dependencyList = new ArrayList<>();
-		if (dependencies!=null) {
-			for(Dependency d : dependencies)
-				dependencyList.add(d);
-		}
-		engine.setDependencies(dependencyList);
-		if(!hasSuppressionRules) return engine;
-		List<SuppressionRule> rules = new ArrayList<>();
-		rules.add(getSuppressionRule(matching));
-		engine.putObject(SUPPRESSION_OBJECT_KEY,rules);
-		return engine;
-	}
+        List<Dependency> dependencyList = new ArrayList<>();
+        if (dependencies != null) {
+            dependencyList.addAll(Arrays.asList(dependencies));
+        }
+        engine.setDependencies(dependencyList);
+        if (!hasSuppressionRules) return engine;
+        List<SuppressionRule> rules = new ArrayList<>();
+        rules.add(getSuppressionRule(matching));
+        engine.putObject(SUPPRESSION_OBJECT_KEY, rules);
+        return engine;
+    }
 
-	private UnusedSuppressionRuleAnalyzer getAnalyzer(boolean flag) {
+    private UnusedSuppressionRuleAnalyzer getAnalyzer(boolean flag) {
         UnusedSuppressionRuleAnalyzer analyzer = new UnusedSuppressionRuleAnalyzer();
-		assertNotNull(analyzer);
+        assertNotNull(analyzer);
 
-		Settings settings = getSettings();
+        Settings settings = getSettings();
         settings.setBoolean(Settings.KEYS.FAIL_ON_UNUSED_SUPPRESSION_RULE, flag);
         analyzer.initialize(settings);
         assertEquals(flag, analyzer.failsForUnusedSuppressionRule());
         assertEquals(0, analyzer.getUnusedSuppressionRuleCount());
 
-		return analyzer;
-	}
-
-	private SuppressionRule getSuppressionRule(boolean matching) {
-        SuppressionRule instance = new SuppressionRule();
-		instance.addVulnerabilityName(getPropertyType("CVE-2023-5072", false, false));
-		instance.setPackageUrl(getPropertyType("^pkg:maven/test." + PACKAGE_NAME + "." + matching, false, false));
-		instance.addCpe(getPropertyType(PACKAGE_NAME, false, false));
-		instance.setBase(false);
-		instance.setMatched(matching);
-		return instance;
+        return analyzer;
     }
 
-	private PropertyType getPropertyType(String value, boolean regex, boolean caseSensitive) {
-		PropertyType property = new PropertyType();
-		property.setValue(value);
-		property.setRegex(regex);
-		property.setCaseSensitive(caseSensitive);
-		return property;
-	}
-
-
+    private SuppressionRule getSuppressionRule(boolean matching) {
+        SuppressionRule instance = new SuppressionRule();
+        instance.addVulnerabilityName(PropertyType.of("CVE-2023-5072"));
+        instance.setPackageUrl(PropertyType.regex("^pkg:maven/test." + PACKAGE_NAME + "." + matching));
+        instance.addCpe(PropertyType.of(PACKAGE_NAME));
+        instance.setBase(false);
+        instance.setMatched(matching);
+        return instance;
+    }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/xml/suppression/PropertyTypeTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/suppression/PropertyTypeTest.java
@@ -20,8 +20,10 @@ package org.owasp.dependencycheck.xml.suppression;
 import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.regex.PatternSyntaxException;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -31,57 +33,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class PropertyTypeTest extends BaseTest {
 
     /**
-     * Test of set and getValue method, of class PropertyType.
-     */
-    @Test
-    void testSetGetValue() {
-
-        PropertyType instance = new PropertyType();
-        String expResult = "test";
-        instance.setValue(expResult);
-        String result = instance.getValue();
-        assertEquals(expResult, result);
-    }
-
-    /**
-     * Test of isRegex method, of class PropertyType.
-     */
-    @Test
-    void testIsRegex() {
-        PropertyType instance = new PropertyType();
-        assertFalse(instance.isRegex());
-        instance.setRegex(true);
-        assertTrue(instance.isRegex());
-    }
-
-    /**
-     * Test of isCaseSensitive method, of class PropertyType.
-     */
-    @Test
-    void testIsCaseSensitive() {
-        PropertyType instance = new PropertyType();
-        assertFalse(instance.isCaseSensitive());
-        instance.setCaseSensitive(true);
-        assertTrue(instance.isCaseSensitive());
-    }
-
-    /**
      * Test of matches method, of class PropertyType.
      */
     @Test
     void testMatches() {
         String text = "Simple";
+        assertTrue(PropertyType.of("simple").matches(text));
+        assertFalse(PropertyType.caseSensitive("simple").matches(text));
+    }
 
-        PropertyType instance = new PropertyType();
-        instance.setValue("simple");
-        assertTrue(instance.matches(text));
-        instance.setCaseSensitive(true);
-        assertFalse(instance.matches(text));
+    @Test
+    void testMatchesRegex() {
+        String text = "Simple";
+        assertTrue(PropertyType.regex("s.*le").matches(text));
+        assertFalse(PropertyType.regexCaseSensitive("s.*le").matches(text));
+    }
 
-        instance.setValue("s.*le");
-        instance.setRegex(true);
-        assertFalse(instance.matches(text));
-        instance.setCaseSensitive(false);
-        assertTrue(instance.matches(text));
+    @Test
+    void testMatchesRegexRethrowsCompilationIssue() {
+        assertThrowsExactly(PatternSyntaxException.class, () -> PropertyType.regex("(badregex").matches("anything"));
+        assertThrowsExactly(PatternSyntaxException.class, () -> PropertyType.regexCaseSensitive("(badregex").matches("anything"));
     }
 }

--- a/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionRuleTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionRuleTest.java
@@ -28,8 +28,10 @@ import org.owasp.dependencycheck.dependency.Confidence;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Vulnerability;
 import org.owasp.dependencycheck.dependency.naming.CpeIdentifier;
+import org.owasp.dependencycheck.dependency.naming.Identifier;
 import org.owasp.dependencycheck.dependency.naming.PurlIdentifier;
 import org.owasp.dependencycheck.utils.CvssUtil;
+import us.springett.parsers.cpe.CpeParser;
 import us.springett.parsers.cpe.exceptions.CpeValidationException;
 
 import java.io.File;
@@ -54,8 +56,7 @@ class SuppressionRuleTest extends BaseTest {
     @Test
     void testFilePath() {
         SuppressionRule instance = new SuppressionRule();
-        PropertyType expResult = new PropertyType();
-        expResult.setValue("test");
+        PropertyType expResult = PropertyType.of("test");
         instance.setFilePath(expResult);
         PropertyType result = instance.getFilePath();
         assertEquals(expResult, result);
@@ -82,8 +83,7 @@ class SuppressionRuleTest extends BaseTest {
         List<PropertyType> cpe = new ArrayList<>();
         instance.setCpe(cpe);
         assertFalse(instance.hasCpe());
-        PropertyType pt = new PropertyType();
-        pt.setValue("one");
+        PropertyType pt = PropertyType.of("one");
         instance.addCpe(pt);
         assertTrue(instance.hasCpe());
         List<PropertyType> result = instance.getCpe();
@@ -149,269 +149,68 @@ class SuppressionRuleTest extends BaseTest {
 
     //</editor-fold>
 
-    //<editor-fold defaultstate="collapsed" desc="Ignored duplicate tests, left in, as empty tests, so IDE doesn't re-generate them">
-    /**
-     * Test of getFilePath method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testGetFilePath() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of setFilePath method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testSetFilePath() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of getSha1 method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testGetSha1() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of setSha1 method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testSetSha1() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of getCpe method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testGetCpe() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of setCpe method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testSetCpe() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of addCpe method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testAddCpe() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of hasCpe method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testHasCpe() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of setCvssBelow method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testSetCvssBelow() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of addCvssBelow method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testAddCvssBelow() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of hasCvssBelow method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testHasCvssBelow() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of getCwe method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testGetCwe() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of setCwe method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testSetCwe() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of addCwe method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testAddCwe() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of hasCwe method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testHasCwe() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of getCve method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testGetCve() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of setCve method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testSetCve() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of addCve method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testAddCve() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    /**
-     * Test of hasCve method, of class SuppressionRule.
-     */
-    @Test
-    @SuppressWarnings("squid:S2699")
-    void testHasCve() {
-        //already tested, this is just left so the IDE doesn't recreate it.
-    }
-
-    //</editor-fold>
-
-    /**
-     * Test of cpeHasNoVersion method, of class SuppressionRule.
-     */
-    @Test
-    void testCpeHasNoVersion() {
-        PropertyType c = new PropertyType();
-        c.setValue("cpe:/a:microsoft:.net_framework:4.5");
-        SuppressionRule instance = new SuppressionRule();
-        assertFalse(instance.cpeHasNoVersion(c));
-        c.setValue("cpe:/a:microsoft:.net_framework:");
-        assertFalse(instance.cpeHasNoVersion(c));
-        c.setValue("cpe:/a:microsoft:.net_framework");
-        assertTrue(instance.cpeHasNoVersion(c));
-    }
-
     /**
      * Test of identifierMatches method, of class SuppressionRule.
      */
     @Test
-    void testCpeMatches() throws CpeValidationException, MalformedPackageURLException {
-        CpeIdentifier identifier = new CpeIdentifier("microsoft", ".net_framework", "4.5", Confidence.HIGHEST);
-
-        PropertyType cpe = new PropertyType();
-        cpe.setValue("cpe:/a:microsoft:.net_framework:4.5");
+    void testCpeMatches() throws Exception {
+        Identifier identifier = new CpeIdentifier("microsoft", ".net_framework", "4.5", Confidence.HIGHEST);
 
         SuppressionRule instance = new SuppressionRule();
         boolean expResult = true;
-        boolean result = instance.identifierMatches(cpe, identifier);
+        boolean result = instance.identifierMatches(PropertyType.of("cpe:/a:microsoft:.net_framework:4.5"), identifier);
         assertEquals(expResult, result);
 
-        cpe.setValue("cpe:/a:microsoft:.net_framework:4.0");
         expResult = false;
-        result = instance.identifierMatches(cpe, identifier);
+        result = instance.identifierMatches(PropertyType.of("cpe:/a:microsoft:.net_framework:4.0"), identifier);
         assertEquals(expResult, result);
 
-        cpe.setValue("CPE:/a:microsoft:.net_framework:4.5");
-        cpe.setCaseSensitive(true);
         expResult = false;
-        result = instance.identifierMatches(cpe, identifier);
+        result = instance.identifierMatches(PropertyType.caseSensitive("CPE:/a:microsoft:.net_framework:4.5"), identifier);
         assertEquals(expResult, result);
 
-        cpe.setValue("cpe:/a:microsoft:.net_framework");
-        cpe.setCaseSensitive(false);
         expResult = true;
-        result = instance.identifierMatches(cpe, identifier);
+        result = instance.identifierMatches(PropertyType.of("cpe:/a:microsoft:.net_framework"), identifier);
         assertEquals(expResult, result);
 
-        cpe.setValue("cpe:/a:microsoft:.*");
-        cpe.setRegex(true);
         expResult = true;
-        result = instance.identifierMatches(cpe, identifier);
+        result = instance.identifierMatches(PropertyType.regex("cpe:/a:microsoft:.*"), identifier);
         assertEquals(expResult, result);
 
-        cpe.setValue("CPE:/a:microsoft:.*");
-        cpe.setRegex(true);
-        cpe.setCaseSensitive(true);
         expResult = false;
-        result = instance.identifierMatches(cpe, identifier);
+        result = instance.identifierMatches(PropertyType.regexCaseSensitive("CPE:/a:microsoft:.*"), identifier);
         assertEquals(expResult, result);
 
-        cpe.setValue("cpe:/a:apache:.*");
-        cpe.setRegex(true);
-        cpe.setCaseSensitive(false);
         expResult = false;
-        result = instance.identifierMatches(cpe, identifier);
+        result = instance.identifierMatches(PropertyType.regex("cpe:/a:apache:.*"), identifier);
         assertEquals(expResult, result);
 
         identifier = new CpeIdentifier("apache", "tomcat", "7.0", Confidence.HIGH);
-        cpe.setValue("cpe:/a:apache:tomcat");
-        cpe.setRegex(false);
-        cpe.setCaseSensitive(false);
         expResult = true;
-        result = instance.identifierMatches(cpe, identifier);
+        result = instance.identifierMatches(PropertyType.of("cpe:/a:apache:tomcat"), identifier);
         assertEquals(expResult, result);
 
-        PurlIdentifier pid = new PurlIdentifier("maven", "org.springframework", "spring-core", "2.5.5", Confidence.HIGH);
-        cpe.setValue("org.springframework:spring-core:2.5.5");
-        cpe.setRegex(false);
-        cpe.setCaseSensitive(false);
-        expResult = true;
-        result = instance.identifierMatches(cpe, pid);
-        assertEquals(expResult, result);
-
-        cpe.setValue("org\\.springframework\\.security:spring.*");
-        cpe.setRegex(true);
-        cpe.setCaseSensitive(false);
+        identifier = new CpeIdentifier(CpeParser.parse("cpe:/a:apache:tomcat_subproduct"), Confidence.HIGH);
         expResult = false;
-        result = instance.identifierMatches(cpe, pid);
+        result = instance.identifierMatches(PropertyType.of("cpe:/a:apache:tomcat:"), identifier);
         assertEquals(expResult, result);
+
+        identifier = new CpeIdentifier(CpeParser.parse("cpe:/a:apache:tomcat"), Confidence.HIGH);
+        expResult = true;
+        result = instance.identifierMatches(PropertyType.of("cpe:/a:apache:tomcat:"), identifier);
+        assertEquals(expResult, result);
+    }
+
+    @Test
+    void testGavMatches() throws Exception {
+        SuppressionRule instance = new SuppressionRule();
+
+        PurlIdentifier id = new PurlIdentifier("maven", "org.springframework", "spring-core", "2.5.5", Confidence.HIGH);
+        PropertyType gav = PropertyType.of("org.springframework:spring-core:2.5.5");
+        assertEquals(true, instance.identifierMatches(gav, id), "gav should match purl");
+
+        gav = PropertyType.regex("org\\.springframework\\.security:spring.*");
+        assertEquals(false, instance.identifierMatches(gav, id), "gav should match purl by regex");
     }
 
     /**
@@ -463,18 +262,11 @@ class SuppressionRuleTest extends BaseTest {
 
         //cpe
         instance = new SuppressionRule();
-        PropertyType pt = new PropertyType();
-        pt.setValue("cpe:/a:microsoft:.net_framework:4.0");
-        instance.addCpe(pt);
+        instance.addCpe(PropertyType.of("cpe:/a:microsoft:.net_framework:4.0"));
         instance.process(dependency);
         assertEquals(1, dependency.getVulnerableSoftwareIdentifiers().size());
-        pt = new PropertyType();
-        pt.setValue("cpe:/a:microsoft:.net_framework:4.5");
-        instance.addCpe(pt);
-        pt = new PropertyType();
-        pt.setValue(".*");
-        pt.setRegex(true);
-        instance.setFilePath(pt);
+        instance.addCpe(PropertyType.of("cpe:/a:microsoft:.net_framework:4.5"));
+        instance.setFilePath(PropertyType.regex(".*"));
         instance.process(dependency);
         assertTrue(dependency.getVulnerableSoftwareIdentifiers().isEmpty());
         assertEquals(1, dependency.getSuppressedIdentifiers().size());
@@ -484,9 +276,7 @@ class SuppressionRuleTest extends BaseTest {
         dependency.addVulnerableSoftwareIdentifier(new CpeIdentifier("microsoft", ".net_framework", "4.0", Confidence.HIGH));
         dependency.addVulnerableSoftwareIdentifier(new CpeIdentifier("microsoft", ".net_framework", "4.5", Confidence.HIGH));
         dependency.addVulnerableSoftwareIdentifier(new CpeIdentifier("microsoft", ".net_framework", "5.0", Confidence.HIGH));
-        pt = new PropertyType();
-        pt.setValue("cpe:/a:microsoft:.net_framework");
-        instance.addCpe(pt);
+        instance.addCpe(PropertyType.of("cpe:/a:microsoft:.net_framework"));
         instance.setBase(true);
         assertEquals(3, dependency.getVulnerableSoftwareIdentifiers().size());
         assertEquals(1, dependency.getSuppressedIdentifiers().size());
@@ -510,22 +300,11 @@ class SuppressionRuleTest extends BaseTest {
 
         //cpe
         SuppressionRule instance = new SuppressionRule();
-        PropertyType pt = new PropertyType();
 
-        pt.setValue("org\\.springframework\\.security:spring.*");
-        pt.setRegex(true);
-        pt.setCaseSensitive(false);
-        instance.setGav(pt);
-
-        pt = new PropertyType();
-        pt.setValue("cpe:/a:mod_security:mod_security");
-        instance.addCpe(pt);
-        pt = new PropertyType();
-        pt.setValue("cpe:/a:springsource:spring_framework");
-        instance.addCpe(pt);
-        pt = new PropertyType();
-        pt.setValue("cpe:/a:vmware:springsource_spring_framework");
-        instance.addCpe(pt);
+        instance.setGav(PropertyType.regex("org\\.springframework\\.security:spring.*"));
+        instance.addCpe(PropertyType.of("cpe:/a:mod_security:mod_security"));
+        instance.addCpe(PropertyType.of("cpe:/a:springsource:spring_framework"));
+        instance.addCpe(PropertyType.of("cpe:/a:vmware:springsource_spring_framework"));
 
         instance.process(dependency);
         assertEquals(1, dependency.getVulnerableSoftwareIdentifiers().size());
@@ -541,25 +320,14 @@ class SuppressionRuleTest extends BaseTest {
 
         dependency.addVulnerability(createVulnerability());
         SuppressionRule instance = new SuppressionRule();
-        //gav
-        PropertyType pt = new PropertyType();
-        pt.setValue("pkg:maven/org.springframework.security/spring-security-web@3.0.0.RELEASE");
-        pt.setRegex(false);
-        pt.setCaseSensitive(false);
-        instance.setPackageUrl(pt);
-
-        pt = new PropertyType();
-        pt.setValue("CVE-2013-1338");
-        instance.addVulnerabilityName(pt);
+        instance.setPackageUrl(PropertyType.of("pkg:maven/org.springframework.security/spring-security-web@3.0.0.RELEASE"));
+        instance.addVulnerabilityName(PropertyType.of("CVE-2013-1338"));
 
         instance.process(dependency);
         assertEquals(1, dependency.getVulnerabilities().size());
         assertEquals(0, dependency.getSuppressedVulnerabilities().size());
 
-
-        pt = new PropertyType();
-        pt.setValue("CVE-2013-1337");
-        instance.addVulnerabilityName(pt);
+        instance.addVulnerabilityName(PropertyType.of("CVE-2013-1337"));
 
         instance.process(dependency);
         assertEquals(0, dependency.getVulnerabilities().size());


### PR DESCRIPTION
## Description of Change

Follows up on #8509 to allow rules with a trailing `:` to indicate a strict match of the last part is intended; rather than potentially matching only a substring of the part (usually an application name). Without this, we'd also need to correct all of the base suppressions to regex, like done in #8522.

e.g.
https://github.com/dependency-check/DependencyCheck/blob/c5f5f681eedab927ff3cad2ed5c229cbce02b206/core/src/main/resources/dependencycheck-base-suppression.xml#L13-L19

Main goal as with #8509 is to reduce false negatives from other products with the same "prefiix" in the name.

Some `CpeIdentifiers` don't include the version at all; making the changes in #8509 fail to suppress some `VulnerableSoftwareIdentifier`s. 

This change 
- allows us to avoid needing regex
- when using regex, memoize the pattern to avoid O(n^2) regex compiling during matching.
  - makes `PropertyType` immutable to do so 

I can split up the regex stuff if preferred; I kept them together since they both touch the same tests.

## Related issues

- required by #8509
- relates to #8522

## Have test cases been added to cover the new functionality?

yes