### PR TITLE
fix(windows): use JAVA_HOME when java is not on PATH

### DIFF
--- a/cli/src/main/conf/windowsBinTemplate.bat
+++ b/cli/src/main/conf/windowsBinTemplate.bat
@@ -50,7 +50,13 @@ for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
 set REPO=
 #ENV_SETUP#
 
-if "%JAVACMD%"=="" set JAVACMD=#JAVA_BINARY#
+if "%JAVACMD%"=="" (
+    if exist "%JAVA_HOME%\bin\java.exe" (
+        set "JAVACMD=%JAVA_HOME%\bin\java.exe"
+    ) else (
+        set "JAVACMD=#JAVA_BINARY#"
+    )
+)
 
 if "%REPO%"=="" set REPO=%BASEDIR%\#REPO#
 

--- a/cli/src/main/conf/windowsBinTemplate.bat
+++ b/cli/src/main/conf/windowsBinTemplate.bat
@@ -51,11 +51,8 @@ set REPO=
 #ENV_SETUP#
 
 if "%JAVACMD%"=="" (
-    if exist "%JAVA_HOME%\bin\java.exe" (
-        set "JAVACMD=%JAVA_HOME%\bin\java.exe"
-    ) else (
-        set "JAVACMD=#JAVA_BINARY#"
-    )
+    set "JAVACMD=#JAVA_BINARY#"
+    if not "%JAVA_HOME%"=="" if exist "%JAVA_HOME%\bin\java.exe" set "JAVACMD=%JAVA_HOME%\bin\java.exe"
 )
 
 if "%REPO%"=="" set REPO=%BASEDIR%\#REPO#


### PR DESCRIPTION
## Description of Change

Updated the Windows launcher template to use JAVA_HOME to locate the Java executable when JAVACMD is not set. If %JAVA_HOME%\bin\java.exe exists, it is used; otherwise, the launcher falls back to the default Java executable (java) on the system PATH.

This change allows the Dependency-Check CLI to run on Windows when JAVA_HOME is configured but java.exe is not present on the PATH, while preserving the existing behavior for users who set JAVACMD or rely on PATH.

## Related issues

**Fixes #8631**
This fixes issue #8631, where the CLI fails on Windows if JAVA_HOME is configured but java.exe is not on PATH.

## Have test cases been added to cover the new functionality?

This change updates the Windows launcher script only. The behavior was verified manually by testing the following scenarios:

JAVA_HOME configured and java.exe not on PATH → CLI starts successfully.
JAVACMD configured → launcher uses JAVACMD.
JAVA_HOME not configured but java.exe available on PATH → existing behavior is preserved.