### PR TITLE
fix(fp): consolidate org.mortbay.jasper suppressions and cover renamed artifacts

### DIFF
--- a/generatedSuppressions.xml
+++ b/generatedSuppressions.xml
@@ -1226,10 +1226,15 @@
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
-    FP per issue #7047
+    FP per issues #8738, #8739 and #8740; supersedes #7047 and #7804.
+    Apache Tomcat's Jasper JSP/EL engines repackaged for Jetty; renamed upstream with a "mortbay-" prefix.
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache-el@.*$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/(mortbay-)?apache-(el|jsp)@.*$</packageUrl>
     <cpe regex="true">cpe:/a:eclipse:jetty(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:jetty:jetty(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:mortbay:jetty(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:mortbay_jetty:jetty(:.*)?$</cpe>
+    <cpe regex="true">cpe:/a:apache:tomcat(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[
@@ -1713,13 +1718,6 @@
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.quarkus/quarkus-hibernate-validator@.*$</packageUrl>
     <cpe regex="true">cpe:/a:hibernate:hibernate-validator(:.*)?$</cpe>
-</suppress>
-<suppress base="true">
-    <notes><![CDATA[
-    FP per issue #7804
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache-jsp@.*$</packageUrl>
-    <cpe regex="true">cpe:/a:apache:tomcat(:.*)?$</cpe>
 </suppress>
 <suppress base="true">
     <notes><![CDATA[


### PR DESCRIPTION
## Description of Change

The artifacts were renamed upstream with a "mortbay-" prefix and are pulled in under the new names by Jetty 12.0.38+ and 12.1.x, so the existing entries no longer match.

## Related issues

Consolidates the suppressions from #7047 and #7804 into a single entry covering both the original and renamed coordinates.

Fixes #8738
Fixes #8739
Fixes #8740

## Have test cases been added to cover the new functionality?

no