### PR TITLE
fix(maven): report the CVSS score that actually failed the build

### DIFF
--- a/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
+++ b/maven/src/main/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojo.java
@@ -2907,14 +2907,9 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
                         || unscoredCvss >= failBuildOnCVSS
                 ) {
                     String name = v.getName();
-                    if (cvssV4 >= 0.0) {
-                        name += "(" + cvssV4 + ")";
-                    } else if (cvssV3 >= 0.0) {
-                        name += "(" + cvssV3 + ")";
-                    } else if (cvssV2 >= 0.0) {
-                        name += "(" + cvssV2 + ")";
-                    } else if (unscoredCvss >= 0.0) {
-                        name += "(" + unscoredCvss + ")";
+                    final double reportedScore = scoreToReport(cvssV2, cvssV3, cvssV4, unscoredCvss, failBuildOnCVSS);
+                    if (reportedScore >= 0.0) {
+                        name += "(" + reportedScore + ")";
                     }
                     if (addName) {
                         addName = false;
@@ -2941,6 +2936,44 @@ public abstract class BaseDependencyCheckMojo extends AbstractMojo implements Ma
             }
             throw new MojoFailureException(msg);
         }
+    }
+
+    /**
+     * Determines the CVSS score to display for a vulnerability listed by
+     * {@link #checkForFailure(org.owasp.dependencycheck.dependency.Dependency[])}.
+     * <p>
+     * The build is failed when <em>any</em> of the CVSS scores of a vulnerability reaches the
+     * configured threshold, so the score that actually reached it is the one to display; showing
+     * the score of the newest CVSS version instead quotes a score below the threshold that the
+     * failure message itself states. When no threshold applies the newest CVSS version is used.
+     *
+     * @param cvssV2 the CVSS v2 base score, or -1 when the vulnerability has no v2 score
+     * @param cvssV3 the CVSS v3 base score, or -1 when the vulnerability has no v3 score
+     * @param cvssV4 the CVSS v4 base score, or -1 when the vulnerability has no v4 score
+     * @param unscoredCvss the score estimated from an unscored severity, or -1 when not applicable
+     * @param threshold the configured failBuildOnCVSS threshold
+     * @return the score to display, or -1 when the vulnerability carries no score at all
+     */
+    static double scoreToReport(double cvssV2, double cvssV3, double cvssV4, double unscoredCvss, float threshold) {
+        if (threshold > 0.0) {
+            if (cvssV4 >= threshold) {
+                return cvssV4;
+            } else if (cvssV3 >= threshold) {
+                return cvssV3;
+            } else if (cvssV2 >= threshold) {
+                return cvssV2;
+            } else if (unscoredCvss >= threshold) {
+                return unscoredCvss;
+            }
+        }
+        if (cvssV4 >= 0.0) {
+            return cvssV4;
+        } else if (cvssV3 >= 0.0) {
+            return cvssV3;
+        } else if (cvssV2 >= 0.0) {
+            return cvssV2;
+        }
+        return unscoredCvss;
     }
 
     /**

--- a/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
+++ b/maven/src/test/java/org/owasp/dependencycheck/maven/BaseDependencyCheckMojoTest.java
@@ -91,6 +91,48 @@ class BaseDependencyCheckMojoTest extends BaseTest {
     }
 
     /**
+     * The build is failed when <em>any</em> of the CVSS scores of a vulnerability reaches the
+     * configured threshold, so the score printed in the failure message must be the score that
+     * actually reached it. Reporting the score of the newest CVSS version instead quotes a score
+     * below the threshold that the very same message states.
+     *
+     * See https://github.com/dependency-check/DependencyCheck/issues/5658
+     */
+    @Test
+    void should_scoreToReport_return_the_score_that_reached_the_threshold() {
+        // CVE-2021-42550 from the issue: CVSSv2 8.5 fails the build at a threshold of 7.0,
+        // while CVSSv3 is only 6.6.
+        assertEquals(8.5, BaseDependencyCheckMojo.scoreToReport(8.5, 6.6, -1, -1, 7.0f));
+        // the newest version is used when it is the one that reached the threshold
+        assertEquals(9.1, BaseDependencyCheckMojo.scoreToReport(4.0, 9.1, -1, -1, 7.0f));
+        assertEquals(9.4, BaseDependencyCheckMojo.scoreToReport(4.0, 6.6, 9.4, -1, 7.0f));
+        // an estimated score for an unscored severity is reported when it reached the threshold
+        assertEquals(8.0, BaseDependencyCheckMojo.scoreToReport(-1, -1, -1, 8.0, 7.0f));
+    }
+
+    /**
+     * With no threshold in play (failBuildOnCVSS &lt;= 0 reports every vulnerability) the newest
+     * CVSS version is still the one to show; this guards the behaviour the change must not alter.
+     */
+    @Test
+    void should_scoreToReport_prefer_the_newest_cvss_version_without_a_threshold() {
+        assertEquals(6.6, BaseDependencyCheckMojo.scoreToReport(8.5, 6.6, -1, -1, 0.0f));
+        assertEquals(4.0, BaseDependencyCheckMojo.scoreToReport(8.5, 6.6, 4.0, -1, 0.0f));
+        assertEquals(8.5, BaseDependencyCheckMojo.scoreToReport(8.5, -1, -1, -1, 0.0f));
+        // nothing scored at all - nothing to display
+        assertEquals(-1.0, BaseDependencyCheckMojo.scoreToReport(-1, -1, -1, -1, 7.0f));
+    }
+
+    /**
+     * A vulnerability below the threshold is never listed by checkForFailure, but the helper is
+     * still expected to fall back to the newest version rather than to invent a score.
+     */
+    @Test
+    void should_scoreToReport_fall_back_when_nothing_reached_the_threshold() {
+        assertEquals(6.6, BaseDependencyCheckMojo.scoreToReport(5.0, 6.6, -1, -1, 9.0f));
+    }
+
+    /**
      * Implementation of ODC Mojo for testing.
      */
     public static class BaseDependencyCheckMojoImpl extends BaseDependencyCheckMojo {


### PR DESCRIPTION
## Description of Change

`checkForFailure` fails the build when **any** of a vulnerability's CVSS scores reaches `failBuildOnCVSS`, but the score it prints is the one from the newest CVSS version present. When an older version is what actually crossed the threshold, the message quotes a score below the threshold it states in the same sentence:

    One or more dependencies were identified with vulnerabilities that have a CVSS
    score greater than or equal to '7.0': CVE-2021-42550(6.6)

There it is the CVSSv2 score of 8.5 that failed the build, not the 6.6 shown — so the message reads as a bug in the threshold rather than as a finding.

The score selection moves into a small helper that returns the score which reached the threshold, and keeps the previous order of preference (v4, then v3, then v2) for the case where no threshold applies. **Which vulnerabilities fail the build is unchanged** — only the number shown in the message changes.

## Related issues

- relates to #5658

## Have test cases been added to cover the new functionality?

Yes. `BaseDependencyCheckMojoTest` gains cases for a v2-only threshold hit, a hit on a newer version, and the no-threshold path. They fail on current `main` — the assertion sees the newest-version score — and pass with the change; `mvn -pl maven test` goes from `BUILD FAILURE` to `Tests run: 6, Failures: 0, Errors: 0`.

AI-assisted (LLM used for drafting); the runs above are mine.