### PR TITLE
fix(fp): remove duplicate oracle:projects base suppression

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -3798,13 +3798,6 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
-        FP per issue #4135
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.eclipse/yasson@.*$</packageUrl>
-        <cpe>cpe:/a:oracle:projects:</cpe>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
         FP per issue #4140, 4256
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.aspectj/aspectj.*@.*$</packageUrl>


### PR DESCRIPTION
## Description of Change

A more generic suppression for `oracle:projects` was merged into `generatedSuppressions` in #8675 so this is surplus to requirements now.

## Related issues

- relates to #8675

## Have test cases been added to cover the new functionality?

N/A