### PR TITLE
fix(fp): extend service project suppression to all Maven artifacts

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -35,7 +35,7 @@
         <notes><![CDATA[
         obvious fp - currently not returning any CVEs
         ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.sonatype\.ossindex/ossindex\-service\-api@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/.*$</packageUrl>
         <cpe regex="true">cpe:/a:service(_project)?:service.*</cpe>
     </suppress>
     <suppress base="true">


### PR DESCRIPTION
## Description of Change

Extend suppression for generic named projects to all maven artifacts. This CPE is incorrectly matching a number of Java projects, just doesn’t happen to match the affected versions of CVes enough to cause reported FPs.

## Related issues

none

## Have test cases been added to cover the new functionality?

N/A