### PR TITLE
fix(core): parse single letter version suffixes without a period

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/utils/DependencyVersionUtil.java
+++ b/core/src/main/java/org/owasp/dependencycheck/utils/DependencyVersionUtil.java
@@ -45,7 +45,7 @@ public final class DependencyVersionUtil {
      * version number using the previous regex.
      */
     private static final Pattern RX_SINGLE_VERSION = Pattern.compile(
-            "\\d+(\\.\\d+){0,6}([._-]?(snapshot|release|final|alpha|beta|rc$|[a-zA-Z]{1,3}[_-]?\\d{1,8}))?");
+            "\\d+(\\.\\d+){0,6}([._-]?(snapshot|release|final|alpha|beta|rc$|[a-zA-Z]{1,3}[_-]?\\d{1,8}|[a-zA-Z]\\b))?");
 
     /**
      * Regular expression to extract the part before the version numbers if

--- a/core/src/test/java/org/owasp/dependencycheck/utils/DependencyVersionUtilTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/DependencyVersionUtilTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.owasp.dependencycheck.BaseTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
@@ -80,6 +81,23 @@ class DependencyVersionUtilTest extends BaseTest {
             }
             assertEquals(expected[i], result, "Failed extraction on \"" + names[i] + "\".");
         }
+    }
+
+    /**
+     * The user visible consequence of dropping the suffix: 8a and 8b both collapse onto "8", so
+     * the version CPEAnalyzer derives from the evidence compares equal to the version of a CPE
+     * for a different release. Its exact match is
+     * {@code parseVersion(evidence).equals(parseVersion(cpe.getVersion()))}, so a dependency at
+     * 8a matched the CPE of 8b, and the identified version printed in the report was "8".
+     */
+    @Test
+    void testParseVersion_singleLetterReleasesAreNotConflated() {
+        final DependencyVersion evidence = DependencyVersionUtil.parseVersion("libjpeg-turbo-8a.tar.gz", true);
+
+        assertEquals("8a", evidence.toString());
+        assertEquals(DependencyVersionUtil.parseVersion("8a"), evidence);
+        assertNotEquals(DependencyVersionUtil.parseVersion("8b"), evidence);
+        assertNotEquals(DependencyVersionUtil.parseVersion("9e"), DependencyVersionUtil.parseVersion("9d"));
     }
 
     /**

--- a/core/src/test/java/org/owasp/dependencycheck/utils/DependencyVersionUtilTest.java
+++ b/core/src/test/java/org/owasp/dependencycheck/utils/DependencyVersionUtilTest.java
@@ -61,6 +61,28 @@ class DependencyVersionUtilTest extends BaseTest {
     }
 
     /**
+     * Test of parseVersion method, of class DependencyVersionUtil, for versions
+     * that consist of a number directly followed by a single letter and no
+     * period - the scheme used by libjpeg (8a, 9d, 9e).
+     *
+     * See https://github.com/dependency-check/DependencyCheck/issues/4139
+     */
+    @Test
+    void testParseVersion_singleLetterSuffixWithoutPeriod() {
+        final String[] names = {"9e", "9d", "8a", "libjpeg-9e", "jpegsr9e"};
+        final String[] expected = {"9e", "9d", "8a", "9e", "9e"};
+
+        for (int i = 0; i < names.length; i++) {
+            final DependencyVersion version = DependencyVersionUtil.parseVersion(names[i]);
+            String result = null;
+            if (version != null) {
+                result = version.toString();
+            }
+            assertEquals(expected[i], result, "Failed extraction on \"" + names[i] + "\".");
+        }
+    }
+
+    /**
      * Test of parseVersion method, of class DependencyVersionUtil.
      */
     @Test


### PR DESCRIPTION
## Description of Change

`DependencyVersionUtil` has two expressions for pulling a version out of a name: `RX_VERSION`, which requires a period, and `RX_SINGLE_VERSION`, which does not. Only the first one accepts a single trailing letter, so libjpeg's scheme of one digit and one letter (`8a`, `9d`, `9e`) never reaches it — the name falls through to `RX_SINGLE_VERSION`, the letter is dropped and the version comes out as `9`. The CPE analyzer then matches every CPE for version 9, among them the vulnerable `9a` and `9c`, which is the false positive described in the issue. The reporter had to work around it with a hint file.

The change adds the missing alternative to `RX_SINGLE_VERSION` so that both expressions accept the same suffixes. I left the pattern flags alone on purpose: `RX_VERSION` is `CASE_INSENSITIVE` and `RX_SINGLE_VERSION` is not, and adding the flag would also have changed how the other alternatives match, which is outside the scope of this issue.

Before changing anything I ran the current and the proposed expression side by side over the names used in the existing tests (`commons-lang3-3.12.0.jar`, `spring-core-5.3.9.RELEASE.jar`, `openssl-1.0.2k`, `lib1.5r4-someflag-R26.jar`, `6`, `utf8`, ...). Only inputs of the "digit followed by a single letter" shape change; everything else parses exactly as before.

## Related issues

- fixes #4139

## Have test cases been added to cover the new functionality?

yes — `DependencyVersionUtilTest.testParseVersion_singleLetterSuffixWithoutPeriod`, covering `9e`, `9d`, `8a` and the two names from the reporter's reproducer. On `main` it fails with `expected: <9e> but was: <9>`.