### PR TITLE
fix(reports): render CVSSv4 baseScore = 0.0 in JSON+XML reports

### DIFF
--- a/core/src/main/resources/templates/jsonReport.vsl
+++ b/core/src/main/resources/templates/jsonReport.vsl
@@ -351,9 +351,7 @@
 #if($vuln.cvssV4.cvssData.providerUrgency)
                         ,"providerUrgency": "$enc.json($vuln.cvssV4.cvssData.providerUrgency)"
 #end
-#if($vuln.cvssV4.cvssData.baseScore)
                         ,"baseScore": $vuln.cvssV4.cvssData.baseScore
-#end
 #if($vuln.cvssV4.cvssData.baseSeverity)
                         ,"baseSeverity": "$enc.json($vuln.cvssV4.cvssData.baseSeverity)"
 #end
@@ -558,9 +556,7 @@
 #if($vuln.cvssV4.cvssData.providerUrgency)
                         ,"providerUrgency": "$enc.json($vuln.cvssV4.cvssData.providerUrgency)"
 #end
-#if($vuln.cvssV4.cvssData.baseScore)
                         ,"baseScore": $vuln.cvssV4.cvssData.baseScore
-#end
 #if($vuln.cvssV4.cvssData.baseSeverity)
                         ,"baseSeverity": "$enc.json($vuln.cvssV4.cvssData.baseSeverity)"
 #end

--- a/core/src/main/resources/templates/xmlReport.vsl
+++ b/core/src/main/resources/templates/xmlReport.vsl
@@ -376,9 +376,7 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
 #if($vuln.cvssV4.cvssData.providerUrgency)
                             <providerUrgency>$enc.xml($vuln.cvssV4.cvssData.providerUrgency)</providerUrgency>
 #end
-#if($vuln.cvssV4.cvssData.baseScore)
                             <baseScore>$enc.xml($vuln.cvssV4.cvssData.baseScore)</baseScore>
-#end
 #if($vuln.cvssV4.cvssData.baseSeverity)
                             <baseSeverity>$enc.xml($vuln.cvssV4.cvssData.baseSeverity)</baseSeverity>
 #end
@@ -575,9 +573,7 @@ Copyright (c) 2018 Jeremy Long. All Rights Reserved.
 #if($vuln.cvssV4.cvssData.providerUrgency)
                             <providerUrgency>$enc.xml($vuln.cvssV4.cvssData.providerUrgency)</providerUrgency>
 #end
-#if($vuln.cvssV4.cvssData.baseScore)
                             <baseScore>$enc.xml($vuln.cvssV4.cvssData.baseScore)</baseScore>
-#end
 #if($vuln.cvssV4.cvssData.baseSeverity)
                             <baseSeverity>$enc.xml($vuln.cvssV4.cvssData.baseSeverity)</baseSeverity>
 #end


### PR DESCRIPTION
## Description of Change

Fixes JSON and XML reports to always include CVSS v4.0 `baseScore`, similar to that for CVSSv2 and CVSSv3.

https://github.com/dependency-check/DependencyCheck/blob/19a45fc77c16865ad1ddffb2113f6b7abbbba731/core/src/main/resources/templates/jsonReport.vsl#L208-L210

https://github.com/dependency-check/DependencyCheck/blob/19a45fc77c16865ad1ddffb2113f6b7abbbba731/core/src/main/resources/templates/jsonReport.vsl#L228-L230

The model object defines `baseScore` as non-null/required (despite being a boxed Double) and most other reports assume it is, so should be safe. The DB technically allows it to be null, but many other places assume it is not.

The current check is problematic as Velocity treats `0` as "false" in the check, which omits 0 scores (SeverityType = NONE) which is incorrect.

Seems safe and simplest to remove the check rather than contort Velocity to do an "is non-null" check. Note that there are many other places where the `baseScore` is taken directly within the `#if` emptiness check, so suspect this was just generated/propagated across all fields in the data naively. It's already assumed to be there in the HTML and SARIF reports, for example.

https://github.com/dependency-check/DependencyCheck/blob/ff1a3671b0bc5c56090cc05d460064e2de808024/core/src/main/resources/templates/htmlReport.vsl#L843

https://github.com/dependency-check/DependencyCheck/blob/ff1a3671b0bc5c56090cc05d460064e2de808024/core/src/main/resources/templates/htmlReport.vsl#L1037-L1041

## Related issues

- fixes #8662

## Have test cases been added to cover the new functionality?

no