### PR TITLE
fix: Add eternal configuration for NODEAUDIT cache results.

### DIFF
--- a/core/src/main/resources/dependencycheck-cache.properties
+++ b/core/src/main/resources/dependencycheck-cache.properties
@@ -47,6 +47,7 @@ jcs.region.NODEAUDIT.cacheattributes=org.apache.commons.jcs3.engine.CompositeCac
 jcs.region.NODEAUDIT.elementattributes=org.apache.commons.jcs3.engine.ElementAttributes
 jcs.region.NODEAUDIT.cacheattributes.MaxObjects=0
 jcs.region.NODEAUDIT.cacheattributes.DiskUsagePattern=UPDATE
+jcs.region.NODEAUDIT.elementattributes.IsEternal=false
 #24 hour default cache life
 jcs.region.NODEAUDIT.elementattributes.MaxLife=86400
 jcs.region.NODEAUDIT.elementattributes.IsSpool=true


### PR DESCRIPTION
## Description of Change

Update configuration file to set isEternal flag value to false, only on NODEAUDIT cache.
Without this, the cache is never refresh.

In documentation for configuration nodeAuditAnalyzerUseCache
Sets whether the Node Audit Analyzer will cache results. Cached results expire after 24 hours.

But it is never the case, results in the cache never expire as they are flagged as eternal.

## Related issues

fixes #8757

## Have test cases been added to cover the new functionality?

yes