### PR TITLE
fix(maven): report the CVSS score that failed the build

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2907,14 +2907,9 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                         || unscoredCvss >= failBuildOnCVSS
                 ) {
                     String name = v.getName();
-                    if (cvssV4 >= 0.0) {
-                        name += "(" + cvssV4 + ")";
-                    } else if (cvssV3 >= 0.0) {
-                        name += "(" + cvssV3 + ")";
-                    } else if (cvssV2 >= 0.0) {
-                        name += "(" + cvssV2 + ")";
-                    } else if (unscoredCvss >= 0.0) {
-                        name += "(" + unscoredCvss + ")";
+                    final double reportedScore = scoreToReport(cvssV2, cvssV3, cvssV4, unscoredCvss, failBuildOnCVSS);
+                    if (reportedScore >= 0.0) {
+                        name += "(" + reportedScore + ")";
                     }
                     if (addName) {
                         addName = false;
@@ -2941,6 +2936,44 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
             }
             throw new MojoFailureException(msg);
         }
+    }
+
+    /**
+     * Determines the CVSS score to display for a vulnerability listed by
+     * {@link #checkForFailure(org.owasp.dependencycheck.dependency.Dependency[])}.
+     * <p>
+     * The build is failed when <em>any</em> of the CVSS scores of a vulnerability reaches the
+     * configured threshold, so the score that actually reached it is the one to display; showing
+     * the score of the newest CVSS version instead quotes a score below the threshold that the
+     * failure message itself states. When no threshold applies the newest CVSS version is used.
+     *
+     * @param cvssV2 the CVSS v2 base score, or -1 when the vulnerability has no v2 score
+     * @param cvssV3 the CVSS v3 base score, or -1 when the vulnerability has no v3 score
+     * @param cvssV4 the CVSS v4 base score, or -1 when the vulnerability has no v4 score
+     * @param unscoredCvss the score estimated from an unscored severity, or -1 when not applicable
+     * @param threshold the configured failBuildOnCVSS threshold
+     * @return the score to display, or -1 when the vulnerability carries no score at all
+     */
+    static double scoreToReport(double cvssV2, double cvssV3, double cvssV4, double unscoredCvss, float threshold) {
+        if (threshold > 0.0) {
+            if (cvssV4 >= threshold) {
+                return cvssV4;
+            } else if (cvssV3 >= threshold) {
+                return cvssV3;
+            } else if (cvssV2 >= threshold) {
+                return cvssV2;
+            } else if (unscoredCvss >= threshold) {
+                return unscoredCvss;
+            }
+        }
+        if (cvssV4 >= 0.0) {
+            return cvssV4;
+        } else if (cvssV3 >= 0.0) {
+            return cvssV3;
+        } else if (cvssV2 >= 0.0) {
+            return cvssV2;
+        }
+        return unscoredCvss;
     }
 
     /**

--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2900,28 +2900,45 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                 final boolean useUnscored = cvssV2 == -1 && cvssV3 == -1 && cvssV4 == -1;
                 final double unscoredCvss = (useUnscored && v.getUnscoredSeverity() != null) ? SeverityUtil.estimateCvssV2(v.getUnscoredSeverity()) : -1;
 
-                if (failBuildOnCVSS <= 0.0
-                        || cvssV2 >= failBuildOnCVSS
-                        || cvssV3 >= failBuildOnCVSS
-                        || cvssV4 >= failBuildOnCVSS
-                        || unscoredCvss >= failBuildOnCVSS
-                ) {
-                    String name = v.getName();
-                    final double reportedScore = scoreToReport(cvssV2, cvssV3, cvssV4, unscoredCvss, failBuildOnCVSS);
-                    if (reportedScore >= 0.0) {
-                        name += "(" + reportedScore + ")";
-                    }
-                    if (addName) {
-                        addName = false;
-                        ids.append(NEW_LINE).append(d.getFileName()).append(" (")
-                                .append(Stream.concat(d.getSoftwareIdentifiers().stream(), d.getVulnerableSoftwareIdentifiers().stream())
-                                        .map(Identifier::getValue)
-                                        .collect(Collectors.joining(", ")))
-                                .append("): ")
-                                .append(name);
+                // the score to display is the one that reached the threshold, so it is picked by
+                // the same comparison that decides whether the vulnerability fails the build
+                final double reportedScore;
+                if (failBuildOnCVSS > 0.0) {
+                    if (cvssV4 >= failBuildOnCVSS) {
+                        reportedScore = cvssV4;
+                    } else if (cvssV3 >= failBuildOnCVSS) {
+                        reportedScore = cvssV3;
+                    } else if (cvssV2 >= failBuildOnCVSS) {
+                        reportedScore = cvssV2;
+                    } else if (unscoredCvss >= failBuildOnCVSS) {
+                        reportedScore = unscoredCvss;
                     } else {
-                        ids.append(", ").append(name);
+                        continue;
                     }
+                } else if (cvssV4 >= 0.0) {
+                    reportedScore = cvssV4;
+                } else if (cvssV3 >= 0.0) {
+                    reportedScore = cvssV3;
+                } else if (cvssV2 >= 0.0) {
+                    reportedScore = cvssV2;
+                } else {
+                    reportedScore = unscoredCvss;
+                }
+
+                String name = v.getName();
+                if (reportedScore >= 0.0) {
+                    name += "(" + reportedScore + ")";
+                }
+                if (addName) {
+                    addName = false;
+                    ids.append(NEW_LINE).append(d.getFileName()).append(" (")
+                            .append(Stream.concat(d.getSoftwareIdentifiers().stream(), d.getVulnerableSoftwareIdentifiers().stream())
+                                    .map(Identifier::getValue)
+                                    .collect(Collectors.joining(", ")))
+                            .append("): ")
+                            .append(name);
+                } else {
+                    ids.append(", ").append(name);
                 }
             }
         }
@@ -2936,44 +2953,6 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
             }
             throw new MojoFailureException(msg);
         }
-    }
-
-    /**
-     * Determines the CVSS score to display for a vulnerability listed by
-     * {@link #checkForFailure(org.owasp.dependencycheck.dependency.Dependency[])}.
-     * <p>
-     * The build is failed when <em>any</em> of the CVSS scores of a vulnerability reaches the
-     * configured threshold, so the score that actually reached it is the one to display; showing
-     * the score of the newest CVSS version instead quotes a score below the threshold that the
-     * failure message itself states. When no threshold applies the newest CVSS version is used.
-     *
-     * @param cvssV2 the CVSS v2 base score, or -1 when the vulnerability has no v2 score
-     * @param cvssV3 the CVSS v3 base score, or -1 when the vulnerability has no v3 score
-     * @param cvssV4 the CVSS v4 base score, or -1 when the vulnerability has no v4 score
-     * @param unscoredCvss the score estimated from an unscored severity, or -1 when not applicable
-     * @param threshold the configured failBuildOnCVSS threshold
-     * @return the score to display, or -1 when the vulnerability carries no score at all
-     */
-    static double scoreToReport(double cvssV2, double cvssV3, double cvssV4, double unscoredCvss, float threshold) {
-        if (threshold > 0.0) {
-            if (cvssV4 >= threshold) {
-                return cvssV4;
-            } else if (cvssV3 >= threshold) {
-                return cvssV3;
-            } else if (cvssV2 >= threshold) {
-                return cvssV2;
-            } else if (unscoredCvss >= threshold) {
-                return unscoredCvss;
-            }
-        }
-        if (cvssV4 >= 0.0) {
-            return cvssV4;
-        } else if (cvssV3 >= 0.0) {
-            return cvssV3;
-        } else if (cvssV2 >= 0.0) {
-            return cvssV2;
-        }
-        return unscoredCvss;
     }
 
     /**

--- a/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
+++ b/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
@@ -17,19 +17,29 @@
  */
 package org.owasp.dependencycheck.maven;
 
+import io.github.jeremylong.openvulnerability.client.nvd.CvssV2;
+import io.github.jeremylong.openvulnerability.client.nvd.CvssV2Data;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.Vulnerability;
 import org.owasp.dependencycheck.exception.ExceptionCollection;
+import org.owasp.dependencycheck.utils.CvssUtil;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.util.Locale;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 
 /**
@@ -99,15 +109,15 @@ class BaseDependencyCheckMojoTest extends BaseTest {
      * See https://github.com/dependency-check/DependencyCheck/issues/5658
      */
     @Test
-    void should_scoreToReport_return_the_score_that_reached_the_threshold() {
+    void should_report_the_score_that_reached_the_threshold() throws Exception {
         // CVE-2021-42550 from the issue: CVSSv2 8.5 fails the build at a threshold of 7.0,
         // while CVSSv3 is only 6.6.
-        assertEquals(8.5, BaseDependencyCheckMojo.scoreToReport(8.5, 6.6, -1, -1, 7.0f));
-        // the newest version is used when it is the one that reached the threshold
-        assertEquals(9.1, BaseDependencyCheckMojo.scoreToReport(4.0, 9.1, -1, -1, 7.0f));
-        assertEquals(9.4, BaseDependencyCheckMojo.scoreToReport(4.0, 6.6, 9.4, -1, 7.0f));
-        // an estimated score for an unscored severity is reported when it reached the threshold
-        assertEquals(8.0, BaseDependencyCheckMojo.scoreToReport(-1, -1, -1, 8.0, 7.0f));
+        final Dependency dependency = dependencyWith("CVE-2021-42550", 8.5, 6.6);
+
+        final MojoFailureException failure = assertThrows(MojoFailureException.class,
+                () -> mojoWithThreshold(7.0f).checkForFailure(new Dependency[]{dependency}));
+
+        assertTrue(failure.getMessage().contains("CVE-2021-42550(8.5)"), failure.getMessage());
     }
 
     /**
@@ -115,21 +125,55 @@ class BaseDependencyCheckMojoTest extends BaseTest {
      * CVSS version is still the one to show; this guards the behaviour the change must not alter.
      */
     @Test
-    void should_scoreToReport_prefer_the_newest_cvss_version_without_a_threshold() {
-        assertEquals(6.6, BaseDependencyCheckMojo.scoreToReport(8.5, 6.6, -1, -1, 0.0f));
-        assertEquals(4.0, BaseDependencyCheckMojo.scoreToReport(8.5, 6.6, 4.0, -1, 0.0f));
-        assertEquals(8.5, BaseDependencyCheckMojo.scoreToReport(8.5, -1, -1, -1, 0.0f));
-        // nothing scored at all - nothing to display
-        assertEquals(-1.0, BaseDependencyCheckMojo.scoreToReport(-1, -1, -1, -1, 7.0f));
+    void should_report_the_newest_cvss_version_without_a_threshold() throws Exception {
+        final Dependency dependency = dependencyWith("CVE-2021-42550", 8.5, 6.6);
+
+        final MojoFailureException failure = assertThrows(MojoFailureException.class,
+                () -> mojoWithThreshold(0.0f).checkForFailure(new Dependency[]{dependency}));
+
+        assertTrue(failure.getMessage().contains("CVE-2021-42550(6.6)"), failure.getMessage());
     }
 
     /**
-     * A vulnerability below the threshold is never listed by checkForFailure, but the helper is
-     * still expected to fall back to the newest version rather than to invent a score.
+     * A vulnerability whose scores all stay below the threshold is not listed at all, so the
+     * build must not be failed for it.
      */
     @Test
-    void should_scoreToReport_fall_back_when_nothing_reached_the_threshold() {
-        assertEquals(6.6, BaseDependencyCheckMojo.scoreToReport(5.0, 6.6, -1, -1, 9.0f));
+    void should_not_fail_the_build_when_nothing_reached_the_threshold() throws Exception {
+        final Dependency dependency = dependencyWith("CVE-2021-42550", 5.0, 6.6);
+
+        assertDoesNotThrow(() -> mojoWithThreshold(9.0f).checkForFailure(new Dependency[]{dependency}));
+    }
+
+    private static Dependency dependencyWith(String cve, double cvssV2Score, double cvssV3Score) {
+        final Vulnerability vulnerability = new Vulnerability(cve);
+        vulnerability.setCvssV2(cvssV2WithScore(cvssV2Score));
+        vulnerability.setCvssV3(CvssUtil.vectorToCvssV3("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L", cvssV3Score));
+
+        final Dependency dependency = new Dependency(true);
+        dependency.setFileName("logback-core-1.2.3.jar");
+        dependency.addVulnerability(vulnerability);
+        return dependency;
+    }
+
+    /**
+     * Only the base score is read by {@code checkForFailure}; the remaining metrics are left unset
+     * because {@link CvssUtil#vectorToCvssV2(String, Double)} cannot round-trip a bare CVSSv2
+     * vector string.
+     */
+    private static CvssV2 cvssV2WithScore(double baseScore) {
+        final String severity = CvssUtil.cvssV2ScoreToSeverity(baseScore);
+        final CvssV2Data data = new CvssV2Data(CvssV2Data.Version._2_0, null, null, null, null, null, null, null,
+                baseScore, severity, null, null, null, null, null, null, null, null, null, null);
+        return new CvssV2(null, null, data, severity, null, null, null, null, null, null, null);
+    }
+
+    private static BaseDependencyCheckMojo mojoWithThreshold(float threshold) throws Exception {
+        final BaseDependencyCheckMojo mojo = new BaseDependencyCheckMojoImpl();
+        final Field field = BaseDependencyCheckMojo.class.getDeclaredField("failBuildOnCVSS");
+        field.setAccessible(true);
+        field.setFloat(mojo, threshold);
+        return mojo;
     }
 
     /**

--- a/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
+++ b/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
@@ -91,6 +91,48 @@ class BaseDependencyCheckMojoTest extends BaseTest {
     }
 
     /**
+     * The build is failed when <em>any</em> of the CVSS scores of a vulnerability reaches the
+     * configured threshold, so the score printed in the failure message must be the score that
+     * actually reached it. Reporting the score of the newest CVSS version instead quotes a score
+     * below the threshold that the very same message states.
+     *
+     * See https://github.com/dependency-check/DependencyCheck/issues/5658
+     */
+    @Test
+    void should_scoreToReport_return_the_score_that_reached_the_threshold() {
+        // CVE-2021-42550 from the issue: CVSSv2 8.5 fails the build at a threshold of 7.0,
+        // while CVSSv3 is only 6.6.
+        assertEquals(8.5, BaseDependencyCheckMojo.scoreToReport(8.5, 6.6, -1, -1, 7.0f));
+        // the newest version is used when it is the one that reached the threshold
+        assertEquals(9.1, BaseDependencyCheckMojo.scoreToReport(4.0, 9.1, -1, -1, 7.0f));
+        assertEquals(9.4, BaseDependencyCheckMojo.scoreToReport(4.0, 6.6, 9.4, -1, 7.0f));
+        // an estimated score for an unscored severity is reported when it reached the threshold
+        assertEquals(8.0, BaseDependencyCheckMojo.scoreToReport(-1, -1, -1, 8.0, 7.0f));
+    }
+
+    /**
+     * With no threshold in play (failBuildOnCVSS &lt;= 0 reports every vulnerability) the newest
+     * CVSS version is still the one to show; this guards the behaviour the change must not alter.
+     */
+    @Test
+    void should_scoreToReport_prefer_the_newest_cvss_version_without_a_threshold() {
+        assertEquals(6.6, BaseDependencyCheckMojo.scoreToReport(8.5, 6.6, -1, -1, 0.0f));
+        assertEquals(4.0, BaseDependencyCheckMojo.scoreToReport(8.5, 6.6, 4.0, -1, 0.0f));
+        assertEquals(8.5, BaseDependencyCheckMojo.scoreToReport(8.5, -1, -1, -1, 0.0f));
+        // nothing scored at all - nothing to display
+        assertEquals(-1.0, BaseDependencyCheckMojo.scoreToReport(-1, -1, -1, -1, 7.0f));
+    }
+
+    /**
+     * A vulnerability below the threshold is never listed by checkForFailure, but the helper is
+     * still expected to fall back to the newest version rather than to invent a score.
+     */
+    @Test
+    void should_scoreToReport_fall_back_when_nothing_reached_the_threshold() {
+        assertEquals(6.6, BaseDependencyCheckMojo.scoreToReport(5.0, 6.6, -1, -1, 9.0f));
+    }
+
+    /**
      * Implementation of ODC Mojo for testing.
      */
     public static class BaseDependencyCheckMojoImpl extends BaseDependencyCheckMojo {


### PR DESCRIPTION
## Description of Change

`checkForFailure` fails the build when **any** of the CVSS scores of a vulnerability reaches `failBuildOnCVSS`, but the score it prints is the one of the newest CVSS version available. When an older version is the one that crossed the threshold, the message contradicts itself:

```
[ERROR] One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0':
[ERROR] logback-core-1.2.3.jar: CVE-2021-42550(6.6)
```

for a CVE whose CVSSv2 score is 8.5, which is what actually failed the build.

The score to print is now chosen by the same comparison that decides whether the vulnerability fails the build: the first CVSS version to reach the threshold (v4, then v3, then v2, then the estimate for an unscored severity) is both the reason for the failure and the score shown, and a vulnerability that reaches none of them is not listed. With no threshold in play (`failBuildOnCVSS <= 0`, i.e. report everything) the newest available version is still used, so nothing changes for vulnerabilities where the newest version is already above the threshold.

I kept the reported score rather than switching to the maximum score (as suggested in the issue thread) because the maximum can come from a version that did not trigger the failure at all.

## Related issues

- related to #5658 - this PR does not fix that issue; unlinked after review

## Have test cases been added to cover the new functionality?

yes - three tests in `BaseDependencyCheckMojoTest` drive `checkForFailure` and assert on the failure message it throws: the case from the issue (v2 8.5 / v3 6.6 at a 7.0 threshold), the unchanged no-threshold behaviour, and a vulnerability below the threshold not failing the build at all. Against the code before this PR the first of the three fails, quoting 6.6 in a message that states 7.0 was exceeded.
