### PR TITLE
perf(core): avoid rewriting all NULL-ecosystem rows during database maintenance

### DIFF
--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -1774,21 +1774,27 @@ public final class CveDB implements AutoCloseable {
                 PreparedStatement psEcosystem = getPreparedStatement(conn, UPDATE_ECOSYSTEM);
                 PreparedStatement psEcosystem2 = getPreparedStatement(conn, UPDATE_ECOSYSTEM2)) {
             if (psEcosystem != null) {
+                final long ecosystemStart = System.currentTimeMillis();
                 final int count = psEcosystem.executeUpdate();
                 if (count > 0) {
-                    LOGGER.info("Updated the CPE ecosystem on {} NVD records", count);
+                    LOGGER.info("Updated the CPE ecosystem on {} NVD records ({} ms)", count,
+                            System.currentTimeMillis() - ecosystemStart);
                 }
             }
             if (psEcosystem2 != null) {
+                final long ecosystemStart = System.currentTimeMillis();
                 final int count = psEcosystem2.executeUpdate();
                 if (count > 0) {
-                    LOGGER.info("Removed the CPE ecosystem on {} NVD records", count);
+                    LOGGER.info("Removed the CPE ecosystem on {} NVD records ({} ms)", count,
+                            System.currentTimeMillis() - ecosystemStart);
                 }
             }
             if (psOrphans != null) {
+                final long orphanStart = System.currentTimeMillis();
                 final int count = psOrphans.executeUpdate();
                 if (count > 0) {
-                    LOGGER.info("Cleaned up {} orphaned NVD records", count);
+                    LOGGER.info("Cleaned up {} orphaned NVD records ({} ms)", count,
+                            System.currentTimeMillis() - orphanStart);
                 }
             }
             final long millis = System.currentTimeMillis() - start;

--- a/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
+++ b/core/src/main/java/org/owasp/dependencycheck/data/nvdcve/CveDB.java
@@ -1776,26 +1776,20 @@ public final class CveDB implements AutoCloseable {
             if (psEcosystem != null) {
                 final long ecosystemStart = System.currentTimeMillis();
                 final int count = psEcosystem.executeUpdate();
-                if (count > 0) {
-                    LOGGER.info("Updated the CPE ecosystem on {} NVD records ({} ms)", count,
-                            System.currentTimeMillis() - ecosystemStart);
-                }
+                LOGGER.info("Updated the CPE ecosystem on {} NVD records ({} ms)", count,
+                        System.currentTimeMillis() - ecosystemStart);
             }
             if (psEcosystem2 != null) {
                 final long ecosystemStart = System.currentTimeMillis();
                 final int count = psEcosystem2.executeUpdate();
-                if (count > 0) {
-                    LOGGER.info("Removed the CPE ecosystem on {} NVD records ({} ms)", count,
-                            System.currentTimeMillis() - ecosystemStart);
-                }
+                LOGGER.info("Removed the CPE ecosystem on {} NVD records ({} ms)", count,
+                        System.currentTimeMillis() - ecosystemStart);
             }
             if (psOrphans != null) {
                 final long orphanStart = System.currentTimeMillis();
                 final int count = psOrphans.executeUpdate();
-                if (count > 0) {
-                    LOGGER.info("Cleaned up {} orphaned NVD records ({} ms)", count,
-                            System.currentTimeMillis() - orphanStart);
-                }
+                LOGGER.info("Cleaned up {} orphaned NVD records ({} ms)", count,
+                        System.currentTimeMillis() - orphanStart);
             }
             final long millis = System.currentTimeMillis() - start;
             //final long seconds = TimeUnit.MILLISECONDS.toSeconds(millis);

--- a/core/src/main/resources/data/dbStatements.properties
+++ b/core/src/main/resources/data/dbStatements.properties
@@ -38,7 +38,7 @@ INSERT_PROPERTY=INSERT INTO properties (id, `value`) VALUES (?, ?)
 UPDATE_PROPERTY=UPDATE properties SET `value` = ? WHERE id = ?
 DELETE_PROPERTY=DELETE FROM properties WHERE id = ?
 
-UPDATE_ECOSYSTEM=UPDATE cpeEntry e SET e.ecosystem=(SELECT cpeEcosystemCache.ecosystem FROM cpeEcosystemCache WHERE cpeEcosystemCache.vendor=e.vendor AND cpeEcosystemCache.product=e.product AND e.ecosystem IS NULL AND cpeEcosystemCache.ecosystem<>'MULTIPLE') WHERE e.ecosystem IS NULL;
+UPDATE_ECOSYSTEM=UPDATE cpeEntry e SET e.ecosystem=(SELECT cpeEcosystemCache.ecosystem FROM cpeEcosystemCache WHERE cpeEcosystemCache.vendor=e.vendor AND cpeEcosystemCache.product=e.product AND cpeEcosystemCache.ecosystem<>'MULTIPLE') WHERE e.ecosystem IS NULL AND EXISTS(SELECT 1 FROM cpeEcosystemCache WHERE cpeEcosystemCache.vendor=e.vendor AND cpeEcosystemCache.product=e.product AND cpeEcosystemCache.ecosystem<>'MULTIPLE');
 UPDATE_ECOSYSTEM2=UPDATE cpeEntry e SET e.ecosystem=null WHERE e.ecosystem IS NOT NULL AND EXISTS(SELECT * FROM cpeEcosystemCache WHERE cpeEcosystemCache.vendor=e.vendor AND cpeEcosystemCache.product=e.product AND cpeEcosystemCache.ecosystem='MULTIPLE');
 
 SELECT_SCHEMA_VERSION=SELECT value FROM properties WHERE id = 'version'

--- a/core/src/main/resources/data/dbStatements_h2.properties
+++ b/core/src/main/resources/data/dbStatements_h2.properties
@@ -14,7 +14,7 @@
 
 MERGE_PROPERTY=MERGE INTO properties (id, `value`) KEY(id) VALUES(?, ?)
 MERGE_CPE_ECOSYSTEM=MERGE INTO cpeEcosystemCache (vendor, product, ecosystem) KEY(vendor, product) VALUES(?, ?, ?)
-CLEANUP_ORPHANS=DELETE FROM cpeEntry WHERE id IN (SELECT id FROM cpeEntry LEFT JOIN software ON cpeEntry.id = software.CPEEntryId WHERE software.CPEEntryId IS NULL)
+CLEANUP_ORPHANS=DELETE FROM cpeEntry WHERE NOT EXISTS (SELECT 1 FROM software WHERE software.CPEEntryId = cpeEntry.id)
 
 UPDATE_VULNERABILITY=SELECT * FROM update_vulnerability(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 


### PR DESCRIPTION
## Summary

Database maintenance **after a full NVD update** rewrites every `cpeEntry` row with a NULL ecosystem on every run.
This causes for a lot of unnecessary updates when using the default H2 database implementation.
Everyone using this plugin for the first time with the default settings is impacted by this and might give the wrong impression that the plugin is `slow` or `inefficient`. This change improves that first experience considerably.

## Technical Details

The `'MULTIPLE'` filter of `UPDATE_ECOSYSTEM` sits inside the correlated subquery, while the outer `WHERE` clause only checks `e.ecosystem IS NULL`. Rows whose vendor/product pair is unknown or mapped to `MULTIPLE` can never receive a value, yet H2 rewrites them with NULL-to-NULL updates each time — ~145k wasted row writes per maintenance run on a typical database.

Since the insert path (`H2Functions.insertSoftware` / `CveDB.updateVulnerabilityInsertSoftware`) already sets the ecosystem from the `CpeEcosystemCache` at insert time, the repair pass has very little real work to do.

## Changes

- `dbStatements.properties`: add an `EXISTS` guard to `UPDATE_ECOSYSTEM` so only rows that will actually receive an ecosystem value are updated (mirrors the approach already used by the MS SQL Server variant).
- `dbStatements_h2.properties`: rewrite `CLEANUP_ORPHANS` as `NOT EXISTS` so H2 probes the `idxSoftwareCpe` index per row instead of materializing a full `LEFT JOIN` of `cpeEntry` against `software` inside an `IN` subquery.
- `CveDB.cleanupDatabase()`: log the elapsed time of each maintenance statement to make future regressions visible.

## Measurements

Full NVD cache rebuild (data feed mirror, H2 database, all years + modified):

| | before | after |
|---|---|---|
| Updated the CPE ecosystem | 144,969 records | 14,080 records (883 ms) |
| Database maintenance total | 189,482 ms | 1,732 ms |
| Check for updates total | 229,147 ms | 47,638 ms |

## Verification

- Verified both rewritten statements against H2 2.3.232 with fixture data: the update touches only fixable rows, leaves unknown/`MULTIPLE` rows NULL, and the orphan delete removes exactly the orphaned rows.
- `mvn -pl maven -am install` builds successfully; ran a full rebuild plus scan through the built plugin against a real project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)