### PR TITLE
docs: fix Maven debug command in `configuration.md`

### DIFF
--- a/maven/src/site/markdown/configuration.md
+++ b/maven/src/site/markdown/configuration.md
@@ -146,7 +146,7 @@ Advanced Configuration
 ====================
 The following properties can be configured in the plugin. However, they are less frequently changed.
 
-Note that any passwords in the below configuration could be exposed if you use `-x` option to debug the build. It is always better to configure the credential in your settings.xml and use the configuration to set the server id instead of placeing the password directly in the pom.xml.
+Note that any passwords in the below configuration could be exposed if you use `-X` option to debug the build. It is always better to configure the credential in your settings.xml and use the configuration to set the server id instead of placeing the password directly in the pom.xml.
 
 | Property                        | Description                                                                                                                                                                                                                          | Default Value                                                                             |
 |---------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|


### PR DESCRIPTION
The argument referenced in the documentation is incorrect:
```
% mvn -x
Unable to parse command line options: Unrecognized option: -x
{...}
Options:
{...}
 -X,--debug                              Produce execution debug output
```