### PR TITLE
chore: remove some unnecessary commons.lang3 usage

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
+++ b/core/src/main/java/org/owasp/dependencycheck/xml/suppression/SuppressionRule.java
@@ -17,8 +17,7 @@
  */
 package org.owasp.dependencycheck.xml.suppression;
 
-import org.apache.commons.lang3.Strings;
-import org.apache.commons.lang3.time.DateFormatUtils;
+import org.h2.util.StringUtils;
 import org.jspecify.annotations.NonNull;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Vulnerability;
@@ -31,6 +30,7 @@ import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.exceptions.CpeEncodingException;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashSet;
@@ -727,8 +727,9 @@ public class SuppressionRule {
 
     private static boolean cpe22UriPrefixMatches(PropertyType suppressionEntry, String cpe22Uri) {
         String candidate = cpe22Uri + cpePartMatchingSuffixFor(suppressionEntry);
-        return (suppressionEntry.isCaseSensitive() ? Strings.CS : Strings.CI)
-                .startsWith(candidate, suppressionEntry.getValue());
+        return suppressionEntry.isCaseSensitive()
+                ? candidate.startsWith(suppressionEntry.getValue())
+                : StringUtils.startsWithIgnoringCase(candidate, suppressionEntry.getValue());
     }
 
     /**
@@ -753,7 +754,7 @@ public class SuppressionRule {
         final StringBuilder sb = new StringBuilder(64);
         sb.append("SuppressionRule{");
         if (until != null) {
-            final String dt = DateFormatUtils.ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.format(until);
+            final String dt = DateTimeFormatter.ISO_DATE_TIME.format(until.toInstant().atZone(until.getTimeZone().toZoneId()));
             sb.append("until=").append(dt).append(',');
         }
         if (filePath != null) {

--- a/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionRuleTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/xml/suppression/SuppressionRuleTest.java
@@ -35,8 +35,12 @@ import us.springett.parsers.cpe.CpeParser;
 import us.springett.parsers.cpe.exceptions.CpeValidationException;
 
 import java.io.File;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
+import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -415,6 +419,16 @@ class SuppressionRuleTest extends BaseTest {
         assertEquals(0, dependency.getVulnerabilities().size(),
                 "A cvssBelow of 5.0 and 7.0 will suppress a vulnerability with a score of 6.0");
         assertEquals(1, dependency.getSuppressedVulnerabilities().size());
+    }
+
+    @Test
+    void testToStringExpiryFormatting() {
+        ZonedDateTime time = ZonedDateTime.of(2024, 6, 1, 12, 0, 0, 0, ZoneId.of("Asia/Singapore"));
+        SuppressionRule rule = new SuppressionRule();
+        Calendar until = Calendar.getInstance(TimeZone.getTimeZone(time.getZone()));
+        until.setTimeInMillis(time.toInstant().toEpochMilli());
+        rule.setUntil(until);
+        assertTrue(rule.toString().contains("until=2024-06-01T12:00:00+08:00"));
     }
 
     @Test


### PR DESCRIPTION
## Description of Change

commons-lang3 often clashes with other plugins, especially in Gradle since we dont isolate classpaths Avoiding using it (or its deprecated methods) where possible for these newer methods only added in more recent versions of commons-lang3, or with a clear alternative.

Would like to remove it more generally (and reduce its usage only to transitives) but will worry about that later.

## Related issues

- fixes #8714

## Have test cases been added to cover the new functionality?

yes