### PR TITLE
fix(fp): extend java_se suppressions to all Maven artifacts

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1897,10 +1897,12 @@
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
-    FP per issue #8257, #8701
+    FP per issue #8257, #8701, #8718, #8719, #8720, #8721, #8722, #8723
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/net\.java\.dev\.jna/.*@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:(oracle|sun):java_se(:.*)?$</cpe>
+    <packageUrl regex="true">^pkg:maven/.*@.*$</packageUrl>
+    <cpe regex="true">cpe:/a:oracle:java_se(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:sun:java_se(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:sun:java_system_web_server(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[


### PR DESCRIPTION
## Description of Change

Extends the generated suppression earlier added to all Maven artifacts. This is analogous to the base suppression like in #8704 but the "not filepath" variant.

I don't think we'd every expect anything in Maven to match these, as the bugs represent issues in the core JDK/runtime mainly C code.

## Related issues

- fixes #8718
- fixes #8719
- fixes #8720
- fixes #8721 
- fixes #8722 
- fixes #8723

## Have test cases been added to cover the new functionality?

N/A