### PR TITLE
fix(core): add missing nvd.api.key entry to dependencycheck.properties

### DIFF
--- a/core/src/main/resources/dependencycheck.properties
+++ b/core/src/main/resources/dependencycheck.properties
@@ -54,6 +54,7 @@ nvd.api.check.validforhours=4
 nvd.api.datafeed.validfordays=7
 nvd.api.max.retry.count=30
 nvd.api.delay=0
+nvd.api.key=
 
 # these are the default NVD API request limits - these can be set lower,
 # but the client used will not let you exceed these values


### PR DESCRIPTION
## Description of Change

Added the missing `nvd.api.key` entry to `dependencycheck.properties` so users can identify the corresponding property for the `nvdApiKey` command line argument.

## Related issues

Fixes #8442

## Have test cases been added to cover the new functionality?

No - documentation/configuration update only.
