### PR TITLE
fix: resolve overridden plugin dependencies correctly (#8570)

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -34,6 +34,7 @@ import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.License;
+import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -1545,6 +1546,14 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
         final CollectRequest collectRequest = new CollectRequest();
         collectRequest.setRoot(new org.eclipse.aether.graph.Dependency(rootArtifact, null));
         collectRequest.setRepositories(project.getRemoteProjectRepositories());
+
+        final Plugin projectPlugin = project.getPlugin(rootArtifact.getGroupId() + ":" + rootArtifact.getArtifactId());
+
+        if (projectPlugin != null) {
+            for (org.apache.maven.model.Dependency dep : projectPlugin.getDependencies()) {
+                collectRequest.addDependency(RepositoryUtils.toDependency(dep, session.getRepositorySession().getArtifactTypeRegistry()));
+            }
+        }
 
         final DependencyResult dependencyResult = repoSystem.resolveDependencies(
                 session.getRepositorySession(), new DependencyRequest(collectRequest, null));


### PR DESCRIPTION
## Description of Change

When a pom.xml overrides a plugin's dependencies like this, dependency-check does not take the overrides into account, which might lead to false positives:

```xml
<build>
	<pluginManagement>
		<plugin>
			<groupId>org.apache.maven.plugins</groupId>
			<artifactId>maven-clean-plugin</artifactId>
			<version>3.5.0</version>
			<dependencies>
				<dependency>
					<groupId>org.codehaus.plexus</groupId>
					<artifactId>plexus-utils</artifactId>
					<version>4.0.3</version>
				</dependency>
			</dependencies>
		</plugin>
	</pluginManagement>
</build>
```

In this particular case, dependency-check reports the following error:

> [ERROR] plexus-utils-3.0.24.jar (pkg:maven/org.codehaus.plexus/plexus-utils@3.0.24, cpe:2.3:a:codehaus-plexus:plexus-utils:3.0.24:*:*:*:*:*:*:*, cpe:2.3:a:utils_project:utils:3.0.24:*:*:*:*:*:*:*): CVE-2025-67030(8.8)

The idea in this PR is to mimic what's done in `mvn dependency:resolve-plugins`, that is to say to enhance the `CollectRequest` with a list of plugin dependencies declared in the pom.xml being scanned:

* a list of plugin dependencies is [created here](https://github.com/apache/maven-dependency-plugin/blob/3712611/src/main/java/org/apache/maven/plugins/dependency/utils/ResolverUtil.java#L239)
* and then passed to the [`CollectRequest` here](https://github.com/apache/maven-dependency-plugin/blob/371261124f9cff27cf0439fe3abaec4e322fae7e/src/main/java/org/apache/maven/plugins/dependency/utils/ResolverUtil.java#L185)
 
## Related issues

This should fix #8570
<!--
e.g 
- fixes #xxxx
- relates to #xxxx
-->

## Have test cases been added to cover the new functionality?

Not yet, I'm just making sure I'm heading towards the right fix for now.