### PR TITLE
build(deps): bump logback from 1.5.32 to 1.5.34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@ Copyright (c) 2012 - Jeremy Long
 
         <!-- upgrading slf4j and logback can cause issues ;) https://github.com/dependency-check/DependencyCheck/issues/4846 -->
         <slf4j.version>2.0.18</slf4j.version>
-        <logback.version>1.5.32</logback.version>
+        <logback.version>1.5.34</logback.version>
 
         <apache.lucene.version>9.12.3</apache.lucene.version>
         <!-- Driver versions as properties for ease of extraction for reuse in Docker builds -->


### PR DESCRIPTION
resolves [#2100](https://github.com/dependency-check/DependencyCheck/security/dependabot/2100)