### PR TITLE
fix(fp): expand oracle:projects suppression to all maven artifacts

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -2190,8 +2190,8 @@
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
-    FP per issue #8674
+    FP per issue #8674, hand-curated due to generic name
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/jakarta\.annotation/jakarta\.annotation-api@.*$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/.*$</packageUrl>
     <cpe regex="true">cpe:/a:oracle:projects(:.*)?$</cpe>
 </suppress>


### PR DESCRIPTION

## Description of Change

Projects is a full Native application and not Java-based. https://docs.oracle.com/cd/E18727_01/doc.121/e13581/T181945T348692.htm

The same FP is found against a whole lot of Oracle-managed libraries in the Java/jakarta ecosystem.

## Related issues

- relates to #8674

## Have test cases been added to cover the new functionality?

N/A