### PR TITLE
fix: improve Java 17+ compatibility by removing jdiagnostics

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -162,10 +162,6 @@ Copyright (c) 2012 Jeremy Long. All Rights Reserved.
             <artifactId>open-vulnerability-clients</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.anarres.jdiagnostics</groupId>
-            <artifactId>jdiagnostics</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.kichik.pecoff4j</groupId>
             <artifactId>pecoff4j</artifactId>
         </dependency>

--- a/core/src/main/java/org/owasp/dependencycheck/data/cache/DataCacheFactory.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/cache/DataCacheFactory.java
@@ -17,12 +17,6 @@
  */
 package org.owasp.dependencycheck.data.cache;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Properties;
-
 import io.github.jeremylong.jcs3.slf4j.Slf4jAdapter;
 import org.apache.commons.jcs3.JCS;
 import org.apache.commons.jcs3.access.CacheAccess;
@@ -36,6 +30,12 @@ import org.owasp.dependencycheck.utils.Settings;
 import org.owasp.dependencycheck.xml.pom.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Properties;
 
 /**
  * Factory to instantiate cache repositories.
@@ -140,7 +140,6 @@ public class DataCacheFactory {
             if (ex instanceof CacheException) {
                 throw ex;
             }
-            //TODO we may want to instrument w/ jdiagnostics per #2509
             LOGGER.debug("Error constructing cache for node audit files", ex);
             throw new CacheException(ex);
         }
@@ -165,7 +164,6 @@ public class DataCacheFactory {
             if (ex instanceof CacheException) {
                 throw ex;
             }
-            //TODO we may want to instrument w/ jdiagnostics per #2509
             LOGGER.debug("Error constructing cache for POM files", ex);
             throw new CacheException(ex);
         }
@@ -190,7 +188,6 @@ public class DataCacheFactory {
             if (ex instanceof CacheException) {
                 throw ex;
             }
-            //TODO we may want to instrument w/ jdiagnostics per #2509
             LOGGER.debug("Error constructing cache for Central files", ex);
             throw new CacheException(ex);
         }

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -22,12 +22,35 @@ import com.google.common.io.Resources;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.github.jeremylong.openvulnerability.client.nvd.Config;
 import io.github.jeremylong.openvulnerability.client.nvd.CpeMatch;
+import io.github.jeremylong.openvulnerability.client.nvd.CvssV2;
+import io.github.jeremylong.openvulnerability.client.nvd.CvssV2Data;
+import io.github.jeremylong.openvulnerability.client.nvd.CvssV3;
+import io.github.jeremylong.openvulnerability.client.nvd.CvssV3Data;
+import io.github.jeremylong.openvulnerability.client.nvd.CvssV4;
+import io.github.jeremylong.openvulnerability.client.nvd.CvssV4Data;
+import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
+import io.github.jeremylong.openvulnerability.client.nvd.LangString;
+import io.github.jeremylong.openvulnerability.client.nvd.Node;
+import io.github.jeremylong.openvulnerability.client.nvd.Reference;
+import io.github.jeremylong.openvulnerability.client.nvd.Weakness;
 import org.apache.commons.collections4.map.ReferenceMap;
+import org.owasp.dependencycheck.analyzer.exception.LambdaExceptionWrapper;
+import org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException;
+import org.owasp.dependencycheck.data.update.cpe.CpeEcosystemCache;
+import org.owasp.dependencycheck.data.update.cpe.CpePlus;
 import org.owasp.dependencycheck.dependency.Vulnerability;
 import org.owasp.dependencycheck.dependency.VulnerableSoftware;
-import org.owasp.dependencycheck.utils.*;
+import org.owasp.dependencycheck.dependency.VulnerableSoftwareBuilder;
+import org.owasp.dependencycheck.utils.InvalidSettingException;
+import org.owasp.dependencycheck.utils.Pair;
+import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import us.springett.parsers.cpe.Cpe;
+import us.springett.parsers.cpe.CpeBuilder;
+import us.springett.parsers.cpe.CpeParser;
+import us.springett.parsers.cpe.exceptions.CpeParsingException;
+import us.springett.parsers.cpe.exceptions.CpeValidationException;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
@@ -40,34 +63,23 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.ResourceBundle;
+import java.util.Set;
 import java.util.stream.Collectors;
-import org.anarres.jdiagnostics.DefaultQuery;
 
 import static org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceStrength.HARD;
 import static org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceStrength.SOFT;
-import org.owasp.dependencycheck.analyzer.exception.LambdaExceptionWrapper;
-import org.owasp.dependencycheck.analyzer.exception.UnexpectedAnalysisException;
-import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
 import static org.owasp.dependencycheck.data.nvdcve.CveDB.PreparedStatementCveDb.*;
-import org.owasp.dependencycheck.data.update.cpe.CpeEcosystemCache;
-import org.owasp.dependencycheck.data.update.cpe.CpePlus;
-import io.github.jeremylong.openvulnerability.client.nvd.CvssV2;
-import io.github.jeremylong.openvulnerability.client.nvd.CvssV2Data;
-import io.github.jeremylong.openvulnerability.client.nvd.CvssV3;
-import io.github.jeremylong.openvulnerability.client.nvd.CvssV3Data;
-import io.github.jeremylong.openvulnerability.client.nvd.CvssV4;
-import io.github.jeremylong.openvulnerability.client.nvd.CvssV4Data;
-import io.github.jeremylong.openvulnerability.client.nvd.LangString;
-import io.github.jeremylong.openvulnerability.client.nvd.Node;
-import io.github.jeremylong.openvulnerability.client.nvd.Reference;
-import io.github.jeremylong.openvulnerability.client.nvd.Weakness;
-import org.owasp.dependencycheck.dependency.VulnerableSoftwareBuilder;
-import us.springett.parsers.cpe.Cpe;
-import us.springett.parsers.cpe.CpeBuilder;
-import us.springett.parsers.cpe.CpeParser;
-import us.springett.parsers.cpe.exceptions.CpeParsingException;
-import us.springett.parsers.cpe.exceptions.CpeValidationException;
 
 /**
  * The database holding information about the NVD CVE data. This class is safe
@@ -120,7 +132,7 @@ public final class CveDB implements AutoCloseable {
 
     /**
      * Utility to extract information from
-     * {@linkplain org.owasp.dependencycheck.data.nvd.json.DefCveItem}.
+     * {@linkplain DefCveItem}.
      */
     private final CveItemOperator cveItemConverter;
     /**
@@ -155,8 +167,6 @@ public final class CveDB implements AutoCloseable {
             }
         } catch (IOException ex) {
             throw new DatabaseException("Unable to update the ecosystem cache", ex);
-        } catch (LinkageError ex) {
-            LOGGER.debug(new DefaultQuery(ex).call().toString());
         }
         return updateCount;
     }

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DatabaseManager.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/DatabaseManager.java
@@ -18,22 +18,6 @@
 package org.owasp.dependencycheck.data.nvdcve;
 
 import com.google.common.io.Resources;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.sql.PreparedStatement;
-import java.sql.Connection;
-import java.sql.Driver;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Locale;
-import java.util.ResourceBundle;
-import javax.annotation.concurrent.ThreadSafe;
-import org.anarres.jdiagnostics.DefaultQuery;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.io.IOUtils;
 import org.owasp.dependencycheck.utils.DBUtils;
@@ -43,6 +27,22 @@ import org.owasp.dependencycheck.utils.FileUtils;
 import org.owasp.dependencycheck.utils.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Locale;
+import java.util.ResourceBundle;
 
 /**
  * Loads the configured database driver and returns the database connection. If
@@ -386,8 +386,6 @@ public final class DatabaseManager {
             }
         } catch (IOException ex) {
             throw new DatabaseException("Unable to create database schema", ex);
-        } catch (LinkageError ex) {
-            LOGGER.debug(new DefaultQuery(ex).call().toString());
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -915,11 +915,6 @@ Copyright (c) 2012 - Jeremy Long
                 <version>9.0.5</version>
             </dependency>
             <dependency>
-                <groupId>org.anarres.jdiagnostics</groupId>
-                <artifactId>jdiagnostics</artifactId>
-                <version>1.0.7</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-jcs3-core</artifactId>
                 <version>3.2.1</version>


### PR DESCRIPTION
## Description of Change

jdiagnostics seems unmaintained, and it does reflection on class internals which is completely disallowed by default on Java 17+ - so at the very time we need it (when there is `LinkageError`) it's most likely to fail and make things even worse. I don't think this is a good idea on modern JVMs.

## Related issues

- fixes https://github.com/dependency-check/dependency-check-gradle/issues/513

## Have test cases been added to cover the new functionality?

N/A